### PR TITLE
ci: revert Release Please to target main and add main→develop sync workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,12 +1,12 @@
-# Release Please: develop へのマージ内容に応じてリリース PR を develop 向けに作成し、
+# Release Please: main へのマージ内容に応じてリリース PR を作成し、
 # その PR マージ時にタグ・GitHub Release を自動作成します。
-# develop を main にマージする際、バージョン更新はすでに develop に含まれるため main と競合しません。
+# main → develop の同期は sync-main-to-develop.yml で自動化されています。
 # Conventional Commits (feat:, fix:, BREAKING CHANGE:) に応じてメジャー / マイナー / パッチが自動判定されます。
 name: Release Please
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
 
 permissions:
   contents: write
@@ -28,4 +28,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
-          target-branch: develop

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -1,0 +1,43 @@
+# main へのプッシュ後に main → develop の同期 PR を自動作成します。
+# Release Please によるバージョン更新等が develop に反映され、競合を防ぎます。
+name: Sync main to develop
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Create sync PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check diff and create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch origin develop
+
+          if git diff --quiet origin/main origin/develop; then
+            echo "main and develop are already in sync"
+            exit 0
+          fi
+
+          EXISTING=$(gh pr list --head main --base develop --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "Sync PR #$EXISTING already exists"
+            exit 0
+          fi
+
+          gh pr create --base develop --head main \
+            --title "chore: sync main to develop" \
+            --body "main ブランチの変更（Release Please によるバージョン更新等）を develop に同期します。
+
+          このPRは自動生成されています。競合がなければそのままマージしてください。"

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -23,14 +23,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+
           git fetch origin develop
 
-          if git diff --quiet origin/main origin/develop; then
-            echo "main and develop are already in sync"
+          COMMITS_TO_SYNC=$(git rev-list --count origin/develop..origin/main)
+          if [ "$COMMITS_TO_SYNC" -eq 0 ]; then
+            echo "No commits in main to sync to develop"
             exit 0
           fi
 
-          EXISTING=$(gh pr list --head main --base develop --state open --json number --jq '.[0].number')
+          EXISTING=$(gh pr list --head main --base develop --state open --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
             echo "Sync PR #$EXISTING already exists"
             exit 0


### PR DESCRIPTION
## 概要

PR #241 で Release Please を develop 向けに変更しましたが、リリースは **main にマージされた（公開された）タイミング** で更新するのが正しいため、元に戻します。

代わりに、main → develop の自動同期ワークフローを追加して、ブランチ間の不整合を防ぎます。

## 変更内容

### `release-please.yml`（revert）
- `on.push.branches`: `[develop]` → `[main]` に戻す
- `target-branch: develop` を削除

### `sync-main-to-develop.yml`（新規）
- main への push をトリガーに、main → develop の同期 PR を自動作成
- Release Please によるバージョン更新等が develop に自動反映される
- 既に同期 PR が存在する場合は重複作成しない

## 今後のフロー

```
develop → main PR マージ
    ↓
Release Please が main で CHANGELOG / version を更新
    ↓
sync-main-to-develop.yml が自動で同期 PR を作成
    ↓
同期 PR をマージ → develop に反映、競合なし
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * リリースプロセスのワークフローを最適化しました。
  * メインブランチからの変更を開発ブランチに自動的に同期する新しいプロセスを導入しました。これにより、ブランチ間の整合性が向上し、リリースサイクルがより効率的になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->