### PR TITLE
fix: allow dev.zedi-note.app and localhost in CORS origin

### DIFF
--- a/docs/specs/railway-dev-setup.md
+++ b/docs/specs/railway-dev-setup.md
@@ -19,23 +19,23 @@
 
 ### 環境変数の状態（Polar まで ✅ 設定済み）
 
-| 変数                     | 状態                                    |
-| ------------------------ | --------------------------------------- |
-| `DATABASE_URL`           | ✅ 設定済み（Railway 参照）             |
-| `REDIS_URL`              | ✅ 設定済み（Railway 参照）             |
-| `BETTER_AUTH_SECRET`     | ✅ 設定済み                             |
-| `BETTER_AUTH_URL`        | ✅ 設定済み                             |
-| `CORS_ORIGIN`            | ✅ 設定済み（`http://localhost:30000`） |
-| `PORT`                   | ✅ `3000`                               |
-| `STORAGE_*`              | ✅ 設定済み                             |
-| `GOOGLE_CLIENT_*`        | ✅ 設定済み                             |
-| `GITHUB_CLIENT_*`        | ✅ 設定済み                             |
-| `OPENAI_API_KEY`         | ✅ 設定済み                             |
-| `ANTHROPIC_API_KEY`      | ✅ 設定済み                             |
-| `GOOGLE_AI_API_KEY`      | ✅ 設定済み                             |
-| `GOOGLE_CUSTOM_SEARCH_*` | ✅ 設定済み                             |
-| `POLAR_ACCESS_TOKEN`     | ✅ 設定済み                             |
-| `POLAR_WEBHOOK_SECRET`   | ✅ 設定済み                             |
+| 変数                     | 状態                                                              |
+| ------------------------ | ----------------------------------------------------------------- |
+| `DATABASE_URL`           | ✅ 設定済み（Railway 参照）                                       |
+| `REDIS_URL`              | ✅ 設定済み（Railway 参照）                                       |
+| `BETTER_AUTH_SECRET`     | ✅ 設定済み                                                       |
+| `BETTER_AUTH_URL`        | ✅ 設定済み                                                       |
+| `CORS_ORIGIN`            | ✅ 設定済み（`https://dev.zedi-note.app,http://localhost:30000`） |
+| `PORT`                   | ✅ `3000`                                                         |
+| `STORAGE_*`              | ✅ 設定済み                                                       |
+| `GOOGLE_CLIENT_*`        | ✅ 設定済み                                                       |
+| `GITHUB_CLIENT_*`        | ✅ 設定済み                                                       |
+| `OPENAI_API_KEY`         | ✅ 設定済み                                                       |
+| `ANTHROPIC_API_KEY`      | ✅ 設定済み                                                       |
+| `GOOGLE_AI_API_KEY`      | ✅ 設定済み                                                       |
+| `GOOGLE_CUSTOM_SEARCH_*` | ✅ 設定済み                                                       |
+| `POLAR_ACCESS_TOKEN`     | ✅ 設定済み                                                       |
+| `POLAR_WEBHOOK_SECRET`   | ✅ 設定済み                                                       |
 
 ### 完了済みタスク（タスク 0〜7）
 
@@ -164,13 +164,33 @@ npm run dev
 
 ### タスク 0: CORS_ORIGIN の修正
 
-現在 `http://localhost:5173` が設定されているが、フロントエンドの開発サーバーはポート `30000` で起動する（`vite.config.ts` のデフォルト値）。
+開発環境では **Cloudflare Pages（dev.zedi-note.app）** と **ローカル開発（localhost:30000）** の両方から API にアクセスできるように、`CORS_ORIGIN` をカンマ区切りで指定する。
+
+**方法 A: CLI で設定**
 
 ```bash
 railway link -p Zedi -e development
 
-railway variable set "CORS_ORIGIN=http://localhost:30000" --service api
+railway variable set "CORS_ORIGIN=https://dev.zedi-note.app,http://localhost:30000" --service api
 ```
