### PR TITLE
ヘッダーAIボタンにグラデーション枠とテキストグラデーションを追加

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
         "react-resizable-panels": "^4.7.0",
         "react-router-dom": "^6.30.1",
         "recharts": "^2.15.4",
+        "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "sql.js": "^1.13.0",
@@ -1416,7 +1417,11 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hast-util-is-element": ["hast-util-is-element@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-to-text": ["hast-util-to-text@4.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "hast-util-is-element": "^3.0.0", "unist-util-find-after": "^5.0.0" } }, "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
@@ -1960,6 +1965,8 @@
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
+    "rehype-highlight": ["rehype-highlight@7.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-text": "^4.0.0", "lowlight": "^3.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA=="],
+
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
@@ -2149,6 +2156,8 @@
     "unenv": ["unenv@2.0.0-rc.14", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.1", "ohash": "^2.0.10", "pathe": "^2.0.3", "ufo": "^1.5.4" } }, "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unist-util-find-after": ["unist-util-find-after@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ=="],
 
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 

--- a/docs/pr-211-review-analysis.md
+++ b/docs/pr-211-review-analysis.md
@@ -1,0 +1,72 @@
+# PR #211 レビューコメント対応判断
+
+対象 PR: https://github.com/otomatty/zedi/pull/211
+
+---
+
+## コメントごとの分析
+
+### コメント #1: グラデーションクラスの定数化
+
+**投稿者:** @gemini-code-assist[bot]  
+**対象:** `src/components/layout/Header/AIChatButton.tsx` L30 付近  
+**指摘内容:** 「from-violet-500 via-fuchsia-500 to-blue-500」がコンポーネント内で4回繰り返されている。将来の変更と一貫性のため、定数に切り出すことを検討してほしい。
+
+**判断:** **対応する**  
+**理由:** 同一の文字列が4箇所に重複しており、色やグラデーションを変える場合に修正漏れが起きやすい。DRY に従い定数化すれば保守性が上がり、プロジェクト規約にも沿う。PR のスコープ内のリファクタとして妥当。
+
+**対応案:** コンポーネント外で `const AI_BUTTON_GRADIENT = "from-violet-500 via-fuchsia-500 to-blue-500"` を定義し、ラッパー div・button（開時）・ホバー用 div・span（閉時グラデーション）の4箇所で `${AI_BUTTON_GRADIENT}` または `bg-gradient-to-r ${AI_BUTTON_GRADIENT}` のように参照する。
+
+---
+
+### コメント #2: rounded-[calc(0.375rem-2px)] を rounded-sm に
+
+**投稿者:** @gemini-code-assist[bot]  
+**対象:** `src/components/layout/Header/AIChatButton.tsx` L33（および L40 のホバー用 div）  
+**指摘内容:** `rounded-[calc(0.375rem-2px)]` は `rounded-md` の値をハードコードしており、テーマの `borderRadius` が変わると意図しない表示になる。`tailwind.config.ts` に基づくと `rounded-sm` がより堅牢。
+
+**判断:** **対応する**  
+**理由:** 当リポジトリの `tailwind.config.ts` では `borderRadius` が `var(--radius)` ベースで定義されている（`md: "calc(var(--radius) - 2px)"`, `sm: "calc(var(--radius) - 4px)"`）。`index.css` で `--radius: 0.75rem`。現状の `0.375rem` はデフォルト Tailwind の rounded-md であり、このプロジェクトのテーマ値と一致していない。内側の角丸をテーマに合わせるなら、ラッパーが `rounded-md`（radius-2px）のとき内側を 2px 分小さくするには `rounded-sm`（radius-4px）が対応する。テーマ変更時も一貫した見た目になる。
+
+**対応案:** ボタンとホバー用 div の `rounded-[calc(0.375rem-2px)]` を `rounded-sm` に置き換える（2箇所）。
+
+---
+
+### コメント #3: text-md を標準のフォントサイズに
+
+**投稿者:** @Copilot  
+**対象:** `src/components/layout/Header/AIChatButton.tsx` L85  
+**指摘内容:** `text-md` は Tailwind の標準フォントサイズユーティリティではなく、このリポジトリの Tailwind 設定にも定義がないため、効果がない可能性がある。`text-sm` や `text-base` の使用を推奨。
+
+**判断:** **対応する**  
+**理由:** Tailwind のデフォルトには `text-md` はなく、`tailwind.config.ts` にも `fontSize` の拡張で `md` はない。そのためこのクラスは効いておらず、意図したフォントサイズになっていない。`text-sm` または `text-base` にすれば確実に反映される。
+
+**対応案:** 「AI」ラベルの `text-md` を `text-sm` に変更する（ヘッダー他要素とのバランスで `text-sm` を推奨。必要なら `text-base` でも可）。
+
+---
+
+### コメント #4: SVG linearGradient の id を useId() で一意に
+
+**投稿者:** @Copilot  
+**対象:** `src/components/layout/Header/AIChatButton.tsx` L47–50（`id="ai-sparkle-gradient"` と `stroke: url(#ai-sparkle-gradient)`）  
+**指摘内容:** `ai-sparkle-gradient` がハードコードされている。AIChatButton が複数箇所で使われると id が重複し invalid HTML になり、`url(#...)` の解決が不安定になる。インスタンスごとに `useId()` で id を生成し、`<linearGradient id={...}>` と `stroke: url(#${id})` の両方で使うことを推奨。
+
+**判断:** **対応する**  
+**理由:** AIChatButton は `Header`（`src/components/layout/Header/index.tsx`）と `PageEditorHeader`（`src/components/editor/PageEditor/PageEditorHeader.tsx`）の両方で使われている。エディタ画面ではメイン Header が隠れていても、レイアウトや将来の変更で同一ページに2インスタンスがマウントされる可能性がある。HTML では id の重複は invalid であり、SVG の `url(#id)` は最初に一致した id を参照するため、表示が意図しないものになるリスクがある。React 18 の `useId()` で一意 id を生成すれば安全で、実装コストも小さい。
+
+**対応案:** コンポーネント先頭で `const gradientId = useId();` を定義し、`<linearGradient id={gradientId}>` と `stroke: \`url(#${gradientId})\``に変更する。必要に応じて id に含まれる`:` を置換する（`gradientId.replace(/:/g, '')`など）。React の useId は通常`:r1:`のような形式なので、SVG id では`gradientId.replaceAll(':', '')` を使うと安全。
+
+---
+
+## サマリー
+
+| #   | 指摘内容                                  | 判断     | 理由（一言）                                                    |
+| --- | ----------------------------------------- | -------- | --------------------------------------------------------------- |
+| 1   | グラデーションクラスを定数に切り出す      | 対応する | 4箇所の重複をやめ、保守性・一貫性を上げるため                   |
+| 2   | rounded-[calc(0.375rem-2px)] → rounded-sm | 対応する | プロジェクトの var(--radius) ベースのテーマと一致させるため     |
+| 3   | text-md → text-sm（または text-base）     | 対応する | text-md は未定義で効いていないため、確実に効くクラスにするため  |
+| 4   | SVG gradient id を useId() で一意に       | 対応する | 複数インスタンス時の id 重複を防ぎ、invalid HTML を解消するため |
+
+---
+
+以上を踏まえ、4件とも対応することを推奨します。

--- a/docs/specs/ai-chat-message-style-investigation.md
+++ b/docs/specs/ai-chat-message-style-investigation.md
@@ -1,0 +1,61 @@
+# AIチャット メッセージ表示スタイル 調査・改善案
+
+## 1. 現状の実装
+
+### 1.1 担当コンポーネント
+
+- `**src/components/ai-chat/AIChatMessage.tsx**`
+  - ユーザー／AI メッセージの表示
+  - AI メッセージは `getDisplayContent()` でアクションブロックを除去した Markdown を `ReactMarkdown` + `remarkGfm` でレンダリング
+  - ラッパー: `className="prose prose-sm dark:prose-invert max-w-none break-words"`
+
+### 1.2 問題点
+
+| 項目                     | 現状                                                                                                  | 仕様（ai-agent-chat-spec §3.1）                       |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| **Prose の有効化**       | `tailwind.config.ts` に `@tailwindcss/typography` が未登録のため、`prose` / `prose-sm` が効いていない | Markdown の見出し・リスト・コード・リンクを適切に表示 |
+| **コードブロック**       | シンタックスハイライトなし・コピーボタンなし                                                          | シンタックスハイライト + コピーボタン                 |
+| **チャット専用スタイル** | なし（prose も未適用のためブラウザデフォルトに近い）                                                  | メッセージバブル内で読みやすい余白・行間・フォント    |
+
+このため「メッセージのスタイルが読みにくい」という体感になっている。
+
+### 1.3 関連ファイル
+
+- `tailwind.config.ts` … 現状 `plugins: [tailwindcssAnimate]` のみ（typography 未使用）
+- `src/index.css` … `highlight.js/styles/github-dark.css` を import 済み（エディタ用）。チャットの ReactMarkdown では未使用
+- エディタは `.tiptap-editor` で見出し・リスト・コード・表などを細かくスタイル定義済み
+
+---
+
+## 2. 改善方針
+
+1. **Tailwind Typography の有効化**
+   `tailwind.config.ts` に `@tailwindcss/typography` を追加し、`prose` を効かせる。
+2. **チャット用 Prose の調整**
+   AI メッセージ用に、見出しサイズ・段落余白・行間・コードブロック余白などを抑えつつ、バブル内で読みやすいスタイルを追加（`index.css` の `.ai-chat-markdown` など）。
+3. **コードブロック**
+
+- `rehype-highlight` でシンタックスハイライト（既存の highlight.js を利用）
+- `<pre>` をラップするコンポーネントで「コピー」ボタンを追加
+
+4. **リンク・リスト・見出し**
+
+- リンクはテーマの `--link-color` に合わせる
+- リスト・見出しは prose の上書きで、チャット内で適度なサイズ・余白に収める
+
+---
+
+## 3. 実装タスク（実施済み／推奨）
+
+- `tailwind.config.ts` に `@tailwindcss/typography` を追加
+- `index.css` に `.ai-chat-markdown` を追加し、見出し・p・ul/ol・code/pre・a・表のスタイルを定義
+- `AIChatMessage.tsx` の AI メッセージ部分を `ai-chat-markdown` でラップ
+- `rehype-highlight` を利用し、`ReactMarkdown` の `rehypePlugins` に追加
+- コードブロック用のカスタム `components.pre`（`CodeBlockWithCopy`）でコピーボタン付きラッパーを実装
+
+---
+
+## 4. 参考
+
+- 仕様: `docs/specs/ai-agent-chat-spec.md` §3.1 メッセージエリア
+- エディタの Markdown スタイル: `src/index.css` の `.tiptap-editor` 系

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "react-resizable-panels": "^4.7.0",
     "react-router-dom": "^6.30.1",
     "recharts": "^2.15.4",
+    "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "sql.js": "^1.13.0",

--- a/src/components/ai-chat/AIChatMessage.tsx
+++ b/src/components/ai-chat/AIChatMessage.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import { Sparkles, User, FileText } from "lucide-react";
+import React, { useRef, useState } from "react";
+import { Sparkles, User, FileText, Copy, Check } from "lucide-react";
 import { ChatMessage, ChatAction, ReferencedPage } from "../../types/aiChat";
 import { getDisplayContent } from "../../lib/aiChatActions";
 import { AIChatActionCard } from "./AIChatActionCard";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
 
 interface AIChatMessageProps {
   message: ChatMessage;
@@ -43,6 +44,38 @@ function renderUserContent(content: string, referencedPages?: ReferencedPage[]) 
   );
 }
 
