### PR TITLE
feat: editor and page queries improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,8 @@ const App = () => (
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        {/* v7_startTransition を無効化: リンククリック後のページ切り替えで表示が即時更新されない問題を防ぐ */}
+        <BrowserRouter future={{ v7_startTransition: false, v7_relativeSplatPath: true }}>
           <AIChatProvider>
             <GlobalShortcutsProvider>
               <GlobalSearchProvider>

--- a/src/components/editor/PageEditor/PageEditorContent.tsx
+++ b/src/components/editor/PageEditor/PageEditorContent.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback } from "react";
+import React, { useRef, useCallback, useMemo } from "react";
 import { Loader2 } from "lucide-react";
 import TiptapEditor from "../TiptapEditor";
 import type { ContentError } from "../TiptapEditor/useContentSanitizer";
@@ -90,6 +90,7 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
   onGenerateWiki,
 }) => {
   const isEditorReadOnly = isReadOnly ?? isWikiGenerating;
+  const hasContent = useMemo(() => isContentNotEmpty(content), [content]);
 
   const contentFocusRef = useRef<(() => void) | null>(null);
   const focusContent = useCallback(() => {
@@ -115,10 +116,10 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
             />
           </div>
           {wikiStatus && onGenerateWiki && (
-            <div className="shrink-0 pt-6">
+            <div className="shrink-0">
               <WikiGeneratorButton
                 title={title}
-                hasContent={isContentNotEmpty(content)}
+                hasContent={hasContent}
                 onGenerate={onGenerateWiki}
                 status={wikiStatus}
               />

--- a/src/components/editor/PageEditor/PageEditorContent.tsx
+++ b/src/components/editor/PageEditor/PageEditorContent.tsx
@@ -4,9 +4,12 @@ import TiptapEditor from "../TiptapEditor";
 import type { ContentError } from "../TiptapEditor/useContentSanitizer";
 import type { CollaborationConfig } from "../TiptapEditor/types";
 import { SourceUrlBadge } from "../SourceUrlBadge";
+import { WikiGeneratorButton } from "../WikiGeneratorButton";
 import { LinkedPagesSection } from "@/components/page/LinkedPagesSection";
 import Container from "@/components/layout/Container";
+import { isContentNotEmpty } from "@/lib/contentUtils";
 import type { UseCollaborationReturn } from "@/lib/collaboration/types";
+import type { WikiGeneratorStatus } from "./types";
 import { PageTitleBlock } from "./PageTitleBlock";
 
 function getCollaborationState(collaboration: UseCollaborationReturn | undefined): {
@@ -54,6 +57,10 @@ interface PageEditorContentProps {
   initialContent?: string;
   /** initialContent をエディタに反映したあとに呼ぶ */
   onInitialContentApplied?: () => void;
+  /** Wiki 生成ステータス */
+  wikiStatus?: WikiGeneratorStatus;
+  /** Wiki 生成コールバック */
+  onGenerateWiki?: () => void;
 }
 
 /**
@@ -79,6 +86,8 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
   collaboration,
   initialContent,
   onInitialContentApplied,
+  wikiStatus,
+  onGenerateWiki,
 }) => {
   const isEditorReadOnly = isReadOnly ?? isWikiGenerating;
 
@@ -94,14 +103,29 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
   return (
     <main className="flex-1 pb-32 pt-6">
       <Container>
-        {/* ページタイトル（コンテンツ上部） */}
-        <PageTitleBlock
-          title={title}
-          onTitleChange={onTitleChange}
-          isReadOnly={isEditorReadOnly}
-          errorMessage={errorMessage}
-          onEnterMoveToContent={!isEditorReadOnly ? focusContent : undefined}
-        />
+        {/* ページタイトルと Wiki 生成ボタン（同一行） */}
+        <div className="flex items-start gap-3 pb-2 pt-6">
+          <div className="min-w-0 flex-1">
+            <PageTitleBlock
+              title={title}
+              onTitleChange={onTitleChange}
+              isReadOnly={isEditorReadOnly}
+              errorMessage={errorMessage}
+              onEnterMoveToContent={!isEditorReadOnly ? focusContent : undefined}
+            />
+          </div>
+          {wikiStatus && onGenerateWiki && (
+            <div className="shrink-0 pt-6">
+              <WikiGeneratorButton
+                title={title}
+                hasContent={isContentNotEmpty(content)}
+                onGenerate={onGenerateWiki}
+                status={wikiStatus}
+              />
+            </div>
+          )}
+        </div>
+
         {/* Source URL Badge - クリップしたページの場合に表示 */}
         {sourceUrl && <SourceUrlBadge sourceUrl={sourceUrl} />}
 
@@ -115,9 +139,6 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
           )}
           {showEditor && (
             <>
-              {isWikiGenerating && (
-                <div className="pointer-events-none absolute inset-0 z-10 rounded-md bg-background/30" />
-              )}
               <TiptapEditor
                 content={content}
                 onChange={onContentChange}
@@ -126,6 +147,7 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
                 pageId={currentPageId || pageId || undefined}
                 pageTitle={title}
                 isReadOnly={isEditorReadOnly}
+                isWikiGenerating={isWikiGenerating}
                 showToolbar={showToolbar}
                 onContentError={onContentError}
                 collaborationConfig={collaborationConfig}

--- a/src/components/editor/PageEditor/PageEditorHeader.test.tsx
+++ b/src/components/editor/PageEditor/PageEditorHeader.test.tsx
@@ -3,24 +3,6 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PageEditorHeader } from "./PageEditorHeader";
 
-vi.mock("../WikiGeneratorButton", () => ({
-  WikiGeneratorButton: ({
-    title,
-    hasContent,
-    onGenerate,
-    status,
-  }: {
-    title: string;
-    hasContent: boolean;
-    onGenerate: () => void;
-    status: string;
-  }) => (
-    <button type="button" onClick={onGenerate} data-testid="wiki-generator-btn">
-      wiki {title} {String(hasContent)} {status}
-    </button>
-  ),
-}));
-
 vi.mock("../ConnectionIndicator", () => ({
   ConnectionIndicator: ({ onReconnect }: { onReconnect: () => void }) => (
     <button type="button" onClick={onReconnect} data-testid="connection-indicator">
@@ -50,15 +32,11 @@ vi.mock("@/contexts/GlobalSearchContext", () => ({
 }));
 
 const defaultProps = {
-  title: "テストページ",
   lastSaved: null as number | null,
-  hasContent: false,
-  wikiStatus: "idle" as const,
   onBack: vi.fn(),
   onDelete: vi.fn(),
   onExportMarkdown: vi.fn(),
   onCopyMarkdown: vi.fn(),
-  onGenerateWiki: vi.fn(),
 };
 
 function renderHeader(overrides = {}) {
@@ -116,14 +94,6 @@ describe("PageEditorHeader", () => {
       const backButton = buttons[0];
       await user.click(backButton);
       expect(onBack).toHaveBeenCalledTimes(1);
-    });
-
-    it("Wiki Generator ボタンをクリックすると onGenerateWiki が呼ばれる", async () => {
-      const user = userEvent.setup();
-      const onGenerateWiki = vi.fn();
-      renderHeader({ onGenerateWiki });
-      await user.click(screen.getByTestId("wiki-generator-btn"));
-      expect(onGenerateWiki).toHaveBeenCalledTimes(1);
     });
 
     it("ドロップダウンを開き Markdownでエクスポート をクリックすると onExportMarkdown が呼ばれる", async () => {

--- a/src/components/editor/PageEditor/PageEditorHeader.tsx
+++ b/src/components/editor/PageEditor/PageEditorHeader.tsx
@@ -35,7 +35,7 @@ interface PageEditorHeaderProps {
 
 /**
  * Header component for PageEditor
- * Contains title input, action buttons, and dropdown menu
+ * Contains search bar, action buttons, and dropdown menu
  */
 export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
   lastSaved,

--- a/src/components/editor/PageEditor/PageEditorHeader.tsx
+++ b/src/components/editor/PageEditor/PageEditorHeader.tsx
@@ -11,9 +11,7 @@ import {
 import Container from "@/components/layout/Container";
 import { HeaderSearchBar } from "@/components/layout/Header/HeaderSearchBar";
 import { useGlobalSearchContextOptional } from "@/contexts/GlobalSearchContext";
-import { WikiGeneratorButton } from "../WikiGeneratorButton";
 import { formatTimeAgo } from "@/lib/dateUtils";
-import type { WikiGeneratorStatus } from "./types";
 import { ConnectionIndicator } from "../ConnectionIndicator";
 import { UserAvatars } from "../UserAvatars";
 import type { ConnectionStatus } from "@/lib/collaboration/types";
@@ -21,16 +19,11 @@ import type { UserPresence } from "@/lib/collaboration/types";
 import { AIChatButton } from "@/components/layout/Header/AIChatButton";
 
 interface PageEditorHeaderProps {
-  /** Wiki Generator ボタン用（タイトル表示は PageTitleBlock で行う） */
-  title: string;
   lastSaved: number | null;
-  hasContent: boolean;
-  wikiStatus: WikiGeneratorStatus;
   onBack: () => void;
   onDelete: () => void;
   onExportMarkdown: () => void;
   onCopyMarkdown: () => void;
-  onGenerateWiki: () => void;
   /** リアルタイムコラボレーション状態（有効時のみ渡す） */
   collaboration?: {
     status: ConnectionStatus;
@@ -45,15 +38,11 @@ interface PageEditorHeaderProps {
  * Contains title input, action buttons, and dropdown menu
  */
 export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
-  title,
   lastSaved,
-  hasContent,
-  wikiStatus,
   onBack,
   onDelete,
   onExportMarkdown,
   onCopyMarkdown,
-  onGenerateWiki,
   collaboration,
 }) => {
   const searchContext = useGlobalSearchContextOptional();
@@ -89,13 +78,6 @@ export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
             </>
           )}
           <AIChatButton />
-          {/* Wiki Generator Button - タイトルがあり本文が空の場合のみ表示 */}
-          <WikiGeneratorButton
-            title={title}
-            hasContent={hasContent}
-            onGenerate={onGenerateWiki}
-            status={wikiStatus}
-          />
           {lastSaved && (
             <span className="hidden text-xs text-muted-foreground sm:inline">
               {formatTimeAgo(lastSaved)}に保存

--- a/src/components/editor/PageEditor/PageEditorLayout.tsx
+++ b/src/components/editor/PageEditor/PageEditorLayout.tsx
@@ -4,7 +4,6 @@ import { PageEditorAlerts } from "./PageEditorAlerts";
 import { PageEditorContent } from "./PageEditorContent";
 import { PageEditorDialogs } from "./PageEditorDialogs";
 import { ContentWithAIChat } from "../../ai-chat/ContentWithAIChat";
-import { isContentNotEmpty } from "@/lib/contentUtils";
 import type { ContentError } from "../TiptapEditor/useContentSanitizer";
 import type { Page } from "@/types/page";
 import type { UseCollaborationReturn } from "@/lib/collaboration/types";
@@ -90,15 +89,11 @@ export const PageEditorLayout: React.FC<PageEditorLayoutProps> = (props) => {
   return (
     <div className="flex min-h-screen flex-col bg-background">
       <PageEditorHeader
-        title={title}
         lastSaved={displayLastSaved}
-        hasContent={isContentNotEmpty(content)}
-        wikiStatus={wikiStatus}
         onBack={onBack}
         onDelete={onDelete}
         onExportMarkdown={onExportMarkdown}
         onCopyMarkdown={onCopyMarkdown}
-        onGenerateWiki={onGenerateWiki}
         collaboration={undefined}
       />
 
@@ -127,6 +122,8 @@ export const PageEditorLayout: React.FC<PageEditorLayoutProps> = (props) => {
           onTitleChange={onTitleChange}
           errorMessage={errorMessage}
           collaboration={isLocalDocEnabled ? collaboration : undefined}
+          wikiStatus={wikiStatus}
+          onGenerateWiki={onGenerateWiki}
           initialContent={pendingInitialContent ?? undefined}
           onInitialContentApplied={() => {
             collaboration?.flushSave?.();

--- a/src/components/editor/PageEditor/usePageEditorState.ts
+++ b/src/components/editor/PageEditor/usePageEditorState.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import type { Page } from "@/types/page";
 
 interface UsePageEditorStateReturn {
@@ -57,11 +57,12 @@ export function usePageEditorState({
   const [isInitialized, setIsInitialized] = useState(false);
   const [originalTitle, setOriginalTitle] = useState<string>("");
   const [contentError, setContentError] = useState<ContentError | null>(null);
+  const prevPageIdRef = useRef<string>(pageId ?? "");
 
-  // ページIDが変わった時に状態をリセット
+  // ページIDが変わった時に即座に状態をリセット（リンクから作成後の遷移で前ページの内容が残る問題を防ぐ）
   useEffect(() => {
-    // 別のページに遷移した場合、状態をリセットして再読み込みを促す
-    if (currentPageId && currentPageId !== pageId && !isNewPage) {
+    if (prevPageIdRef.current !== pageId && !isNewPage) {
+      prevPageIdRef.current = pageId;
       setIsInitialized(false);
       setCurrentPageId(null);
       setTitle("");
@@ -71,7 +72,7 @@ export function usePageEditorState({
       setOriginalTitle("");
       setContentError(null);
     }
-  }, [pageId, currentPageId, isNewPage]);
+  }, [pageId, isNewPage]);
 
   const initialize = useCallback(
     (page: Page) => {

--- a/src/components/editor/TiptapEditor.tsx
+++ b/src/components/editor/TiptapEditor.tsx
@@ -52,6 +52,7 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
   focusContentRef,
   initialContent,
   onInitialContentApplied,
+  isWikiGenerating = false,
 }) => {
   const { editorFontSizePx } = useGeneralSettings();
   const editorContainerRef = useRef<HTMLDivElement>(null);
@@ -160,6 +161,7 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
     onContentError,
     isReadOnly,
     pageId: pageId ?? "",
+    isWikiGenerating,
     collaborationConfig,
     focusContentRef,
     initialContent,

--- a/src/components/editor/TiptapEditor/editorConfig.ts
+++ b/src/components/editor/TiptapEditor/editorConfig.ts
@@ -116,6 +116,8 @@ export function createEditorExtensions(options: EditorExtensionsOptions): Extens
       link: false,
       // CodeBlockLowlight を使うため StarterKit の codeBlock は無効
       codeBlock: false,
+      // 下で個別に Underline を追加するため StarterKit の underline は無効
+      underline: false,
     }),
     // Typography for smart quotes and dashes
     Typography,

--- a/src/components/editor/TiptapEditor/types.ts
+++ b/src/components/editor/TiptapEditor/types.ts
@@ -40,6 +40,8 @@ export interface TiptapEditorProps {
   initialContent?: string;
   /** initialContent をエディタに反映したあとに呼ぶ */
   onInitialContentApplied?: () => void;
+  /** Wiki生成中（この間はリンク判定をスキップしてちらつきを防ぐ） */
+  isWikiGenerating?: boolean;
 }
 
 /**

--- a/src/components/editor/TiptapEditor/useEditorLifecycle.ts
+++ b/src/components/editor/TiptapEditor/useEditorLifecycle.ts
@@ -12,6 +12,7 @@ interface UseEditorLifecycleOptions {
   onContentError: TiptapEditorProps["onContentError"];
   isReadOnly: boolean;
   pageId: string;
+  isWikiGenerating?: boolean;
   collaborationConfig: TiptapEditorProps["collaborationConfig"];
   focusContentRef: TiptapEditorProps["focusContentRef"];
   initialContent: TiptapEditorProps["initialContent"];
@@ -27,6 +28,7 @@ export function useEditorLifecycle({
   onContentError,
   isReadOnly,
   pageId,
+  isWikiGenerating = false,
   collaborationConfig,
   focusContentRef,
   initialContent,
@@ -85,5 +87,6 @@ export function useEditorLifecycle({
     content,
     pageId: pageId || undefined,
     onChange,
+    skipSync: isWikiGenerating,
   });
 }

--- a/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
@@ -58,7 +58,8 @@ export function useWikiLinkNavigation(): UseWikiLinkNavigationReturn {
 
       if (foundPage) {
         // 既存ページが見つかった場合はそのページに移動
-        navigate(`/page/${foundPage.id}`);
+        // flushSync で即時反映（v7_startTransition による遅延でフォーカスしないと表示が更新されない問題を防ぐ）
+        navigate(`/page/${foundPage.id}`, { replace: false, flushSync: true });
       } else {
         // ページが見つからなかった場合は確認ダイアログを表示
         setPendingCreatePageTitle(title);
@@ -84,7 +85,8 @@ export function useWikiLinkNavigation(): UseWikiLinkNavigationReturn {
       });
       setCreatePageDialogOpen(false);
       setPendingCreatePageTitle(null);
-      navigate(`/page/${newPage.id}`);
+      // flushSync で即時反映（v7_startTransition による遅延でフォーカスしないと表示が更新されない問題を防ぐ）
+      navigate(`/page/${newPage.id}`, { replace: false, flushSync: true });
     } catch (error) {
       console.error("Failed to create page:", error);
     }

--- a/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
@@ -58,7 +58,7 @@ export function useWikiLinkNavigation(): UseWikiLinkNavigationReturn {
 
       if (foundPage) {
         // 既存ページが見つかった場合はそのページに移動
-        // flushSync で即時反映（v7_startTransition による遅延でフォーカスしないと表示が更新されない問題を防ぐ）
+        // flushSync でルーティング変更を即時反映し、WikiLink クリック直後に画面遷移が行われるようにする
         navigate(`/page/${foundPage.id}`, { replace: false, flushSync: true });
       } else {
         // ページが見つからなかった場合は確認ダイアログを表示
@@ -85,7 +85,7 @@ export function useWikiLinkNavigation(): UseWikiLinkNavigationReturn {
       });
       setCreatePageDialogOpen(false);
       setPendingCreatePageTitle(null);
-      // flushSync で即時反映（v7_startTransition による遅延でフォーカスしないと表示が更新されない問題を防ぐ）
+      // flushSync でルーティング変更を即時反映し、作成直後に画面遷移が行われるようにする
       navigate(`/page/${newPage.id}`, { replace: false, flushSync: true });
     } catch (error) {
       console.error("Failed to create page:", error);

--- a/src/components/editor/TiptapEditor/useWikiLinkStatusSync.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkStatusSync.ts
@@ -8,6 +8,8 @@ interface UseWikiLinkStatusSyncOptions {
   content: string;
   pageId: string | undefined;
   onChange: (content: string) => void;
+  /** true の間は同期をスキップ（Wiki生成中のリンクスタイルちらつき防止） */
+  skipSync?: boolean;
 }
 
 /**
@@ -22,6 +24,7 @@ export function useWikiLinkStatusSync({
   content,
   pageId,
   onChange,
+  skipSync = false,
 }: UseWikiLinkStatusSyncOptions): void {
   const { checkExistence } = useWikiLinkExistsChecker();
 
@@ -32,7 +35,9 @@ export function useWikiLinkStatusSync({
   }>({ pageId: null, wikiLinkCount: 0 });
 
   useEffect(() => {
-    if (!editor || !content || !pageId) return;
+    if (skipSync || !editor || !content || !pageId) {
+      return;
+    }
 
     // 現在のWikiLink数を取得
     const currentWikiLinks = extractWikiLinksFromContent(content);
@@ -83,7 +88,7 @@ export function useWikiLinkStatusSync({
     // コンテンツ反映を待ってから実行
     const timer = setTimeout(updateWikiLinkStatus, 150);
     return () => clearTimeout(timer);
-  }, [editor, content, checkExistence, pageId, onChange]);
+  }, [skipSync, editor, content, checkExistence, pageId, onChange]);
 }
 
 // --- ヘルパー関数 ---

--- a/src/components/page/LinkedPagesSection.test.tsx
+++ b/src/components/page/LinkedPagesSection.test.tsx
@@ -218,7 +218,9 @@ describe("LinkedPagesSection", () => {
     });
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/page/new-page-id");
+      expect(mockNavigate).toHaveBeenCalledWith("/page/new-page-id", {
+        flushSync: true,
+      });
     });
   });
 

--- a/src/components/page/LinkedPagesSection.tsx
+++ b/src/components/page/LinkedPagesSection.tsx
@@ -57,7 +57,7 @@ export function LinkedPagesSection({ pageId, isSyncingLinks = false }: LinkedPag
     // Create a new page with the ghost link title
     try {
       const newPage = await createPageMutation.mutateAsync({ title });
-      navigate(`/page/${newPage.id}`);
+      navigate(`/page/${newPage.id}`, { flushSync: true });
     } catch (error) {
       console.error("Failed to create page:", error);
     }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { useSession, signOut, getSession } from "@/lib/auth/authClient";
 import {
   useMockAuth,
@@ -13,6 +13,19 @@ const isE2EMode = import.meta.env.VITE_E2E_TEST === "true";
 function useBetterAuth() {
   const { data: session, isPending } = useSession();
 
+  const getTokenStable = useCallback(async () => {
+    try {
+      const s = await getSession();
+      return s.data?.session?.token ?? null;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const signOutStable = useCallback(async () => {
+    await signOut();
+  }, []);
+
   return {
     isLoaded: !isPending,
     isSignedIn: !!session,
@@ -21,17 +34,8 @@ function useBetterAuth() {
     orgId: null,
     orgRole: null,
     orgSlug: null,
-    getToken: async () => {
-      try {
-        const s = await getSession();
-        return s.data?.session?.token ?? null;
-      } catch {
-        return null;
-      }
-    },
-    signOut: async () => {
-      await signOut();
-    },
+    getToken: getTokenStable,
+    signOut: signOutStable,
   };
 }
 

--- a/src/hooks/usePageQueries.ts
+++ b/src/hooks/usePageQueries.ts
@@ -331,6 +331,9 @@ export function useCreatePage() {
       queryClient.invalidateQueries({ queryKey: pageKeys.lists() });
       queryClient.invalidateQueries({ queryKey: pageKeys.summaries() });
 
+      // 作成したページの detail キャッシュを即時設定（リンクから作成後すぐの遷移でタイトル・コンテンツが正しく表示されるようにする）
+      queryClient.setQueryData<Page | null>(pageKeys.detail(userId, newPage.id), newPage);
+
       // Optimistically update the cache
       queryClient.setQueryData<Page[]>(pageKeys.list(userId), (old = []) => [newPage, ...old]);
 

--- a/src/lib/contentUtils.test.ts
+++ b/src/lib/contentUtils.test.ts
@@ -724,6 +724,28 @@ describe("sanitizeTiptapContent - wikiLink promotion", () => {
     expect(codeNode.content[0].marks).toBeUndefined();
   });
 
+  it("should keep [[ ]] (empty title) as plain text, not wikiLink", () => {
+    const input = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Empty [[ ]] brackets." }],
+        },
+      ],
+    });
+
+    const result = sanitizeTiptapContent(input);
+    const parsed = JSON.parse(result.content);
+    const nodes = parsed.content[0].content;
+
+    expect(nodes).toHaveLength(3);
+    expect(nodes[0].text).toBe("Empty ");
+    expect(nodes[1].text).toBe("[[ ]]");
+    expect(nodes[1].marks).toBeUndefined();
+    expect(nodes[2].text).toBe(" brackets.");
+  });
+
   it("should NOT convert [[]] in inline code (code mark)", () => {
     const input = JSON.stringify({
       type: "doc",

--- a/src/lib/contentUtils.test.ts
+++ b/src/lib/contentUtils.test.ts
@@ -550,3 +550,204 @@ describe("buildContentErrorMessage", () => {
     expect(message).toContain("移行データに問題があります");
   });
 });
+
+describe("sanitizeTiptapContent - wikiLink promotion", () => {
+  it("should convert plain text [[Title]] to wikiLink marks", () => {
+    const input = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "See [[My Page]] for details." }],
+        },
+      ],
+    });
+
+    const result = sanitizeTiptapContent(input);
+    const parsed = JSON.parse(result.content);
+    const nodes = parsed.content[0].content;
+
+    expect(nodes).toHaveLength(3);
+    expect(nodes[0]).toEqual({ type: "text", text: "See " });
+    expect(nodes[1].text).toBe("[[My Page]]");
+    expect(nodes[1].marks).toHaveLength(1);
+    expect(nodes[1].marks[0].type).toBe("wikiLink");
+    expect(nodes[1].marks[0].attrs.title).toBe("My Page");
+    expect(nodes[2]).toEqual({ type: "text", text: " for details." });
+  });
+
+  it("should convert multiple [[]] patterns in the same text node", () => {
+    const input = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Link [[A]] and [[B]] here." }],
+        },
+      ],
+    });
+
+    const result = sanitizeTiptapContent(input);
+    const parsed = JSON.parse(result.content);
+    const nodes = parsed.content[0].content;
+
+    expect(nodes).toHaveLength(5);
+    expect(nodes[0].text).toBe("Link ");
+    expect(nodes[1].text).toBe("[[A]]");
+    expect(nodes[1].marks[0].attrs.title).toBe("A");
+    expect(nodes[2].text).toBe(" and ");
+    expect(nodes[3].text).toBe("[[B]]");
+    expect(nodes[3].marks[0].attrs.title).toBe("B");
+    expect(nodes[4].text).toBe(" here.");
+  });
+
+  it("should not double-convert text that already has wikiLink marks", () => {
+    const input = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "[[Existing]]",
+              marks: [
+                {
+                  type: "wikiLink",
+                  attrs: { title: "Existing", exists: true, referenced: false },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = sanitizeTiptapContent(input);
+    const parsed = JSON.parse(result.content);
+    const nodes = parsed.content[0].content;
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].marks).toHaveLength(1);
+    expect(nodes[0].marks[0].type).toBe("wikiLink");
+  });
+
+  it("should preserve existing marks (e.g. bold) alongside new wikiLink marks", () => {
+    const input = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "bold [[Link]]",
+              marks: [{ type: "bold" }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = sanitizeTiptapContent(input);
+    const parsed = JSON.parse(result.content);
+    const nodes = parsed.content[0].content;
+
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0].text).toBe("bold ");
+    expect(nodes[0].marks).toEqual([{ type: "bold" }]);
+    expect(nodes[1].text).toBe("[[Link]]");
+    expect(nodes[1].marks).toHaveLength(2);
+    expect(nodes[1].marks[0].type).toBe("bold");
+    expect(nodes[1].marks[1].type).toBe("wikiLink");
+  });
+
+  it("should handle text with no [[]] patterns unchanged", () => {
+    const input = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "No wiki links here." }],
+        },
+      ],
+    });
+
+    const result = sanitizeTiptapContent(input);
+    const parsed = JSON.parse(result.content);
+    const nodes = parsed.content[0].content;
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].text).toBe("No wiki links here.");
+    expect(nodes[0].marks).toBeUndefined();
+  });
+
+  it("should handle [[]] at the start and end of text", () => {
+    const input = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "[[Start]]" }],
+        },
+      ],
+    });
+
+    const result = sanitizeTiptapContent(input);
+    const parsed = JSON.parse(result.content);
+    const nodes = parsed.content[0].content;
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].text).toBe("[[Start]]");
+    expect(nodes[0].marks[0].type).toBe("wikiLink");
+    expect(nodes[0].marks[0].attrs.title).toBe("Start");
+  });
+
+  it("should NOT convert [[]] inside codeBlock nodes", () => {
+    const input = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "javascript" },
+          content: [{ type: "text", text: "const arr = [[1, 2]];" }],
+        },
+      ],
+    });
+
+    const result = sanitizeTiptapContent(input);
+    const parsed = JSON.parse(result.content);
+    const codeNode = parsed.content[0];
+
+    expect(codeNode.content).toHaveLength(1);
+    expect(codeNode.content[0].text).toBe("const arr = [[1, 2]];");
+    expect(codeNode.content[0].marks).toBeUndefined();
+  });
+
+  it("should NOT convert [[]] in inline code (code mark)", () => {
+    const input = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "[[not a link]]",
+              marks: [{ type: "code" }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = sanitizeTiptapContent(input);
+    const parsed = JSON.parse(result.content);
+    const nodes = parsed.content[0].content;
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].text).toBe("[[not a link]]");
+    expect(nodes[0].marks).toHaveLength(1);
+    expect(nodes[0].marks[0].type).toBe("code");
+  });
+});

--- a/src/lib/contentUtils.ts
+++ b/src/lib/contentUtils.ts
@@ -126,9 +126,18 @@ function splitTextNodeByWikiLinks(textNode: Record<string, unknown>): Record<str
     }
 
     const title = match[1].trim();
+    if (!title) {
+      result.push({
+        type: "text",
+        text: match[0],
+        ...(existingMarks.length > 0 ? { marks: existingMarks } : {}),
+      });
+      lastIndex = regex.lastIndex;
+      continue;
+    }
     const wikiLinkMark: Record<string, unknown> = {
       type: "wikiLink",
-      attrs: { title, exists: true, referenced: false },
+      attrs: { title, exists: false, referenced: false },
     };
     result.push({
       type: "text",

--- a/src/lib/contentUtils.ts
+++ b/src/lib/contentUtils.ts
@@ -70,8 +70,11 @@ export function sanitizeTiptapContent(content: string): SanitizeResult {
 
     const sanitizedDoc = sanitizeNode(doc, removedNodeTypes, removedMarkTypes);
 
+    // Promote plain-text [[...]] patterns to wikiLink marks
+    const promotedDoc = sanitizedDoc ? promoteWikiLinksInNode(sanitizedDoc) : sanitizedDoc;
+
     return {
-      content: JSON.stringify(sanitizedDoc),
+      content: JSON.stringify(promotedDoc),
       hadErrors: removedNodeTypes.size > 0 || removedMarkTypes.size > 0,
       removedNodeTypes: Array.from(removedNodeTypes),
       removedMarkTypes: Array.from(removedMarkTypes),
@@ -86,6 +89,95 @@ export function sanitizeTiptapContent(content: string): SanitizeResult {
       removedMarkTypes: ["JSON parse error"],
     };
   }
+}
+
+/**
+ * Split a text node's text by [[...]] patterns and produce an array of text nodes,
+ * applying wikiLink marks to the matched segments.
+ * Existing marks on the original node are preserved on all resulting segments.
+ */
+function splitTextNodeByWikiLinks(textNode: Record<string, unknown>): Record<string, unknown>[] {
+  const text = textNode.text as string;
+  if (!text) return [textNode];
+
+  const existingMarks = (textNode.marks as Array<Record<string, unknown>>) || [];
+
+  const hasWikiLinkMark = existingMarks.some(
+    (m) => (m as Record<string, unknown>).type === "wikiLink",
+  );
+  if (hasWikiLinkMark) return [textNode];
+
+  // Skip text nodes with inline code marks
+  const hasCodeMark = existingMarks.some((m) => (m as Record<string, unknown>).type === "code");
+  if (hasCodeMark) return [textNode];
+
+  const regex = /\[\[([^\]]+)\]\]/g;
+  let match: RegExpExecArray | null;
+  const result: Record<string, unknown>[] = [];
+  let lastIndex = 0;
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      result.push({
+        type: "text",
+        text: text.slice(lastIndex, match.index),
+        ...(existingMarks.length > 0 ? { marks: existingMarks } : {}),
+      });
+    }
+
+    const title = match[1].trim();
+    const wikiLinkMark: Record<string, unknown> = {
+      type: "wikiLink",
+      attrs: { title, exists: true, referenced: false },
+    };
+    result.push({
+      type: "text",
+      text: match[0],
+      marks: [...existingMarks, wikiLinkMark],
+    });
+    lastIndex = regex.lastIndex;
+  }
+
+  if (result.length === 0) return [textNode];
+
+  if (lastIndex < text.length) {
+    result.push({
+      type: "text",
+      text: text.slice(lastIndex),
+      ...(existingMarks.length > 0 ? { marks: existingMarks } : {}),
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Recursively promote plain-text [[...]] patterns to wikiLink marks.
+ * Returns a new node tree (does not mutate in place).
+ */
+const SKIP_WIKILINK_PROMOTION_NODES = new Set(["codeBlock", "code_block"]);
+
+function promoteWikiLinksInNode(node: Record<string, unknown>): Record<string, unknown> {
+  if (!node || typeof node !== "object") return node;
+
+  // Don't promote inside code blocks
+  if (SKIP_WIKILINK_PROMOTION_NODES.has(node.type as string)) return node;
+
+  const result: Record<string, unknown> = { ...node };
+
+  if (Array.isArray(node.content)) {
+    const newContent: Record<string, unknown>[] = [];
+    for (const child of node.content as Array<Record<string, unknown>>) {
+      if (child.type === "text" && typeof child.text === "string") {
+        newContent.push(...splitTextNodeByWikiLinks(child));
+      } else {
+        newContent.push(promoteWikiLinksInNode(child));
+      }
+    }
+    result.content = newContent;
+  }
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
## 概要
現在の実装内容をdevelopブランチにマージするためのPRです。

## 変更内容
- **PageEditor**: Content, Header, Layout, usePageEditorStateの改善
- **TiptapEditor**: editorConfig, types, useEditorLifecycle, wiki link navigation/status syncの改善
- **Hooks**: usePageQueries, useAuthの改善
- **その他**: contentUtils, LinkedPagesSection, App.tsxの更新

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatically convert plain text wiki links (`[[...]]`) to proper wiki links in the editor.
  * Repositioned wiki generator controls to the content area.

* **Bug Fixes**
  * Reduced UI flicker during navigation and content generation.
  * Improved page navigation responsiveness with immediate UI updates.
  * Faster navigation to newly created pages through optimized caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->