### PR TITLE
ci: run Release Please on develop and target develop

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,12 +1,12 @@
-# Release Please: main へのマージ内容に応じてリリース PR を作成し、
+# Release Please: develop へのマージ内容に応じてリリース PR を develop 向けに作成し、
 # その PR マージ時にタグ・GitHub Release を自動作成します。
-# Conventional Commits (feat:, fix:, BREAKING CHANGE:) に応じて
-# メジャー / マイナー / パッチが自動判定されます。
+# develop を main にマージする際、バージョン更新はすでに develop に含まれるため main と競合しません。
+# Conventional Commits (feat:, fix:, BREAKING CHANGE:) に応じてメジャー / マイナー / パッチが自動判定されます。
 name: Release Please
 
 on:
   push:
-    branches: [main]
+    branches: [develop]
 
 permissions:
   contents: write
@@ -28,3 +28,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: develop


### PR DESCRIPTION
## 概要
Release Please を **main ではなく develop** 向けに変更します。

## 変更内容
- `on.push.branches`: `[main]` → `[develop]`
- `target-branch: develop` を明示指定
- コメントを「develop 向けにリリース PR を作成し、develop にマージされた時点でタグ・Release を作る」旨に更新

## 理由
- リリースバージョン更新は develop で行い、main との競合を避ける
- develop にマージされた時点でタグ・GitHub Release が作成される
- main は必要に応じて develop をマージするだけの運用にできる

Made with [Cursor](https://cursor.com)