### PR TITLE
fix(api): use SYNC_AI_MODELS_SECRET for HMAC in admin sync secureCompare

### DIFF
--- a/server/api/src/routes/ai/admin.ts
+++ b/server/api/src/routes/ai/admin.ts
@@ -10,8 +10,8 @@ import type { AppEnv } from "../../types/index.js";
 const SYNC_SECRET = process.env.SYNC_AI_MODELS_SECRET ?? "";
 
 function secureCompare(a: string, b: string): boolean {
-  const aHash = crypto.createHmac("sha256", "sync-secret").update(a).digest();
-  const bHash = crypto.createHmac("sha256", "sync-secret").update(b).digest();
+  const aHash = crypto.createHmac("sha256", SYNC_SECRET).update(a).digest();
+  const bHash = crypto.createHmac("sha256", SYNC_SECRET).update(b).digest();
   return crypto.timingSafeEqual(aHash, bHash);
 }
 


### PR DESCRIPTION
## 概要
AI 管理エンドポイント (`/api/ai/admin/sync-models`) の `secureCompare` で、HMAC のキーがハードコードの `"sync-secret"` になっていたため、環境変数 `SYNC_AI_MODELS_SECRET` をキーに使うように変更しました。

## 変更内容
- `server/api/src/routes/ai/admin.ts`: `secureCompare` 内の `createHmac("sha256", "sync-secret")` を `createHmac("sha256", SYNC_SECRET)` に変更
- timing-safe 比較の挙動はそのまま。ソースに秘密が残らないようにするための修正です。

## 関連
GitHub 公開前のセキュリティ確認で指摘した点の対応です。

Made with [Cursor](https://cursor.com)