### PR TITLE
chore(lint): Phase 2-A — fix strict rules for #71

### DIFF
--- a/scripts/sync/sync-aurora-dev-data.ts
+++ b/scripts/sync/sync-aurora-dev-data.ts
@@ -1043,14 +1043,14 @@ async function main(): Promise<void> {
       console.error("❌ Prod and dev connections required for prod-to-dev.");
       process.exit(1);
     }
-    await runDirection("prod-to-dev", prodConn!, devConn!, config, options);
+    await runDirection("prod-to-dev", prodConn, devConn, config, options);
   }
   if (options.direction === "dev-to-prod" || options.direction === "bidirectional") {
     if (!prodConn || !devConn) {
       console.error("❌ Prod and dev connections required for dev-to-prod.");
       process.exit(1);
     }
-    await runDirection("dev-to-prod", prodConn!, devConn!, config, options);
+    await runDirection("dev-to-prod", prodConn, devConn, config, options);
   }
 
   console.log(`

--- a/src/components/ai-chat/AIChatInput.tsx
+++ b/src/components/ai-chat/AIChatInput.tsx
@@ -61,8 +61,8 @@ export function AIChatInput({ onSendMessage, onStopStreaming }: AIChatInputProps
     if (!editor) return;
     const chips = editor.querySelectorAll<HTMLElement>("[data-page-id]");
     const newRefs = Array.from(chips).map((el) => ({
-      id: el.dataset.pageId!,
-      title: el.dataset.pageTitle!,
+      id: el.dataset.pageId ?? "",
+      title: el.dataset.pageTitle ?? "",
     }));
     setPendingRefs((prev) => {
       if (prev.length === newRefs.length && prev.every((r, i) => r.id === newRefs[i]?.id))

--- a/src/components/ai-chat/AIChatModelSelector.tsx
+++ b/src/components/ai-chat/AIChatModelSelector.tsx
@@ -28,13 +28,16 @@ export function AIChatModelSelector() {
         const settings = await loadAISettings();
         const savedModelId = settings?.modelId;
         const matched = savedModelId ? available.find((m) => m.id === savedModelId) : null;
-        const initial = matched ?? available[0]!;
-        setSelectedModel({
-          id: initial.id,
-          provider: initial.provider,
-          model: initial.modelId,
-          displayName: initial.displayName,
-        });
+        const first = available[0];
+        const initial = matched ?? first;
+        if (initial) {
+          setSelectedModel({
+            id: initial.id,
+            provider: initial.provider,
+            model: initial.modelId,
+            displayName: initial.displayName,
+          });
+        }
       }
     } catch {
       // フォールバック: 設定画面のモデルを使用

--- a/src/components/editor/PageEditor/PageEditorContent.tsx
+++ b/src/components/editor/PageEditor/PageEditorContent.tsx
@@ -71,12 +71,15 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
   );
 
   const collaborationConfig =
-    useCollaborationMode && collaboration
+    useCollaborationMode &&
+    collaboration?.ydoc &&
+    collaboration?.xmlFragment &&
+    collaboration?.collaborationUser
       ? {
-          ydoc: collaboration.ydoc!,
-          xmlFragment: collaboration.xmlFragment!,
-          awareness: collaboration.awareness, // undefined in local mode
-          user: collaboration.collaborationUser!,
+          ydoc: collaboration.ydoc,
+          xmlFragment: collaboration.xmlFragment,
+          awareness: collaboration.awareness,
+          user: collaboration.collaborationUser,
           updateCursor: collaboration.updateCursor,
           updateSelection: collaboration.updateSelection,
         }

--- a/src/components/editor/TiptapEditor/SlashSuggestionLayer.tsx
+++ b/src/components/editor/TiptapEditor/SlashSuggestionLayer.tsx
@@ -184,7 +184,7 @@ export const SlashSuggestionLayer: React.FC<SlashSuggestionLayerProps> = ({
   suggestionRef,
   onClose,
 }) => {
-  if (!suggestionState?.active || !position || !editor) return null;
+  if (!suggestionState?.active || !suggestionState.range || !position || !editor) return null;
 
   return (
     <div
@@ -198,7 +198,7 @@ export const SlashSuggestionLayer: React.FC<SlashSuggestionLayerProps> = ({
         ref={suggestionRef}
         editor={editor}
         query={suggestionState.query}
-        range={suggestionState.range!}
+        range={suggestionState.range}
         onClose={onClose}
       />
     </div>

--- a/src/components/editor/TiptapEditor/WikiLinkSuggestionLayer.tsx
+++ b/src/components/editor/TiptapEditor/WikiLinkSuggestionLayer.tsx
@@ -24,7 +24,7 @@ export const WikiLinkSuggestionLayer: React.FC<WikiLinkSuggestionLayerProps> = (
   onSelect,
   onClose,
 }) => {
-  if (!suggestionState?.active || !position || !editor) return null;
+  if (!suggestionState?.active || !suggestionState.range || !position || !editor) return null;
 
   return (
     <div
@@ -38,7 +38,7 @@ export const WikiLinkSuggestionLayer: React.FC<WikiLinkSuggestionLayerProps> = (
         ref={suggestionRef}
         editor={editor}
         query={suggestionState.query}
-        range={suggestionState.range!}
+        range={suggestionState.range}
         onSelect={onSelect}
         onClose={onClose}
       />

--- a/src/components/editor/TiptapEditor/useEditorSetup.ts
+++ b/src/components/editor/TiptapEditor/useEditorSetup.ts
@@ -115,14 +115,15 @@ export function useEditorSetup(options: UseEditorSetupOptions) {
             }
           },
         },
-        collaboration: useCollaborationMode
-          ? {
-              document: collaborationConfig!.ydoc,
-              field: "default",
-              awareness: collaborationConfig!.awareness,
-              user: collaborationConfig!.user,
-            }
-          : undefined,
+        collaboration:
+          useCollaborationMode && collaborationConfig
+            ? {
+                document: collaborationConfig.ydoc,
+                field: "default",
+                awareness: collaborationConfig.awareness,
+                user: collaborationConfig.user,
+              }
+            : undefined,
       }),
       content: useCollaborationMode ? undefined : initialParsedContent,
       autofocus: autoFocus ? "end" : false,

--- a/src/hooks/useAISettings.ts
+++ b/src/hooks/useAISettings.ts
@@ -133,7 +133,8 @@ export function useAISettings(): UseAISettingsReturn {
         setAvailableModels(result.models);
         // 現在選択中のモデルが新しいリストにない場合、最初のモデルを選択
         if (!result.models.includes(settings.model)) {
-          setSettings((prev) => ({ ...prev, model: result.models![0] }));
+          const first = result.models[0];
+          if (first) setSettings((prev) => ({ ...prev, model: first }));
         }
       }
 

--- a/src/lib/aiClient.test.ts
+++ b/src/lib/aiClient.test.ts
@@ -103,7 +103,9 @@ describe("aiClient", () => {
   describe("saveCachedModels", () => {
     it("saves models to localStorage", () => {
       saveCachedModels("openai", ["gpt-5-mini"]);
-      const stored = JSON.parse(localStorage.getItem(CACHE_KEY)!);
+      const raw = localStorage.getItem(CACHE_KEY);
+      expect(raw).toBeTruthy();
+      const stored = JSON.parse(raw ?? "{}");
       expect(stored.openai.models).toEqual(["gpt-5-mini"]);
       expect(stored.openai.provider).toBe("openai");
       expect(stored.openai.cachedAt).toBeGreaterThan(0);

--- a/src/lib/aiService.test.ts
+++ b/src/lib/aiService.test.ts
@@ -26,37 +26,31 @@ let googleMock: {
 
 // OpenAI SDKのモック
 vi.mock("openai", () => ({
-  default: class OpenAI {
-    constructor() {
-      if (!openAIMock) {
-        throw new Error("OpenAI mock is not configured");
-      }
-      return openAIMock;
+  default: function OpenAI() {
+    if (!openAIMock) {
+      throw new Error("OpenAI mock is not configured");
     }
+    return openAIMock;
   },
 }));
 
 // Anthropic SDKのモック
 vi.mock("@anthropic-ai/sdk", () => ({
-  default: class Anthropic {
-    constructor() {
-      if (!anthropicMock) {
-        throw new Error("Anthropic mock is not configured");
-      }
-      return anthropicMock;
+  default: function Anthropic() {
+    if (!anthropicMock) {
+      throw new Error("Anthropic mock is not configured");
     }
+    return anthropicMock;
   },
 }));
 
 // Google GenAI SDKのモック
 vi.mock("@google/genai", () => ({
-  GoogleGenAI: class GoogleGenAI {
-    constructor() {
-      if (!googleMock) {
-        throw new Error("GoogleGenAI mock is not configured");
-      }
-      return googleMock;
+  GoogleGenAI: function GoogleGenAI() {
+    if (!googleMock) {
+      throw new Error("GoogleGenAI mock is not configured");
     }
+    return googleMock;
   },
 }));
 

--- a/src/lib/auth/cognitoAuth.test.ts
+++ b/src/lib/auth/cognitoAuth.test.ts
@@ -83,7 +83,9 @@ describe("cognitoAuth", () => {
       expect(state.expiresAt).toBeGreaterThanOrEqual(before + 7200 * 1000);
       expect(state.expiresAt).toBeLessThanOrEqual(Date.now() + 7200 * 1000);
 
-      const stored = JSON.parse(localStorage.getItem("zedi_cognito_auth")!);
+      const storedRaw = localStorage.getItem("zedi_cognito_auth");
+      expect(storedRaw).toBeTruthy();
+      const stored = JSON.parse(storedRaw ?? "{}");
       expect(stored.tokens.id_token).toBe("id-tok");
     });
   });

--- a/src/lib/collaboration/CollaborationManager.test.ts
+++ b/src/lib/collaboration/CollaborationManager.test.ts
@@ -6,25 +6,22 @@ const mockYDocDestroy = vi.fn();
 const mockYDocGetXmlFragment = vi.fn().mockReturnValue({ toJSON: () => "" });
 
 vi.mock("yjs", () => ({
-  Doc: class {
-    on = mockYDocOn;
-    destroy = mockYDocDestroy;
-    getXmlFragment = mockYDocGetXmlFragment;
+  Doc: function Doc() {
+    return { on: mockYDocOn, destroy: mockYDocDestroy, getXmlFragment: mockYDocGetXmlFragment };
   },
   encodeStateAsUpdate: vi.fn(() => new Uint8Array([0, 0])),
   applyUpdate: vi.fn(),
-  XmlFragment: class {},
-  XmlElement: class {},
-  XmlText: class {},
+  XmlFragment: function XmlFragment() {},
+  XmlElement: function XmlElement() {},
+  XmlText: function XmlText() {},
 }));
 
 const mockIdbOn = vi.fn();
 const mockIdbDestroy = vi.fn();
 
 vi.mock("y-indexeddb", () => ({
-  IndexeddbPersistence: class {
-    on = mockIdbOn;
-    destroy = mockIdbDestroy;
+  IndexeddbPersistence: function IndexeddbPersistence() {
+    return { on: mockIdbOn, destroy: mockIdbDestroy };
   },
 }));
 

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -293,7 +293,7 @@ export class CollaborationManager {
     const onlineUsers: UserPresence[] = [];
 
     states.forEach((state, clientId) => {
-      if (clientId !== this.awareness!.clientID && state.userId) {
+      if (clientId !== (this.awareness?.clientID ?? null) && state.userId) {
         onlineUsers.push(state as UserPresence);
       }
     });

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -65,11 +65,14 @@ export function groupPagesByDate(pages: Page[]): DateGroup[] {
 
   sortedKeys.forEach((dateKey) => {
     const date = parseISO(dateKey);
-    result.push({
-      date: dateKey,
-      label: formatDateLabel(date),
-      pages: groups.get(dateKey)!,
-    });
+    const pages = groups.get(dateKey);
+    if (pages) {
+      result.push({
+        date: dateKey,
+        label: formatDateLabel(date),
+        pages,
+      });
+    }
   });
 
   return result;

--- a/src/lib/pageRepository/StorageAdapterPageRepository.test.ts
+++ b/src/lib/pageRepository/StorageAdapterPageRepository.test.ts
@@ -126,8 +126,10 @@ describe("StorageAdapterPageRepository", () => {
 
       const page = await repo.getPage(LOCAL_USER_ID, "page-1");
       expect(page).not.toBeNull();
-      expect(page!.id).toBe("page-1");
-      expect(page!.title).toBe("Hello");
+      if (page) {
+        expect(page.id).toBe("page-1");
+        expect(page.title).toBe("Hello");
+      }
     });
 
     it("returns null when page not found", async () => {
@@ -308,7 +310,7 @@ describe("StorageAdapterPageRepository", () => {
       (adapter.getAllPages as ReturnType<typeof vi.fn>).mockResolvedValue(pages);
       const dup = await repo.checkDuplicateTitle(LOCAL_USER_ID, "Unique Title");
       expect(dup).not.toBeNull();
-      expect(dup!.id).toBe("p1");
+      if (dup) expect(dup.id).toBe("p1");
     });
 
     it("excludes current page from duplicate check", async () => {

--- a/src/lib/storageSettings.ts
+++ b/src/lib/storageSettings.ts
@@ -59,7 +59,7 @@ export async function loadStorageSettings(): Promise<StorageSettings | null> {
     const parsed = JSON.parse(stored) as StorageSettings;
 
     // 認証情報を復号化
-    const config = { ...parsed.config };
+    let config: typeof parsed.config = { ...parsed.config };
 
     for (const field of SENSITIVE_FIELDS) {
       const value = config[field as keyof typeof config];
@@ -69,7 +69,8 @@ export async function loadStorageSettings(): Promise<StorageSettings | null> {
         } catch {
           // 復号化に失敗した場合はフィールドをクリア
           console.warn(`Failed to decrypt field: ${field}`);
-          delete (config as Record<string, unknown>)[field];
+          const { [field]: _, ...rest } = config as Record<string, unknown>;
+          config = rest as typeof config;
         }
       }
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,7 +23,9 @@ if (!isE2EMode && !import.meta.env.VITE_COGNITO_CLIENT_ID) {
   console.warn("[Auth] VITE_COGNITO_CLIENT_ID is not set; sign-in will fail.");
 }
 
-createRoot(document.getElementById("root")!).render(
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("Root element #root not found");
+createRoot(rootEl).render(
   <StrictMode>
     <AuthProvider>
       <App />

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -27,7 +27,6 @@ global.ResizeObserver = class ResizeObserver {
   observe = vi.fn();
   unobserve = vi.fn();
   disconnect = vi.fn();
-  constructor(_callback: ResizeObserverCallback) {}
 };
 
 // Mock IntersectionObserver (constructor として new されるため class で定義)
@@ -39,5 +38,4 @@ global.IntersectionObserver = class IntersectionObserver {
   unobserve = vi.fn();
   disconnect = vi.fn();
   takeRecords = vi.fn().mockReturnValue([]);
-  constructor(_callback: IntersectionObserverCallback) {}
 };

--- a/terraform/modules/ai-api/lambda/src/lib/db.ts
+++ b/terraform/modules/ai-api/lambda/src/lib/db.ts
@@ -46,8 +46,11 @@ export async function execute<T = Record<string, unknown>>(
   params: Record<string, unknown> = {},
   env?: EnvConfig,
 ): Promise<T[]> {
-  const resourceArn = env?.AURORA_CLUSTER_ARN ?? process.env.AURORA_CLUSTER_ARN!;
-  const secretArn = env?.DB_CREDENTIALS_SECRET ?? process.env.DB_CREDENTIALS_SECRET!;
+  const resourceArn = env?.AURORA_CLUSTER_ARN ?? process.env.AURORA_CLUSTER_ARN;
+  const secretArn = env?.DB_CREDENTIALS_SECRET ?? process.env.DB_CREDENTIALS_SECRET;
+  if (!resourceArn || !secretArn) {
+    throw new Error("AURORA_CLUSTER_ARN and DB_CREDENTIALS_SECRET are required");
+  }
   const database = env?.AURORA_DATABASE_NAME ?? process.env.AURORA_DATABASE_NAME ?? "zedi";
 
   const parameters = Object.entries(params).map(([name, value]) => toParameter(name, value));

--- a/terraform/modules/api/lambda/src/__tests__/routes/media.test.ts
+++ b/terraform/modules/api/lambda/src/__tests__/routes/media.test.ts
@@ -39,7 +39,7 @@ vi.mock("../../middleware/auth", () => ({
   },
 }));
 vi.mock("@aws-sdk/client-s3", () => {
-  class MockS3Client {}
+  function MockS3Client() {}
   return {
     S3Client: MockS3Client,
     PutObjectCommand: class PutObjectCommand {

--- a/terraform/modules/api/lambda/src/middleware/auth.ts
+++ b/terraform/modules/api/lambda/src/middleware/auth.ts
@@ -34,9 +34,12 @@ export const authRequired = createMiddleware<AppEnv>(async (c, next) => {
     throw new HTTPException(401, { message: "User not found" });
   }
 
-  c.set("cognitoSub", sub);
-  c.set("userId", result[0]!.id);
-  c.set("userEmail", result[0]!.email);
+  const user = result[0];
+  if (user) {
+    c.set("cognitoSub", sub);
+    c.set("userId", user.id);
+    c.set("userEmail", user.email);
+  }
   await next();
 });
 
@@ -58,9 +61,12 @@ export const authOptional = createMiddleware<AppEnv>(async (c, next) => {
       .limit(1);
 
     if (result.length) {
-      c.set("cognitoSub", sub);
-      c.set("userId", result[0]!.id);
-      c.set("userEmail", result[0]!.email);
+      const user = result[0];
+      if (user) {
+        c.set("cognitoSub", sub);
+        c.set("userId", user.id);
+        c.set("userEmail", user.email);
+      }
     }
   }
 

--- a/terraform/modules/api/lambda/src/middleware/auth.ts
+++ b/terraform/modules/api/lambda/src/middleware/auth.ts
@@ -30,16 +30,12 @@ export const authRequired = createMiddleware<AppEnv>(async (c, next) => {
     .where(eq(users.cognitoSub, sub))
     .limit(1);
 
-  if (!result.length) {
-    throw new HTTPException(401, { message: "User not found" });
-  }
-
   const user = result[0];
-  if (user) {
-    c.set("cognitoSub", sub);
-    c.set("userId", user.id);
-    c.set("userEmail", user.email);
-  }
+  if (!user) throw new HTTPException(401, { message: "User not found" });
+
+  c.set("cognitoSub", sub);
+  c.set("userId", user.id);
+  c.set("userEmail", user.email);
   await next();
 });
 
@@ -60,13 +56,11 @@ export const authOptional = createMiddleware<AppEnv>(async (c, next) => {
       .where(eq(users.cognitoSub, sub))
       .limit(1);
 
-    if (result.length) {
-      const user = result[0];
-      if (user) {
-        c.set("cognitoSub", sub);
-        c.set("userId", user.id);
-        c.set("userEmail", user.email);
-      }
+    const user = result[0];
+    if (user) {
+      c.set("cognitoSub", sub);
+      c.set("userId", user.id);
+      c.set("userEmail", user.email);
     }
   }
 

--- a/terraform/modules/api/lambda/src/routes/media.ts
+++ b/terraform/modules/api/lambda/src/routes/media.ts
@@ -105,12 +105,13 @@ app.get("/:id", authRequired, async (c) => {
     throw new HTTPException(404, { message: "Media not found" });
   }
 
-  // 署名付き GET URL を生成して 302 リダイレクト
+  const row = result[0];
+  if (!row) throw new HTTPException(404, { message: "Media not found" });
   const signedUrl = await getSignedUrl(
     s3,
     new GetObjectCommand({
       Bucket: env.MEDIA_BUCKET,
-      Key: result[0]!.s3Key,
+      Key: row.s3Key,
     }),
     { expiresIn: 3600 },
   );

--- a/terraform/modules/api/lambda/src/routes/media.ts
+++ b/terraform/modules/api/lambda/src/routes/media.ts
@@ -101,10 +101,6 @@ app.get("/:id", authRequired, async (c) => {
 
   const result = await db.select().from(media).where(eq(media.id, mediaId)).limit(1);
 
-  if (!result.length) {
-    throw new HTTPException(404, { message: "Media not found" });
-  }
-
   const row = result[0];
   if (!row) throw new HTTPException(404, { message: "Media not found" });
   const signedUrl = await getSignedUrl(

--- a/terraform/modules/api/lambda/src/routes/notes.ts
+++ b/terraform/modules/api/lambda/src/routes/notes.ts
@@ -49,7 +49,8 @@ async function getNoteRole(
     .limit(1);
 
   if (!noteResult.length) return { role: null, note: null };
-  const note = noteResult[0]!;
+  const note = noteResult[0];
+  if (!note) return { role: null, note: null };
 
   // オーナーチェック
   if (note.ownerId === userId) return { role: "owner", note };
@@ -69,7 +70,8 @@ async function getNoteRole(
       .limit(1);
 
     if (member.length) {
-      return { role: member[0]!.role as "editor" | "viewer", note };
+      const firstMember = member[0];
+      if (firstMember) return { role: firstMember.role as "editor" | "viewer", note };
     }
   }
 
@@ -140,7 +142,8 @@ app.put("/:noteId", authRequired, async (c) => {
     .limit(1);
 
   if (!note.length) throw new HTTPException(404, { message: "Note not found" });
-  if (note[0]!.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
+  const noteRow = note[0];
+  if (noteRow?.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
 
   const body = await c.req.json<{
     title?: string;
@@ -181,7 +184,8 @@ app.delete("/:noteId", authRequired, async (c) => {
     .limit(1);
 
   if (!note.length) throw new HTTPException(404, { message: "Note not found" });
-  if (note[0]!.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
+  const noteRow = note[0];
+  if (noteRow?.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
 
   await db
     .update(notes)
@@ -418,10 +422,12 @@ app.put("/:noteId/pages", authRequired, async (c) => {
 
   // page_ids の順番で sort_order を更新
   for (let i = 0; i < body.page_ids.length; i++) {
+    const pageId = body.page_ids[i];
+    if (!pageId) continue;
     await db
       .update(notePages)
       .set({ sortOrder: i, updatedAt: new Date() })
-      .where(and(eq(notePages.noteId, noteId), eq(notePages.pageId, body.page_ids[i]!)));
+      .where(and(eq(notePages.noteId, noteId), eq(notePages.pageId, pageId)));
   }
 
   await db.update(notes).set({ updatedAt: new Date() }).where(eq(notes.id, noteId));
@@ -474,7 +480,8 @@ app.post("/:noteId/members", authRequired, async (c) => {
     .limit(1);
 
   if (!note.length) throw new HTTPException(404, { message: "Note not found" });
-  if (note[0]!.ownerId !== userId) {
+  const noteRow = note[0];
+  if (noteRow?.ownerId !== userId) {
     throw new HTTPException(403, { message: "Only the owner can add members" });
   }
 
@@ -521,7 +528,8 @@ app.delete("/:noteId/members/:memberEmail", authRequired, async (c) => {
     .limit(1);
 
   if (!note.length) throw new HTTPException(404, { message: "Note not found" });
-  if (note[0]!.ownerId !== userId) {
+  const noteRow = note[0];
+  if (noteRow?.ownerId !== userId) {
     throw new HTTPException(403, { message: "Only the owner can remove members" });
   }
 

--- a/terraform/modules/api/lambda/src/routes/notes.ts
+++ b/terraform/modules/api/lambda/src/routes/notes.ts
@@ -48,7 +48,6 @@ async function getNoteRole(
     .where(and(eq(notes.id, noteId), eq(notes.isDeleted, false)))
     .limit(1);
 
-  if (!noteResult.length) return { role: null, note: null };
   const note = noteResult[0];
   if (!note) return { role: null, note: null };
 
@@ -69,9 +68,9 @@ async function getNoteRole(
       )
       .limit(1);
 
-    if (member.length) {
-      const firstMember = member[0];
-      if (firstMember) return { role: firstMember.role as "editor" | "viewer", note };
+    const firstMember = member[0];
+    if (firstMember) {
+      return { role: firstMember.role as "editor" | "viewer", note };
     }
   }
 
@@ -141,9 +140,9 @@ app.put("/:noteId", authRequired, async (c) => {
     .where(and(eq(notes.id, noteId), eq(notes.isDeleted, false)))
     .limit(1);
 
-  if (!note.length) throw new HTTPException(404, { message: "Note not found" });
   const noteRow = note[0];
-  if (noteRow?.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
+  if (!noteRow) throw new HTTPException(404, { message: "Note not found" });
+  if (noteRow.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
 
   const body = await c.req.json<{
     title?: string;
@@ -183,9 +182,9 @@ app.delete("/:noteId", authRequired, async (c) => {
     .where(and(eq(notes.id, noteId), eq(notes.isDeleted, false)))
     .limit(1);
 
-  if (!note.length) throw new HTTPException(404, { message: "Note not found" });
   const noteRow = note[0];
-  if (noteRow?.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
+  if (!noteRow) throw new HTTPException(404, { message: "Note not found" });
+  if (noteRow.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
 
   await db
     .update(notes)
@@ -479,9 +478,9 @@ app.post("/:noteId/members", authRequired, async (c) => {
     .where(and(eq(notes.id, noteId), eq(notes.isDeleted, false)))
     .limit(1);
 
-  if (!note.length) throw new HTTPException(404, { message: "Note not found" });
   const noteRow = note[0];
-  if (noteRow?.ownerId !== userId) {
+  if (!noteRow) throw new HTTPException(404, { message: "Note not found" });
+  if (noteRow.ownerId !== userId) {
     throw new HTTPException(403, { message: "Only the owner can add members" });
   }
 
@@ -527,9 +526,9 @@ app.delete("/:noteId/members/:memberEmail", authRequired, async (c) => {
     .where(and(eq(notes.id, noteId), eq(notes.isDeleted, false)))
     .limit(1);
 
-  if (!note.length) throw new HTTPException(404, { message: "Note not found" });
   const noteRow = note[0];
-  if (noteRow?.ownerId !== userId) {
+  if (!noteRow) throw new HTTPException(404, { message: "Note not found" });
+  if (noteRow.ownerId !== userId) {
     throw new HTTPException(403, { message: "Only the owner can remove members" });
   }
 

--- a/terraform/modules/api/lambda/src/routes/pages.ts
+++ b/terraform/modules/api/lambda/src/routes/pages.ts
@@ -31,7 +31,8 @@ app.get("/:id/content", authRequired, async (c) => {
   if (!page.length) {
     throw new HTTPException(404, { message: "Page not found" });
   }
-  if (page[0]!.ownerId !== userId) {
+  const pageRow = page[0];
+  if (pageRow?.ownerId !== userId) {
     throw new HTTPException(403, { message: "Forbidden" });
   }
 
@@ -46,8 +47,8 @@ app.get("/:id/content", authRequired, async (c) => {
     return c.json({ content: null, version: 0 });
   }
 
-  // ydoc_state を base64 で返す
-  const row = content[0]!;
+  const row = content[0];
+  if (!row) return c.json({ content: null, version: 0 });
   const ydocBase64 =
     row.ydocState instanceof Buffer
       ? row.ydocState.toString("base64")
@@ -90,7 +91,8 @@ app.put("/:id/content", authRequired, async (c) => {
   if (!page.length) {
     throw new HTTPException(404, { message: "Page not found" });
   }
-  if (page[0]!.ownerId !== userId) {
+  const pageRow = page[0];
+  if (pageRow?.ownerId !== userId) {
     throw new HTTPException(403, { message: "Forbidden" });
   }
 
@@ -123,7 +125,7 @@ app.put("/:id/content", authRequired, async (c) => {
       });
     }
 
-    // ページタイトルを更新
+    const updatedRow = updated[0];
     if (body.title !== undefined) {
       await db
         .update(pages)
@@ -131,7 +133,7 @@ app.put("/:id/content", authRequired, async (c) => {
         .where(eq(pages.id, pageId));
     }
 
-    return c.json({ version: updated[0]!.version });
+    return c.json({ version: updatedRow?.version ?? 0 });
   }
 
   // No optimistic locking: UPSERT
@@ -161,7 +163,8 @@ app.put("/:id/content", authRequired, async (c) => {
       .where(eq(pages.id, pageId));
   }
 
-  return c.json({ version: result[0]!.version });
+  const resultRow = result[0];
+  return c.json({ version: resultRow?.version ?? 0 });
 });
 
 // ── POST /pages ─────────────────────────────────────────────────────────────
@@ -185,7 +188,8 @@ app.post("/", authRequired, async (c) => {
     })
     .returning();
 
-  const row = result[0]!;
+  const row = result[0];
+  if (!row) throw new HTTPException(500, { message: "Insert failed" });
   return c.json(
     {
       id: row.id,
@@ -218,7 +222,8 @@ app.delete("/:id", authRequired, async (c) => {
   if (!page.length) {
     throw new HTTPException(404, { message: "Page not found" });
   }
-  if (page[0]!.ownerId !== userId) {
+  const pageRow = page[0];
+  if (pageRow?.ownerId !== userId) {
     throw new HTTPException(403, { message: "Forbidden" });
   }
 

--- a/terraform/modules/api/lambda/src/routes/pages.ts
+++ b/terraform/modules/api/lambda/src/routes/pages.ts
@@ -28,13 +28,9 @@ app.get("/:id/content", authRequired, async (c) => {
     .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
     .limit(1);
 
-  if (!page.length) {
-    throw new HTTPException(404, { message: "Page not found" });
-  }
   const pageRow = page[0];
-  if (pageRow?.ownerId !== userId) {
-    throw new HTTPException(403, { message: "Forbidden" });
-  }
+  if (!pageRow) throw new HTTPException(404, { message: "Page not found" });
+  if (pageRow.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
 
   // コンテンツ取得
   const content = await db
@@ -42,10 +38,6 @@ app.get("/:id/content", authRequired, async (c) => {
     .from(pageContents)
     .where(eq(pageContents.pageId, pageId))
     .limit(1);
-
-  if (!content.length) {
-    return c.json({ content: null, version: 0 });
-  }
 
   const row = content[0];
   if (!row) return c.json({ content: null, version: 0 });
@@ -88,13 +80,9 @@ app.put("/:id/content", authRequired, async (c) => {
     .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
     .limit(1);
 
-  if (!page.length) {
-    throw new HTTPException(404, { message: "Page not found" });
-  }
   const pageRow = page[0];
-  if (pageRow?.ownerId !== userId) {
-    throw new HTTPException(403, { message: "Forbidden" });
-  }
+  if (!pageRow) throw new HTTPException(404, { message: "Page not found" });
+  if (pageRow.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
 
   const ydocBuffer = Buffer.from(body.content, "base64");
 
@@ -126,6 +114,8 @@ app.put("/:id/content", authRequired, async (c) => {
     }
 
     const updatedRow = updated[0];
+    if (!updatedRow) throw new HTTPException(500, { message: "Update failed" });
+
     if (body.title !== undefined) {
       await db
         .update(pages)
@@ -133,7 +123,7 @@ app.put("/:id/content", authRequired, async (c) => {
         .where(eq(pages.id, pageId));
     }
 
-    return c.json({ version: updatedRow?.version ?? 0 });
+    return c.json({ version: updatedRow.version ?? 0 });
   }
 
   // No optimistic locking: UPSERT
@@ -164,7 +154,8 @@ app.put("/:id/content", authRequired, async (c) => {
   }
 
   const resultRow = result[0];
-  return c.json({ version: resultRow?.version ?? 0 });
+  if (!resultRow) throw new HTTPException(500, { message: "Upsert failed" });
+  return c.json({ version: resultRow.version });
 });
 
 // ── POST /pages ─────────────────────────────────────────────────────────────
@@ -219,13 +210,9 @@ app.delete("/:id", authRequired, async (c) => {
     .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
     .limit(1);
 
-  if (!page.length) {
-    throw new HTTPException(404, { message: "Page not found" });
-  }
   const pageRow = page[0];
-  if (pageRow?.ownerId !== userId) {
-    throw new HTTPException(403, { message: "Forbidden" });
-  }
+  if (!pageRow) throw new HTTPException(404, { message: "Page not found" });
+  if (pageRow.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
 
   await db
     .update(pages)

--- a/terraform/modules/api/lambda/src/routes/syncPages.ts
+++ b/terraform/modules/api/lambda/src/routes/syncPages.ts
@@ -136,23 +136,26 @@ app.post("/", authRequired, async (c) => {
         updatedAt: clientTime,
       });
       results.push({ id: p.id, action: "created" });
-    } else if (clientTime > existing[0]!.updatedAt) {
-      // クライアント側が新しい: 更新
-      await db
-        .update(pages)
-        .set({
-          title: p.title ?? null,
-          contentPreview: p.content_preview ?? null,
-          thumbnailUrl: p.thumbnail_url ?? null,
-          sourceUrl: p.source_url ?? null,
-          sourcePageId: p.source_page_id ?? null,
-          isDeleted: p.is_deleted ?? false,
-          updatedAt: clientTime,
-        })
-        .where(eq(pages.id, p.id));
-      results.push({ id: p.id, action: "updated" });
     } else {
-      results.push({ id: p.id, action: "skipped" });
+      const existingRow = existing[0];
+      if (existingRow && clientTime > existingRow.updatedAt) {
+        // クライアント側が新しい: 更新
+        await db
+          .update(pages)
+          .set({
+            title: p.title ?? null,
+            contentPreview: p.content_preview ?? null,
+            thumbnailUrl: p.thumbnail_url ?? null,
+            sourceUrl: p.source_url ?? null,
+            sourcePageId: p.source_page_id ?? null,
+            isDeleted: p.is_deleted ?? false,
+            updatedAt: clientTime,
+          })
+          .where(eq(pages.id, p.id));
+        results.push({ id: p.id, action: "updated" });
+      } else {
+        results.push({ id: p.id, action: "skipped" });
+      }
     }
   }
 

--- a/terraform/modules/api/lambda/src/routes/users.ts
+++ b/terraform/modules/api/lambda/src/routes/users.ts
@@ -50,14 +50,14 @@ app.post("/upsert", async (c) => {
   const existing = await db.select().from(users).where(eq(users.cognitoSub, cognitoSub)).limit(1);
 
   let result;
-  if (existing.length > 0) {
-    const existingRow = existing[0];
+  const existingRow = existing[0];
+  if (existingRow) {
     result = await db
       .update(users)
       .set({
         email,
-        displayName: body.display_name || (existingRow?.displayName ?? null),
-        avatarUrl: body.avatar_url || (existingRow?.avatarUrl ?? null),
+        displayName: body.display_name || (existingRow.displayName ?? null),
+        avatarUrl: body.avatar_url || (existingRow.avatarUrl ?? null),
         updatedAt: new Date(),
       })
       .where(eq(users.cognitoSub, cognitoSub))
@@ -66,14 +66,14 @@ app.post("/upsert", async (c) => {
     // 新規ユーザー: 同一メールの行が既にあればそちらの cognito_sub を更新
     const existingByEmail = await db.select().from(users).where(eq(users.email, email)).limit(1);
 
-    if (existingByEmail.length > 0) {
-      const existingRow = existingByEmail[0];
+    const existingByEmailRow = existingByEmail[0];
+    if (existingByEmailRow) {
       result = await db
         .update(users)
         .set({
           cognitoSub,
-          displayName: body.display_name || (existingRow?.displayName ?? null),
-          avatarUrl: body.avatar_url || (existingRow?.avatarUrl ?? null),
+          displayName: body.display_name || (existingByEmailRow.displayName ?? null),
+          avatarUrl: body.avatar_url || (existingByEmailRow.avatarUrl ?? null),
           updatedAt: new Date(),
         })
         .where(eq(users.email, email))

--- a/terraform/modules/api/lambda/src/routes/users.ts
+++ b/terraform/modules/api/lambda/src/routes/users.ts
@@ -51,13 +51,13 @@ app.post("/upsert", async (c) => {
 
   let result;
   if (existing.length > 0) {
-    // cognito_sub が既に存在 → UPDATE
+    const existingRow = existing[0];
     result = await db
       .update(users)
       .set({
         email,
-        displayName: body.display_name || existing[0]!.displayName,
-        avatarUrl: body.avatar_url || existing[0]!.avatarUrl,
+        displayName: body.display_name || (existingRow?.displayName ?? null),
+        avatarUrl: body.avatar_url || (existingRow?.avatarUrl ?? null),
         updatedAt: new Date(),
       })
       .where(eq(users.cognitoSub, cognitoSub))
@@ -67,13 +67,13 @@ app.post("/upsert", async (c) => {
     const existingByEmail = await db.select().from(users).where(eq(users.email, email)).limit(1);
 
     if (existingByEmail.length > 0) {
-      // 同じメールだが別の cognito_sub → cognito_sub を更新（アカウント統合）
+      const existingRow = existingByEmail[0];
       result = await db
         .update(users)
         .set({
           cognitoSub,
-          displayName: body.display_name || existingByEmail[0]!.displayName,
-          avatarUrl: body.avatar_url || existingByEmail[0]!.avatarUrl,
+          displayName: body.display_name || (existingRow?.displayName ?? null),
+          avatarUrl: body.avatar_url || (existingRow?.avatarUrl ?? null),
           updatedAt: new Date(),
         })
         .where(eq(users.email, email))

--- a/terraform/modules/api/lambda/src/services/aiProviders.ts
+++ b/terraform/modules/api/lambda/src/services/aiProviders.ts
@@ -86,7 +86,9 @@ export async function* streamOpenAI(
     throw new Error(`OpenAI API failed: ${res.status} - ${text}`);
   }
 
-  yield* parseSSEStream(res.body!, (raw) => {
+  const streamBody = res.body;
+  if (!streamBody) throw new Error("OpenAI API response has no body");
+  yield* parseSSEStream(streamBody, (raw) => {
     const data = JSON.parse(raw) as {
       choices: Array<{ delta: { content?: string }; finish_reason?: string | null }>;
     };
@@ -187,7 +189,9 @@ export async function* streamAnthropic(
     throw new Error(`Anthropic API failed: ${res.status} - ${text}`);
   }
 
-  yield* parseSSEStream(res.body!, (raw) => {
+  const streamBody = res.body;
+  if (!streamBody) throw new Error("Anthropic API response has no body");
+  yield* parseSSEStream(streamBody, (raw) => {
     const event = JSON.parse(raw) as {
       type: string;
       delta?: { text?: string; stop_reason?: string };
@@ -326,7 +330,9 @@ export async function* streamGoogle(
     throw new Error(`Google AI API failed: ${res.status} - ${text}`);
   }
 
-  yield* parseSSEStream(res.body!, (raw) => {
+  const streamBody = res.body;
+  if (!streamBody) throw new Error("Google AI API response has no body");
+  yield* parseSSEStream(streamBody, (raw) => {
     const data = JSON.parse(raw) as {
       candidates?: Array<{
         content?: { parts?: Array<{ text?: string }> };

--- a/terraform/modules/api/lambda/src/services/commitService.ts
+++ b/terraform/modules/api/lambda/src/services/commitService.ts
@@ -45,8 +45,9 @@ async function fetchImageAsBuffer(
   if (sourceUrl.startsWith("data:")) {
     const match = sourceUrl.match(/^data:([^;]+);base64,(.+)$/);
     if (!match) throw new Error("Invalid data URI");
-    const mimeType = match[1]!;
-    const base64 = match[2]!;
+    const mimeType = match[1];
+    const base64 = match[2];
+    if (mimeType === undefined || base64 === undefined) throw new Error("Invalid data URI");
     const buffer = Buffer.from(base64, "base64");
     const ext = mimeType.split("/")[1]?.split("+")[0] || "png";
     return { buffer, mimeType, ext };
@@ -70,7 +71,8 @@ async function fetchImageAsBuffer(
 
   const arrayBuffer = await response.arrayBuffer();
   const buffer = Buffer.from(arrayBuffer);
-  const mimeType = contentType.split(";")[0]!.trim();
+  const contentTypePart = contentType.split(";")[0];
+  const mimeType = (contentTypePart ?? contentType).trim();
   const ext = mimeType.split("/")[1]?.split("+")[0] || "png";
   return { buffer, mimeType, ext };
 }

--- a/terraform/modules/api/lambda/src/services/commitService.ts
+++ b/terraform/modules/api/lambda/src/services/commitService.ts
@@ -44,10 +44,9 @@ async function fetchImageAsBuffer(
 ): Promise<{ buffer: Buffer; mimeType: string; ext: string }> {
   if (sourceUrl.startsWith("data:")) {
     const match = sourceUrl.match(/^data:([^;]+);base64,(.+)$/);
-    if (!match) throw new Error("Invalid data URI");
+    if (!match?.[1] || !match[2]) throw new Error("Invalid data URI");
     const mimeType = match[1];
     const base64 = match[2];
-    if (mimeType === undefined || base64 === undefined) throw new Error("Invalid data URI");
     const buffer = Buffer.from(base64, "base64");
     const ext = mimeType.split("/")[1]?.split("+")[0] || "png";
     return { buffer, mimeType, ext };

--- a/terraform/modules/api/lambda/src/services/usageService.ts
+++ b/terraform/modules/api/lambda/src/services/usageService.ts
@@ -76,7 +76,8 @@ export async function validateModelAccess(
     throw new Error("Model not found or inactive");
   }
 
-  const m = model[0]!;
+  const m = model[0];
+  if (!m) throw new Error("Model not found or inactive");
   if (m.tierRequired === "pro" && tier === "free") {
     throw new Error("FORBIDDEN");
   }


### PR DESCRIPTION
## 概要
Issue #71 Phase 2-A のコード修正です。ESLint の 4 ルール（no-non-null-assertion, no-extraneous-class, no-useless-constructor, no-dynamic-delete）の違反を解消しました。ルール自体はまだ `warn` のままです。

## 変更内容
- **no-useless-constructor**: 空のコンストラクタを削除（`src/test/setup.ts`）
- **no-extraneous-class**: モックの class を関数に変更（aiService.test, CollaborationManager.test, media.test）
- **no-dynamic-delete**: `storageSettings.ts` でオブジェクト rest でキー削除
- **no-non-null-assertion**: `!` を optional chaining / 型ガードで置換（src, scripts, terraform Lambda）
- **その他**: aiProviders の `body` 二重宣言を `streamBody` に変更、users.ts の `||`/`??` に括弧を追加

## 確認
- [x] `bun run lint` エラー 0
- [x] `bun run test:run` 成功
- [x] `bun run build` 成功
- [x] terraform api Lambda `npm run build` 成功

Closes #71 (Phase 2-A)

Made with [Cursor](https://cursor.com)