### PR TITLE
fix(useCollaboration): disconnect 時に state を完全リセット

### DIFF
--- a/src/hooks/useCollaboration.ts
+++ b/src/hooks/useCollaboration.ts
@@ -55,7 +55,15 @@ export function useCollaboration({
   // Manager初期化（ゲスト時も local モードで IndexedDB のみ有効）
   useEffect(() => {
     if (!enabled || !pageId) {
-      queueMicrotask(() => setState((prev) => ({ ...prev, status: "disconnected" })));
+      queueMicrotask(() => {
+        setState({
+          status: "disconnected",
+          isSynced: false,
+          onlineUsers: [],
+          pendingChanges: 0,
+        });
+        setManagerSnapshot({ ydoc: undefined, xmlFragment: undefined, awareness: undefined });
+      });
       return;
     }
 

--- a/src/hooks/useCollaboration.ts
+++ b/src/hooks/useCollaboration.ts
@@ -23,6 +23,16 @@ const initialState: CollaborationState = {
   pendingChanges: 0,
 };
 
+const emptyManagerSnapshot: {
+  ydoc: UseCollaborationReturn["ydoc"];
+  xmlFragment: UseCollaborationReturn["xmlFragment"];
+  awareness: UseCollaborationReturn["awareness"];
+} = {
+  ydoc: undefined,
+  xmlFragment: undefined,
+  awareness: undefined,
+};
+
 /**
  * リアルタイムコラボレーション機能を提供するフック
  * 未ログイン時は effectiveUserId = local-user で Y.Doc + IndexedDB のみ使用。
@@ -43,11 +53,7 @@ export function useCollaboration({
   const { userId, getToken, isSignedIn } = useAuth();
   const { user } = useUser();
   const [state, setState] = useState<CollaborationState>(initialState);
-  const [managerSnapshot, setManagerSnapshot] = useState<{
-    ydoc: UseCollaborationReturn["ydoc"];
-    xmlFragment: UseCollaborationReturn["xmlFragment"];
-    awareness: UseCollaborationReturn["awareness"];
-  }>({ ydoc: undefined, xmlFragment: undefined, awareness: undefined });
+  const [managerSnapshot, setManagerSnapshot] = useState(emptyManagerSnapshot);
   const managerRef = useRef<CollaborationManager | null>(null);
 
   const effectiveUserId = isSignedIn && userId ? userId : LOCAL_USER_ID;
@@ -56,13 +62,8 @@ export function useCollaboration({
   useEffect(() => {
     if (!enabled || !pageId) {
       queueMicrotask(() => {
-        setState({
-          status: "disconnected",
-          isSynced: false,
-          onlineUsers: [],
-          pendingChanges: 0,
-        });
-        setManagerSnapshot({ ydoc: undefined, xmlFragment: undefined, awareness: undefined });
+        setState({ ...initialState, status: "disconnected" });
+        setManagerSnapshot(emptyManagerSnapshot);
       });
       return;
     }
@@ -114,7 +115,7 @@ export function useCollaboration({
       unsubscribe();
       manager.destroy();
       managerRef.current = null;
-      setManagerSnapshot({ ydoc: undefined, xmlFragment: undefined, awareness: undefined });
+      setManagerSnapshot(emptyManagerSnapshot);
     };
   }, [
     pageId,


### PR DESCRIPTION
## 概要
PR #192 に対する CodeRabbit の追加レビュー（3/4）に対応する修正です。

## 指摘内容
`!enabled || !pageId` の early return 時に `status: "disconnected"` のみを更新しており、前セッションの `onlineUsers` や `isSynced` 等が残る可能性がある。共有ノートから個人ページへ遷移した際などに、切断済みなのに他ユーザー表示が残る問題が起き得る。

## 変更内容
- `CollaborationState` 全体（status, isSynced, onlineUsers, pendingChanges）をリセットするよう変更
- `managerSnapshot` も明示的にクリアして一貫性を確保

## 参考
- CodeRabbit レビューコメント: https://github.com/otomatty/zedi/pull/192

Made with [Cursor](https://cursor.com)