### PR TITLE
feat(terraform): 本番フロントエンドのカスタムドメイン設定を追加

### DIFF
--- a/terraform/cloudflare/dns.tf
+++ b/terraform/cloudflare/dns.tf
@@ -9,7 +9,7 @@ resource "cloudflare_record" "api_cname" {
   type            = "CNAME"
   content         = var.api_cname_target
   proxied         = false
-  ttl             = 1 # 1 = auto
+  ttl             = 1    # 1 = auto
   allow_overwrite = true # adopt existing record if present
 }
 
@@ -37,6 +37,16 @@ resource "cloudflare_record" "realtime_railway_verify" {
   name    = "_railway-verify.realtime"
   type    = "TXT"
   content = var.realtime_railway_verify_txt
+  ttl     = 1
+}
+
+# zedi-note.app -> Cloudflare Pages (zedi); proxied for SSL
+resource "cloudflare_record" "pages_prod_cname" {
+  zone_id = data.cloudflare_zone.zedi.id
+  name    = "@"
+  type    = "CNAME"
+  content = "${cloudflare_pages_project.zedi.name}.pages.dev"
+  proxied = true
   ttl     = 1
 }
 

--- a/terraform/cloudflare/pages.tf
+++ b/terraform/cloudflare/pages.tf
@@ -11,6 +11,13 @@ resource "cloudflare_pages_project" "zedi_dev" {
   production_branch = "develop"
 }
 
+# Custom domain for production frontend (zedi-note.app)
+resource "cloudflare_pages_domain" "zedi_prod" {
+  account_id   = var.cloudflare_account_id
+  project_name = cloudflare_pages_project.zedi.name
+  domain       = var.zone_domain
+}
+
 # Custom domain for dev frontend (e.g. dev.zedi-note.app)
 resource "cloudflare_pages_domain" "zedi_dev" {
   account_id   = var.cloudflare_account_id


### PR DESCRIPTION
## Summary
- 本番フロントエンド (`zedi` Pages プロジェクト) に `zedi-note.app` のカスタムドメインを追加
- `zedi.pages.dev` ではアクセス可能だが、`zedi-note.app` では DNS が解決されない問題を修正

## Changes
- **`terraform/cloudflare/pages.tf`**: `cloudflare_pages_domain.zedi_prod` リソースを追加（`zedi-note.app` → Pages プロジェクト `zedi`）
- **`terraform/cloudflare/dns.tf`**: `cloudflare_record.pages_prod_cname` を追加（`@` → `zedi.pages.dev`、proxied で SSL 対応）

## Note
マージ後、Terraform Cloud で `terraform apply` を実行する必要があります。

## Test plan
- [ ] `terraform validate` 成功を確認済み
- [ ] `terraform apply` 後、`zedi-note.app` が正常に解決されること
- [ ] `https://zedi-note.app` でフロントエンドが表示されること


Made with [Cursor](https://cursor.com)