+
+**方法 B: CLI が使えない場合（ダッシュボードで設定）**
+
+CLI で `railway variable set` を実行しても出力がなく終了する場合は、Railway ダッシュボードから設定する。
+
+1. ブラウザで [railway.com](https://railway.com) にログインする。
+2. プロジェクト **Zedi** を開く。
+3. 左上の環境切り替えで **development** を選択する。
+4. キャンバス上で **api** サービスをクリックする。
+5. 上部タブの **Variables** を開く。
+6. 既存の `CORS_ORIGIN` がある場合は行の右側の **⋯** → **Edit** で値を変更する。ない場合は **New Variable** をクリックする。
+7. 変数名: `CORS_ORIGIN`  
+   値: `https://dev.zedi-note.app,http://localhost:30000`  
+   （カンマ区切り、スペースは入れてもよい）
+8. **Add** または **Update** で保存する。
+9. 画面に表示される **Staged changes** を確認し、**Deploy**（または **Redeploy**）を実行する。変数変更後は自動で再デプロイされる場合もある。
+
+これで `https://dev.zedi-note.app` と `http://localhost:30000` の両方から API にアクセスできる。
 
 ---
 
@@ -337,26 +357,26 @@ railway variable set \
 
 タスク 0〜7 完了後、`api` サービスの環境変数は以下の状態になっている:
 
-| 変数                             | 値の種別                                      |
-| -------------------------------- | --------------------------------------------- |
-| `PORT`                           | `3000`                                        |
-| `DATABASE_URL`                   | Railway 内部参照（自動）                      |
-| `REDIS_URL`                      | Railway 内部参照（自動）                      |
-| `BETTER_AUTH_SECRET`             | ランダム文字列（設定済み）                    |
-| `BETTER_AUTH_URL`                | `https://api-development-b126.up.railway.app` |
-| `CORS_ORIGIN`                    | `http://localhost:30000`                      |
-| `STORAGE_ENDPOINT`               | Storage Bucket のエンドポイント               |
-| `STORAGE_ACCESS_KEY`             | Storage Bucket のアクセスキー                 |
-| `STORAGE_SECRET_KEY`             | Storage Bucket のシークレットキー             |
-| `STORAGE_BUCKET_NAME`            | Storage Bucket のバケット名                   |
-| `GOOGLE_CLIENT_ID`               | Google OAuth Client ID                        |
-| `GOOGLE_CLIENT_SECRET`           | Google OAuth Client Secret                    |
-| `GITHUB_CLIENT_ID`               | GitHub OAuth Client ID                        |
-| `GITHUB_CLIENT_SECRET`           | GitHub OAuth Client Secret                    |
-| `OPENAI_API_KEY`                 | OpenAI API キー                               |
-| `ANTHROPIC_API_KEY`              | Anthropic API キー                            |
-| `GOOGLE_AI_API_KEY`              | Google AI API キー                            |
-| `GOOGLE_CUSTOM_SEARCH_API_KEY`   | Google Custom Search API キー                 |
-| `GOOGLE_CUSTOM_SEARCH_ENGINE_ID` | Google Custom Search Engine ID                |
-| `POLAR_ACCESS_TOKEN`             | Polar アクセストークン                        |
-| `POLAR_WEBHOOK_SECRET`           | Polar Webhook シークレット                    |
+| 変数                             | 値の種別                                           |
+| -------------------------------- | -------------------------------------------------- |
+| `PORT`                           | `3000`                                             |
+| `DATABASE_URL`                   | Railway 内部参照（自動）                           |
+| `REDIS_URL`                      | Railway 内部参照（自動）                           |
+| `BETTER_AUTH_SECRET`             | ランダム文字列（設定済み）                         |
+| `BETTER_AUTH_URL`                | `https://api-development-b126.up.railway.app`      |
+| `CORS_ORIGIN`                    | `https://dev.zedi-note.app,http://localhost:30000` |
+| `STORAGE_ENDPOINT`               | Storage Bucket のエンドポイント                    |
+| `STORAGE_ACCESS_KEY`             | Storage Bucket のアクセスキー                      |
+| `STORAGE_SECRET_KEY`             | Storage Bucket のシークレットキー                  |
+| `STORAGE_BUCKET_NAME`            | Storage Bucket のバケット名                        |
+| `GOOGLE_CLIENT_ID`               | Google OAuth Client ID                             |
+| `GOOGLE_CLIENT_SECRET`           | Google OAuth Client Secret                         |
+| `GITHUB_CLIENT_ID`               | GitHub OAuth Client ID                             |
+| `GITHUB_CLIENT_SECRET`           | GitHub OAuth Client Secret                         |
+| `OPENAI_API_KEY`                 | OpenAI API キー                                    |
+| `ANTHROPIC_API_KEY`              | Anthropic API キー                                 |
+| `GOOGLE_AI_API_KEY`              | Google AI API キー                                 |
+| `GOOGLE_CUSTOM_SEARCH_API_KEY`   | Google Custom Search API キー                      |
+| `GOOGLE_CUSTOM_SEARCH_ENGINE_ID` | Google Custom Search Engine ID                     |
+| `POLAR_ACCESS_TOKEN`             | Polar アクセストークン                             |
+| `POLAR_WEBHOOK_SECRET`           | Polar Webhook シークレット                         |

--- a/docs/specs/railway-remaining-tasks.md
+++ b/docs/specs/railway-remaining-tasks.md
@@ -576,11 +576,11 @@ railway variable set \
   --skip-deploys
 ```
 
-| 変数                 | development                  | production                  |
-| -------------------- | ---------------------------- | --------------------------- |
-| `BETTER_AUTH_URL`    | `https://<dev-api-ドメイン>` | `https://api.zedi-note.app` |
-| `CORS_ORIGIN`        | `http://localhost:5173`      | `https://zedi-note.app`     |
-| `BETTER_AUTH_SECRET` | 開発用の値                   | **別のランダム値**          |
+| 変数                 | development                                        | production                  |
+| -------------------- | -------------------------------------------------- | --------------------------- |
+| `BETTER_AUTH_URL`    | `https://<dev-api-ドメイン>`                       | `https://api.zedi-note.app` |
+| `CORS_ORIGIN`        | `https://dev.zedi-note.app,http://localhost:30000` | `https://zedi-note.app`     |
+| `BETTER_AUTH_SECRET` | 開発用の値                                         | **別のランダム値**          |
 
 ### 6.5 OAuth コールバック URL の追加
 

--- a/server/api/src/app.ts
+++ b/server/api/src/app.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { getAllowedOrigins, isWildcardCors } from "./lib/cors.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { dbMiddleware } from "./middleware/db.js";
 import { redisMiddleware } from "./middleware/redis.js";
@@ -30,23 +31,19 @@ import subscriptionManageRoutes from "./routes/subscriptionManage.js";
 export function createApp(): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
 
-  const rawCorsOrigin = process.env.CORS_ORIGIN?.trim() || "";
-  const isWildcard = !rawCorsOrigin || rawCorsOrigin === "*";
+  const wildcard = isWildcardCors();
+  const allowedOrigins = getAllowedOrigins();
 
   app.use(
     "*",
     cors({
       origin: (origin) => {
-        if (isWildcard) return "*";
-        const allowed = rawCorsOrigin
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean);
-        return origin && allowed.includes(origin) ? origin : allowed[0];
+        if (wildcard) return "*";
+        return origin && allowedOrigins.includes(origin) ? origin : allowedOrigins[0];
       },
       allowMethods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
       allowHeaders: ["Content-Type", "Authorization"],
-      credentials: !isWildcard,
+      credentials: !wildcard,
       maxAge: 86400,
     }),
   );

