### PR TITLE
fix: PR #88 レビューフィードバック対応

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -31,8 +31,8 @@ VITE_REALTIME_URL=wss://realtime.zedi-note.app
 # Polar（Pro プラン課金）
 # Polar dashboard > Products > "..." > Copy Product ID
 # 未設定の場合、Pro チェックアウトは開けずエラーがコンソールに出ます。
-VITE_POLAR_PRO_MONTHLY_PRODUCT_ID=your_polar_monthly_product_id
-VITE_POLAR_PRO_YEARLY_PRODUCT_ID=your_polar_yearly_product_id
+VITE_POLAR_PRO_MONTHLY_PRODUCT_ID=your-product-id-here
+VITE_POLAR_PRO_YEARLY_PRODUCT_ID=your-product-id-here
 
 # -----------------------------------------------------------------------------
 # デプロイ用（scripts/deploy/deploy-to-aws.ts で参照）

--- a/db/aurora/migrate.mjs
+++ b/db/aurora/migrate.mjs
@@ -186,7 +186,14 @@ try {
     }
 
     const safeFile = file.replace(/'/g, "''");
-    runSql(`INSERT INTO _schema_migrations (filename) VALUES ('${safeFile}');`, tmpDir);
+    const recorded = runSql(
+      `INSERT INTO _schema_migrations (filename) VALUES ('${safeFile}') ON CONFLICT DO NOTHING;`,
+      tmpDir,
+    );
+    if (!recorded.ok) {
+      console.error(`\n${file}: failed to record in _schema_migrations: ${recorded.error}`);
+      process.exit(1);
+    }
     console.log(`${file}: ${ok} statement(s) applied.`);
   }
 

--- a/src/components/editor/TiptapEditor/useEditorSetup.ts
+++ b/src/components/editor/TiptapEditor/useEditorSetup.ts
@@ -64,6 +64,7 @@ export function useEditorSetup(options: UseEditorSetupOptions) {
   } = options;
 
   const isEditorInitializedRef = useRef(false);
