### PR TITLE
fix: ノートAPI残存不一致を修正 (members/pages エンドポイント)

### DIFF
--- a/server/api/src/__tests__/routes/notes/members.test.ts
+++ b/server/api/src/__tests__/routes/notes/members.test.ts
@@ -181,11 +181,17 @@ describe("DELETE /api/notes/:noteId/members/:memberEmail", () => {
 // ── PUT /api/notes/:noteId/members/:memberEmail ─────────────────────────────
 
 describe("PUT /api/notes/:noteId/members/:memberEmail", () => {
-  it("should update member role and return { updated: true }", async () => {
+  it("should update member role and return updated NoteMemberItem", async () => {
     const mockNote = createMockNote();
+    const updatedRow = createMockMember({
+      noteId: NOTE_ID,
+      memberEmail: OTHER_USER_EMAIL,
+      role: "editor",
+    });
     const { app } = createTestApp([
       [mockNote], // requireNoteOwner
       [], // update noteMembers
+      [updatedRow], // select updated member
     ]);
 
     const encoded = encodeURIComponent(OTHER_USER_EMAIL);
@@ -197,7 +203,28 @@ describe("PUT /api/notes/:noteId/members/:memberEmail", () => {
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
-    expect(body).toEqual({ updated: true });
+    expect(body).toMatchObject({
+      note_id: NOTE_ID,
+      member_email: OTHER_USER_EMAIL,
+      role: "editor",
+      invited_by_user_id: TEST_USER_ID,
+    });
+    expect(body).toHaveProperty("created_at");
+    expect(body).toHaveProperty("updated_at");
+  });
+
+  it("should return 400 when role is missing", async () => {
+    const mockNote = createMockNote();
+    const { app } = createTestApp([[mockNote]]);
+
+    const encoded = encodeURIComponent(OTHER_USER_EMAIL);
+    const res = await app.request(`/api/notes/${NOTE_ID}/members/${encoded}`, {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
   });
 
   it("should return 403 when non-owner tries to update", async () => {
@@ -238,8 +265,16 @@ describe("PUT /api/notes/:noteId/members/:memberEmail", () => {
 describe("GET /api/notes/:noteId/members", () => {
   it("should return a flat array of NoteMemberItem with snake_case keys", async () => {
     const mockNote = createMockNote();
-    const member1 = createMockMember({ member_email: OTHER_USER_EMAIL, role: "editor" });
-    const member2 = createMockMember({ member_email: "third@example.com", role: "viewer" });
+    const member1 = createMockMember({
+      noteId: NOTE_ID,
+      memberEmail: OTHER_USER_EMAIL,
+      role: "editor",
+    });
+    const member2 = createMockMember({
+      noteId: NOTE_ID,
+      memberEmail: "third@example.com",
+      role: "viewer",
+    });
 
     const { app } = createTestApp([
       [mockNote], // getNoteRole (owner)
@@ -258,13 +293,22 @@ describe("GET /api/notes/:noteId/members", () => {
 
     const first = body[0];
     expect(first).toBeDefined();
-    expect(first).toHaveProperty("note_id");
-    expect(first).toHaveProperty("member_email");
-    expect(first).toHaveProperty("role");
-    expect(first).toHaveProperty("invited_by_user_id");
+    expect(first).toMatchObject({
+      note_id: NOTE_ID,
+      member_email: OTHER_USER_EMAIL,
+      role: "editor",
+      invited_by_user_id: TEST_USER_ID,
+    });
     expect(first).toHaveProperty("created_at");
     expect(first).toHaveProperty("updated_at");
     expect(first).not.toHaveProperty("members");
+
+    const second = body[1];
+    expect(second).toMatchObject({
+      note_id: NOTE_ID,
+      member_email: "third@example.com",
+      role: "viewer",
+    });
   });
 
   it("should return empty array when note has no members", async () => {

--- a/server/api/src/__tests__/routes/notes/members.test.ts
+++ b/server/api/src/__tests__/routes/notes/members.test.ts
@@ -178,10 +178,65 @@ describe("DELETE /api/notes/:noteId/members/:memberEmail", () => {
   });
 });
 
+// ── PUT /api/notes/:noteId/members/:memberEmail ─────────────────────────────
+
+describe("PUT /api/notes/:noteId/members/:memberEmail", () => {
+  it("should update member role and return { updated: true }", async () => {
+    const mockNote = createMockNote();
+    const { app } = createTestApp([
+      [mockNote], // requireNoteOwner
+      [], // update noteMembers
+    ]);
+
+    const encoded = encodeURIComponent(OTHER_USER_EMAIL);
+    const res = await app.request(`/api/notes/${NOTE_ID}/members/${encoded}`, {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ role: "editor" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toEqual({ updated: true });
+  });
+
+  it("should return 403 when non-owner tries to update", async () => {
+    const mockNote = createMockNote({ ownerId: OTHER_USER_ID });
+    const { app } = createTestApp([
+      [mockNote], // requireNoteOwner (owner mismatch)
+    ]);
+
+    const encoded = encodeURIComponent(OTHER_USER_EMAIL);
+    const res = await app.request(`/api/notes/${NOTE_ID}/members/${encoded}`, {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ role: "editor" }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("should return 400 for invalid role", async () => {
+    const mockNote = createMockNote();
+    const { app } = createTestApp([
+      [mockNote], // requireNoteOwner
+    ]);
+
+    const encoded = encodeURIComponent(OTHER_USER_EMAIL);
+    const res = await app.request(`/api/notes/${NOTE_ID}/members/${encoded}`, {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ role: "admin" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
 // ── GET /api/notes/:noteId/members ──────────────────────────────────────────
 
 describe("GET /api/notes/:noteId/members", () => {
-  it("should return members in { members: [...] } format", async () => {
+  it("should return a flat array of NoteMemberItem with snake_case keys", async () => {
     const mockNote = createMockNote();
     const member1 = createMockMember({ member_email: OTHER_USER_EMAIL, role: "editor" });
     const member2 = createMockMember({ member_email: "third@example.com", role: "viewer" });
@@ -196,17 +251,20 @@ describe("GET /api/notes/:noteId/members", () => {
     });
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { members: Record<string, unknown>[] };
+    const body = (await res.json()) as Record<string, unknown>[];
 
-    expect(body).toHaveProperty("members");
-    expect(body.members).toHaveLength(2);
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(2);
 
-    const first = body.members[0];
+    const first = body[0];
     expect(first).toBeDefined();
-    expect(first).toHaveProperty("member_email", OTHER_USER_EMAIL);
-    expect(first).toHaveProperty("role", "editor");
-    expect(first).toHaveProperty("invited_by");
+    expect(first).toHaveProperty("note_id");
+    expect(first).toHaveProperty("member_email");
+    expect(first).toHaveProperty("role");
+    expect(first).toHaveProperty("invited_by_user_id");
     expect(first).toHaveProperty("created_at");
+    expect(first).toHaveProperty("updated_at");
+    expect(first).not.toHaveProperty("members");
   });
 
   it("should return empty array when note has no members", async () => {
@@ -220,8 +278,9 @@ describe("GET /api/notes/:noteId/members", () => {
       headers: authHeaders(),
     });
 
-    const body = (await res.json()) as { members: unknown[] };
-    expect(body.members).toHaveLength(0);
+    const body = (await res.json()) as unknown[];
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(0);
   });
 
   it("should return 403 for private note accessed by non-member", async () => {

--- a/server/api/src/__tests__/routes/notes/pages.test.ts
+++ b/server/api/src/__tests__/routes/notes/pages.test.ts
@@ -24,6 +24,7 @@ vi.mock("../../../middleware/auth.js", () => ({
 }));
 
 import {
+  TEST_USER_ID,
   OTHER_USER_ID,
   createMockNote,
   createMockPageListRow,
@@ -40,7 +41,7 @@ describe("POST /api/notes/:noteId/pages", () => {
     const mockNote = createMockNote();
     const { app } = createTestApp([
       [mockNote], // getNoteRole → findActiveNoteById (owner)
-      [{ id: "pg-new" }], // page exists check
+      [{ id: "pg-new", ownerId: TEST_USER_ID }], // page exists check
       [{ max: 2 }], // maxOrder query
       [], // insert notePages
       [], // update notes.updatedAt
@@ -59,7 +60,13 @@ describe("POST /api/notes/:noteId/pages", () => {
 
   it("should use provided sort_order when specified", async () => {
     const mockNote = createMockNote();
-    const { app } = createTestApp([[mockNote], [{ id: "pg-new" }], [{ max: 5 }], [], []]);
+    const { app } = createTestApp([
+      [mockNote],
+      [{ id: "pg-new", ownerId: TEST_USER_ID }],
+      [{ max: 5 }],
+      [],
+      [],
+    ]);
 
     const res = await app.request(`/api/notes/${NOTE_ID}/pages`, {
       method: "POST",
@@ -71,7 +78,49 @@ describe("POST /api/notes/:noteId/pages", () => {
     expect(body).toEqual({ added: true, sort_order: 10 });
   });
 
-  it("should return 400 when page_id is missing", async () => {
+  it("should accept camelCase pageId as alias for page_id", async () => {
+    const mockNote = createMockNote();
+    const { app } = createTestApp([
+      [mockNote], // getNoteRole → findActiveNoteById (owner)
+      [{ id: "pg-camel", ownerId: TEST_USER_ID }], // page exists check
+      [{ max: 0 }], // maxOrder query
+      [], // insert notePages
+      [], // update notes.updatedAt
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/pages`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ pageId: "pg-camel" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty("added", true);
+  });
+
+  it("should create a new page when title is provided without page_id", async () => {
+    const mockNote = createMockNote();
+    const { app } = createTestApp([
+      [mockNote], // getNoteRole
+      [{ id: "pg-created" }], // insert pages → returning
+      [{ max: 0 }], // maxOrder query
+      [], // insert notePages
+      [], // update notes.updatedAt
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/pages`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ title: "New Page" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty("added", true);
+  });
+
+  it("should return 400 when neither page_id nor title is provided", async () => {
     const mockNote = createMockNote();
     const { app } = createTestApp([
       [mockNote], // getNoteRole

--- a/server/api/src/__tests__/routes/notes/setup.ts
+++ b/server/api/src/__tests__/routes/notes/setup.ts
@@ -67,10 +67,13 @@ export function createMockPageListRow(overrides: Record<string, unknown> = {}) {
 
 export function createMockMember(overrides: Record<string, unknown> = {}) {
   return {
-    member_email: OTHER_USER_EMAIL,
+    noteId: "note-test-001",
+    memberEmail: OTHER_USER_EMAIL,
     role: "viewer",
-    invited_by: TEST_USER_ID,
-    created_at: new Date("2026-01-01T00:00:00Z"),
+    invitedByUserId: TEST_USER_ID,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    member_email: OTHER_USER_EMAIL,
     ...overrides,
   };
 }

--- a/server/api/src/__tests__/routes/notes/setup.ts
+++ b/server/api/src/__tests__/routes/notes/setup.ts
@@ -65,6 +65,7 @@ export function createMockPageListRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
+/** Mock row shape matches DB select (camelCase). Route maps to snake_case in response. */
 export function createMockMember(overrides: Record<string, unknown> = {}) {
   return {
     noteId: "note-test-001",
@@ -73,7 +74,6 @@ export function createMockMember(overrides: Record<string, unknown> = {}) {
     invitedByUserId: TEST_USER_ID,
     createdAt: new Date("2026-01-01T00:00:00Z"),
     updatedAt: new Date("2026-01-01T00:00:00Z"),
-    member_email: OTHER_USER_EMAIL,
     ...overrides,
   };
 }

--- a/server/api/src/routes/notes/members.ts
+++ b/server/api/src/routes/notes/members.ts
@@ -2,6 +2,7 @@
  * ノートメンバー管理ルート
  *
  * POST   /:noteId/members                 — メンバー追加
+ * PUT    /:noteId/members/:memberEmail     — メンバーロール更新
  * DELETE /:noteId/members/:memberEmail     — メンバー削除
  * GET    /:noteId/members                  — メンバー一覧
  */
@@ -15,6 +16,14 @@ import type { NoteMemberRole } from "./types.js";
 import { requireNoteOwner, getNoteRole } from "./helpers.js";
 
 const app = new Hono<AppEnv>();
+
+function validateMemberRole(role: string | undefined): NoteMemberRole {
+  if (role === undefined) return "viewer";
+  if (role !== "viewer" && role !== "editor") {
+    throw new HTTPException(400, { message: "role must be 'viewer' or 'editor'" });
+  }
+  return role;
+}
 
 // ── POST /:noteId/members ───────────────────────────────────────────────────
 app.post("/:noteId/members", authRequired, async (c) => {
@@ -34,10 +43,7 @@ app.post("/:noteId/members", authRequired, async (c) => {
     throw new HTTPException(400, { message: "member_email is required" });
   }
 
-  if (body.role !== undefined && body.role !== "viewer" && body.role !== "editor") {
-    throw new HTTPException(400, { message: "role must be 'viewer' or 'editor'" });
-  }
-  const memberRole: NoteMemberRole = (body.role as NoteMemberRole) ?? "viewer";
+  const memberRole = validateMemberRole(body.role);
 
   await db
     .insert(noteMembers)
@@ -57,6 +63,32 @@ app.post("/:noteId/members", authRequired, async (c) => {
     });
 
   return c.json({ added: true });
+});
+
+// ── PUT /:noteId/members/:memberEmail ───────────────────────────────────────
+app.put("/:noteId/members/:memberEmail", authRequired, async (c) => {
+  const noteId = c.req.param("noteId");
+  const memberEmail = decodeURIComponent(c.req.param("memberEmail")).trim().toLowerCase();
+  const userId = c.get("userId");
+  const db = c.get("db");
+
+  await requireNoteOwner(db, noteId, userId, "Only the owner can update members");
+
+  const body = await c.req.json<{ role: string }>();
+  const memberRole = validateMemberRole(body.role);
+
+  await db
+    .update(noteMembers)
+    .set({ role: memberRole, updatedAt: new Date() })
+    .where(
+      and(
+        eq(noteMembers.noteId, noteId),
+        eq(noteMembers.memberEmail, memberEmail),
+        eq(noteMembers.isDeleted, false),
+      ),
+    );
+
+  return c.json({ updated: true });
 });
 
 // ── DELETE /:noteId/members/:memberEmail ─────────────────────────────────────
@@ -91,16 +123,27 @@ app.get("/:noteId/members", authRequired, async (c) => {
 
   const result = await db
     .select({
-      member_email: noteMembers.memberEmail,
+      noteId: noteMembers.noteId,
+      memberEmail: noteMembers.memberEmail,
       role: noteMembers.role,
-      invited_by: noteMembers.invitedByUserId,
-      created_at: noteMembers.createdAt,
+      invitedByUserId: noteMembers.invitedByUserId,
+      createdAt: noteMembers.createdAt,
+      updatedAt: noteMembers.updatedAt,
     })
     .from(noteMembers)
     .where(and(eq(noteMembers.noteId, noteId), eq(noteMembers.isDeleted, false)))
     .orderBy(asc(noteMembers.createdAt));
 
-  return c.json({ members: result });
+  return c.json(
+    result.map((m) => ({
+      note_id: m.noteId,
+      member_email: m.memberEmail,
+      role: m.role,
+      invited_by_user_id: m.invitedByUserId,
+      created_at: m.createdAt,
+      updated_at: m.updatedAt,
+    })),
+  );
 });
 
 export default app;

--- a/server/api/src/routes/notes/members.ts
+++ b/server/api/src/routes/notes/members.ts
@@ -74,7 +74,10 @@ app.put("/:noteId/members/:memberEmail", authRequired, async (c) => {
 
   await requireNoteOwner(db, noteId, userId, "Only the owner can update members");
 
-  const body = await c.req.json<{ role: string }>();
+  const body = await c.req.json<{ role?: string }>();
+  if (body.role === undefined || body.role === null) {
+    throw new HTTPException(400, { message: "role is required" });
+  }
   const memberRole = validateMemberRole(body.role);
 
   await db
@@ -88,7 +91,35 @@ app.put("/:noteId/members/:memberEmail", authRequired, async (c) => {
       ),
     );
 
-  return c.json({ updated: true });
+  const [updated] = await db
+    .select({
+      noteId: noteMembers.noteId,
+      memberEmail: noteMembers.memberEmail,
+      role: noteMembers.role,
+      invitedByUserId: noteMembers.invitedByUserId,
+      createdAt: noteMembers.createdAt,
+      updatedAt: noteMembers.updatedAt,
+    })
+    .from(noteMembers)
+    .where(
+      and(
+        eq(noteMembers.noteId, noteId),
+        eq(noteMembers.memberEmail, memberEmail),
+        eq(noteMembers.isDeleted, false),
+      ),
+    )
+    .limit(1);
+  if (!updated) {
+    throw new HTTPException(404, { message: "Member not found" });
+  }
+  return c.json({
+    note_id: updated.noteId,
+    member_email: updated.memberEmail,
+    role: updated.role,
+    invited_by_user_id: updated.invitedByUserId,
+    created_at: updated.createdAt,
+    updated_at: updated.updatedAt,
+  });
 });
 
 // ── DELETE /:noteId/members/:memberEmail ─────────────────────────────────────

--- a/server/api/src/routes/notes/pages.ts
+++ b/server/api/src/routes/notes/pages.ts
@@ -36,7 +36,9 @@ app.post("/:noteId/pages", authRequired, async (c) => {
     sort_order?: number;
   }>();
 
-  const pageId = body.page_id ?? body.pageId;
+  const rawPageId = body.page_id ?? body.pageId;
+  const pageId =
+    typeof rawPageId === "string" && rawPageId.trim() !== "" ? rawPageId.trim() : undefined;
 
   if (!pageId && !body.title) {
     throw new HTTPException(400, { message: "page_id or title is required" });

--- a/server/api/src/routes/notes/pages.ts
+++ b/server/api/src/routes/notes/pages.ts
@@ -30,23 +30,44 @@ app.post("/:noteId/pages", authRequired, async (c) => {
   }
 
   const body = await c.req.json<{
-    page_id: string;
+    page_id?: string;
+    pageId?: string;
+    title?: string;
     sort_order?: number;
   }>();
 
-  if (!body.page_id) {
-    throw new HTTPException(400, { message: "page_id is required" });
+  const pageId = body.page_id ?? body.pageId;
+
+  if (!pageId && !body.title) {
+    throw new HTTPException(400, { message: "page_id or title is required" });
   }
 
-  const page = await db
-    .select({ id: pages.id, ownerId: pages.ownerId })
-    .from(pages)
-    .where(and(eq(pages.id, body.page_id), eq(pages.isDeleted, false)))
-    .limit(1);
+  let targetPageId: string;
 
-  const firstPage = page[0];
-  if (!firstPage) throw new HTTPException(404, { message: "Page not found" });
-  if (firstPage.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
+  if (pageId) {
+    const page = await db
+      .select({ id: pages.id, ownerId: pages.ownerId })
+      .from(pages)
+      .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
+      .limit(1);
+
+    const firstPage = page[0];
+    if (!firstPage) throw new HTTPException(404, { message: "Page not found" });
+    if (firstPage.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
+    targetPageId = firstPage.id;
+  } else {
+    const created = await db
+      .insert(pages)
+      .values({
+        ownerId: userId,
+        title: body.title ?? null,
+      })
+      .returning();
+
+    const newPage = created[0];
+    if (!newPage) throw new HTTPException(500, { message: "Failed to create page" });
+    targetPageId = newPage.id;
+  }
 
   const maxOrder = await db
     .select({ max: sql<number>`COALESCE(MAX(${notePages.sortOrder}), 0)` })
@@ -59,7 +80,7 @@ app.post("/:noteId/pages", authRequired, async (c) => {
     .insert(notePages)
     .values({
       noteId,
-      pageId: body.page_id,
+      pageId: targetPageId,
       addedByUserId: userId,
       sortOrder,
     })


### PR DESCRIPTION
## 概要

Issue #198 の主要5バグは PR #199 で修正済みだが、members/pages サブルートにサーバー/クライアント間のレスポンス不一致が残存していたため修正。

## 変更点

- `GET /:noteId/members`: `{ members: [...] }` ラッパーを廃止し、クライアントの `NoteMemberItem[]` 型に合致するフラット配列を返すように変更。フィールド名を `invited_by` → `invited_by_user_id` に修正し、`note_id` / `updated_at` を追加
- `POST /:noteId/pages`: `page_id` (snake_case) に加え `pageId` (camelCase) も受け付けるように修正。`title` のみ指定でページ新規作成＋ノートへの追加にも対応
- `PUT /:noteId/members/:email`: クライアントが呼び出していたメンバーロール更新エンドポイントを新規追加
- テストのモックデータに `ownerId` を追加し、ページ所有権チェックでの偽陽性 403 を修正

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `cd server/api && npx vitest run` で全49テストがパスすることを確認
2. `bun run lint` でエラーがないことを確認
3. ノート作成 → 詳細表示 → ページ追加 → メンバー管理の一連フローが動作することを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #198

Made with [Cursor](https://cursor.com)