### PR TITLE
Code formatting issues

### DIFF
--- a/src/components/editor/CodeBlockWithCopyNodeView.tsx
+++ b/src/components/editor/CodeBlockWithCopyNodeView.tsx
@@ -22,19 +22,16 @@ export const CodeBlockWithCopyNodeView: React.FC<NodeViewProps> = ({ node }) => 
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
       setCopied(true);
       timeoutRef.current = setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // ignore
+    } catch (err) {
+      console.error("Failed to copy code to clipboard:", err);
     }
   };
 
   const language = (node.attrs.language as string) ?? "";
 
   return (
-    <NodeViewWrapper as="div" className="group/code relative mb-4">
-      <pre
-        ref={preRef}
-        className="overflow-x-auto rounded-lg bg-muted p-4 font-mono text-sm"
-      >
+    <NodeViewWrapper as="div" className="group/code relative">
+      <pre ref={preRef} className="overflow-x-auto">
         <NodeViewContent as="code" className={language ? `language-${language}` : ""} />
       </pre>
       <button
@@ -42,7 +39,7 @@ export const CodeBlockWithCopyNodeView: React.FC<NodeViewProps> = ({ node }) => 
         contentEditable={false}
         onClick={handleCopy}
         aria-label={copied ? "Copied" : "Copy code"}
-        className="absolute right-2 top-2 rounded border border-border/60 bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 focus:outline-none group-hover/code:opacity-100"
+        className="absolute right-2 top-2 rounded border border-border/60 bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover/code:opacity-100"
       >
         {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
       </button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`CodeBlockWithCopyNodeView.tsx` のフォーマット修正と、PR #270 で指摘されたレビューコメントへの対応を行いました。

## 変更点

-   `src/components/editor/CodeBlockWithCopyNodeView.tsx` のコードフォーマットを修正。
-   クリップボードコピー失敗時にエラーを無視せず `console.error` でログ出力するように変更。
-   `NodeViewWrapper` から `mb-4` を削除し、グローバルCSS (`.tiptap-editor pre`) でマージンを管理するように変更。
-   コードブロックにフォーカスした際の視認性向上のため、`focus-visible:ring-2 focus-visible:ring-ring` を追加。
-   `pre` タグのスタイル重複を解消し、グローバルCSS (`.tiptap-editor pre`) を利用するように変更。

## 変更の種類

-   [x] 🐛 バグ修正 (Bug fix)
-   [ ] ✨ 新機能 (New feature)
-   [ ] 💥 破壊的変更 (Breaking change)
-   [ ] 📝 ドキュメント (Documentation)
-   [x] 🎨 スタイル/リファクタリング (Style/Refactor)
-   [ ] 🧪 テスト (Tests)
-   [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1.  `bun run format:check` を実行し、フォーマットエラーがないことを確認。
2.  アプリケーションを起動し、エディタのコードブロック機能が正常に動作することを確認。
3.  コードブロックのコピーボタンが機能することを確認。
4.  コードブロックにフォーカスした際に、リングが表示され視認性が向上していることを確認。

## チェックリスト

-   [ ] テストがすべてパスする
-   [ ] Lint エラーがない
-   [ ] 必要に応じてドキュメントを更新した
-   [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

<!-- Before/After のスクリーンショット -->

## 関連 Issue

PR #270 のレビューコメント対応

---
<p><a href="https://cursor.com/agents/bc-f3582d24-52af-46f7-b979-27440805f5e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3582d24-52af-46f7-b979-27440805f5e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->