### PR TITLE
docs(terraform): DNS proxy Toggle Trick comment for Railway cert

### DIFF
--- a/docs/pr-191-investigation-cloudflare-railway.md
+++ b/docs/pr-191-investigation-cloudflare-railway.md
@@ -1,0 +1,107 @@
+# PR #191 調査: Cloudflare proxy と Railway SSL（実装は正・コメント修正）
+
+## 結論
+
+- **実装（`proxied = false`）は正しい。** api / realtime は **恒常的に DNS-only（グレークラウド）** とする設計で問題ない。
+- **コメントが誤っている。** 「一時的に false にしてあとで true に戻す」は Railway の「Toggle Trick」手順の説明であり、**このリポジトリの意図（恒常的に false）と一致していない。** コメントを「DNS-only が意図した恒常状態」と分かるように修正する。
+
+---
+
+## 1. Cloudflare のプロキシ有無の違い
+
+| 設定               | アイコン         | 動作                                                                                                                   |
+| ------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **Proxied (ON)**   | オレンジクラウド | トラフィックは Cloudflare 経由。Cloudflare が SSL 終端し、オリジンへは Cloudflare が接続。CDN・DDoS 対策・WAF が有効。 |
+| **DNS only (OFF)** | グレークラウド   | トラフィックは **直接オリジンへ**。Cloudflare は DNS 解決のみ。オリジン（ここでは Railway）が SSL を提供。             |
+
+公式: [Proxy status - Cloudflare DNS](https://developers.cloudflare.com/dns/proxy-status)
+
+---
+
+## 2. Railway 公式ドキュメントの「Toggle Trick」
+
+**出典**: [Railway – Troubleshooting SSL](https://docs.railway.com/guides/troubleshooting-ssl)
+
+> **The Toggle Trick:** If your certificate is stuck on "Validating Challenges," try **temporarily** turning the Cloudflare proxy **OFF** (grey cloud), wait for Railway to issue the certificate (you'll see a green checkmark in Railway), **then turn the proxy back ON** (orange cloud). This removes Cloudflare from the validation path and allows Railway's Let's Encrypt challenge to reach the origin directly.
+
+- これは **証明書発行が「Validating Challenges」で止まったときの一時的な対処** として書かれている。
+- 手順: 一時的に OFF → 証明書発行 → **再度 ON にする** ことが Railway ドキュメント上の想定。
+
+---
+
+## 3. 恒常的に DNS-only（proxied = false）が正しいケース
+
+Railway の「Toggle Trick」は「一時的に OFF にしてから ON に戻す」手順だが、**恒常的にプロキシ OFF のままにしておく構成も有効**です。
+
+- **DNS-only を恒常にする利点**
+  - Railway がオリジンで Let's Encrypt 証明書を発行・保持し、クライアントは **Railway と直接 TLS 通信** する。
+  - Cloudflare の SSL モード（Full / Full Strict）や証明書更新タイミングを気にしなくてよい。
+  - API や WebSocket（realtime）のようにキャッシュや CDN が不要なサブドメインでは、プロキシを挟まない方がシンプルなことが多い。
+
+- **Cloudflare の公式的な使い分け**
+  - グレークラウドは「API やオリジン直アクセスが必要なサービス」「プロキシを挟むと都合が悪い場合」に使う、と説明されている。
+
+したがって、**api.zedi-note.app / realtime.zedi-note.app を恒常的に `proxied = false` にする実装は、Cloudflare の設定として正しい。**
+
+---
+
+## 4. 何が「コメントの誤り」か
+
+現在のコメント:
+
+```hcl
+# Toggle Trick: temporarily proxied=false for Railway cert issuance, then switch back to true
+```
+
+- これは **Railway の「Toggle Trick」手順**（一時的に OFF → 発行 → ON に戻す）を説明している。
+- 一方、**この Terraform では `proxied = false` が固定** であり、「true に戻す」状態はコードに存在しない。
+- つまり **「then switch back to true」がこのリポジトリの意図と一致していない** ＝ コメントが実装と食い違っている。
+
+実装の意図が「恒常的に DNS-only」であれば、コメントは **「恒常的に proxied=false」** である理由を説明すべき。
+
+---
+
+## 5. コメント修正案（実装＝恒常 DNS-only に合わせる）
+
+**api / realtime の CNAME 用に、次のいずれか（または組み合わせ）で置き換える。**
+
+### 案 1: 短い説明
+
+```hcl
+# api.zedi-note.app -> Railway API
+# DNS-only (proxied=false): traffic goes directly to Railway; Railway provides SSL at origin.
+```
+
+```hcl
+# realtime.zedi-note.app -> Railway Hocuspocus
+# DNS-only (proxied=false): traffic goes directly to Railway; Railway provides SSL at origin.
+```
+
+### 案 2: 理由を少し補足
+
+```hcl
+# api.zedi-note.app -> Railway API
+# DNS-only by design. We do not use Cloudflare proxy here; Railway issues and serves SSL.
+```
+
+```hcl
+# realtime.zedi-note.app -> Railway Hocuspocus
+# DNS-only by design. We do not use Cloudflare proxy here; Railway issues and serves SSL.
+```
+
+### 案 3: 将来の運用者向けに「Toggle Trick」に言及する場合
+
+```hcl
+# api.zedi-note.app -> Railway API
+# DNS-only (proxied=false). Railway provides SSL at origin. Intentional permanent state; not using Cloudflare proxy for this subdomain.
+```
+
+- 「Intentional permanent state」で「true に戻す想定ではない」ことを明示できる。
+
+---
+
+## 6. 推奨
+
+- **実装はそのまま**（`proxied = false` のまま）。
+- **コメントのみ修正**し、「恒常的に DNS-only」であることと、Railway がオリジンで SSL を提供していることを書く。
+- 上記のうち **案 1 または 案 2** を採用すると、レビュー指摘（「コメントとコードの矛盾」）も解消できる。

--- a/docs/pr-191-review-response.md
+++ b/docs/pr-191-review-response.md
@@ -1,0 +1,100 @@
+# PR #191 レビュー対応案
+
+## レビュー指摘の要約
+
+**Gemini Code Assist** と **GitHub Copilot** の両方から、同じ内容が指摘されています。
+
+| 指摘内容                                                                                                                                     |
+| -------------------------------------------------------------------------------------------------------------------------------------------- |
+| コメントでは「一時的に `proxied=false` にして、その後 `true` に戻す」と書いているが、コードでは `proxied = false` がハードコードされている。 |
+| そのため Terraform は常に DNS-only を強制し、「true に戻す」状態をコードで表現できていない。                                                 |
+| 手動で Cloudflare 上を `proxied = true` にしても、次回 `terraform apply` で上書きされてしまう。                                              |
+| **IaC の状態とコメントで説明している運用が一致しておらず、混乱を招く。**                                                                     |
+
+---
+
+## 対応方針の選択肢
+
+### 案 A: コメントを現状のコードに合わせる（最小変更）
+
+**やること**
+
+- 「Toggle Trick」の文言をやめ、**現在のコードの状態（常に `proxied = false`）** を説明するコメントに変更する。
+- 運用で「証明書発行後に Cloudflare 経由に戻したい場合」は、**Terraform の値を `true` に変更して apply する**旨をコメントに書く。
+
+**メリット**
+
+- 変更が少ない（`dns.tf` のコメントのみ）。
+- 変数や tfvars を増やさない。
+
+**デメリット**
+
+- 「トグル」は Terraform の値を書き換えて apply する手順になり、コメントで「手動で Cloudflare をいじる」と誤解されないように書く必要がある。
+
+**コメント例（案 A）**
+
+```hcl
+# api.zedi-note.app -> Railway API
+# DNS-only (proxied=false) for Railway-origin SSL. To use Cloudflare proxy, set proxied=true here and terraform apply.
+```
+
+---
+
+### 案 B: コードを運用に合わせる（変数でトグル可能にする）★推奨
+
+**やること**
+
+1. **変数追加**（`variables.tf`）
+   - 例: `api_proxied` と `realtime_proxied`（bool、default = `true`）
+   - または 1 つにまとめる: `railway_subdomains_proxied`（bool、default = `true`）
+2. **`dns.tf`**
+   - `api_cname` / `realtime_cname` の `proxied` にその変数を参照させる。
+3. **コメント**
+   - 「通常は `true`。Railway 証明書発行時だけ変数を `false` にして apply → 発行後に `true` に戻して apply」と記載。
+
+**運用イメージ**
+
+- **通常時**: 変数 = `true`（デフォルト） → Cloudflare プロキシ有効。
+- **証明書発行時**: 変数を `false` に変更 → `terraform apply` → 証明書取得後、変数を `true` に戻して `terraform apply`。
+
+**メリット**
+
+- コメントの「一時的に false → その後 true」と Terraform の状態が一致する。
+- トグルが「変数の変更 + apply」で再現でき、IaC と運用が一致する。
+- レビュー指摘（「コメントとコードの矛盾」「apply で上書きされる」）を解消できる。
+
+**デメリット**
+
+- 変数と `dns.tf` の修正が必要（作業量は少なめ）。
+
+---
+
+## 推奨: 案 B（変数化）
+
+- 指摘は「コメントとコードを一致させるか、コードを運用に合わせるか」のどちらかであり、**案 B は「コードを運用に合わせる」方**です。
+- 「Toggle Trick」を Terraform 上で再現できるため、今後の証明書更新時も手順が明確になります。
+- 既存の `variables.tf` のスタイルに合わせて 1 変数（例: `railway_subdomains_proxied`）にまとめると、api / realtime を同時にトグルできて運用もしやすいです。
+
+---
+
+## 案 B を採用する場合の具体的な変更例
+
+1. **`variables.tf`** に追加:
+
+```hcl
+# Railway api/realtime subdomains: Cloudflare proxy on/off
+# Set to false only during Railway custom-domain cert issuance; then set back to true and apply.
+variable "railway_subdomains_proxied" {
+  type        = bool
+  description = "Proxied for api.zedi-note.app and realtime.zedi-note.app. Use false temporarily for Railway cert issuance."
+  default     = true
+}
+```
+
+2. **`dns.tf`** の `api_cname` / `realtime_cname` で `proxied` を変数参照に変更し、コメントを上記運用に合わせて修正（「通常は true、証明書発行時のみ false にして apply」と明記）。
+
+3. **現状どおりプロキシ無効にしたい場合**
+   - 変数のデフォルトを一時的に `false` にするか、`terraform.tfvars` や CI の変数で `railway_subdomains_proxied = false` を渡す。
+   - 証明書発行が終わったら `true` に戻す。
+
+この内容で PR #191 に修正を push し、レビューへの対応として「案 B を採用し、変数化でコメントとコードを一致させた」と返信する形がおすすめです。

--- a/terraform/cloudflare/dns.tf
+++ b/terraform/cloudflare/dns.tf
@@ -2,7 +2,8 @@ data "cloudflare_zone" "zedi" {
   name = var.zone_domain
 }
 
-# api.zedi-note.app -> Railway API (DNS only; proxied = false for Railway SSL)
+# api.zedi-note.app -> Railway API
+# Toggle Trick: temporarily proxied=false for Railway cert issuance, then switch back to true
 resource "cloudflare_record" "api_cname" {
   zone_id         = data.cloudflare_zone.zedi.id
   name            = "api"
@@ -21,7 +22,8 @@ resource "cloudflare_record" "api_railway_verify" {
   ttl     = 1
 }
 
-# realtime.zedi-note.app -> Railway Hocuspocus (DNS only)
+# realtime.zedi-note.app -> Railway Hocuspocus
+# Toggle Trick: temporarily proxied=false for Railway cert issuance, then switch back to true
 resource "cloudflare_record" "realtime_cname" {
   zone_id         = data.cloudflare_zone.zedi.id
   name            = "realtime"

--- a/terraform/cloudflare/dns.tf
+++ b/terraform/cloudflare/dns.tf
@@ -3,7 +3,7 @@ data "cloudflare_zone" "zedi" {
 }
 
 # api.zedi-note.app -> Railway API
-# Toggle Trick: temporarily proxied=false for Railway cert issuance, then switch back to true
+# DNS-only by design (proxied=false). We do not use Cloudflare proxy here; Railway issues and serves SSL at origin.
 resource "cloudflare_record" "api_cname" {
   zone_id         = data.cloudflare_zone.zedi.id
   name            = "api"
@@ -23,7 +23,7 @@ resource "cloudflare_record" "api_railway_verify" {
 }
 
 # realtime.zedi-note.app -> Railway Hocuspocus
-# Toggle Trick: temporarily proxied=false for Railway cert issuance, then switch back to true
+# DNS-only by design (proxied=false). We do not use Cloudflare proxy here; Railway issues and serves SSL at origin.
 resource "cloudflare_record" "realtime_cname" {
   zone_id         = data.cloudflare_zone.zedi.id
   name            = "realtime"


### PR DESCRIPTION
## 変更内容
- `terraform/cloudflare/dns.tf`: api / realtime の CNAME に「Toggle Trick」のコメントを追加
  - 一時的に `proxied=false` で Railway 証明書発行を行い、その後 `true` に戻す運用を明記

## 対象リソース
- `api.zedi-note.app` (Railway API)
- `realtime.zedi-note.app` (Railway Hocuspocus)

develop 向け PR です。

Made with [Cursor](https://cursor.com)