+  const lastReportedContentRef = useRef<string | null>(null);
 
   const initialParsedContent = useMemo(() => {
     if (!content) return undefined;
@@ -76,14 +77,15 @@ export function useEditorSetup(options: UseEditorSetupOptions) {
   }, [content]);
 
   useEffect(() => {
-    if (content && initialParsedContent === undefined) {
-      onContentError?.({
-        message: "コンテンツの解析に失敗しました。データが破損している可能性があります。",
-        removedNodeTypes: [],
-        removedMarkTypes: [],
-        wasSanitized: false,
-      });
-    }
+    if (!content || initialParsedContent !== undefined) return;
+    if (lastReportedContentRef.current === content) return;
+    lastReportedContentRef.current = content;
+    onContentError?.({
+      message: "コンテンツの解析に失敗しました。データが破損している可能性があります。",
+      removedNodeTypes: [],
+      removedMarkTypes: [],
+      wasSanitized: false,
+    });
   }, [content, initialParsedContent, onContentError]);
 
   const useCollaborationMode = Boolean(

--- a/src/components/editor/TiptapEditor/useEditorSetup.ts
+++ b/src/components/editor/TiptapEditor/useEditorSetup.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useEditor } from "@tiptap/react";
 import type { Editor } from "@tiptap/core";
 import type { WikiLinkSuggestionState } from "../extensions/wikiLinkSuggestionPlugin";
@@ -65,12 +65,18 @@ export function useEditorSetup(options: UseEditorSetupOptions) {
 
   const isEditorInitializedRef = useRef(false);
 
-  let initialParsedContent: unknown = undefined;
-  if (content) {
+  const initialParsedContent = useMemo(() => {
+    if (!content) return undefined;
     try {
-      initialParsedContent = JSON.parse(content);
+      return JSON.parse(content);
     } catch (e) {
       console.error("Failed to parse content:", e);
+      return undefined;
+    }
+  }, [content]);
+
+  useEffect(() => {
+    if (content && initialParsedContent === undefined) {
       onContentError?.({
         message: "コンテンツの解析に失敗しました。データが破損している可能性があります。",
         removedNodeTypes: [],
@@ -78,11 +84,16 @@ export function useEditorSetup(options: UseEditorSetupOptions) {
         wasSanitized: false,
       });
     }
-  }
+  }, [content, initialParsedContent, onContentError]);
 
   const useCollaborationMode = Boolean(
     collaborationConfig?.xmlFragment && collaborationConfig?.user,
   );
+
+  const slashStateRef = useRef(slashState);
+  slashStateRef.current = slashState;
+  const suggestionStateRef = useRef(suggestionState);
+  suggestionStateRef.current = suggestionState;
 
   const editor = useEditor(
     {
@@ -132,8 +143,9 @@ export function useEditorSetup(options: UseEditorSetupOptions) {
       editorProps: {
         ...defaultEditorProps,
         handleKeyDown: (_view, event) => {
-          if (slashState?.active && slashRef.current) return slashRef.current.onKeyDown(event);
-          if (suggestionState?.active && suggestionRef.current)
+          if (slashStateRef.current?.active && slashRef.current)
+            return slashRef.current.onKeyDown(event);
+          if (suggestionStateRef.current?.active && suggestionRef.current)
             return suggestionRef.current.onKeyDown(event);
           return false;
         },

--- a/src/lib/aiService.ts
+++ b/src/lib/aiService.ts
@@ -294,13 +294,13 @@ function processSSEDataLine(
   return false;
 }
 
-/** HTTP ストリーミングレスポンスを SSE として読み、onComplete まで処理する */
+/** HTTP ストリーミングレスポンスを SSE として読み、onComplete まで処理する。正常完了時は true を返す。 */
 async function consumeSSEStream(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   state: { fullContent: string; finishReason?: string; lastUsage?: AIResponseUsage },
   callbacks: AIServiceCallbacks,
   abortSignal?: AbortSignal,
-): Promise<void> {
+): Promise<boolean> {
   const decoder = new TextDecoder();
   let buffer = "";
 
@@ -328,12 +328,13 @@ async function consumeSSEStream(
         continue;
       }
       if (processSSEDataLine(payload, state, callbacks)) {
-        return;
+        return true;
       }
 
       newlineIndex = buffer.indexOf("\n");
     }
   }
+  return false;
 }
 
 async function fetchAIChatResponse(
@@ -386,8 +387,8 @@ async function handleAIChatHttpResponse(
       finishReason: undefined as string | undefined,
       lastUsage: undefined as AIResponseUsage | undefined,
     };
-    await consumeSSEStream(reader, state, callbacks, abortSignal);
-    if (state.fullContent) {
+    const streamCompleted = await consumeSSEStream(reader, state, callbacks, abortSignal);
+    if (!streamCompleted && state.fullContent) {
       callbacks.onComplete?.({
         content: state.fullContent,
         finishReason: state.finishReason,

--- a/src/lib/aiService.ts
+++ b/src/lib/aiService.ts
@@ -328,6 +328,7 @@ async function consumeSSEStream(
         continue;
       }
       if (processSSEDataLine(payload, state, callbacks)) {
+        await reader.cancel();
         return true;
       }
 
@@ -394,6 +395,8 @@ async function handleAIChatHttpResponse(
         finishReason: state.finishReason,
         usage: state.lastUsage,
       });
+    } else if (!streamCompleted && !state.fullContent) {
+      callbacks.onError?.(new Error("ストリーミングレスポンスが空のまま切断されました"));
     }
     return;
   }

--- a/src/lib/sync/syncWithApi.test.ts
+++ b/src/lib/sync/syncWithApi.test.ts
@@ -186,6 +186,34 @@ describe("syncWithApi", () => {
     );
   });
 
+  it("clears stale local links when pulled page has 0 links", async () => {
+    const serverPage = {
+      id: "p1",
+      owner_id: TEST_USER_ID,
+      source_page_id: null,
+      title: "Page",
+      content_preview: null,
+      thumbnail_url: null,
+      source_url: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-05-01T00:00:00Z",
+      is_deleted: false,
+    };
+    const adapter = createMockAdapter();
+    const api = createMockApi({
+      getSyncPages: vi.fn().mockResolvedValue({
+        pages: [serverPage],
+        links: [],
+        ghost_links: [],
+        server_time: new Date().toISOString(),
+      }),
+    });
+
+    await syncWithApi(adapter, api, TEST_USER_ID);
+
+    expect(adapter.saveLinks).toHaveBeenCalledWith("p1", []);
+  });
+
   // ── PUSH ──────────────────────────────────────────────────────────────
 
   it("pushes locally modified pages to server", async () => {
@@ -211,6 +239,59 @@ describe("syncWithApi", () => {
     await syncWithApi(adapter, api, TEST_USER_ID);
 
     expect(api.postSyncPages).toHaveBeenCalled();
+  });
+
+  it("sends links and ghost_links only in last chunk when pushing >100 pages", async () => {
+    const PAGE_PUSH_CHUNK_SIZE = 100;
+    const manyPages: PageMetadata[] = Array.from({ length: PAGE_PUSH_CHUNK_SIZE + 1 }, (_, i) => ({
+      id: `page-${i}`,
+      ownerId: TEST_USER_ID,
+      sourcePageId: null,
+      title: `Page ${i}`,
+      contentPreview: null,
+      thumbnailUrl: null,
+      sourceUrl: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now() + i,
+      isDeleted: false,
+    }));
+
+    const adapter = createMockAdapter({
+      getLastSyncTime: vi.fn().mockResolvedValue(0),
+      getAllPages: vi.fn().mockResolvedValue(manyPages),
+      getLinks: vi
+        .fn()
+        .mockImplementation((pageId: string) =>
+          pageId === "page-0"
+            ? Promise.resolve([{ sourceId: "page-0", targetId: "page-1", createdAt: Date.now() }])
+            : Promise.resolve([]),
+        ),
+      getGhostLinks: vi.fn().mockResolvedValue([]),
+    });
+    const postSyncPages = vi.fn().mockResolvedValue({
+      server_time: new Date().toISOString(),
+      conflicts: [],
+    });
+    const api = createMockApi({
+      getSyncPages: vi.fn().mockResolvedValue({
+        pages: [],
+        links: [],
+        ghost_links: [],
+        server_time: new Date().toISOString(),
+      }),
+      postSyncPages,
+    });
+
+    await syncWithApi(adapter, api, TEST_USER_ID);
+
+    expect(postSyncPages).toHaveBeenCalledTimes(2);
+    const [firstCall, secondCall] = postSyncPages.mock.calls;
+    expect(firstCall[0].pages).toHaveLength(PAGE_PUSH_CHUNK_SIZE);
+    expect(firstCall[0].links).toBeUndefined();
+    expect(firstCall[0].ghost_links).toBeUndefined();
+    expect(secondCall[0].pages).toHaveLength(1);
+    expect(secondCall[0].links).toBeDefined();
+    expect(secondCall[0].ghost_links).toBeDefined();
   });
 
   it("skips push on initial sync when local was empty", async () => {

--- a/src/lib/sync/syncWithApi.ts
+++ b/src/lib/sync/syncWithApi.ts
@@ -193,19 +193,25 @@ async function applyPull(
     ghost_links: SyncGhostLinkItem[];
   },
 ): Promise<void> {
+  const pulledPageIds = new Set(res.pages.map((p) => p.id));
+
   for (const row of res.pages) {
     const meta = syncPageToMetadata(row);
     const local = await adapter.getPage(meta.id);
     if (local && local.updatedAt > meta.updatedAt) continue;
     await adapter.upsertPage(meta);
   }
+
   const linkBySource = new Map<string, SyncLinkItem[]>();
   for (const l of res.links) {
     const list = linkBySource.get(l.source_id) ?? [];
     list.push(l);
     linkBySource.set(l.source_id, list);
   }
-  for (const [sourceId, items] of linkBySource) {
+  const linkSources = new Set(pulledPageIds);
+  for (const sourceId of linkBySource.keys()) linkSources.add(sourceId);
+  for (const sourceId of linkSources) {
+    const items = linkBySource.get(sourceId) ?? [];
     const links: Link[] = items.map((l) => ({
       sourceId: l.source_id,
       targetId: l.target_id,
@@ -213,13 +219,17 @@ async function applyPull(
     }));
     await adapter.saveLinks(sourceId, links);
   }
+
   const ghostBySource = new Map<string, SyncGhostLinkItem[]>();
   for (const g of res.ghost_links) {
     const list = ghostBySource.get(g.source_page_id) ?? [];
     list.push(g);
     ghostBySource.set(g.source_page_id, list);
   }
-  for (const [sourcePageId, items] of ghostBySource) {
+  const ghostSources = new Set(pulledPageIds);
+  for (const sourceId of ghostBySource.keys()) ghostSources.add(sourceId);
+  for (const sourceId of ghostSources) {
+    const items = ghostBySource.get(sourceId) ?? [];
     const ghostLinks: GhostLink[] = items.map((g) => ({
       linkText: g.link_text,
       sourcePageId: g.source_page_id,
@@ -227,7 +237,7 @@ async function applyPull(
       originalTargetPageId: g.original_target_page_id ?? null,
       originalNoteId: g.original_note_id ?? null,
     }));
-    await adapter.saveGhostLinks(sourcePageId, ghostLinks);
+    await adapter.saveGhostLinks(sourceId, ghostLinks);
   }
 }
 
@@ -278,13 +288,13 @@ async function pushPagesToApi(
   if (pushPages.length > PAGE_PUSH_CHUNK_SIZE) {
     for (let i = 0; i < pushPages.length; i += PAGE_PUSH_CHUNK_SIZE) {
       const chunk = pushPages.slice(i, i + PAGE_PUSH_CHUNK_SIZE);
-      await api.postSyncPages({ pages: chunk });
+      const isLastChunk = i + PAGE_PUSH_CHUNK_SIZE >= pushPages.length;
+      await api.postSyncPages({
+        pages: chunk,
+        links: isLastChunk ? pushLinks : undefined,
+        ghost_links: isLastChunk ? pushGhostLinks : undefined,
+      });
     }
-    await api.postSyncPages({
-      pages: [],
-      links: pushLinks,
-      ghost_links: pushGhostLinks,
-    });
   } else {
     await api.postSyncPages({
       pages: pushPages,

--- a/src/lib/sync/syncWithApi.ts
+++ b/src/lib/sync/syncWithApi.ts
@@ -5,7 +5,7 @@
  */
 
 import type { StorageAdapter } from "@/lib/storageAdapter/StorageAdapter";
-import type { PageMetadata, Link, GhostLink } from "@/lib/storageAdapter/types";
+import type { PageMetadata, GhostLink } from "@/lib/storageAdapter/types";
 import type { ApiClient } from "@/lib/api/apiClient";
 import type { SyncPageItem, SyncLinkItem, SyncGhostLinkItem } from "@/lib/api/types";
 
@@ -185,6 +185,28 @@ function computeSince(
   return lastSync ? new Date(lastSync).toISOString() : undefined;
 }
 
+/** links/ghost_links を source ごとにグループ化し、pulledPageIds を含む全 source に対して保存する（stale クリア含む） */
+async function applyRelatedItems<T, U>(
+  items: T[],
+  pulledPageIds: Set<string>,
+  getSourceId: (item: T) => string,
+  mapToLocal: (items: T[]) => U[],
+  saveFn: (sourceId: string, localItems: U[]) => Promise<void>,
+): Promise<void> {
+  const bySource = new Map<string, T[]>();
+  for (const item of items) {
+    const sid = getSourceId(item);
+    const list = bySource.get(sid) ?? [];
+    list.push(item);
+    bySource.set(sid, list);
+  }
+  const allSourceIds = new Set([...pulledPageIds, ...bySource.keys()]);
+  for (const sourceId of allSourceIds) {
+    const sourceItems = bySource.get(sourceId) ?? [];
+    await saveFn(sourceId, mapToLocal(sourceItems));
+  }
+}
+
 async function applyPull(
   adapter: StorageAdapter,
   res: {
@@ -202,43 +224,35 @@ async function applyPull(
     await adapter.upsertPage(meta);
   }
 
-  const linkBySource = new Map<string, SyncLinkItem[]>();
-  for (const l of res.links) {
-    const list = linkBySource.get(l.source_id) ?? [];
-    list.push(l);
-    linkBySource.set(l.source_id, list);
-  }
-  const linkSources = new Set(pulledPageIds);
-  for (const sourceId of linkBySource.keys()) linkSources.add(sourceId);
-  for (const sourceId of linkSources) {
-    const items = linkBySource.get(sourceId) ?? [];
-    const links: Link[] = items.map((l) => ({
-      sourceId: l.source_id,
-      targetId: l.target_id,
-      createdAt: typeof l.created_at === "string" ? new Date(l.created_at).getTime() : l.created_at,
-    }));
-    await adapter.saveLinks(sourceId, links);
-  }
+  await applyRelatedItems(
+    res.links,
+    pulledPageIds,
+    (l) => l.source_id,
+    (items) =>
+      items.map((l) => ({
+        sourceId: l.source_id,
+        targetId: l.target_id,
+        createdAt:
+          typeof l.created_at === "string" ? new Date(l.created_at).getTime() : l.created_at,
+      })),
+    (sourceId, links) => adapter.saveLinks(sourceId, links),
+  );
 
-  const ghostBySource = new Map<string, SyncGhostLinkItem[]>();
-  for (const g of res.ghost_links) {
-    const list = ghostBySource.get(g.source_page_id) ?? [];
-    list.push(g);
-    ghostBySource.set(g.source_page_id, list);
-  }
-  const ghostSources = new Set(pulledPageIds);
-  for (const sourceId of ghostBySource.keys()) ghostSources.add(sourceId);
-  for (const sourceId of ghostSources) {
-    const items = ghostBySource.get(sourceId) ?? [];
-    const ghostLinks: GhostLink[] = items.map((g) => ({
-      linkText: g.link_text,
-      sourcePageId: g.source_page_id,
-      createdAt: typeof g.created_at === "string" ? new Date(g.created_at).getTime() : g.created_at,
-      originalTargetPageId: g.original_target_page_id ?? null,
-      originalNoteId: g.original_note_id ?? null,
-    }));
-    await adapter.saveGhostLinks(sourceId, ghostLinks);
-  }
+  await applyRelatedItems(
+    res.ghost_links,
+    pulledPageIds,
+    (g) => g.source_page_id,
+    (items) =>
+      items.map((g) => ({
+        linkText: g.link_text,
+        sourcePageId: g.source_page_id,
+        createdAt:
+          typeof g.created_at === "string" ? new Date(g.created_at).getTime() : g.created_at,
+        originalTargetPageId: g.original_target_page_id ?? null,
+        originalNoteId: g.original_note_id ?? null,
+      })),
+    (sourcePageId, ghostLinks) => adapter.saveGhostLinks(sourcePageId, ghostLinks),
+  );
 }
 
 function getPagesForPush(


### PR DESCRIPTION
## Summary

PR #88 マージ後に CodeRabbit / Gemini Code Assist から指摘された問題を修正します。

- **migrate.mjs**: apply パスの INSERT に `ON CONFLICT DO NOTHING` と戻り値チェックを追加（baseline パスと同等の堅牢性に）
- **useEditorSetup.ts**: `JSON.parse(content)` を `useMemo` でメモ化し、毎レンダー実行と無限再レンダーループリスクを解消。`handleKeyDown` 内の stale closure を ref ミラーリングで修正
- **aiService.ts**: `consumeSSEStream` が正常完了時に `true` を返すようにし、`onComplete` の二重呼び出しを防止（ストリーム途中切断時のフォールバックは維持）
- **syncWithApi.ts**: `pushPagesToApi` で空 pages 配列を POST する代わりに最後のチャンクに links/ghost_links を含める（サーバー 400 エラーを回避）。`applyPull` でプルされたページのリンクが0件の場合もローカルのstaleリンクをクリア
- **.env.production.example**: Polar のプレースホルダー名を統一

## Test plan

- [x] `npx tsc --noEmit` パス
- [x] `vitest run src/lib/aiService.test.ts` 全16テストパス
- [x] `vitest run src/lib/sync/syncWithApi.test.ts` 全10テストパス
- [x] リンターエラーなし

Closes: PR #88 review comments

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved database migration reliability with enhanced error handling and failure detection.
  * Enhanced content synchronization to properly handle all related data during pulls.
  * Fixed streaming completion detection to prevent duplicate completion callbacks.

* **Chores**
  * Updated configuration example values for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->