### PR TITLE
chore: Terraform 削除、Railway デプロイ設定修正、Dependabot develop 向け

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   # Frontend + root dependencies (Bun/npm)
   - package-ecosystem: npm
     directory: /
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -16,6 +17,7 @@ updates:
   # Hocuspocus server
   - package-ecosystem: npm
     directory: /server/hocuspocus
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -25,17 +27,10 @@ updates:
     open-pull-requests-limit: 5
     labels: [dependencies]
 
-  # Terraform providers
-  - package-ecosystem: terraform
-    directory: /terraform
-    schedule:
-      interval: weekly
-      day: monday
-    labels: [dependencies, terraform]
-
   # GitHub Actions
   - package-ecosystem: github-actions
     directory: /
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - working-directory: server/api
+      - name: Run migrations
+        working-directory: server/api
         run: npm ci && npx drizzle-kit migrate
         env:
           DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
@@ -21,19 +22,21 @@ jobs:
   deploy-api:
     needs: migrate
     runs-on: ubuntu-latest
+    container: ghcr.io/railwayapp/cli:latest
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-      - uses: railwayapp/cli-action@v1
-        with:
-          token: ${{ secrets.RAILWAY_TOKEN }}
-          command: up --service api --environment development -d
+      - name: Deploy API to Railway
+        run: railway up ./server/api --service api --environment development -d
 
   deploy-hocuspocus:
     needs: migrate
     runs-on: ubuntu-latest
+    container: ghcr.io/railwayapp/cli:latest
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-      - uses: railwayapp/cli-action@v1
-        with:
-          token: ${{ secrets.RAILWAY_TOKEN }}
-          command: up --service hocuspocus --environment development -d
+      - name: Deploy Hocuspocus to Railway
+        run: railway up ./server/hocuspocus --service hocuspocus --environment development -d

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -26,23 +26,25 @@ jobs:
     name: Deploy API
     needs: migrate
     runs-on: ubuntu-latest
+    container: ghcr.io/railwayapp/cli:latest
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-      - uses: railwayapp/cli-action@v1
-        with:
-          token: ${{ secrets.RAILWAY_TOKEN }}
-          command: up --service api --environment production -d
+      - name: Deploy API to Railway
+        run: railway up ./server/api --service api --environment production -d
 
   deploy-hocuspocus:
     name: Deploy Hocuspocus
     needs: migrate
     runs-on: ubuntu-latest
+    container: ghcr.io/railwayapp/cli:latest
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-      - uses: railwayapp/cli-action@v1
-        with:
-          token: ${{ secrets.RAILWAY_TOKEN }}
-          command: up --service hocuspocus --environment production -d
+      - name: Deploy Hocuspocus to Railway
+        run: railway up ./server/hocuspocus --service hocuspocus --environment production -d
 
   deploy-frontend:
     name: Deploy Frontend

--- a/server/api/railway.json
+++ b/server/api/railway.json
@@ -2,7 +2,7 @@
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "server/api/Dockerfile"
+    "dockerfilePath": "Dockerfile"
   },
   "deploy": {
     "startCommand": "node dist/index.js",

--- a/server/hocuspocus/railway.json
+++ b/server/hocuspocus/railway.json
@@ -2,7 +2,7 @@
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "server/hocuspocus/Dockerfile"
+    "dockerfilePath": "Dockerfile"
   },
   "deploy": {
     "healthcheckPath": "/health",


### PR DESCRIPTION
## 概要
- Terraform を Dependabot から削除（Railway 移行により terraform ディレクトリは廃止）
- Railway デプロイワークフローを公式 CLI 方式に修正
- railway.json の dockerfilePath を CLI デプロイ用に修正

## 変更内容
- **dependabot.yml**: Terraform の更新設定を削除
- **deploy-dev.yml / deploy-prod.yml**: `railwayapp/cli-action` を `ghcr.io/railwayapp/cli:latest` コンテナ + `railway up` に変更、monorepo パス指定を追加
- **railway.json**: `dockerfilePath` を `Dockerfile` に修正（`railway up ./server/api` 用）

Made with [Cursor](https://cursor.com)