--- a/server/api/src/lib/cors.ts
+++ b/server/api/src/lib/cors.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared CORS_ORIGIN parsing. Use this instead of duplicating logic in app.ts and routes.
+ */
+export function getAllowedOrigins(): string[] {
+  const raw = process.env.CORS_ORIGIN?.trim() || "";
+  if (!raw || raw === "*") return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function isWildcardCors(): boolean {
+  const raw = process.env.CORS_ORIGIN?.trim() || "";
+  return !raw || raw === "*";
+}

--- a/server/api/src/routes/checkout.ts
+++ b/server/api/src/routes/checkout.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { Polar } from "@polar-sh/sdk";
+import { getAllowedOrigins } from "../lib/cors.js";
 import { authRequired } from "../middleware/auth.js";
 import { getEnv } from "../lib/env.js";
 import type { AppEnv } from "../types/index.js";
@@ -19,16 +20,14 @@ app.post("/checkout", authRequired, async (c) => {
     server: process.env.NODE_ENV === "production" ? "production" : "sandbox",
   });
 
-  const rawCors = process.env.CORS_ORIGIN?.trim() || "";
-  const allowedOrigins =
-    rawCors && rawCors !== "*"
-      ? rawCors
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean)
-      : [];
+  const allowedOrigins = getAllowedOrigins();
   const origin = c.req.header("Origin");
