### PR TITLE
fix(ci): Cloudflare Pages デプロイ時の UTF-8 コミットメッセージエラーを回避

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -56,4 +56,4 @@ jobs:
           packageManager: bun
           # Cloudflare API truncates commit message at ~384 bytes without UTF-8 boundary check (workers-sdk#11749).
           # Use an explicit ASCII-only message to avoid "Invalid commit message" (code 8000111) when git message contains multi-byte chars.
-          command: pages deploy dist --project-name=zedi-dev --commit-message "Deploy from GitHub Actions (develop)"
+          command: pages deploy dist --project-name=zedi-dev --commit-message "Deploy from GitHub Actions (develop) ${{ github.sha }}"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -54,4 +54,6 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: bun
-          command: pages deploy dist --project-name=zedi-dev
+          # Cloudflare API truncates commit message at ~384 bytes without UTF-8 boundary check (workers-sdk#11749).
+          # Use an explicit ASCII-only message to avoid "Invalid commit message" (code 8000111) when git message contains multi-byte chars.
+          command: pages deploy dist --project-name=zedi-dev --commit-message "Deploy from GitHub Actions (develop)"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -59,7 +59,7 @@ jobs:
           packageManager: bun
           # Cloudflare API truncates commit message at ~384 bytes without UTF-8 boundary check (workers-sdk#11749).
           # Use an explicit ASCII-only message to avoid "Invalid commit message" (code 8000111).
-          command: pages deploy dist --project-name=zedi --commit-message "Deploy from GitHub Actions (main)"
+          command: pages deploy dist --project-name=zedi --commit-message "Deploy from GitHub Actions (main) ${{ github.sha }}"
 
   deploy-admin:
     name: Deploy Admin
@@ -88,4 +88,4 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: bun
           # Avoid Cloudflare "Invalid commit message" (8000111) for long UTF-8 git messages (workers-sdk#11749).
-          command: pages deploy admin/dist --project-name=zedi-admin --commit-message "Deploy admin from GitHub Actions (main)"
+          command: pages deploy admin/dist --project-name=zedi-admin --commit-message "Deploy admin from GitHub Actions (main) ${{ github.sha }}"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -57,7 +57,9 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: bun
-          command: pages deploy dist --project-name=zedi
+          # Cloudflare API truncates commit message at ~384 bytes without UTF-8 boundary check (workers-sdk#11749).
+          # Use an explicit ASCII-only message to avoid "Invalid commit message" (code 8000111).
+          command: pages deploy dist --project-name=zedi --commit-message "Deploy from GitHub Actions (main)"
 
   deploy-admin:
     name: Deploy Admin
@@ -85,4 +87,5 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: bun
-          command: pages deploy admin/dist --project-name=zedi-admin
+          # Avoid Cloudflare "Invalid commit message" (8000111) for long UTF-8 git messages (workers-sdk#11749).
+          command: pages deploy admin/dist --project-name=zedi-admin --commit-message "Deploy admin from GitHub Actions (main)"


### PR DESCRIPTION
## 概要

Cloudflare Pages デプロイで「Invalid commit message, it must be a valid UTF-8 string」（code 8000111）が発生する問題を回避するため、`wrangler pages deploy` に `--commit-message` で ASCII のみの短いメッセージを明示的に渡すようにしました。Cloudflare API がコミットメッセージを約 384 バイトで切り捨てる際に UTF-8 境界を考慮しない既知の不具合（workers-sdk#11749）のため、日本語等を含むコミットでデプロイが失敗していました。

## 変更点

- `.github/workflows/deploy-dev.yml`: `pages deploy dist --project-name=zedi-dev` に `--commit-message "Deploy from GitHub Actions (develop)"` を追加
- `.github/workflows/deploy-prod.yml`: フロントの `pages deploy dist --project-name=zedi` に `--commit-message "Deploy from GitHub Actions (main)"` を追加
- `.github/workflows/deploy-prod.yml`: 管理画面の `pages deploy admin/dist --project-name=zedi-admin` に `--commit-message "Deploy admin from GitHub Actions (main)"` を追加
- 各ステップにコメントで Cloudflare の不具合参照（workers-sdk#11749）を追記

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. 本 PR を develop にマージ後、develop への push で Deploy Development ワークフローが実行されることを確認する。
2. Cloudflare Pages のデプロイが成功し、エラー 8000111 が発生しないことを確認する。
3. （任意）main へのマージ後も Deploy Production が同様に成功することを確認する。

## チェックリスト

- [x] テストがすべてパスする（ワークフローのみの変更のため `bun run test:run` は既存のまま）
- [x] Lint エラーがない（warning のみ、既存）
- [x] 必要に応じてドキュメントを更新した（コメントで理由を記載）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

なし（CI のみ）

## 関連 Issue

<!-- PR #262 のデプロイ失敗対応 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * Cloudflareデプロイメントの信頼性を向上。デプロイプロセス中のコミットメッセージハンドリングを最適化し、エラーの発生を防止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->