### PR TITLE
feat: 画像アップロード時にクライアント側で WebP 変換 (fix #256)

### DIFF
--- a/.cursor/rules/pr-and-branch-naming.mdc
+++ b/.cursor/rules/pr-and-branch-naming.mdc
@@ -1,0 +1,11 @@
+---
+description: PR とブランチの命名規則。PR 作成・ブランチ作成時に従う。
+globs: ".github/PULL_REQUEST_TEMPLATE.md,**/PULL_REQUEST*"
+alwaysApply: false
+---
+
+# ブランチ・PR 命名規則
+
+- **ブランチ名**: `feature/説明` または `fix/説明`（例: `feature/ai-models-ui`, `fix/search-crash`）。Issue ベースなら `feature/123`。Cursor Cloud Agent が自動作成する場合は `cursor/` プレフィックスが付くことがあるが、手動で PR を作る際は上記形式を推奨。
+- **PR タイトル**: 変更内容を正しく表すこと。Conventional Commits 形式（例: `feat(admin): AIモデル管理UI拡張 (#218)`）。単一トピックなら代表コミットメッセージをそのまま使用。日本語・英語はコミットの多数に合わせる。
+- タイトルに「Config argument parsing」のように、実際の変更と無関係な文言を付けないこと。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,12 @@ bun run test:run       # Vitest 単体テスト
 - 既存のディレクトリ構成・命名規則に合わせる。
 - Conventional Commits 形式でコミット（`feat:`, `fix:`, `docs:` 等）。
 
+## ブランチ・PR の命名規則
+
+- **ブランチ**: `feature/説明` または `fix/説明`（例: `feature/ai-models-ui`, `fix/search-crash`）。Issue 番号から作る場合は `feature/123` のようにする。
+- **PR タイトル**: コミットメッセージに合わせる。単一トピックの PR は代表的なコミットをそのまま使う。Conventional Commits 形式（例: `feat(admin): AIモデル管理UI拡張 (#218)`）。変更内容を正しく表すタイトルにし、「Config argument parsing」のように無関係な文言にしない。
+- **Cursor Cloud Agent で PR を作る場合**: リポジトリのルール（本ファイルや `.cursor/rules/`）はエージェントが参照する場合があるが、Cloud Agent 起動時に「PR を作成するときはタイトルを Conventional Commits 形式にし、変更内容を表す文言にすること」とプロンプトに含めると確実。API で起動する場合は `target.branchName` でブランチ名を指定できる（[Cloud Agents API](https://cursor.com/docs/background-agent/api/overview)）。PR タイトルを直接指定する API パラメータは 2026 年現在ないため、プロンプトで指示するか、作成後に手動で修正する。
+
 ## PR レビュー観点
 
 - セキュリティ・パフォーマンスへの影響。

--- a/src/components/editor/TiptapEditor/useImageUploadManagerHelpers.ts
+++ b/src/components/editor/TiptapEditor/useImageUploadManagerHelpers.ts
@@ -1,6 +1,6 @@
 import type { MutableRefObject } from "react";
 import type { Editor } from "@tiptap/core";
-import { getStorageProvider, getSettingsForUpload } from "@/lib/storage";
+import { getStorageProvider, getSettingsForUpload, convertToWebP } from "@/lib/storage";
 import type { StorageSettings } from "@/types/storage";
 
 export function updateUploadNodeAttributesImpl(
@@ -143,7 +143,8 @@ export async function runSingleUpload(params: RunUploadParams): Promise<void> {
   uploadTimersRef.current.set(uploadId, timerId);
 
   try {
-    const url = await provider.uploadImage(file, {
+    const fileToUpload = await convertToWebP(file);
+    const url = await provider.uploadImage(fileToUpload, {
       onProgress: (progress) => {
         hasRealProgress = true;
         updateUploadNodeAttributes(uploadId, {
@@ -155,8 +156,8 @@ export async function runSingleUpload(params: RunUploadParams): Promise<void> {
     updateUploadNodeAttributes(uploadId, { progress: 100 });
     replaceUploadNodeWithImage(uploadId, {
       src: url,
-      alt: file.name,
-      title: file.name,
+      alt: fileToUpload.name,
+      title: fileToUpload.name,
       storageProviderId: uploadSettings.provider,
     });
   } catch (error) {

--- a/src/components/editor/TiptapEditor/useThumbnailCommit.ts
+++ b/src/components/editor/TiptapEditor/useThumbnailCommit.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import type { Editor } from "@tiptap/core";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
-import { getStorageProvider, getSettingsForUpload } from "@/lib/storage";
+import { getStorageProvider, getSettingsForUpload, convertToWebP } from "@/lib/storage";
 import type { StorageSettings } from "@/types/storage";
 
 const getThumbnailApiBaseUrl = () => (import.meta.env.VITE_API_BASE_URL as string) ?? "";
@@ -116,10 +116,13 @@ export function useThumbnailCommit({
           providerId = result.provider;
         } else {
           const file = await fetchImageAsFile(imageUrl, previewUrl);
+          const fileToUpload = await convertToWebP(file);
           const provider = getStorageProvider(uploadSettings, {
             getToken: async () => null,
           });
-          finalUrl = await provider.uploadImage(file, { fileName: file.name });
+          finalUrl = await provider.uploadImage(fileToUpload, {
+            fileName: fileToUpload.name,
+          });
           providerId = uploadSettings.provider;
         }
 

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -7,6 +7,7 @@ import {
   getStorageProvider,
   getSettingsForUpload,
   isStorageConfiguredForUpload,
+  convertToWebP,
   UploadProgress,
 } from "@/lib/storage";
 
@@ -65,8 +66,11 @@ export function useImageUpload(): UseImageUploadReturn {
           getToken,
         });
 
+        // ストレージ節約のため WebP に変換してからアップロード
+        const fileToUpload = await convertToWebP(file);
+
         // アップロード実行
-        const url = await provider.uploadImage(file, {
+        const url = await provider.uploadImage(fileToUpload, {
           onProgress: (progress) => {
             setState((prev) => ({ ...prev, progress }));
           },
@@ -75,7 +79,7 @@ export function useImageUpload(): UseImageUploadReturn {
         setState((prev) => ({
           ...prev,
           isUploading: false,
-          progress: { loaded: file.size, total: file.size, percentage: 100 },
+          progress: { loaded: fileToUpload.size, total: fileToUpload.size, percentage: 100 },
         }));
 
         return url;

--- a/src/lib/storage/convertToWebP.test.ts
+++ b/src/lib/storage/convertToWebP.test.ts
@@ -108,6 +108,39 @@ describe("convertToWebP", () => {
     expect(result.type).toBe("image/png");
   });
 
+  it("returns original file when toBlob falls back to PNG", async () => {
+    const pngFile = createPngFile();
+    const fallbackBlob = new Blob(["png"], { type: "image/png" });
+
+    const OriginalImage = globalThis.Image;
+    vi.stubGlobal(
+      "Image",
+      class MockImage extends OriginalImage {
+        constructor() {
+          super();
+          queueMicrotask(() => {
+            Object.defineProperty(this, "naturalWidth", { value: 1 });
+            Object.defineProperty(this, "naturalHeight", { value: 1 });
+            this.onload?.();
+          });
+        }
+      },
+    );
+
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation((callback) => {
+      callback?.(fallbackBlob);
+    });
+
+    const result = await convertToWebP(pngFile);
+
+    expect(result).toBe(pngFile);
+    expect(result.name).toBe("test.png");
+    expect(result.type).toBe("image/png");
+  });
+
   it("preserves base filename when converting", async () => {
     const pngFile = new File([createPngFile()], "my-photo-2024.png", {
       type: "image/png",

--- a/src/lib/storage/convertToWebP.test.ts
+++ b/src/lib/storage/convertToWebP.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { convertToWebP } from "./convertToWebP";
+
+// 1x1 透明 PNG（S3Provider と同じ）
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+function createPngFile(): File {
+  const binary = atob(PNG_BASE64);
+  const array = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    array[i] = binary.charCodeAt(i);
+  }
+  return new File([array], "test.png", { type: "image/png" });
+}
+
+describe("convertToWebP", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns non-image file as-is", async () => {
+    const file = new File(["hello"], "doc.txt", { type: "text/plain" });
+    const result = await convertToWebP(file);
+    expect(result).toBe(file);
+    expect(result.name).toBe("doc.txt");
+    expect(result.type).toBe("text/plain");
+  });
+
+  it("returns WebP file as-is", async () => {
+    const file = new File(["webpdata"], "image.webp", { type: "image/webp" });
+    const result = await convertToWebP(file);
+    expect(result).toBe(file);
+    expect(result.name).toBe("image.webp");
+    expect(result.type).toBe("image/webp");
+  });
+
+  it("converts PNG to WebP when canvas.toBlob supports webp", async () => {
+    const pngFile = createPngFile();
+    const mockBlob = new Blob(["webp"], { type: "image/webp" });
+
+    // jsdom の Image は blob URL を読み込まないため、onload を即時発火させる
+    const OriginalImage = globalThis.Image;
+    vi.stubGlobal(
+      "Image",
+      class MockImage extends OriginalImage {
+        constructor() {
+          super();
+          queueMicrotask(() => {
+            Object.defineProperty(this, "naturalWidth", { value: 1 });
+            Object.defineProperty(this, "naturalHeight", { value: 1 });
+            this.onload?.();
+          });
+        }
+      },
+    );
+
+    // jsdom の getContext は未実装のためモック
+    const mockDrawImage = vi.fn();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+      drawImage: mockDrawImage,
+    } as unknown as CanvasRenderingContext2D);
+
+    const toBlobSpy = vi.spyOn(HTMLCanvasElement.prototype, "toBlob");
+    toBlobSpy.mockImplementation((callback) => {
+      callback?.(mockBlob);
+    });
+
+    const result = await convertToWebP(pngFile);
+
+    expect(result).not.toBe(pngFile);
+    expect(result.name).toBe("test.webp");
+    expect(result.type).toBe("image/webp");
+    expect(result.size).toBe(mockBlob.size);
+  });
+
+  it("returns original file when canvas.toBlob returns null (webp unsupported)", async () => {
+    const pngFile = createPngFile();
+
+    const OriginalImage = globalThis.Image;
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+    vi.stubGlobal(
+      "Image",
+      class MockImage extends OriginalImage {
+        constructor() {
+          super();
+          queueMicrotask(() => {
+            Object.defineProperty(this, "naturalWidth", { value: 1 });
+            Object.defineProperty(this, "naturalHeight", { value: 1 });
+            this.onload?.();
+          });
+        }
+      },
+    );
+
+    const toBlobSpy = vi.spyOn(HTMLCanvasElement.prototype, "toBlob");
+    toBlobSpy.mockImplementation((callback) => {
+      callback?.(null);
+    });
+
+    const result = await convertToWebP(pngFile);
+
+    expect(result).toBe(pngFile);
+    expect(result.name).toBe("test.png");
+    expect(result.type).toBe("image/png");
+  });
+
+  it("preserves base filename when converting", async () => {
+    const pngFile = new File([createPngFile()], "my-photo-2024.png", {
+      type: "image/png",
+    });
+    const mockBlob = new Blob(["webp"], { type: "image/webp" });
+
+    const OriginalImage = globalThis.Image;
+    vi.stubGlobal(
+      "Image",
+      class MockImage extends OriginalImage {
+        constructor() {
+          super();
+          queueMicrotask(() => {
+            Object.defineProperty(this, "naturalWidth", { value: 1 });
+            Object.defineProperty(this, "naturalHeight", { value: 1 });
+            this.onload?.();
+          });
+        }
+      },
+    );
+
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+
+    vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation((callback) => {
+      callback?.(mockBlob);
+    });
+
+    const result = await convertToWebP(pngFile);
+
+    expect(result.name).toBe("my-photo-2024.webp");
+  });
+});

--- a/src/lib/storage/convertToWebP.test.ts
+++ b/src/lib/storage/convertToWebP.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { convertToWebP } from "./convertToWebP";
 
 // 1x1 透明 PNG（S3Provider と同じ）
@@ -15,12 +15,9 @@ function createPngFile(): File {
 }
 
 describe("convertToWebP", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("returns non-image file as-is", async () => {

--- a/src/lib/storage/convertToWebP.ts
+++ b/src/lib/storage/convertToWebP.ts
@@ -48,14 +48,14 @@ export async function convertToWebP(file: File): Promise<File> {
       canvas.toBlob(resolve, "image/webp", WEBP_QUALITY);
     });
 
-    if (!blob) {
+    if (!blob || blob.type !== "image/webp") {
       return file;
     }
 
     const baseName = file.name.replace(/\.[^.]+$/, "") || "image";
     return new File([blob], `${baseName}.webp`, {
-      type: "image/webp",
-      lastModified: Date.now(),
+      type: blob.type,
+      lastModified: file.lastModified,
     });
   } catch {
     return file;

--- a/src/lib/storage/convertToWebP.ts
+++ b/src/lib/storage/convertToWebP.ts
@@ -26,50 +26,40 @@ export async function convertToWebP(file: File): Promise<File> {
     return file;
   }
 
-  return new Promise((resolve) => {
-    const img = new Image();
-    const objectUrl = URL.createObjectURL(file);
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const image = new Image();
+      image.onload = () => resolve(image);
+      image.onerror = reject;
+      image.src = objectUrl;
+    });
 
-    img.onload = () => {
-      URL.revokeObjectURL(objectUrl);
+    const canvas = document.createElement("canvas");
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return file;
+    }
+    ctx.drawImage(img, 0, 0);
 
-      try {
-        const canvas = document.createElement("canvas");
-        canvas.width = img.naturalWidth;
-        canvas.height = img.naturalHeight;
-        const ctx = canvas.getContext("2d");
-        if (!ctx) {
-          resolve(file);
-          return;
-        }
-        ctx.drawImage(img, 0, 0);
+    const blob = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob(resolve, "image/webp", WEBP_QUALITY);
+    });
 
-        canvas.toBlob(
-          (blob) => {
-            if (!blob) {
-              resolve(file);
-              return;
-            }
-            const baseName = file.name.replace(/\.[^.]+$/, "") || "image";
-            const webpFile = new File([blob], `${baseName}.webp`, {
-              type: "image/webp",
-              lastModified: Date.now(),
-            });
-            resolve(webpFile);
-          },
-          "image/webp",
-          WEBP_QUALITY,
-        );
-      } catch {
-        resolve(file);
-      }
-    };
+    if (!blob) {
+      return file;
+    }
 
-    img.onerror = () => {
-      URL.revokeObjectURL(objectUrl);
-      resolve(file);
-    };
-
-    img.src = objectUrl;
-  });
+    const baseName = file.name.replace(/\.[^.]+$/, "") || "image";
+    return new File([blob], `${baseName}.webp`, {
+      type: "image/webp",
+      lastModified: Date.now(),
+    });
+  } catch {
+    return file;
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
 }

--- a/src/lib/storage/convertToWebP.ts
+++ b/src/lib/storage/convertToWebP.ts
@@ -1,0 +1,75 @@
+/**
+ * 画像を WebP 形式に変換するユーティリティ
+ * ストレージ節約のため、アップロード前にクライアント側で変換する
+ *
+ * @see https://github.com/otomatty/zedi/issues/256
+ */
+
+const WEBP_QUALITY = 0.82; // 80〜85 程度（容量と画質のバランス）
+
+/**
+ * 画像ファイルを WebP 形式に変換する
+ *
+ * - 既に WebP の場合はそのまま返す
+ * - アニメーション GIF は静止画（1フレーム目）として WebP に変換
+ * - canvas.toBlob('image/webp') が非対応の環境では元のファイルを返す
+ *
+ * @param file 画像ファイル
+ * @returns WebP 形式の File、または変換失敗時は元の File
+ */
+export async function convertToWebP(file: File): Promise<File> {
+  if (!file.type.startsWith("image/")) {
+    return file;
+  }
+
+  if (file.type === "image/webp") {
+    return file;
+  }
+
+  return new Promise((resolve) => {
+    const img = new Image();
+    const objectUrl = URL.createObjectURL(file);
+
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+
+      try {
+        const canvas = document.createElement("canvas");
+        canvas.width = img.naturalWidth;
+        canvas.height = img.naturalHeight;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          resolve(file);
+          return;
+        }
+        ctx.drawImage(img, 0, 0);
+
+        canvas.toBlob(
+          (blob) => {
+            if (!blob) {
+              resolve(file);
+              return;
+            }
+            const baseName = file.name.replace(/\.[^.]+$/, "") || "image";
+            const webpFile = new File([blob], `${baseName}.webp`, {
+              type: "image/webp",
+              lastModified: Date.now(),
+            });
+            resolve(webpFile);
+          },
+          "image/webp",
+          WEBP_QUALITY,
+        );
+      } catch {
+        resolve(file);
+      }
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      resolve(file);
+    };
+
+    img.src = objectUrl;
+  });
+}

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -121,8 +121,9 @@ export function isStorageConfiguredForUpload(settings: StorageSettings): boolean
   return settings.provider !== "s3" && isProviderConfigured(settings.provider, settings.config);
 }
 
-// Re-export types
+// Re-export types and utilities
 export * from "./types";
+export { convertToWebP } from "./convertToWebP";
 export { GyazoProvider } from "./providers/GyazoProvider";
 export { GitHubProvider } from "./providers/GitHubProvider";
 export { GoogleDriveProvider } from "./providers/GoogleDriveProvider";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

画像アップロード時にクライアントサイドで画像をWebP形式に変換する機能を追加します。これにより、ストレージ容量の削減と表示パフォーマンスの向上が期待されます。

## 変更点

- `src/lib/storage/convertToWebP.ts` を追加し、Canvas API を利用したWebP変換ロジックを実装
  - 既存のWebPファイルはそのまま、アニメーションGIFは1フレーム目を静止画として変換
  - `canvas.toBlob('image/webp')` 非対応ブラウザ向けに元のファイルを返すフォールバックを実装
- 以下のアップロード箇所にWebP変換処理を組み込み
  - `src/hooks/useImageUpload.ts` (画像作成ダイアログなど)
  - `src/components/editor/TiptapEditor/useImageUploadManagerHelpers.ts` (エディタへのドラッグ＆ドロップ)
  - `src/components/editor/TiptapEditor/useThumbnailCommit.ts` (サムネイル保存)
- 変換後のファイル名を `.webp` に統一し、Content-Type を `image/webp` に設定
- `convertToWebP` の単体テスト (`src/lib/storage/convertToWebP.test.ts`) を追加

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1.  アプリケーションを起動し、以下の手順で画像をアップロードする
    - 画像作成ダイアログから (例: `src/hooks/useImageUpload.ts` 経由)
    - エディタに画像をドラッグ＆ドロップ (例: `src/components/editor/TiptapEditor/useImageUploadManagerHelpers.ts` 経由)
    - サムネイルを保存 (例: `src/components/editor/TiptapEditor/useThumbnailCommit.ts` 経由)
2.  PNG, JPEG, GIF (アニメーション含む), 既存のWebPファイルなど、様々な形式の画像をアップロードする
3.  アップロードされた画像がWebP形式に変換され、ファイル名が `.webp` になっていることを確認する
4.  ブラウザが `canvas.toBlob('image/webp')` をサポートしていない環境でテストし、元のファイルがアップロードされることを確認する
5.  `npm test` を実行し、すべてのテストがパスすることを確認する

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

<!-- Before/After のスクリーンショット -->

## 関連 Issue

Closes #256

---
<p><a href="https://cursor.com/agents/bc-f9c58fcf-2264-40b9-ad16-ec6d647bcd87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9c58fcf-2264-40b9-ad16-ec6d647bcd87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 画像アップロード時に自動でWebPへ変換してから送信するようになりました（エディターやサムネイルなどのアップロード経路に適用）。変換後のファイル名をメタデータに反映します。既存の進行表示やエラー処理は維持されています。

* **テスト**
  * WebP変換機能の包括的なテストスイートを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->