### PR TITLE
fix(ci): add debug step for prod migrate DATABASE_URL

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,6 +16,17 @@ jobs:
           bun-version: "1.2"
       - name: Install dependencies
         run: bun install --frozen-lockfile
+      - name: Debug database connection (masked)
+        run: |
+          if [ -n "$DATABASE_URL" ]; then
+            echo "DATABASE_URL is set"
+            echo "DB user: $(echo "$DATABASE_URL" | sed -E 's|postgresql://([^:]+):.*|\1|')"
+            echo "DB host: $(echo "$DATABASE_URL" | sed -E 's|postgresql://[^@]+@([^:/]+).*|\1|')"
+          else
+            echo "DATABASE_URL is not set"
+          fi
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
       - name: Run migrations
         working-directory: server/api
         run: bunx drizzle-kit migrate


### PR DESCRIPTION
## 概要

本番デプロイで `password authentication failed for user "zedi"` が発生している問題の調査のため、マイグレーション実行前に `DATABASE_URL` のデバッグ出力を追加する。

## 変更内容

- `deploy-prod.yml` の migrate job に Debug ステップを追加
- `DATABASE_URL` が設定されているか、DB ユーザー名、DB ホスト名をログに出力（パスワードは非表示）

## 確認後の対応

- デバッグ完了後、本ステップは削除する