### PR TITLE
fix: サムネイル画像検索の500エラー修正とユーザー指定ストレージ対応

### DIFF
--- a/src/components/editor/TiptapEditor.tsx
+++ b/src/components/editor/TiptapEditor.tsx
@@ -171,7 +171,11 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
     isEditorInitializedRef,
   });
 
-  const { handleInsertThumbnailImage } = useThumbnailCommit({ editorRef, pageTitle });
+  const { handleInsertThumbnailImage } = useThumbnailCommit({
+    editorRef,
+    pageTitle,
+    storageSettings,
+  });
 
   const handleGoToStorageSettings = useCallback(() => {
     const returnTo = `${location.pathname}${location.search}`;

--- a/src/components/editor/TiptapEditor/useThumbnailCommit.ts
+++ b/src/components/editor/TiptapEditor/useThumbnailCommit.ts
@@ -2,15 +2,79 @@ import { useCallback } from "react";
 import type { Editor } from "@tiptap/core";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
+import { getStorageProvider, getSettingsForUpload } from "@/lib/storage";
+import type { StorageSettings } from "@/types/storage";
 
 const getThumbnailApiBaseUrl = () => (import.meta.env.VITE_ZEDI_API_BASE_URL as string) ?? "";
 
 interface UseThumbnailCommitOptions {
   editorRef: React.RefObject<Editor | null>;
   pageTitle: string;
+  storageSettings: StorageSettings;
 }
 
-export function useThumbnailCommit({ editorRef, pageTitle }: UseThumbnailCommitOptions) {
+async function fetchImageAsFile(imageUrl: string, fallbackUrl?: string): Promise<File> {
+  const tryFetch = async (url: string): Promise<File> => {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Image fetch failed: ${res.status}`);
+    const blob = await res.blob();
+    const contentType = blob.type || "image/png";
+    const ext = contentType.split("/")[1]?.split("+")[0] || "png";
+    return new File([blob], `thumbnail-${Date.now()}.${ext}`, { type: contentType });
+  };
+
+  try {
+    return await tryFetch(imageUrl);
+  } catch (err) {
+    if (fallbackUrl && fallbackUrl !== imageUrl) {
+      return await tryFetch(fallbackUrl);
+    }
+    throw err;
+  }
+}
+
+async function commitViaServerS3(
+  imageUrl: string,
+  altText: string,
+  previewUrl: string | undefined,
+  token: string,
+  baseUrl: string,
+): Promise<{ imageUrl: string; provider: string }> {
+  const response = await fetch(`${baseUrl}/api/thumbnail/commit`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      sourceUrl: imageUrl,
+      fallbackUrl: previewUrl,
+      title: altText,
+    }),
+  });
+
+  if (!response.ok) {
+    let message = `画像の保存に失敗しました: ${response.status}`;
+    try {
+      const data = (await response.json()) as { error?: string; message?: string };
+      if (data?.message) message = data.message;
+      else if (data?.error) message = data.error;
+    } catch {
+      // ignore parse errors
+    }
+    throw new Error(message);
+  }
+
+  const data = (await response.json()) as { imageUrl?: string; provider?: string };
+  if (!data.imageUrl) throw new Error("画像のURLが取得できませんでした");
+  return { imageUrl: data.imageUrl, provider: data.provider ?? "s3" };
+}
+
+export function useThumbnailCommit({
+  editorRef,
+  pageTitle,
+  storageSettings,
+}: UseThumbnailCommitOptions) {
   const { getToken } = useAuth();
   const { toast } = useToast();
   const thumbnailApiBaseUrl = getThumbnailApiBaseUrl();
@@ -28,44 +92,34 @@ export function useThumbnailCommit({ editorRef, pageTitle }: UseThumbnailCommitO
         });
         return;
       }
-      if (!thumbnailApiBaseUrl) {
-        toast({
-          title: "設定エラー",
-          description: "APIのURLが設定されていません",
-          variant: "destructive",
-        });
-        return;
-      }
 
       const altText = alt || pageTitle || "thumbnail";
+      const uploadSettings = getSettingsForUpload(storageSettings);
+      const useS3 = uploadSettings.provider === "s3";
 
       try {
-        const response = await fetch(`${thumbnailApiBaseUrl}/api/thumbnail/commit`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
-            sourceUrl: imageUrl,
-            fallbackUrl: previewUrl,
-            title: altText,
-          }),
-        });
+        let finalUrl: string;
+        let providerId: string;
 
-        if (!response.ok) {
-          let message = `画像の保存に失敗しました: ${response.status}`;
-          try {
-            const data = (await response.json()) as { error?: string };
-            if (data?.error) message = data.error;
-          } catch {
-            // ignore parse errors
+        if (useS3) {
+          if (!thumbnailApiBaseUrl) {
+            throw new Error("APIのURLが設定されていません");
           }
-          throw new Error(message);
+          const result = await commitViaServerS3(
+            imageUrl,
+            altText,
+            previewUrl,
+            token,
+            thumbnailApiBaseUrl,
+          );
+          finalUrl = result.imageUrl;
+          providerId = result.provider;
+        } else {
+          const provider = getStorageProvider(uploadSettings, { getToken });
+          const file = await fetchImageAsFile(imageUrl, previewUrl);
+          finalUrl = await provider.uploadImage(file, { fileName: file.name });
+          providerId = uploadSettings.provider;
         }
-
-        const data = (await response.json()) as { imageUrl?: string; provider?: string };
-        if (!data.imageUrl) throw new Error("画像のURLが取得できませんでした");
 
         editor
           .chain()
@@ -73,10 +127,10 @@ export function useThumbnailCommit({ editorRef, pageTitle }: UseThumbnailCommitO
           .insertContentAt(0, {
             type: "image",
             attrs: {
-              src: data.imageUrl,
+              src: finalUrl,
               alt: altText,
               title: altText,
-              storageProviderId: "s3",
+              storageProviderId: providerId,
             },
           })
           .run();
@@ -88,7 +142,7 @@ export function useThumbnailCommit({ editorRef, pageTitle }: UseThumbnailCommitO
         });
       }
     },
-    [editorRef, getToken, thumbnailApiBaseUrl, pageTitle, toast],
+    [editorRef, getToken, thumbnailApiBaseUrl, pageTitle, toast, storageSettings],
   );
 
   return { handleInsertThumbnailImage };

--- a/src/components/editor/TiptapEditor/useThumbnailCommit.ts
+++ b/src/components/editor/TiptapEditor/useThumbnailCommit.ts
@@ -115,8 +115,8 @@ export function useThumbnailCommit({
           finalUrl = result.imageUrl;
           providerId = result.provider;
         } else {
-          const provider = getStorageProvider(uploadSettings, { getToken });
           const file = await fetchImageAsFile(imageUrl, previewUrl);
+          const provider = getStorageProvider(uploadSettings, { getToken });
           finalUrl = await provider.uploadImage(file, { fileName: file.name });
           providerId = uploadSettings.provider;
         }
@@ -135,9 +135,15 @@ export function useThumbnailCommit({
           })
           .run();
       } catch (error) {
+        const isFetchError =
+          error instanceof TypeError ||
+          (error instanceof Error &&
+            /Failed to fetch|CORS|NetworkError|Image fetch failed/i.test(error.message));
         toast({
           title: "画像の保存に失敗しました",
-          description: error instanceof Error ? error.message : "画像の保存に失敗しました",
+          description: isFetchError
+            ? "画像の取得に失敗しました。ネットワーク環境をご確認ください。"
+            : "しばらくしてからもう一度お試しください。",
           variant: "destructive",
         });
       }

--- a/terraform/modules/api/lambda/src/__tests__/routes/thumbnail/commit.test.ts
+++ b/terraform/modules/api/lambda/src/__tests__/routes/thumbnail/commit.test.ts
@@ -23,23 +23,25 @@ vi.mock("../../../middleware/rateLimiter", () => ({
   },
 }));
 
+const defaultEnv = {
+  CORS_ORIGIN: "*",
+  MEDIA_BUCKET: "b",
+  AI_SECRETS_ARN: "a",
+  RATE_LIMIT_TABLE: "r",
+  THUMBNAIL_SECRETS_ARN: "a",
+  THUMBNAIL_BUCKET: "test-thumbnail-bucket",
+  THUMBNAIL_CLOUDFRONT_URL: "https://thumbnails.test.example.com",
+  ENVIRONMENT: "test",
+  POLAR_SECRET_ARN: "a",
+  COGNITO_USER_POOL_ID: "p",
+  COGNITO_REGION: "us-east-1",
+  AURORA_CLUSTER_ARN: "a",
+  DB_CREDENTIALS_SECRET: "a",
+  AURORA_DATABASE_NAME: "zedi",
+};
+
 vi.mock("../../../env", () => ({
-  getEnvConfig: vi.fn(() => ({
-    CORS_ORIGIN: "*",
-    MEDIA_BUCKET: "b",
-    AI_SECRETS_ARN: "a",
-    RATE_LIMIT_TABLE: "r",
-    THUMBNAIL_SECRETS_ARN: "a",
-    THUMBNAIL_BUCKET: "test-thumbnail-bucket",
-    THUMBNAIL_CLOUDFRONT_URL: "https://thumbnails.test.example.com",
-    ENVIRONMENT: "test",
-    POLAR_SECRET_ARN: "a",
-    COGNITO_USER_POOL_ID: "p",
-    COGNITO_REGION: "us-east-1",
-    AURORA_CLUSTER_ARN: "a",
-    DB_CREDENTIALS_SECRET: "a",
-    AURORA_DATABASE_NAME: "zedi",
-  })),
+  getEnvConfig: vi.fn(() => defaultEnv),
   resetEnvCache: vi.fn(),
 }));
 
@@ -47,6 +49,7 @@ vi.mock("../../../services/commitService", () => ({
   commitImage: mockCommitImage,
 }));
 
+import { getEnvConfig } from "../../../env";
 import commitRoutes from "../../../routes/thumbnail/commit";
 
 describe("Thumbnail Commit API", () => {
@@ -55,6 +58,8 @@ describe("Thumbnail Commit API", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getEnvConfig).mockReturnValue(defaultEnv);
+
     mockDb = createMockDb();
     app = new Hono<AppEnv>();
     app.use("*", async (c, next) => {
@@ -96,5 +101,47 @@ describe("Thumbnail Commit API", () => {
       expect.anything(),
       expect.anything(),
     );
+  });
+
+  it("returns 503 when THUMBNAIL_BUCKET is not set", async () => {
+    vi.mocked(getEnvConfig).mockReturnValue({
+      ...defaultEnv,
+      THUMBNAIL_BUCKET: "",
+    });
+
+    const res = await jsonRequest(app, "POST", "/", {
+      sourceUrl: "https://example.com/image.jpg",
+    });
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error?: string; message?: string };
+    expect(body.error ?? body.message).toContain("保存先が設定されていません");
+    expect(mockCommitImage).not.toHaveBeenCalled();
+  });
+
+  it("returns 413 when storage quota exceeded", async () => {
+    mockCommitImage.mockRejectedValueOnce(new Error("STORAGE_QUOTA_EXCEEDED"));
+
+    const res = await jsonRequest(app, "POST", "/", {
+      sourceUrl: "https://example.com/image.jpg",
+    });
+
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { error?: string; message?: string };
+    expect(body.error ?? body.message).toContain("容量制限");
+    expect(mockCommitImage).toHaveBeenCalled();
+  });
+
+  it("returns 502 when commitImage throws other error", async () => {
+    mockCommitImage.mockRejectedValueOnce(new Error("S3 upload failed"));
+
+    const res = await jsonRequest(app, "POST", "/", {
+      sourceUrl: "https://example.com/image.jpg",
+    });
+
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error?: string; message?: string };
+    expect(body.error ?? body.message).toContain("サムネイルの保存に失敗しました");
+    expect(mockCommitImage).toHaveBeenCalled();
   });
 });

--- a/terraform/modules/api/lambda/src/__tests__/routes/thumbnail/imageSearch.test.ts
+++ b/terraform/modules/api/lambda/src/__tests__/routes/thumbnail/imageSearch.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
 
 const { mockSearchImages, mockGetThumbnailSecrets, mockGetRequired } = vi.hoisted(() => ({
   mockSearchImages: vi.fn(),
@@ -22,23 +23,25 @@ vi.mock("../../../middleware/rateLimiter", () => ({
   },
 }));
 
+const defaultEnv = {
+  CORS_ORIGIN: "*",
+  MEDIA_BUCKET: "b",
+  AI_SECRETS_ARN: "a",
+  RATE_LIMIT_TABLE: "r",
+  THUMBNAIL_SECRETS_ARN: "arn:aws:secretsmanager:test:thumbnail",
+  THUMBNAIL_BUCKET: "b",
+  THUMBNAIL_CLOUDFRONT_URL: "https://t",
+  ENVIRONMENT: "test",
+  POLAR_SECRET_ARN: "a",
+  COGNITO_USER_POOL_ID: "p",
+  COGNITO_REGION: "us-east-1",
+  AURORA_CLUSTER_ARN: "a",
+  DB_CREDENTIALS_SECRET: "a",
+  AURORA_DATABASE_NAME: "zedi",
+};
+
 vi.mock("../../../env", () => ({
-  getEnvConfig: vi.fn(() => ({
-    CORS_ORIGIN: "*",
-    MEDIA_BUCKET: "b",
-    AI_SECRETS_ARN: "a",
-    RATE_LIMIT_TABLE: "r",
-    THUMBNAIL_SECRETS_ARN: "arn:aws:secretsmanager:test:thumbnail",
-    THUMBNAIL_BUCKET: "b",
-    THUMBNAIL_CLOUDFRONT_URL: "https://t",
-    ENVIRONMENT: "test",
-    POLAR_SECRET_ARN: "a",
-    COGNITO_USER_POOL_ID: "p",
-    COGNITO_REGION: "us-east-1",
-    AURORA_CLUSTER_ARN: "a",
-    DB_CREDENTIALS_SECRET: "a",
-    AURORA_DATABASE_NAME: "zedi",
-  })),
+  getEnvConfig: vi.fn(() => defaultEnv),
   resetEnvCache: vi.fn(),
 }));
 
@@ -51,6 +54,7 @@ vi.mock("../../../services/imageSearch", () => ({
   searchImages: mockSearchImages,
 }));
 
+import { getEnvConfig } from "../../../env";
 import imageSearchRoutes from "../../../routes/thumbnail/imageSearch";
 
 describe("Thumbnail Image Search API", () => {
@@ -58,8 +62,16 @@ describe("Thumbnail Image Search API", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getEnvConfig).mockReturnValue(defaultEnv);
+
     app = new Hono();
     app.route("/", imageSearchRoutes);
+    app.onError((err, c) => {
+      if (err instanceof HTTPException) {
+        return c.json({ error: err.message }, err.status);
+      }
+      return c.json({ error: "Internal server error" }, 500);
+    });
 
     mockGetThumbnailSecrets.mockResolvedValue({
       GOOGLE_CUSTOM_SEARCH_API_KEY: "test-api-key",
@@ -132,5 +144,40 @@ describe("Thumbnail Image Search API", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { nextCursor: string | undefined };
     expect(body.nextCursor).toBe("2");
+  });
+
+  it("returns 503 when THUMBNAIL_SECRETS_ARN is not set", async () => {
+    vi.mocked(getEnvConfig).mockReturnValue({
+      ...defaultEnv,
+      THUMBNAIL_SECRETS_ARN: "",
+    });
+
+    const res = await app.request("/?query=test");
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error?: string; message?: string };
+    expect(body.error ?? body.message).toContain("API キーが未設定");
+    expect(mockSearchImages).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when getThumbnailSecrets throws", async () => {
+    mockGetThumbnailSecrets.mockRejectedValueOnce(new Error("secrets fetch failed"));
+
+    const res = await app.request("/?query=test");
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error?: string; message?: string };
+    expect(body.error ?? body.message).toContain("API キーの取得に失敗");
+    expect(mockSearchImages).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when searchImages throws", async () => {
+    mockSearchImages.mockRejectedValueOnce(new Error("Google API error"));
+
+    const res = await app.request("/?query=test");
+
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error?: string; message?: string };
+    expect(body.error ?? body.message).toContain("画像検索に失敗しました");
   });
 });

--- a/terraform/modules/api/lambda/src/routes/thumbnail/commit.ts
+++ b/terraform/modules/api/lambda/src/routes/thumbnail/commit.ts
@@ -50,10 +50,7 @@ app.post("/", authRequired, rateLimiter, async (c) => {
     }
     console.error("Thumbnail commit failed:", err);
     throw new HTTPException(502, {
-      message:
-        err instanceof Error
-          ? `サムネイルの保存に失敗しました: ${err.message}`
-          : "サムネイルの保存に失敗しました",
+      message: "サムネイルの保存に失敗しました。しばらくしてからもう一度お試しください。",
     });
   }
 });

--- a/terraform/modules/api/lambda/src/routes/thumbnail/commit.ts
+++ b/terraform/modules/api/lambda/src/routes/thumbnail/commit.ts
@@ -26,15 +26,36 @@ app.post("/", authRequired, rateLimiter, async (c) => {
     throw new HTTPException(400, { message: "sourceUrl is required" });
   }
 
-  const { imageUrl } = await commitImage(
-    userId,
-    body.sourceUrl.trim(),
-    body.fallbackUrl?.trim(),
-    env,
-    db,
-  );
+  if (!env.THUMBNAIL_BUCKET) {
+    throw new HTTPException(503, {
+      message: "サムネイルの保存先が設定されていません",
+    });
+  }
 
-  return c.json({ imageUrl, provider: "s3" as const });
+  try {
+    const { imageUrl } = await commitImage(
+      userId,
+      body.sourceUrl.trim(),
+      body.fallbackUrl?.trim(),
+      env,
+      db,
+    );
+
+    return c.json({ imageUrl, provider: "s3" as const });
+  } catch (err) {
+    if (err instanceof Error && err.message === "STORAGE_QUOTA_EXCEEDED") {
+      throw new HTTPException(413, {
+        message: "ストレージの容量制限に達しました。不要な画像を削除してください。",
+      });
+    }
+    console.error("Thumbnail commit failed:", err);
+    throw new HTTPException(502, {
+      message:
+        err instanceof Error
+          ? `サムネイルの保存に失敗しました: ${err.message}`
+          : "サムネイルの保存に失敗しました",
+    });
+  }
 });
 
 export default app;

--- a/terraform/modules/api/lambda/src/routes/thumbnail/imageSearch.ts
+++ b/terraform/modules/api/lambda/src/routes/thumbnail/imageSearch.ts
@@ -48,8 +48,7 @@ app.get("/", authRequired, rateLimiter, async (c) => {
   } catch (err) {
     console.error("Image search failed:", err);
     throw new HTTPException(502, {
-      message:
-        err instanceof Error ? `画像検索に失敗しました: ${err.message}` : "画像検索に失敗しました",
+      message: "画像検索に失敗しました。しばらくしてからもう一度お試しください。",
     });
   }
 

--- a/terraform/modules/api/lambda/src/routes/thumbnail/imageSearch.ts
+++ b/terraform/modules/api/lambda/src/routes/thumbnail/imageSearch.ts
@@ -2,6 +2,7 @@
  * GET /api/thumbnail/image-search — サムネイル画像検索
  */
 import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
 import { authRequired } from "../../middleware/auth";
 import { rateLimiter } from "../../middleware/rateLimiter";
 import { getEnvConfig } from "../../env";
@@ -22,11 +23,35 @@ app.get("/", authRequired, rateLimiter, async (c) => {
     return c.json({ items: [], nextCursor: undefined } satisfies ImageSearchResponse);
   }
 
-  const secrets = await getThumbnailSecrets(env.THUMBNAIL_SECRETS_ARN);
-  const apiKey = getRequired(secrets, "GOOGLE_CUSTOM_SEARCH_API_KEY");
-  const engineId = getRequired(secrets, "GOOGLE_CUSTOM_SEARCH_ENGINE_ID");
+  if (!env.THUMBNAIL_SECRETS_ARN) {
+    throw new HTTPException(503, {
+      message: "画像検索は現在利用できません（API キーが未設定です）",
+    });
+  }
 
-  const items = await searchImages(query, apiKey, engineId, cursor, limit);
+  let apiKey: string;
+  let engineId: string;
+  try {
+    const secrets = await getThumbnailSecrets(env.THUMBNAIL_SECRETS_ARN);
+    apiKey = getRequired(secrets, "GOOGLE_CUSTOM_SEARCH_API_KEY");
+    engineId = getRequired(secrets, "GOOGLE_CUSTOM_SEARCH_ENGINE_ID");
+  } catch (err) {
+    console.error("Failed to load thumbnail secrets:", err);
+    throw new HTTPException(503, {
+      message: "画像検索は現在利用できません（API キーの取得に失敗しました）",
+    });
+  }
+
+  let items: Awaited<ReturnType<typeof searchImages>>;
+  try {
+    items = await searchImages(query, apiKey, engineId, cursor, limit);
+  } catch (err) {
+    console.error("Image search failed:", err);
+    throw new HTTPException(502, {
+      message:
+        err instanceof Error ? `画像検索に失敗しました: ${err.message}` : "画像検索に失敗しました",
+    });
+  }
 
   // 重複除去
   const seen = new Set<string>();


### PR DESCRIPTION
## Summary

- サムネイル画像検索 (`/api/thumbnail/image-search`) と画像コミット (`/api/thumbnail/commit`) のエラーハンドリングを改善し、本番環境で発生していた 500 エラーを適切なステータスコード (503/502/413) とメッセージに置き換えた
- サムネイル画像の保存先をユーザーのストレージ設定に対応させ、S3（デフォルト）以外の外部ストレージ（Gyazo / GitHub / Google Drive）でもサムネイル保存が可能になった

## Changes

### サーバーサイド (Lambda)

**`terraform/modules/api/lambda/src/routes/thumbnail/imageSearch.ts`**
- `THUMBNAIL_SECRETS_ARN` 未設定時は 503 を返すガード追加
- Secrets Manager 取得失敗時は 503、Google Custom Search API 失敗時は 502 を返す
- `console.error` でログ出力を追加

**`terraform/modules/api/lambda/src/routes/thumbnail/commit.ts`**
- `THUMBNAIL_BUCKET` 未設定時は 503 を返すガード追加
- `STORAGE_QUOTA_EXCEEDED` エラーを 413 で返す
- その他エラーを 502 で返しメッセージを明確化

### フロントエンド

**`src/components/editor/TiptapEditor/useThumbnailCommit.ts`**
- `storageSettings` を受け取り、ユーザーのストレージ設定に基づいて保存先を切り替え
- S3: 従来通りサーバーサイド `/api/thumbnail/commit` で保存
- 外部ストレージ: クライアントサイドで画像取得 → `StorageProvider.uploadImage()` でアップロード
- `storageProviderId` を実際のプロバイダーに合わせて設定

**`src/components/editor/TiptapEditor.tsx`**
- `useThumbnailCommit` に `storageSettings` を渡すように変更

## Test plan

- [ ] 本番環境で `THUMBNAIL_SECRETS_ARN` / Google Custom Search API Key が正しく設定されていることを確認
- [ ] 画像検索で API キー未設定時に 503 エラーメッセージが表示されることを確認
- [ ] S3（デフォルトストレージ）でのサムネイル保存が従来通り動作することを確認
- [ ] 外部ストレージ（Gyazo 等）設定時にサムネイル保存が外部ストレージに保存されることを確認
- [ ] AI 画像生成 → サムネイル保存が正常に動作することを確認


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for thumbnail operations with clearer error messages and appropriate failure responses.
  * Added environment validation to ensure thumbnail functionality is properly configured before use.

* **Improvements**
  * Extended storage backend support to accommodate multiple upload provider options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->