### PR TITLE
fix(auth): dev環境のOAuth state mismatchを解消

### DIFF
--- a/server/api/src/auth.ts
+++ b/server/api/src/auth.ts
@@ -38,8 +38,7 @@ export const auth = betterAuth({
 
   advanced: {
     defaultCookieAttributes: (() => {
-      const isHttps = getEnv("BETTER_AUTH_URL").startsWith("https://");
-      return isHttps
+      return new URL(getEnv("BETTER_AUTH_URL")).protocol === "https:"
         ? { sameSite: "none" as const, secure: true }
         : { sameSite: "lax" as const, secure: false };
     })(),

--- a/server/api/src/auth.ts
+++ b/server/api/src/auth.ts
@@ -38,8 +38,8 @@ export const auth = betterAuth({
 
   advanced: {
     defaultCookieAttributes: (() => {
-      const isProduction = process.env.NODE_ENV === "production";
-      return isProduction
+      const isHttps = getEnv("BETTER_AUTH_URL").startsWith("https://");
+      return isHttps
         ? { sameSite: "none" as const, secure: true }
         : { sameSite: "lax" as const, secure: false };
     })(),


### PR DESCRIPTION
## 概要

dev環境（dev.zedi-note.app / localhost:30000）で認証時に発生していた Better Auth の `State mismatch: State not persisted correctly` エラーを解消するため、クッキー属性の判定を `NODE_ENV` から `BETTER_AUTH_URL` の HTTPS 有無に変更しました。

## 変更点

- `server/api/src/auth.ts`: `advanced.defaultCookieAttributes` の判定を `process.env.NODE_ENV === "production"` から `getEnv("BETTER_AUTH_URL").startsWith("https://")` に変更
- Railway dev では `NODE_ENV` が未設定のため `sameSite: lax` となり、クロスオリジンで state cookie が保存されず OAuth が失敗していた問題を修正

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. この変更を develop にマージし、Railway dev にデプロイされることを確認
2. https://dev.zedi-note.app から Google/GitHub でサインインし、認証が完了することを確認
3. 必要に応じて localhost:30000 からも同様に確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

なし

Made with [Cursor](https://cursor.com)