-  const baseUrl = origin && allowedOrigins.includes(origin) ? origin : allowedOrigins[0];
+  let baseUrl: string | undefined;
+  if (origin && allowedOrigins.includes(origin)) {
+    baseUrl = origin;
+  } else if (!origin && allowedOrigins.length > 0) {
+    baseUrl = allowedOrigins[0];
+  }
   const successUrl = baseUrl ? `${baseUrl}/pricing?checkout=success` : undefined;
 
   const checkout = await polar.checkouts.create({

--- a/server/api/src/routes/checkout.ts
+++ b/server/api/src/routes/checkout.ts
@@ -19,9 +19,17 @@ app.post("/checkout", authRequired, async (c) => {
     server: process.env.NODE_ENV === "production" ? "production" : "sandbox",
   });
 
-  const corsOrigin = process.env.CORS_ORIGIN;
-  const successUrl =
-    corsOrigin && corsOrigin !== "*" ? `${corsOrigin}/pricing?checkout=success` : undefined;
+  const rawCors = process.env.CORS_ORIGIN?.trim() || "";
+  const allowedOrigins =
+    rawCors && rawCors !== "*"
+      ? rawCors
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+  const origin = c.req.header("Origin");
+  const baseUrl = origin && allowedOrigins.includes(origin) ? origin : allowedOrigins[0];
+  const successUrl = baseUrl ? `${baseUrl}/pricing?checkout=success` : undefined;
 
   const checkout = await polar.checkouts.create({
     products: [productId],


### PR DESCRIPTION
## 概要
develop 環境で `dev.zedi-note.app` と `localhost:30000` の両方から API にアクセスできるよう、CORS_ORIGIN を複数オリジン対応にし、ドキュメントを更新しました。state_mismatch 認証エラー対策の一環です。

## 変更内容
- **server/api/src/routes/checkout.ts**: `CORS_ORIGIN` がカンマ区切りで複数指定されている場合、Polar の successUrl をリクエストの `Origin` から決定するよう変更
- **docs/specs/railway-dev-setup.md**: CORS_ORIGIN を `https://dev.zedi-note.app,http://localhost:30000` に設定する手順を記載。CLI が使えない場合の **ダッシュボードでの設定手順** を追加
- **docs/specs/railway-remaining-tasks.md**: development の CORS_ORIGIN 推奨値を上記に更新

## マージ先
`develop`

Made with [Cursor](https://cursor.com)