### PR TITLE
feat(editor): add copy button on hover to code blocks in page editor

### DIFF
--- a/src/components/editor/CodeBlockWithCopyNodeView.tsx
+++ b/src/components/editor/CodeBlockWithCopyNodeView.tsx
@@ -39,7 +39,7 @@ export const CodeBlockWithCopyNodeView: React.FC<NodeViewProps> = ({ node }) => 
         contentEditable={false}
         onClick={handleCopy}
         aria-label={copied ? "Copied" : "Copy code"}
-        className="absolute right-2 top-2 rounded border border-border/60 bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover/code:opacity-100"
+        className="absolute right-2 top-2 rounded border border-border/60 bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-muted group-hover/code:opacity-100"
       >
         {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
       </button>

--- a/src/components/editor/CodeBlockWithCopyNodeView.tsx
+++ b/src/components/editor/CodeBlockWithCopyNodeView.tsx
@@ -22,19 +22,16 @@ export const CodeBlockWithCopyNodeView: React.FC<NodeViewProps> = ({ node }) => 
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
       setCopied(true);
       timeoutRef.current = setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // ignore
+    } catch (err) {
+      console.error("Failed to copy code to clipboard:", err);
     }
   };
 
   const language = (node.attrs.language as string) ?? "";
 
   return (
-    <NodeViewWrapper as="div" className="group/code relative mb-4">
-      <pre
-        ref={preRef}
-        className="overflow-x-auto rounded-lg bg-muted p-4 font-mono text-sm"
-      >
+    <NodeViewWrapper as="div" className="group/code relative">
+      <pre ref={preRef} className="overflow-x-auto">
         <NodeViewContent as="code" className={language ? `language-${language}` : ""} />
       </pre>
       <button
@@ -42,7 +39,7 @@ export const CodeBlockWithCopyNodeView: React.FC<NodeViewProps> = ({ node }) => 
         contentEditable={false}
         onClick={handleCopy}
         aria-label={copied ? "Copied" : "Copy code"}
-        className="absolute right-2 top-2 rounded border border-border/60 bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 focus:outline-none group-hover/code:opacity-100"
+        className="absolute right-2 top-2 rounded border border-border/60 bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover/code:opacity-100"
       >
         {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
       </button>

--- a/src/components/editor/CodeBlockWithCopyNodeView.tsx
+++ b/src/components/editor/CodeBlockWithCopyNodeView.tsx
@@ -1,0 +1,51 @@
+import React, { useRef, useState, useEffect } from "react";
+import { NodeViewWrapper, NodeViewContent, type NodeViewProps } from "@tiptap/react";
+import { Copy, Check } from "lucide-react";
+
+export const CodeBlockWithCopyNodeView: React.FC<NodeViewProps> = ({ node }) => {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    },
+    [],
+  );
+
+  const handleCopy = async () => {
+    const text = preRef.current?.textContent ?? "";
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      setCopied(true);
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // ignore
+    }
+  };
+
+  const language = (node.attrs.language as string) ?? "";
+
+  return (
+    <NodeViewWrapper as="div" className="group/code relative mb-4">
+      <pre
+        ref={preRef}
+        className="overflow-x-auto rounded-lg bg-muted p-4 font-mono text-sm"
+      >
+        <NodeViewContent as="code" className={language ? `language-${language}` : ""} />
+      </pre>
+      <button
+        type="button"
+        contentEditable={false}
+        onClick={handleCopy}
+        aria-label={copied ? "Copied" : "Copy code"}
+        className="absolute right-2 top-2 rounded border border-border/60 bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 focus:outline-none group-hover/code:opacity-100"
+      >
+        {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+      </button>
+    </NodeViewWrapper>
+  );
+};

--- a/src/components/editor/TiptapEditor/editorConfig.ts
+++ b/src/components/editor/TiptapEditor/editorConfig.ts
@@ -13,8 +13,8 @@ import { Table, TableRow, TableCell, TableHeader } from "@tiptap/extension-table
 import { TextStyle } from "@tiptap/extension-text-style";
 import { Color } from "@tiptap/extension-color";
 import { Mathematics } from "@tiptap/extension-mathematics";
-import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
 import { common, createLowlight } from "lowlight";
+import { CodeBlockWithCopy } from "../extensions/CodeBlockWithCopyExtension";
 import { ImageUpload, type ImageUploadOptions } from "../extensions/ImageUploadExtension";
 import { StorageImage, type StorageImageOptions } from "../extensions/StorageImageExtension";
 import { WikiLink } from "../extensions/WikiLinkExtension";
@@ -157,8 +157,8 @@ export function createEditorExtensions(options: EditorExtensionsOptions): Extens
       multicolor: false,
     }),
     Underline,
-    // --- Phase 1: Code Block with syntax highlighting ---
-    CodeBlockLowlight.configure({
+    // --- Phase 1: Code Block with syntax highlighting and copy button ---
+    CodeBlockWithCopy.configure({
       lowlight,
       defaultLanguage: null,
     }),

--- a/src/components/editor/extensions/CodeBlockWithCopyExtension.ts
+++ b/src/components/editor/extensions/CodeBlockWithCopyExtension.ts
@@ -1,0 +1,13 @@
+import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import { CodeBlockWithCopyNodeView } from "../CodeBlockWithCopyNodeView";
+
+/**
+ * CodeBlockLowlight extended with a copy button on hover.
+ * Renders a React NodeView that shows a copy icon in the top-right when hovering over the code block.
+ */
+export const CodeBlockWithCopy = CodeBlockLowlight.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(CodeBlockWithCopyNodeView);
+  },
+});


### PR DESCRIPTION
## 概要

ページエディター（TipTap）内のコードブロックに、ホバー時に右上に表示される「コピー」ボタンを追加しました。AIチャットと同様の UX をページエディターでも提供し、ワンクリックでコードをクリップボードにコピーできるようにします。

## 変更点

- `src/components/editor/CodeBlockWithCopyNodeView.tsx`: コードブロック用 React NodeView コンポーネント（ホバー時にコピーボタンを表示、クリックでコピー＋「Copied」フィードバック 2 秒間、`aria-label` でアクセシビリティ対応）
- `src/components/editor/extensions/CodeBlockWithCopyExtension.ts`: `CodeBlockLowlight` を `ReactNodeViewRenderer` で拡張
- `src/components/editor/TiptapEditor/editorConfig.ts`: `CodeBlockLowlight` を `CodeBlockWithCopy` に差し替え

## 変更の種類

- [x] ✨ 新機能 (New feature)

## テスト方法

1. `bun run dev` で開発サーバーを起動
2. ページを開き、エディターでコードブロックを挿入（``` または スラッシュコマンドから「コードブロック」を選択）
3. コードブロックにマウスをホバーすると、右上にコピーアイコンボタンが表示されることを確認
4. ボタンをクリックし、コードがクリップボードにコピーされ、「Copied」表示に変わることを確認
5. フォーカス時にボタンが表示されることを確認（`focus:opacity-100`）

## チェックリスト

- [ ] テストがすべてパスする（`bun run test:run`）
- [ ] Lint エラーがない（`bun run lint`）
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

<!-- コードブロックにホバーしたときのコピーボタン表示を撮影して追加 -->

## 関連 Issue

Closes #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * コードブロックにコピー機能を追加しました。コード内容をワンクリックで クリップボードにコピーできるようになり、ユーザー体験が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->