### PR TITLE
fix: PR #212 レビューコメント対応

### DIFF
--- a/docs/guides/postgres-collation-version-fix.md
+++ b/docs/guides/postgres-collation-version-fix.md
@@ -6,7 +6,7 @@
 
 ログに以下のような警告が出る場合:
 
-```
+```text
 WARNING:  database "zedi" has a collation version mismatch
 DETAIL:  The database was created using collation version 2.41, but the operating system provides version 2.36.
 HINT:  Rebuild all objects in this database that use the default collation and run ALTER DATABASE zedi REFRESH COLLATION VERSION, or build PostgreSQL with the right library version.

--- a/server/api/src/__tests__/routes/notes/members.test.ts
+++ b/server/api/src/__tests__/routes/notes/members.test.ts
@@ -47,8 +47,7 @@ describe("POST /api/notes/:noteId/members", () => {
     });
     const { app, chains } = createTestApp([
       [mockNote], // requireNoteOwner → findActiveNoteById (owner)
-      [], // insert noteMembers
-      [addedMember], // select added member
+      [addedMember], // insert noteMembers with .returning()
     ]);
 
     const res = await app.request(`/api/notes/${NOTE_ID}/members`, {
@@ -84,7 +83,7 @@ describe("POST /api/notes/:noteId/members", () => {
   it("should default role to 'viewer' when not specified", async () => {
     const mockNote = createMockNote();
     const addedMember = createMockMember({ role: "viewer" });
-    const { app, chains } = createTestApp([[mockNote], [], [addedMember]]);
+    const { app, chains } = createTestApp([[mockNote], [addedMember]]);
 
     await app.request(`/api/notes/${NOTE_ID}/members`, {
       method: "POST",

--- a/server/api/src/__tests__/routes/notes/members.test.ts
+++ b/server/api/src/__tests__/routes/notes/members.test.ts
@@ -38,11 +38,17 @@ const NOTE_ID = "note-test-001";
 // ── POST /api/notes/:noteId/members ─────────────────────────────────────────
 
 describe("POST /api/notes/:noteId/members", () => {
-  it("should add a member and return { added: true }", async () => {
+  it("should add a member and return the added member (NoteMemberItem)", async () => {
     const mockNote = createMockNote();
+    const addedMember = createMockMember({
+      noteId: NOTE_ID,
+      memberEmail: OTHER_USER_EMAIL,
+      role: "editor",
+    });
     const { app, chains } = createTestApp([
       [mockNote], // requireNoteOwner → findActiveNoteById (owner)
       [], // insert noteMembers
+      [addedMember], // select added member
     ]);
 
     const res = await app.request(`/api/notes/${NOTE_ID}/members`, {
@@ -53,7 +59,14 @@ describe("POST /api/notes/:noteId/members", () => {
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
-    expect(body).toEqual({ added: true });
+    expect(body).toMatchObject({
+      note_id: NOTE_ID,
+      member_email: OTHER_USER_EMAIL,
+      role: "editor",
+      invited_by_user_id: TEST_USER_ID,
+    });
+    expect(body).toHaveProperty("created_at");
+    expect(body).toHaveProperty("updated_at");
 
     const insertCall = chains.find((c) => c.startMethod === "insert");
     expect(insertCall).toBeDefined();
@@ -70,7 +83,8 @@ describe("POST /api/notes/:noteId/members", () => {
 
   it("should default role to 'viewer' when not specified", async () => {
     const mockNote = createMockNote();
-    const { app, chains } = createTestApp([[mockNote], []]);
+    const addedMember = createMockMember({ role: "viewer" });
+    const { app, chains } = createTestApp([[mockNote], [], [addedMember]]);
 
     await app.request(`/api/notes/${NOTE_ID}/members`, {
       method: "POST",
@@ -188,10 +202,9 @@ describe("PUT /api/notes/:noteId/members/:memberEmail", () => {
       memberEmail: OTHER_USER_EMAIL,
       role: "editor",
     });
-    const { app } = createTestApp([
+    const { app, chains } = createTestApp([
       [mockNote], // requireNoteOwner
-      [], // update noteMembers
-      [updatedRow], // select updated member
+      [updatedRow], // update noteMembers with .returning()
     ]);
 
     const encoded = encodeURIComponent(OTHER_USER_EMAIL);
@@ -211,6 +224,11 @@ describe("PUT /api/notes/:noteId/members/:memberEmail", () => {
     });
     expect(body).toHaveProperty("created_at");
     expect(body).toHaveProperty("updated_at");
+
+    const updateCall = chains.find((c) => c.startMethod === "update");
+    expect(updateCall).toBeDefined();
+    const setOp = updateCall?.ops.find((op) => op.method === "set");
+    expect((setOp?.args[0] as Record<string, unknown>)?.role).toBe("editor");
   });
 
   it("should return 400 when role is missing", async () => {

--- a/server/api/src/__tests__/routes/notes/pages.test.ts
+++ b/server/api/src/__tests__/routes/notes/pages.test.ts
@@ -145,6 +145,51 @@ describe("POST /api/notes/:noteId/pages", () => {
     expect(res.status).toBe(400);
   });
 
+  it("should return 400 when title is empty string", async () => {
+    const mockNote = createMockNote();
+    const { app } = createTestApp([[mockNote]]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/pages`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ title: "" }),
+    });
+
+    expect(res.status).toBe(400);
+    const text = await res.text();
+    expect(text).toContain("title must be a non-empty string");
+  });
+
+  it("should return 400 when title is whitespace-only", async () => {
+    const mockNote = createMockNote();
+    const { app } = createTestApp([[mockNote]]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/pages`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ title: "   " }),
+    });
+
+    expect(res.status).toBe(400);
+    const text = await res.text();
+    expect(text).toContain("title must be a non-empty string");
+  });
+
+  it("should return 400 when title is not a string", async () => {
+    const mockNote = createMockNote();
+    const { app } = createTestApp([[mockNote]]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/pages`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ title: 123 }),
+    });
+
+    expect(res.status).toBe(400);
+    const text = await res.text();
+    expect(text).toContain("title must be a non-empty string");
+  });
+
   it("should return 404 when page does not exist", async () => {
     const mockNote = createMockNote();
     const { app } = createTestApp([

--- a/server/api/src/__tests__/routes/notes/pages.test.ts
+++ b/server/api/src/__tests__/routes/notes/pages.test.ts
@@ -101,12 +101,12 @@ describe("POST /api/notes/:noteId/pages", () => {
 
   it("should create a new page when title is provided without page_id", async () => {
     const mockNote = createMockNote();
-    const { app } = createTestApp([
+    const { app, chains } = createTestApp([
       [mockNote], // getNoteRole
-      [{ id: "pg-created" }], // insert pages → returning
-      [{ max: 0 }], // maxOrder query
-      [], // insert notePages
-      [], // update notes.updatedAt
+      [{ id: "pg-created" }], // insert pages → returning (inside transaction)
+      [{ max: 0 }], // maxOrder query (inside transaction)
+      [], // insert notePages (inside transaction)
+      [], // update notes.updatedAt (inside transaction)
     ]);
 
     const res = await app.request(`/api/notes/${NOTE_ID}/pages`, {
@@ -118,6 +118,16 @@ describe("POST /api/notes/:noteId/pages", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).toHaveProperty("added", true);
+    expect(body).toHaveProperty("sort_order");
+
+    const insertCalls = chains.filter((c) => c.startMethod === "insert");
+    const pageInsert = insertCalls[0];
+    expect(pageInsert).toBeDefined();
+    const valuesOp = pageInsert?.ops.find((op) => op.method === "values");
+    expect(valuesOp?.args[0]).toMatchObject({
+      ownerId: TEST_USER_ID,
+      title: "New Page",
+    });
   });
 
   it("should return 400 when neither page_id nor title is provided", async () => {

--- a/server/api/src/__tests__/routes/notes/setup.ts
+++ b/server/api/src/__tests__/routes/notes/setup.ts
@@ -123,6 +123,9 @@ export function createMockDb(results: unknown[]) {
 
   const db = new Proxy({} as Record<string, (...args: unknown[]) => unknown>, {
     get(_, prop: string) {
+      if (prop === "transaction") {
+        return (fn: (tx: typeof db) => Promise<unknown>) => fn(db);
+      }
       return (...args: unknown[]) => {
         const idx = chainIndex++;
         const ops: { method: string; args: unknown[] }[] = [];

--- a/server/api/src/routes/notes/members.ts
+++ b/server/api/src/routes/notes/members.ts
@@ -45,7 +45,7 @@ app.post("/:noteId/members", authRequired, async (c) => {
 
   const memberRole = validateMemberRole(body.role);
 
-  await db
+  const [member] = await db
     .insert(noteMembers)
     .values({
       noteId,
@@ -60,26 +60,15 @@ app.post("/:noteId/members", authRequired, async (c) => {
         isDeleted: false,
         updatedAt: new Date(),
       },
-    });
-
-  const [member] = await db
-    .select({
+    })
+    .returning({
       noteId: noteMembers.noteId,
       memberEmail: noteMembers.memberEmail,
       role: noteMembers.role,
       invitedByUserId: noteMembers.invitedByUserId,
       createdAt: noteMembers.createdAt,
       updatedAt: noteMembers.updatedAt,
-    })
-    .from(noteMembers)
-    .where(
-      and(
-        eq(noteMembers.noteId, noteId),
-        eq(noteMembers.memberEmail, memberEmail),
-        eq(noteMembers.isDeleted, false),
-      ),
-    )
-    .limit(1);
+    });
   if (!member) {
     throw new HTTPException(500, { message: "Failed to retrieve added member" });
   }

--- a/server/api/src/routes/notes/members.ts
+++ b/server/api/src/routes/notes/members.ts
@@ -62,36 +62,7 @@ app.post("/:noteId/members", authRequired, async (c) => {
       },
     });
 
-  return c.json({ added: true });
-});
-
-// ── PUT /:noteId/members/:memberEmail ───────────────────────────────────────
-app.put("/:noteId/members/:memberEmail", authRequired, async (c) => {
-  const noteId = c.req.param("noteId");
-  const memberEmail = decodeURIComponent(c.req.param("memberEmail")).trim().toLowerCase();
-  const userId = c.get("userId");
-  const db = c.get("db");
-
-  await requireNoteOwner(db, noteId, userId, "Only the owner can update members");
-
-  const body = await c.req.json<{ role?: string }>();
-  if (body.role === undefined || body.role === null) {
-    throw new HTTPException(400, { message: "role is required" });
-  }
-  const memberRole = validateMemberRole(body.role);
-
-  await db
-    .update(noteMembers)
-    .set({ role: memberRole, updatedAt: new Date() })
-    .where(
-      and(
-        eq(noteMembers.noteId, noteId),
-        eq(noteMembers.memberEmail, memberEmail),
-        eq(noteMembers.isDeleted, false),
-      ),
-    );
-
-  const [updated] = await db
+  const [member] = await db
     .select({
       noteId: noteMembers.noteId,
       memberEmail: noteMembers.memberEmail,
@@ -109,6 +80,52 @@ app.put("/:noteId/members/:memberEmail", authRequired, async (c) => {
       ),
     )
     .limit(1);
+  if (!member) {
+    throw new HTTPException(500, { message: "Failed to retrieve added member" });
+  }
+  return c.json({
+    note_id: member.noteId,
+    member_email: member.memberEmail,
+    role: member.role,
+    invited_by_user_id: member.invitedByUserId,
+    created_at: member.createdAt,
+    updated_at: member.updatedAt,
+  });
+});
+
+// ── PUT /:noteId/members/:memberEmail ───────────────────────────────────────
+app.put("/:noteId/members/:memberEmail", authRequired, async (c) => {
+  const noteId = c.req.param("noteId");
+  const memberEmail = decodeURIComponent(c.req.param("memberEmail")).trim().toLowerCase();
+  const userId = c.get("userId");
+  const db = c.get("db");
+
+  await requireNoteOwner(db, noteId, userId, "Only the owner can update members");
+
+  const body = await c.req.json<{ role?: string }>();
+  if (body.role === undefined || body.role === null) {
+    throw new HTTPException(400, { message: "role is required" });
+  }
+  const memberRole = validateMemberRole(body.role);
+
+  const [updated] = await db
+    .update(noteMembers)
+    .set({ role: memberRole, updatedAt: new Date() })
+    .where(
+      and(
+        eq(noteMembers.noteId, noteId),
+        eq(noteMembers.memberEmail, memberEmail),
+        eq(noteMembers.isDeleted, false),
+      ),
+    )
+    .returning({
+      noteId: noteMembers.noteId,
+      memberEmail: noteMembers.memberEmail,
+      role: noteMembers.role,
+      invitedByUserId: noteMembers.invitedByUserId,
+      createdAt: noteMembers.createdAt,
+      updatedAt: noteMembers.updatedAt,
+    });
   if (!updated) {
     throw new HTTPException(404, { message: "Member not found" });
   }

--- a/server/api/src/routes/notes/pages.ts
+++ b/server/api/src/routes/notes/pages.ts
@@ -39,12 +39,18 @@ app.post("/:noteId/pages", authRequired, async (c) => {
   const rawPageId = body.page_id ?? body.pageId;
   const pageId =
     typeof rawPageId === "string" && rawPageId.trim() !== "" ? rawPageId.trim() : undefined;
+  const title =
+    typeof body.title === "string" && body.title.trim() !== "" ? body.title.trim() : undefined;
 
-  if (!pageId && !body.title) {
+  if (!pageId && body.title !== undefined && title === undefined) {
+    throw new HTTPException(400, { message: "title must be a non-empty string" });
+  }
+  if (!pageId && !title) {
     throw new HTTPException(400, { message: "page_id or title is required" });
   }
 
   let targetPageId: string;
+  let sortOrder: number;
 
   if (pageId) {
     const page = await db
@@ -57,45 +63,75 @@ app.post("/:noteId/pages", authRequired, async (c) => {
     if (!firstPage) throw new HTTPException(404, { message: "Page not found" });
     if (firstPage.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
     targetPageId = firstPage.id;
-  } else {
-    const created = await db
-      .insert(pages)
+
+    const maxOrder = await db
+      .select({ max: sql<number>`COALESCE(MAX(${notePages.sortOrder}), 0)` })
+      .from(notePages)
+      .where(and(eq(notePages.noteId, noteId), eq(notePages.isDeleted, false)));
+
+    sortOrder = body.sort_order ?? (maxOrder[0]?.max ?? 0) + 1;
+
+    await db
+      .insert(notePages)
       .values({
-        ownerId: userId,
-        title: body.title ?? null,
-      })
-      .returning();
-
-    const newPage = created[0];
-    if (!newPage) throw new HTTPException(500, { message: "Failed to create page" });
-    targetPageId = newPage.id;
-  }
-
-  const maxOrder = await db
-    .select({ max: sql<number>`COALESCE(MAX(${notePages.sortOrder}), 0)` })
-    .from(notePages)
-    .where(and(eq(notePages.noteId, noteId), eq(notePages.isDeleted, false)));
-
-  const sortOrder = body.sort_order ?? (maxOrder[0]?.max ?? 0) + 1;
-
-  await db
-    .insert(notePages)
-    .values({
-      noteId,
-      pageId: targetPageId,
-      addedByUserId: userId,
-      sortOrder,
-    })
-    .onConflictDoUpdate({
-      target: [notePages.noteId, notePages.pageId],
-      set: {
-        isDeleted: false,
+        noteId,
+        pageId: targetPageId,
+        addedByUserId: userId,
         sortOrder,
-        updatedAt: new Date(),
-      },
-    });
+      })
+      .onConflictDoUpdate({
+        target: [notePages.noteId, notePages.pageId],
+        set: {
+          isDeleted: false,
+          sortOrder,
+          updatedAt: new Date(),
+        },
+      });
 
-  await db.update(notes).set({ updatedAt: new Date() }).where(eq(notes.id, noteId));
+    await db.update(notes).set({ updatedAt: new Date() }).where(eq(notes.id, noteId));
+  } else {
+    const result = await db.transaction(async (tx) => {
+      const created = await tx
+        .insert(pages)
+        .values({
+          ownerId: userId,
+          title: title ?? null,
+        })
+        .returning();
+
+      const newPage = created[0];
+      if (!newPage) throw new HTTPException(500, { message: "Failed to create page" });
+      const newPageId = newPage.id;
+
+      const maxOrder = await tx
+        .select({ max: sql<number>`COALESCE(MAX(${notePages.sortOrder}), 0)` })
+        .from(notePages)
+        .where(and(eq(notePages.noteId, noteId), eq(notePages.isDeleted, false)));
+
+      const order = body.sort_order ?? (maxOrder[0]?.max ?? 0) + 1;
+
+      await tx
+        .insert(notePages)
+        .values({
+          noteId,
+          pageId: newPageId,
+          addedByUserId: userId,
+          sortOrder: order,
+        })
+        .onConflictDoUpdate({
+          target: [notePages.noteId, notePages.pageId],
+          set: {
+            isDeleted: false,
+            sortOrder: order,
+            updatedAt: new Date(),
+          },
+        });
+
+      await tx.update(notes).set({ updatedAt: new Date() }).where(eq(notes.id, noteId));
+      return { sortOrder: order };
+    });
+    sortOrder = result.sortOrder;
+  }
 
   return c.json({ added: true, sort_order: sortOrder });
 });

--- a/server/api/src/routes/notes/pages.ts
+++ b/server/api/src/routes/notes/pages.ts
@@ -53,42 +53,46 @@ app.post("/:noteId/pages", authRequired, async (c) => {
   let sortOrder: number;
 
   if (pageId) {
-    const page = await db
-      .select({ id: pages.id, ownerId: pages.ownerId })
-      .from(pages)
-      .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
-      .limit(1);
+    const result = await db.transaction(async (tx) => {
+      const page = await tx
+        .select({ id: pages.id, ownerId: pages.ownerId })
+        .from(pages)
+        .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
+        .limit(1);
 
-    const firstPage = page[0];
-    if (!firstPage) throw new HTTPException(404, { message: "Page not found" });
-    if (firstPage.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
-    targetPageId = firstPage.id;
+      const firstPage = page[0];
+      if (!firstPage) throw new HTTPException(404, { message: "Page not found" });
+      if (firstPage.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
+      const resolvedPageId = firstPage.id;
 
-    const maxOrder = await db
-      .select({ max: sql<number>`COALESCE(MAX(${notePages.sortOrder}), 0)` })
-      .from(notePages)
-      .where(and(eq(notePages.noteId, noteId), eq(notePages.isDeleted, false)));
+      const maxOrder = await tx
+        .select({ max: sql<number>`COALESCE(MAX(${notePages.sortOrder}), 0)` })
+        .from(notePages)
+        .where(and(eq(notePages.noteId, noteId), eq(notePages.isDeleted, false)));
 
-    sortOrder = body.sort_order ?? (maxOrder[0]?.max ?? 0) + 1;
+      const order = body.sort_order ?? (maxOrder[0]?.max ?? 0) + 1;
 
-    await db
-      .insert(notePages)
-      .values({
-        noteId,
-        pageId: targetPageId,
-        addedByUserId: userId,
-        sortOrder,
-      })
-      .onConflictDoUpdate({
-        target: [notePages.noteId, notePages.pageId],
-        set: {
-          isDeleted: false,
-          sortOrder,
-          updatedAt: new Date(),
-        },
-      });
+      await tx
+        .insert(notePages)
+        .values({
+          noteId,
+          pageId: resolvedPageId,
+          addedByUserId: userId,
+          sortOrder: order,
+        })
+        .onConflictDoUpdate({
+          target: [notePages.noteId, notePages.pageId],
+          set: {
+            isDeleted: false,
+            sortOrder: order,
+            updatedAt: new Date(),
+          },
+        });
 
-    await db.update(notes).set({ updatedAt: new Date() }).where(eq(notes.id, noteId));
+      await tx.update(notes).set({ updatedAt: new Date() }).where(eq(notes.id, noteId));
+      return { sortOrder: order };
+    });
+    sortOrder = result.sortOrder;
   } else {
     const result = await db.transaction(async (tx) => {
       const created = await tx

--- a/src/components/ai-chat/AIChatMessage.tsx
+++ b/src/components/ai-chat/AIChatMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { Sparkles, User, FileText, Copy, Check } from "lucide-react";
 import { ChatMessage, ChatAction, ReferencedPage } from "../../types/aiChat";
 import { getDisplayContent } from "../../lib/aiChatActions";
@@ -48,14 +48,20 @@ function renderUserContent(content: string, referencedPages?: ReferencedPage[]) 
 function CodeBlockWithCopy({ children }: { children?: React.ReactNode }) {
   const preRef = useRef<HTMLPreElement>(null);
   const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+  }, []);
 
   const handleCopy = async () => {
     const text = preRef.current?.textContent ?? "";
     if (!text) return;
     try {
       await navigator.clipboard.writeText(text);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000);
     } catch {
       // ignore
     }

--- a/src/components/ai-chat/AIChatMessage.tsx
+++ b/src/components/ai-chat/AIChatMessage.tsx
@@ -50,9 +50,12 @@ function CodeBlockWithCopy({ children }: { children?: React.ReactNode }) {
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => () => {
-    if (timeoutRef.current) clearTimeout(timeoutRef.current);
-  }, []);
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    },
+    [],
+  );
 
   const handleCopy = async () => {
     const text = preRef.current?.textContent ?? "";

--- a/src/components/ai-chat/AIChatPagePreview.tsx
+++ b/src/components/ai-chat/AIChatPagePreview.tsx
@@ -46,7 +46,7 @@ export function AIChatPagePreview({ action, onConfirm, onEdit, onCancel }: AICha
           onClick={onCancel}
           className="rounded-md border px-3 py-1.5 text-xs transition-colors hover:bg-accent"
         >
-          キャンセル
+          {t("aiChat.actions.close")}
         </button>
         <button
           onClick={onEdit}

--- a/src/components/layout/Header/AIChatButton.tsx
+++ b/src/components/layout/Header/AIChatButton.tsx
@@ -33,7 +33,10 @@ export function AIChatButton() {
   return (
     <div className={`rounded-md bg-gradient-to-r ${AI_BUTTON_GRADIENT} p-[2px]`}>
       <button
+        type="button"
         onClick={handleClick}
+        aria-label={t("aiChat.title")}
+        aria-pressed={isOpen}
         className={`group relative flex items-center gap-1.5 rounded-sm px-3 py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
           isOpen
             ? `bg-gradient-to-r ${AI_BUTTON_GRADIENT} text-white shadow-sm`


### PR DESCRIPTION
## 概要

PR #212（develop → main マージ）に対するレビュー指摘（CodeRabbit / Copilot / Gemini Code Assist）の対応です。

## 変更点

- **members API**: POST の戻り値を `NoteMemberItem`（snake_case）に統一。PUT は `.returning()` で 1 クエリに統合。
- **pages API**: `body.title` のランタイム検証（非文字列・空文字で 400）。新規ページ作成＋ノート紐付けを `db.transaction()` で原子化。
- **AIChatMessage**: CodeBlockWithCopy の `setTimeout` をアンマウント時に `clearTimeout` でクリーンアップ。
- **AIChatPagePreview**: キャンセルボタンを `t("aiChat.actions.close")` に変更（i18n）。
- **AIChatButton**: `aria-label` と `aria-pressed` を追加（アクセシビリティ）。
- **docs**: postgres-collation ガイドのコードブロックに ```text``` を指定（MD040）。
- **tests**: モックで `db.transaction(fn)` を実行するよう `setup.ts` を修正。members/pages のテストで `chains` を assert。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [x] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `server/api` で `npm test -- --run src/__tests__/routes/notes/members.test.ts src/__tests__/routes/notes/pages.test.ts` でノート API テストを実行。
2. ルートで `bun run test:run` でフロント含むテストを実行。

## チェックリスト

- [x] テストがすべてパスする
- [ ] Lint エラーがない（既存の admin 側 1 件あり。本 PR の変更ファイルにはエラーなし）
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

- 対応判断メモ: `docs/pr-212-review-response.md`（同一リポジトリ内）
- 元 PR: #212

Made with [Cursor](https://cursor.com)