### PR TITLE
fix: Postgres Dockerfile を v17 に更新（データ互換性修正）

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,3 +1,3 @@
-FROM postgres:16-bookworm
+FROM postgres:17-bookworm
 
 COPY docker/postgres/initdb.d/ /docker-entrypoint-initdb.d/


### PR DESCRIPTION
## Summary
- Postgres-prod が CRASHED 状態
- 原因: データディレクトリは PostgreSQL 17 で初期化されていたが、`docker/postgres/Dockerfile` は `postgres:16-bookworm` を指定
- PostgreSQL はメジャーバージョン間でデータファイルの後方互換性がないため、PG 16 で PG 17 のデータを読もうとして FATAL エラー

## Error
```
FATAL: database files are incompatible with server
DETAIL: The data directory was initialized by PostgreSQL version 17,
which is not compatible with this version 16.13
```

## Fix
`docker/postgres/Dockerfile` のベースイメージを `postgres:17-bookworm` に変更

## Test plan
- [ ] develop マージ後、main にマージして Railway が Postgres-prod を正常に起動すること
- [ ] 既存データが保持されていること


Made with [Cursor](https://cursor.com)