### PR TITLE
chore: server/api を Dependabot に追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,19 @@ updates:
     open-pull-requests-limit: 10
     labels: [dependencies]
 
+  # API server
+  - package-ecosystem: npm
+    directory: /server/api
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5
+    labels: [dependencies]
+
   # Hocuspocus server
   - package-ecosystem: npm
     directory: /server/hocuspocus


### PR DESCRIPTION
## 概要
server/api の package.json を Dependabot の監視対象に追加します。

## 次のステップ
- この PR をマージ後、GitHub の **Settings** → **Code security and analysis** → **Dependabot** で「Check for updates」を実行すると、develop 向けの Dependabot PR が作成されます（次回月曜の定期実行を待たずに）

Made with [Cursor](https://cursor.com)