+/** Code block with syntax highlighting and copy button */
+function CodeBlockWithCopy({ children }: { children?: React.ReactNode }) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const text = preRef.current?.textContent ?? "";
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="group/code relative">
+      <pre ref={preRef}>{children}</pre>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "Copied" : "Copy code"}
+        className="absolute right-2 top-2 rounded border border-border/60 bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 group-hover/code:opacity-100"
+      >
+        {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+      </button>
+    </div>
+  );
+}
+
 export function AIChatMessage({ message, onExecuteAction }: AIChatMessageProps) {
   const isUser = message.role === "user";
   const displayContent = isUser ? message.content : getDisplayContent(message.content);
@@ -68,8 +101,16 @@ export function AIChatMessage({ message, onExecuteAction }: AIChatMessageProps) 
           {isUser ? (
             renderUserContent(displayContent, message.referencedPages)
           ) : (
-            <div className="prose prose-sm dark:prose-invert max-w-none break-words">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{displayContent}</ReactMarkdown>
+            <div className="ai-chat-markdown">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeHighlight]}
+                components={{
+                  pre: CodeBlockWithCopy,
+                }}
+              >
+                {displayContent}
+              </ReactMarkdown>
               {message.isStreaming && (
                 <span className="ml-1 inline-block h-4 w-1.5 animate-pulse bg-current align-middle" />
               )}

--- a/src/components/ai-chat/AIChatPagePreview.tsx
+++ b/src/components/ai-chat/AIChatPagePreview.tsx
@@ -22,7 +22,7 @@ export function AIChatPagePreview({ action, onConfirm, onEdit, onCancel }: AICha
 
       {/* Content Preview */}
       <div className="max-h-48 overflow-y-auto px-4 py-3">
-        <div className="prose prose-sm dark:prose-invert max-w-none">
+        <div className="prose prose-sm max-w-none dark:prose-invert">
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{action.content}</ReactMarkdown>
         </div>
       </div>

--- a/src/components/layout/Header/AIChatButton.tsx
+++ b/src/components/layout/Header/AIChatButton.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { useTranslation } from "react-i18next";
 import { useAIChatStore } from "../../../stores/aiChatStore";
 import { useAIChatContext } from "../../../contexts/AIChatContext";
@@ -5,12 +6,15 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { loadAISettings } from "../../../lib/aiSettings";
 import { Sparkles } from "lucide-react";
 
+const AI_BUTTON_GRADIENT = "from-violet-500 via-fuchsia-500 to-blue-500";
+
 export function AIChatButton() {
   const { t } = useTranslation();
   const { isOpen, togglePanel, isStreaming } = useAIChatStore();
   const { aiChatAvailable } = useAIChatContext();
   const navigate = useNavigate();
   const location = useLocation();
+  const gradientId = useId().replaceAll(":", "");
 
   // AIチャットが利用できないページではボタンを非表示
   if (!aiChatAvailable) return null;
@@ -27,26 +31,28 @@ export function AIChatButton() {
   };
 
   return (
-    <div className="rounded-md bg-gradient-to-r from-violet-500 via-fuchsia-500 to-blue-500 p-[2px]">
+    <div className={`rounded-md bg-gradient-to-r ${AI_BUTTON_GRADIENT} p-[2px]`}>
       <button
         onClick={handleClick}
-        className={`group relative flex items-center gap-1.5 rounded-[calc(0.375rem-2px)] px-3 py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+        className={`group relative flex items-center gap-1.5 rounded-sm px-3 py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
           isOpen
-            ? "bg-gradient-to-r from-violet-500 via-fuchsia-500 to-blue-500 text-white shadow-sm"
+            ? `bg-gradient-to-r ${AI_BUTTON_GRADIENT} text-white shadow-sm`
             : "bg-background text-muted-foreground hover:bg-accent/50 hover:text-foreground"
         }`}
         title={`${t("aiChat.title")} (Ctrl+Shift+A)`}
       >
         {/* ホバー時の背景グロー効果 (開いていない時のみ) */}
         {!isOpen && (
-          <div className="absolute inset-0 rounded-[calc(0.375rem-2px)] bg-gradient-to-r from-violet-500 via-fuchsia-500 to-blue-500 opacity-0 blur transition-opacity duration-500 group-hover:opacity-10" />
+          <div
+            className={`absolute inset-0 rounded-sm bg-gradient-to-r ${AI_BUTTON_GRADIENT} opacity-0 blur transition-opacity duration-500 group-hover:opacity-10`}
+          />
         )}
 
         {/* グラデーションの定義だけを行う非表示のSVG (開いていない時のみ使用) */}
         {!isOpen && (
           <svg width="0" height="0" className="absolute">
             <defs>
-              <linearGradient id="ai-sparkle-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+              <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
                 <stop offset="0%" stopColor="#8B5CF6">
                   <animate
                     attributeName="stop-color"
@@ -78,14 +84,12 @@ export function AIChatButton() {
 
         <Sparkles
           className={`relative h-6 w-6 ${isStreaming ? "animate-pulse" : ""}`}
-          style={isOpen ? { stroke: "currentColor" } : { stroke: "url(#ai-sparkle-gradient)" }}
+          style={isOpen ? { stroke: "currentColor" } : { stroke: `url(#${gradientId})` }}
           aria-hidden="true"
         />
         <span
-          className={`text-md relative font-medium ${
-            !isOpen
-              ? "bg-gradient-to-r from-violet-500 via-fuchsia-500 to-blue-500 bg-clip-text text-transparent"
-              : ""
+          className={`relative text-sm font-medium ${
+            !isOpen ? `bg-gradient-to-r ${AI_BUTTON_GRADIENT} bg-clip-text text-transparent` : ""
           }`}
         >
           AI

--- a/src/components/layout/Header/AIChatButton.tsx
+++ b/src/components/layout/Header/AIChatButton.tsx
@@ -27,60 +27,70 @@ export function AIChatButton() {
   };
 
   return (
-    <button
-      onClick={handleClick}
-      className={`group relative flex items-center gap-1.5 rounded-md px-3 py-2 transition-all duration-300 ${
-        isOpen
-          ? "bg-gradient-to-r from-violet-500 via-fuchsia-500 to-blue-500 text-white shadow-sm"
-          : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-      }`}
-      title={`${t("aiChat.title")} (Ctrl+Shift+A)`}
-    >
-      {/* ホバー時の背景グロー効果 (開いていない時のみ) */}
-      {!isOpen && (
-        <div className="absolute inset-0 rounded-md bg-gradient-to-r from-violet-500 via-fuchsia-500 to-blue-500 opacity-0 blur transition-opacity duration-500 group-hover:opacity-10" />
-      )}
+    <div className="rounded-md bg-gradient-to-r from-violet-500 via-fuchsia-500 to-blue-500 p-[2px]">
+      <button
+        onClick={handleClick}
+        className={`group relative flex items-center gap-1.5 rounded-[calc(0.375rem-2px)] px-3 py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+          isOpen
+            ? "bg-gradient-to-r from-violet-500 via-fuchsia-500 to-blue-500 text-white shadow-sm"
+            : "bg-background text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+        }`}
+        title={`${t("aiChat.title")} (Ctrl+Shift+A)`}
+      >
+        {/* ホバー時の背景グロー効果 (開いていない時のみ) */}
+        {!isOpen && (
+          <div className="absolute inset-0 rounded-[calc(0.375rem-2px)] bg-gradient-to-r from-violet-500 via-fuchsia-500 to-blue-500 opacity-0 blur transition-opacity duration-500 group-hover:opacity-10" />
+        )}
 
-      {/* グラデーションの定義だけを行う非表示のSVG (開いていない時のみ使用) */}
-      {!isOpen && (
-        <svg width="0" height="0" className="absolute">
-          <defs>
-            <linearGradient id="ai-sparkle-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-              <stop offset="0%" stopColor="#8B5CF6">
-                <animate
-                  attributeName="stop-color"
-                  values="#8B5CF6;#EC4899;#3B82F6;#8B5CF6"
-                  dur="4s"
-                  repeatCount="indefinite"
-                />
-              </stop>
-              <stop offset="50%" stopColor="#EC4899">
-                <animate
-                  attributeName="stop-color"
-                  values="#EC4899;#3B82F6;#8B5CF6;#EC4899"
-                  dur="4s"
-                  repeatCount="indefinite"
-                />
-              </stop>
-              <stop offset="100%" stopColor="#3B82F6">
-                <animate
-                  attributeName="stop-color"
-                  values="#3B82F6;#8B5CF6;#EC4899;#3B82F6"
-                  dur="4s"
-                  repeatCount="indefinite"
-                />
-              </stop>
-            </linearGradient>
-          </defs>
-        </svg>
-      )}
+        {/* グラデーションの定義だけを行う非表示のSVG (開いていない時のみ使用) */}
+        {!isOpen && (
+          <svg width="0" height="0" className="absolute">
+            <defs>
+              <linearGradient id="ai-sparkle-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stopColor="#8B5CF6">
+                  <animate
+                    attributeName="stop-color"
+                    values="#8B5CF6;#EC4899;#3B82F6;#8B5CF6"
+                    dur="4s"
+                    repeatCount="indefinite"
+                  />
+                </stop>
+                <stop offset="50%" stopColor="#EC4899">
+                  <animate
+                    attributeName="stop-color"
+                    values="#EC4899;#3B82F6;#8B5CF6;#EC4899"
+                    dur="4s"
+                    repeatCount="indefinite"
+                  />
+                </stop>
+                <stop offset="100%" stopColor="#3B82F6">
+                  <animate
+                    attributeName="stop-color"
+                    values="#3B82F6;#8B5CF6;#EC4899;#3B82F6"
+                    dur="4s"
+                    repeatCount="indefinite"
+                  />
+                </stop>
+              </linearGradient>
+            </defs>
+          </svg>
+        )}
 
-      <Sparkles
-        className={`relative h-6 w-6 ${isStreaming ? "animate-pulse" : ""}`}
-        style={isOpen ? { stroke: "currentColor" } : { stroke: "url(#ai-sparkle-gradient)" }}
-        aria-hidden="true"
-      />
-      <span className="text-md relative font-medium">AI</span>
-    </button>
+        <Sparkles
+          className={`relative h-6 w-6 ${isStreaming ? "animate-pulse" : ""}`}
+          style={isOpen ? { stroke: "currentColor" } : { stroke: "url(#ai-sparkle-gradient)" }}
+          aria-hidden="true"
+        />
+        <span
+          className={`text-md relative font-medium ${
+            !isOpen
+              ? "bg-gradient-to-r from-violet-500 via-fuchsia-500 to-blue-500 bg-clip-text text-transparent"
+              : ""
+          }`}
+        >
+          AI
+        </span>
+      </button>
+    </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -423,6 +423,104 @@
     background: hsl(var(--primary) / 0.15);
     border-radius: 2px;
   }
+
+  /* AI Chat: Markdown in message bubbles – readable, compact */
+  .ai-chat-markdown {
+    @apply max-w-none break-words text-sm;
+    line-height: 1.65;
+  }
+
+  .ai-chat-markdown > * + * {
+    @apply mt-3;
+  }
+
+  .ai-chat-markdown p:first-child {
+    @apply mt-0;
+  }
+
+  .ai-chat-markdown p:last-child {
+    @apply mb-0;
+  }
+
+  .ai-chat-markdown h1 {
+    @apply mb-2 mt-4 text-base font-bold first:mt-0;
+  }
+
+  .ai-chat-markdown h2 {
+    @apply mb-2 mt-3 text-[15px] font-semibold first:mt-0;
+  }
+
+  .ai-chat-markdown h3 {
+    @apply mb-1.5 mt-2.5 text-sm font-semibold first:mt-0;
+  }
+
+  .ai-chat-markdown ul,
+  .ai-chat-markdown ol {
+    @apply my-2 pl-5;
+  }
+
+  .ai-chat-markdown ul {
+    @apply list-disc;
+  }
+
+  .ai-chat-markdown ol {
+    @apply list-decimal;
+  }
+
+  .ai-chat-markdown li {
+    @apply my-0.5;
+  }
+
+  .ai-chat-markdown li > p {
+    @apply my-0;
+  }
+
+  .ai-chat-markdown blockquote {
+    @apply my-2 border-l-2 border-primary/40 pl-3 italic text-muted-foreground;
+  }
+
+  .ai-chat-markdown code {
+    @apply rounded bg-muted/80 px-1.5 py-0.5 font-mono text-[13px];
+  }
+
+  .ai-chat-markdown pre {
+    @apply my-2 overflow-x-auto rounded-lg bg-muted/80 p-3 text-[13px];
+  }
+
+  .ai-chat-markdown pre code {
+    @apply bg-transparent p-0;
+  }
+
+  .ai-chat-markdown pre code.hljs {
+    background: transparent;
+    padding: 0;
+  }
+
+  .ai-chat-markdown a {
+    @apply font-medium underline underline-offset-2 transition-colors;
+    color: hsl(var(--link-color));
+  }
+
+  .ai-chat-markdown a:hover {
+    @apply opacity-90;
+  }
+
+  .ai-chat-markdown strong {
+    @apply font-semibold;
+  }
+
+  .ai-chat-markdown table {
+    @apply my-2 w-full border-collapse text-left;
+  }
+
+  .ai-chat-markdown th,
+  .ai-chat-markdown td {
+    @apply border border-border px-2 py-1.5 text-left align-top;
+  }
+
+  .ai-chat-markdown th {
+    @apply bg-muted/50 font-semibold;
+  }
 }
 
 @layer utilities {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from "tailwindcss";
 import tailwindcssAnimate from "tailwindcss-animate";
+import tailwindcssTypography from "@tailwindcss/typography";
 
 export default {
   darkMode: ["class"],
@@ -106,5 +107,5 @@ export default {
       },
     },
   },
-  plugins: [tailwindcssAnimate],
+  plugins: [tailwindcssAnimate, tailwindcssTypography],
 } satisfies Config;


### PR DESCRIPTION
## 概要

ヘッダーのAIボタンを目立たせるため、グラデーションのボーダーと「AI」テキストへのグラデーション適用を追加しました。

## 変更点

- AIボタンをグラデーション背景のラッパーで囲み、2px のグラデーション枠線を表示
- パネル閉時、「AI」ラベルにアイコンと同じ紫→ピンク→青のグラデーションを適用
- キーボードフォーカス用の `focus-visible` リングを追加

## 変更の種類

- [x] 🎨 スタイル/リファクタリング (Style/Refactor)

## テスト方法

1. 開発サーバー起動後、ヘッダー中央のAIボタンを確認
2. パネル閉時: グラデーション枠・「AI」テキストのグラデーション表示を確認
3. パネル開時: グラデーション枠が維持され、テキストが白であることを確認
4. Tab でフォーカス移動し、フォーカスリングが表示されることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

<!-- なし -->
