### PR TITLE
feat(ai-chat): wikilink rendering, user edit/resend, conversation history, split message component

### DIFF
--- a/docs/reviews/review-develop-20250308-2.md
+++ b/docs/reviews/review-develop-20250308-2.md
@@ -1,0 +1,69 @@
+# セルフレビュー: develop（未コミット変更）
+
+**日時**: 2025-03-08
+**ベース**: develop（作業ツリーの未コミット変更）
+**変更ファイル数**: 10 files
+**関連ファイル数**: 8 files（変更本体＋テスト・呼び出し元）
+
+## サマリー
+
+AIチャットまわりの未コミット変更を対象にしたセルフレビュー。メッセージ表示に WikiLink（`[[Title]]`）のレンダリングを追加し、`AIChatWikiLink` コンポーネントで既存ページへのリンク／未存在ページはゴースト表示にしている。またユーザーメッセージの長押し／クリック編集・再送信、会話のページ紐付け・履歴の読み込み、アクション実行（create-page / create-multiple-pages）などの機能が含まれる。
+
+## ファイルサイズ
+
+| ファイル                                  | 行数 | 判定                           |
+| ----------------------------------------- | ---- | ------------------------------ |
+| src/components/ai-chat/AIChatMessage.tsx  | 340  | Warning: 250行超（分割を推奨） |
+| src/components/ai-chat/AIChatMessages.tsx | 51   | OK                             |
+| src/components/ai-chat/AIChatPanel.tsx    | 186  | OK                             |
+| src/components/ai-chat/AIChatWikiLink.tsx | 33   | OK                             |
+| src/hooks/useAIChat.ts                    | 106  | OK                             |
+| src/hooks/useAIChatExecute.ts             | 188  | OK                             |
+| src/lib/aiChatActions.ts                  | 31   | OK                             |
+| src/lib/aiChatPrompt.ts                   | 97   | OK                             |
+| src/i18n/locales/en/aiChat.json           | 69   | OK                             |
+| src/i18n/locales/ja/aiChat.json           | 69   | OK                             |
+
+## 指摘事項
+
+### 🔴 Critical（マージ前に修正必須）
+
+なし。
+
+### 🟡 Warning（修正を推奨）
+
+| #   | ファイル                                  | 行  | 観点             | 指摘内容                                | 推奨修正                                                                                                                                                                                                           |
+| --- | ----------------------------------------- | --- | ---------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | src/components/ai-chat/AIChatMessage.tsx  | -   | 可読性・保守性   | ファイルが 340 行で 250 行を超えている  | 責務ごとに分割を推奨。例: `replaceWikiLinksInMarkdown` を `aiChatMarkdownHelpers.ts` などに切り出し、`CodeBlockWithCopy` を別コンポーネントファイルに、`UserMessageBubble` を `AIChatUserMessageBubble.tsx` に分離 |
+| 2   | src/components/ai-chat/AIChatWikiLink.tsx | -   | プロジェクト規約 | Prettier チェックでフォーマット警告あり | `bun run format` または `prettier --write src/components/ai-chat/AIChatWikiLink.tsx` で整形                                                                                                                        |
+
+### 🟢 Info（任意の改善提案）
+
+| #   | ファイル                                 | 行  | 観点             | 指摘内容                                                                      | 推奨修正                                                                                                                 |
+| --- | ---------------------------------------- | --- | ---------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| 1   | src/components/ai-chat/AIChatMessage.tsx | 244 | アクセシビリティ | Code block の Copy ボタンが `aria-label` で "Copied" / "Copy code" の英語固定 | i18n（aiChat.json）に `copyCode` / `copied` を追加して `t("aiChat.actions.copyCode")` などで統一すると多言語対応しやすい |
+| 2   | src/hooks/useAIChatExecute.ts            | 98  | 設計             | `useAIChatStore.getState()` を非 React コンテキストで使用                     | 現状のストア設計で問題ないが、テスト時に `selectedModel` を差し替えたい場合は store の inject や引数化を検討可能         |
+
+## テストカバレッジ
+
+| 変更ファイル                              | テストファイル                | 状態                    |
+| ----------------------------------------- | ----------------------------- | ----------------------- |
+| src/lib/aiChatPrompt.ts                   | src/lib/aiChatPrompt.test.ts  | ✅ 既存テストあり       |
+| src/lib/aiChatActions.ts                  | src/lib/aiChatActions.test.ts | ✅ 既存テストあり       |
+| src/components/ai-chat/AIChatMessage.tsx  | -                             | ⚠️ テスト未作成         |
+| src/components/ai-chat/AIChatMessages.tsx | -                             | ⚠️ テスト未作成         |
+| src/components/ai-chat/AIChatPanel.tsx    | -                             | ⚠️ テスト未作成         |
+| src/components/ai-chat/AIChatWikiLink.tsx | -                             | ⚠️ テスト未作成（新規） |
+| src/hooks/useAIChat.ts                    | -                             | ⚠️ テスト未作成         |
+| src/hooks/useAIChatExecute.ts             | -                             | ⚠️ テスト未作成         |
+
+## Lint / Format チェック
+
+- **ESLint**: `bun run lint` → 0 errors, 57 warnings（変更ファイルに起因する error / warning はなし）
+- **Prettier**: `bun run format:check` → 変更ファイルのうち `src/components/ai-chat/AIChatWikiLink.tsx` で [warn] あり（上記 Warning #2）
+
+## 統計
+
+- Critical: 0 件
+- Warning: 2 件
+- Info: 2 件

--- a/src/components/ai-chat/AIChatCodeBlock.tsx
+++ b/src/components/ai-chat/AIChatCodeBlock.tsx
@@ -1,0 +1,43 @@
+import { useRef, useState, useEffect } from "react";
+import { Copy, Check } from "lucide-react";
+
+/** Code block with syntax highlighting and copy button */
+export function CodeBlockWithCopy({ children }: { children?: React.ReactNode }) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    },
+    [],
+  );
+
+  const handleCopy = async () => {
+    const text = preRef.current?.textContent ?? "";
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      setCopied(true);
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="group/code relative">
+      <pre ref={preRef}>{children}</pre>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "Copied" : "Copy code"}
+        className="absolute right-2 top-2 rounded border border-border/60 bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 group-hover/code:opacity-100"
+      >
+        {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+      </button>
+    </div>
+  );
+}

--- a/src/components/ai-chat/AIChatCodeBlock.tsx
+++ b/src/components/ai-chat/AIChatCodeBlock.tsx
@@ -1,8 +1,11 @@
+import type { ReactNode } from "react";
 import { useRef, useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { Copy, Check } from "lucide-react";
 
 /** Code block with syntax highlighting and copy button */
-export function CodeBlockWithCopy({ children }: { children?: React.ReactNode }) {
+export function CodeBlockWithCopy({ children }: { children?: ReactNode }) {
+  const { t } = useTranslation();
   const preRef = useRef<HTMLPreElement>(null);
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -33,7 +36,7 @@ export function CodeBlockWithCopy({ children }: { children?: React.ReactNode }) 
       <button
         type="button"
         onClick={handleCopy}
-        aria-label={copied ? "Copied" : "Copy code"}
+        aria-label={copied ? t("aiChat.actions.copiedCode") : t("aiChat.actions.copyCode")}
         className="absolute right-2 top-2 rounded border border-border/60 bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 group-hover/code:opacity-100"
       >
         {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}

--- a/src/components/ai-chat/AIChatMessage.tsx
+++ b/src/components/ai-chat/AIChatMessage.tsx
@@ -64,11 +64,17 @@ export function AIChatMessage({
                   pre: CodeBlockWithCopy,
                   a: ({ href, children }) => {
                     if (href?.startsWith("wiki:")) {
-                      const title = decodeURIComponent(href.slice(5));
+                      let title: string;
+                      try {
+                        title = decodeURIComponent(href.slice(5));
+                      } catch {
+                        title = href.slice(5);
+                      }
                       return <AIChatWikiLink title={title} />;
                     }
+                    const safeHref = href && /^(https?|mailto|tel):/i.test(href) ? href : undefined;
                     return (
-                      <a href={href} target="_blank" rel="noopener noreferrer">
+                      <a href={safeHref} target="_blank" rel="noopener noreferrer">
                         {children}
                       </a>
                     );

--- a/src/components/ai-chat/AIChatMessage.tsx
+++ b/src/components/ai-chat/AIChatMessage.tsx
@@ -1,8 +1,11 @@
-import React, { useRef, useState, useEffect } from "react";
-import { Sparkles, User, FileText, Copy, Check } from "lucide-react";
-import { ChatMessage, ChatAction, ReferencedPage } from "../../types/aiChat";
+import { Sparkles, User } from "lucide-react";
+import { ChatMessage, ChatAction } from "../../types/aiChat";
 import { getDisplayContent } from "../../lib/aiChatActions";
 import { AIChatActionCard } from "./AIChatActionCard";
+import { AIChatWikiLink } from "./AIChatWikiLink";
+import { UserMessageBubble, renderUserContent } from "./AIChatUserMessageBubble";
+import { CodeBlockWithCopy } from "./AIChatCodeBlock";
+import { replaceWikiLinksInMarkdown } from "./aiChatMarkdownHelpers";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
@@ -10,84 +13,19 @@ import rehypeHighlight from "rehype-highlight";
 interface AIChatMessageProps {
   message: ChatMessage;
   onExecuteAction?: (action: ChatAction) => void;
+  onEditMessage?: (messageId: string, newContent: string) => void;
+  isStreaming?: boolean;
 }
 
-/** Render user message content with inline @PageTitle styled as badges */
-function renderUserContent(content: string, referencedPages?: ReferencedPage[]) {
-  if (!referencedPages || referencedPages.length === 0) {
-    return <div className="whitespace-pre-wrap break-words">{content}</div>;
-  }
-
-  // Build a regex that matches @Title for each referenced page
-  const escapedTitles = referencedPages.map((p) => p.title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
-  const pattern = new RegExp(`(@(?:${escapedTitles.join("|")}))(?=\\s|$)`, "g");
-  const parts = content.split(pattern);
-
-  return (
-    <div className="whitespace-pre-wrap break-words">
-      {parts.map((part, i) => {
-        const matchedRef = referencedPages.find((p) => part === `@${p.title}`);
-        if (matchedRef) {
-          return (
-            <span
-              key={i}
-              className="mx-0.5 inline-flex items-center gap-0.5 rounded bg-primary-foreground/20 px-1.5 py-0 align-baseline text-xs font-medium text-primary-foreground/90"
-            >
-              <FileText className="h-3 w-3 shrink-0" />
-              {matchedRef.title}
-            </span>
-          );
-        }
-        return <React.Fragment key={i}>{part}</React.Fragment>;
-      })}
-    </div>
-  );
-}
-
-/** Code block with syntax highlighting and copy button */
-function CodeBlockWithCopy({ children }: { children?: React.ReactNode }) {
-  const preRef = useRef<HTMLPreElement>(null);
-  const [copied, setCopied] = useState(false);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(
-    () => () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    },
-    [],
-  );
-
-  const handleCopy = async () => {
-    const text = preRef.current?.textContent ?? "";
-    if (!text) return;
-    try {
-      await navigator.clipboard.writeText(text);
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      setCopied(true);
-      timeoutRef.current = setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // ignore
-    }
-  };
-
-  return (
-    <div className="group/code relative">
-      <pre ref={preRef}>{children}</pre>
-      <button
-        type="button"
-        onClick={handleCopy}
-        aria-label={copied ? "Copied" : "Copy code"}
-        className="absolute right-2 top-2 rounded border border-border/60 bg-muted/90 px-2 py-1 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 group-hover/code:opacity-100"
-      >
-        {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-      </button>
-    </div>
-  );
-}
-
-export function AIChatMessage({ message, onExecuteAction }: AIChatMessageProps) {
+export function AIChatMessage({
+  message,
+  onExecuteAction,
+  onEditMessage,
+  isStreaming = false,
+}: AIChatMessageProps) {
   const isUser = message.role === "user";
   const displayContent = isUser ? message.content : getDisplayContent(message.content);
+  const showUserEdit = isUser && onEditMessage;
 
   return (
     <div className={`mb-4 flex gap-3 ${isUser ? "flex-row-reverse" : "flex-row"}`}>
@@ -107,7 +45,15 @@ export function AIChatMessage({ message, onExecuteAction }: AIChatMessageProps) 
               : "rounded-tl-sm bg-muted text-foreground"
           }`}
         >
-          {isUser ? (
+          {isUser && showUserEdit ? (
+            <UserMessageBubble
+              content={displayContent}
+              referencedPages={message.referencedPages}
+              messageId={message.id}
+              onEditMessage={onEditMessage}
+              isStreaming={isStreaming}
+            />
+          ) : isUser ? (
             renderUserContent(displayContent, message.referencedPages)
           ) : (
             <div className="ai-chat-markdown">
@@ -116,9 +62,20 @@ export function AIChatMessage({ message, onExecuteAction }: AIChatMessageProps) 
                 rehypePlugins={[rehypeHighlight]}
                 components={{
                   pre: CodeBlockWithCopy,
+                  a: ({ href, children }) => {
+                    if (href?.startsWith("wiki:")) {
+                      const title = decodeURIComponent(href.slice(5));
+                      return <AIChatWikiLink title={title} />;
+                    }
+                    return (
+                      <a href={href} target="_blank" rel="noopener noreferrer">
+                        {children}
+                      </a>
+                    );
+                  },
                 }}
               >
-                {displayContent}
+                {replaceWikiLinksInMarkdown(displayContent)}
               </ReactMarkdown>
               {message.isStreaming && (
                 <span className="ml-1 inline-block h-4 w-1.5 animate-pulse bg-current align-middle" />
@@ -127,7 +84,6 @@ export function AIChatMessage({ message, onExecuteAction }: AIChatMessageProps) 
           )}
         </div>
 
-        {/* Model name label for assistant messages */}
         {!isUser && message.modelDisplayName && !message.isStreaming && (
           <span className="mt-0.5 px-1 text-[10px] text-muted-foreground">
             {message.modelDisplayName}
@@ -136,7 +92,6 @@ export function AIChatMessage({ message, onExecuteAction }: AIChatMessageProps) 
 
         {message.error && <div className="mt-1 text-xs text-destructive">{message.error}</div>}
 
-        {/* Action Cards */}
         {message.actions && message.actions.length > 0 && onExecuteAction && (
           <div className="mt-2 w-full space-y-2">
             {message.actions.map((action, i) => (

--- a/src/components/ai-chat/AIChatMessages.tsx
+++ b/src/components/ai-chat/AIChatMessages.tsx
@@ -7,12 +7,16 @@ interface AIChatMessagesProps {
   messages: ChatMessage[];
   onSuggestionClick: (text: string) => void;
   onExecuteAction?: (action: ChatAction) => void;
+  onEditMessage?: (messageId: string, newContent: string) => void;
+  isStreaming?: boolean;
 }
 
 export function AIChatMessages({
   messages,
   onSuggestionClick,
   onExecuteAction,
+  onEditMessage,
+  isStreaming = false,
 }: AIChatMessagesProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -34,7 +38,13 @@ export function AIChatMessages({
   return (
     <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto scroll-smooth p-4">
       {messages.map((message) => (
-        <AIChatMessage key={message.id} message={message} onExecuteAction={onExecuteAction} />
+        <AIChatMessage
+          key={message.id}
+          message={message}
+          onExecuteAction={onExecuteAction}
+          onEditMessage={onEditMessage}
+          isStreaming={isStreaming}
+        />
       ))}
     </div>
   );

--- a/src/components/ai-chat/AIChatPanel.tsx
+++ b/src/components/ai-chat/AIChatPanel.tsx
@@ -39,7 +39,15 @@ export function AIChatPanel() {
   // 現在のページに紐付いた会話一覧
   const pageConversations = getConversationsForPage(pageContext?.pageId, pageContext?.type);
 
-  const { messages, sendMessage, stopStreaming, clearMessages, loadMessages } = useAIChat({
+  const {
+    messages,
+    sendMessage,
+    stopStreaming,
+    clearMessages,
+    loadMessages,
+    editAndResend,
+    isStreaming,
+  } = useAIChat({
     pageContext,
     contextEnabled,
   });
@@ -112,6 +120,13 @@ export function AIChatPanel() {
     [activeConversationId, deleteConversation, setActiveConversation, clearMessages],
   );
 
+  const handleEditMessage = useCallback(
+    (messageId: string, newContent: string) => {
+      editAndResend(messageId, newContent);
+    },
+    [editAndResend],
+  );
+
   const handleExecuteAction = useCallback(
     async (action: ChatAction) => {
       try {
@@ -159,6 +174,8 @@ export function AIChatPanel() {
         messages={messages}
         onSuggestionClick={handleSendMessage}
         onExecuteAction={handleExecuteAction}
+        onEditMessage={handleEditMessage}
+        isStreaming={isStreaming}
       />
 
       <div className="border-t bg-background p-4">

--- a/src/components/ai-chat/AIChatUserMessageBubble.tsx
+++ b/src/components/ai-chat/AIChatUserMessageBubble.tsx
@@ -1,0 +1,188 @@
+import React, { useRef, useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { FileText } from "lucide-react";
+import type { ReferencedPage } from "../../types/aiChat";
+
+const LONG_PRESS_MS = 500;
+
+export interface UserMessageBubbleProps {
+  content: string;
+  referencedPages?: ReferencedPage[];
+  messageId: string;
+  onEditMessage: (messageId: string, newContent: string) => void;
+  isStreaming: boolean;
+}
+
+/** Render user message content with inline @PageTitle styled as badges */
+export function renderUserContent(content: string, referencedPages?: ReferencedPage[]) {
+  if (!referencedPages || referencedPages.length === 0) {
+    return <div className="whitespace-pre-wrap break-words">{content}</div>;
+  }
+
+  const escapedTitles = referencedPages.map((p) => p.title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const pattern = new RegExp(`(@(?:${escapedTitles.join("|")}))(?=\\s|$)`, "g");
+  const parts = content.split(pattern);
+
+  return (
+    <div className="whitespace-pre-wrap break-words">
+      {parts.map((part, i) => {
+        const matchedRef = referencedPages.find((p) => part === `@${p.title}`);
+        if (matchedRef) {
+          return (
+            <span
+              key={i}
+              className="mx-0.5 inline-flex items-center gap-0.5 rounded bg-primary-foreground/20 px-1.5 py-0 align-baseline text-xs font-medium text-primary-foreground/90"
+            >
+              <FileText className="h-3 w-3 shrink-0" />
+              {matchedRef.title}
+            </span>
+          );
+        }
+        return <React.Fragment key={i}>{part}</React.Fragment>;
+      })}
+    </div>
+  );
+}
+
+export function UserMessageBubble({
+  content,
+  referencedPages,
+  messageId,
+  onEditMessage,
+  isStreaming,
+}: UserMessageBubbleProps) {
+  const { t } = useTranslation();
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(content);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressTriggeredRef = useRef(false);
+  const lastPointerTypeRef = useRef<string>("");
+
+  const canEdit = !isStreaming;
+
+  const startEdit = useCallback(() => {
+    if (!canEdit) return;
+    setEditValue(content);
+    setIsEditing(true);
+  }, [canEdit, content]);
+
+  const cancelEdit = useCallback(() => {
+    setIsEditing(false);
+    setEditValue(content);
+  }, [content]);
+
+  const submitEdit = useCallback(() => {
+    const trimmed = editValue.trim();
+    if (trimmed) {
+      onEditMessage(messageId, trimmed);
+      setIsEditing(false);
+    }
+  }, [editValue, messageId, onEditMessage]);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (!canEdit) return;
+      lastPointerTypeRef.current = e.pointerType;
+      longPressTriggeredRef.current = false;
+      longPressTimerRef.current = setTimeout(() => {
+        longPressTimerRef.current = null;
+        longPressTriggeredRef.current = true;
+        startEdit();
+      }, LONG_PRESS_MS);
+    },
+    [canEdit, startEdit],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (!canEdit) return;
+      if (longPressTriggeredRef.current) {
+        longPressTriggeredRef.current = false;
+        e.preventDefault();
+        return;
+      }
+      if (lastPointerTypeRef.current === "touch") return;
+      startEdit();
+    },
+    [canEdit, startEdit],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current);
+    };
+  }, []);
+
+  if (isEditing) {
+    return (
+      <div className="flex flex-col gap-2">
+        <textarea
+          className="min-h-[80px] w-full resize-y rounded border border-primary-foreground/30 bg-primary-foreground/10 px-2 py-1.5 text-sm text-primary-foreground placeholder:text-primary-foreground/60 focus:outline-none focus:ring-1 focus:ring-primary-foreground/50"
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === "Escape") cancelEdit();
+          }}
+          rows={3}
+          autoFocus
+          aria-label={t("aiChat.actions.resend")}
+        />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              cancelEdit();
+            }}
+            className="rounded border border-primary-foreground/50 px-2 py-1 text-xs"
+          >
+            {t("aiChat.actions.cancel")}
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              submitEdit();
+            }}
+            className="rounded bg-primary-foreground/20 px-2 py-1 text-xs font-medium"
+          >
+            {t("aiChat.actions.resend")}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={canEdit ? "cursor-pointer select-none" : ""}
+      role={canEdit ? "button" : undefined}
+      tabIndex={canEdit ? 0 : undefined}
+      onKeyDown={
+        canEdit
+          ? (e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                startEdit();
+              }
+            }
+          : undefined
+      }
+      onClick={canEdit ? handleClick : undefined}
+      onPointerDown={canEdit ? handlePointerDown : undefined}
+      onPointerUp={canEdit ? handlePointerUp : undefined}
+      onPointerLeave={canEdit ? handlePointerUp : undefined}
+    >
+      {renderUserContent(content, referencedPages)}
+    </div>
+  );
+}

--- a/src/components/ai-chat/AIChatUserMessageBubble.tsx
+++ b/src/components/ai-chat/AIChatUserMessageBubble.tsx
@@ -19,6 +19,7 @@ export function renderUserContent(content: string, referencedPages?: ReferencedP
     return <div className="whitespace-pre-wrap break-words">{content}</div>;
   }
 
+  const titleToPage = new Map(referencedPages.map((p) => [`@${p.title}`, p]));
   const escapedTitles = referencedPages.map((p) => p.title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
   const pattern = new RegExp(`(@(?:${escapedTitles.join("|")}))(?=\\s|$)`, "g");
   const parts = content.split(pattern);
@@ -26,7 +27,7 @@ export function renderUserContent(content: string, referencedPages?: ReferencedP
   return (
     <div className="whitespace-pre-wrap break-words">
       {parts.map((part, i) => {
-        const matchedRef = referencedPages.find((p) => part === `@${p.title}`);
+        const matchedRef = titleToPage.get(part);
         if (matchedRef) {
           return (
             <span

--- a/src/components/ai-chat/AIChatUserMessageBubble.tsx
+++ b/src/components/ai-chat/AIChatUserMessageBubble.tsx
@@ -19,8 +19,9 @@ export function renderUserContent(content: string, referencedPages?: ReferencedP
     return <div className="whitespace-pre-wrap break-words">{content}</div>;
   }
 
-  const titleToPage = new Map(referencedPages.map((p) => [`@${p.title}`, p]));
-  const escapedTitles = referencedPages.map((p) => p.title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const sortedPages = [...referencedPages].sort((a, b) => b.title.length - a.title.length);
+  const titleToPage = new Map(sortedPages.map((p) => [`@${p.title}`, p]));
+  const escapedTitles = sortedPages.map((p) => p.title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
   const pattern = new RegExp(`(@(?:${escapedTitles.join("|")}))(?=\\s|$)`, "g");
   const parts = content.split(pattern);
 
@@ -74,11 +75,14 @@ export function UserMessageBubble({
 
   const submitEdit = useCallback(() => {
     const trimmed = editValue.trim();
-    if (trimmed) {
-      onEditMessage(messageId, trimmed);
+    if (!trimmed) return;
+    if (trimmed === content.trim()) {
       setIsEditing(false);
+      return;
     }
-  }, [editValue, messageId, onEditMessage]);
+    onEditMessage(messageId, trimmed);
+    setIsEditing(false);
+  }, [content, editValue, messageId, onEditMessage]);
 
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {

--- a/src/components/ai-chat/AIChatUserMessageBubble.tsx
+++ b/src/components/ai-chat/AIChatUserMessageBubble.tsx
@@ -22,7 +22,8 @@ export function renderUserContent(content: string, referencedPages?: ReferencedP
   const sortedPages = [...referencedPages].sort((a, b) => b.title.length - a.title.length);
   const titleToPage = new Map(sortedPages.map((p) => [`@${p.title}`, p]));
   const escapedTitles = sortedPages.map((p) => p.title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
-  const pattern = new RegExp(`(@(?:${escapedTitles.join("|")}))(?=\\s|$)`, "g");
+  // Allow boundary after @Title: whitespace, end, or punctuation (e.g. @AI Chat, @ページ。)
+  const pattern = new RegExp(`(@(?:${escapedTitles.join("|")}))(?=[\\s\\p{P}\\p{S}]|$)`, "gu");
   const parts = content.split(pattern);
 
   return (
@@ -105,6 +106,13 @@ export function UserMessageBubble({
     }
   }, []);
 
+  const handlePointerCancel = useCallback(() => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
+
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
       if (!canEdit) return;
@@ -179,6 +187,10 @@ export function UserMessageBubble({
                 e.preventDefault();
                 startEdit();
               }
+              if (e.key === " ") {
+                e.preventDefault();
+                startEdit();
+              }
             }
           : undefined
       }
@@ -186,6 +198,7 @@ export function UserMessageBubble({
       onPointerDown={canEdit ? handlePointerDown : undefined}
       onPointerUp={canEdit ? handlePointerUp : undefined}
       onPointerLeave={canEdit ? handlePointerUp : undefined}
+      onPointerCancel={canEdit ? handlePointerCancel : undefined}
     >
       {renderUserContent(content, referencedPages)}
     </div>

--- a/src/components/ai-chat/AIChatWikiLink.tsx
+++ b/src/components/ai-chat/AIChatWikiLink.tsx
@@ -1,0 +1,33 @@
+import { Link } from "react-router-dom";
+import { usePageStore } from "../../stores/pageStore";
+
+interface AIChatWikiLinkProps {
+  /** WikiLink title (e.g. from [[Title]]) */
+  title: string;
+}
+
+/**
+ * Renders a clickable WikiLink in AI chat. Resolves title to page id;
+ * existing pages link to /page/:id, missing pages render as ghost style.
+ */
+export function AIChatWikiLink({ title }: AIChatWikiLinkProps) {
+  const getPageByTitle = usePageStore((s) => s.getPageByTitle);
+  const page = getPageByTitle(title.trim());
+
+  if (page) {
+    return (
+      <Link
+        to={`/page/${page.id}`}
+        className="rounded px-0.5 font-medium text-primary underline decoration-primary/50 underline-offset-2 transition-colors hover:decoration-primary"
+      >
+        [[{title}]]
+      </Link>
+    );
+  }
+
+  return (
+    <span className="rounded px-0.5 font-medium text-muted-foreground underline decoration-muted-foreground/60 decoration-dashed underline-offset-2">
+      [[{title}]]
+    </span>
+  );
+}

--- a/src/components/ai-chat/aiChatMarkdownHelpers.ts
+++ b/src/components/ai-chat/aiChatMarkdownHelpers.ts
@@ -1,0 +1,9 @@
+/**
+ * Converts [[Title]] in AI markdown to [Title](wiki:Title) so we can render as AIChatWikiLink.
+ */
+export function replaceWikiLinksInMarkdown(content: string): string {
+  return content.replace(/\[\[([^\]]+)\]\]/g, (_, title: string) => {
+    const t = title.trim();
+    return t ? `[${t}](wiki:${encodeURIComponent(t)})` : `[[${title}]]`;
+  });
+}

--- a/src/components/ai-chat/aiChatMarkdownHelpers.ts
+++ b/src/components/ai-chat/aiChatMarkdownHelpers.ts
@@ -1,9 +1,36 @@
+const PLACEHOLDER_PREFIX = "\u0001WIKI_PH\u0002";
+const PLACEHOLDER_SUFFIX = "\u0002WIKI_PH\u0001";
+
 /**
  * Converts [[Title]] in AI markdown to [Title](wiki:Title) so we can render as AIChatWikiLink.
+ * Skips code fences (```...```) and inline code (`...`) so literal [[...]] in code is not altered.
  */
 export function replaceWikiLinksInMarkdown(content: string): string {
-  return content.replace(/\[\[([^\]]+)\]\]/g, (_, title: string) => {
+  const codeChunks: string[] = [];
+
+  const withPlaceholders = content
+    // Fenced code blocks (```...```)
+    .replace(/```[\s\S]*?```/g, (match) => {
+      const id = codeChunks.length;
+      codeChunks.push(match);
+      return `${PLACEHOLDER_PREFIX}${id}${PLACEHOLDER_SUFFIX}`;
+    })
+    // Inline code (`...`), minimal: non-greedy, no nested backticks
+    .replace(/`[^`]*`/g, (match) => {
+      const id = codeChunks.length;
+      codeChunks.push(match);
+      return `${PLACEHOLDER_PREFIX}${id}${PLACEHOLDER_SUFFIX}`;
+    });
+
+  const withWikiLinks = withPlaceholders.replace(/\[\[([^\]]+)\]\]/g, (_, title: string) => {
     const t = title.trim();
     return t ? `[${t}](wiki:${encodeURIComponent(t)})` : `[[${title}]]`;
   });
+
+  let out = withWikiLinks;
+  for (let i = 0; i < codeChunks.length; i++) {
+    const placeholder = `${PLACEHOLDER_PREFIX}${i}${PLACEHOLDER_SUFFIX}`;
+    out = out.split(placeholder).join(codeChunks[i]);
+  }
+  return out;
 }

--- a/src/hooks/useAIChat.ts
+++ b/src/hooks/useAIChat.ts
@@ -21,12 +21,18 @@ export function useAIChat({
   const streamingContentRef = useRef<string>("");
 
   const sendMessage = useCallback(
-    async (content: string, messageRefs: ReferencedPage[] = []) => {
+    async (
+      content: string,
+      messageRefs: ReferencedPage[] = [],
+      options?: { initialMessages?: ChatMessage[] },
+    ) => {
+      const baseMessages = options?.initialMessages ?? messages;
       try {
         await executeSendMessage({
           content,
           messageRefs,
-          currentMessages: messages,
+          currentMessages: baseMessages,
+          initialMessages: options?.initialMessages,
           pageContext,
           contextEnabled,
           existingPageTitles,
@@ -72,6 +78,20 @@ export function useAIChat({
     }
   }, [messages, sendMessage]);
 
+  /** 指定したユーザーメッセージを編集して再送信。そのメッセージ以降を破棄し、新内容でAI応答を生成する */
+  const editAndResend = useCallback(
+    async (messageId: string, newContent: string) => {
+      const index = messages.findIndex((m) => m.id === messageId);
+      if (index < 0) return;
+      const message = messages[index];
+      if (message.role !== "user") return;
+      const refs = message.referencedPages ?? [];
+      const truncated = messages.slice(0, index);
+      await sendMessage(newContent, refs, { initialMessages: truncated });
+    },
+    [messages, sendMessage],
+  );
+
   return {
     messages,
     error,
@@ -81,5 +101,6 @@ export function useAIChat({
     clearMessages,
     loadMessages,
     retryLastMessage,
+    editAndResend,
   };
 }

--- a/src/hooks/useAIChatExecute.ts
+++ b/src/hooks/useAIChatExecute.ts
@@ -68,8 +68,7 @@ export async function executeSendMessage(params: ExecuteSendMessageParams): Prom
   if (initialMessages !== undefined) {
     setMessages([...initialMessages, userMessage, assistantMessage]);
   } else {
-    setMessages((prev) => [...prev, userMessage]);
-    setMessages((prev) => [...prev, assistantMessage]);
+    setMessages((prev) => [...prev, userMessage, assistantMessage]);
   }
 
   setStreaming(true);

--- a/src/hooks/useAIChatExecute.ts
+++ b/src/hooks/useAIChatExecute.ts
@@ -18,6 +18,8 @@ export interface ExecuteSendMessageParams {
   content: string;
   messageRefs: ReferencedPage[];
   currentMessages: ChatMessage[];
+  /** 指定時はこの履歴の直後にユーザー/助手メッセージを追加（チェックポイント編集で使用） */
+  initialMessages?: ChatMessage[];
   pageContext: PageContext | null;
   contextEnabled: boolean;
   existingPageTitles: string[];
@@ -33,6 +35,7 @@ export async function executeSendMessage(params: ExecuteSendMessageParams): Prom
     content,
     messageRefs,
     currentMessages,
+    initialMessages,
     pageContext,
     contextEnabled,
     existingPageTitles,
@@ -52,7 +55,6 @@ export async function executeSendMessage(params: ExecuteSendMessageParams): Prom
     referencedPages: messageRefs.length > 0 ? messageRefs : undefined,
     timestamp: Date.now(),
   };
-  setMessages((prev) => [...prev, userMessage]);
 
   const assistantMessageId = crypto.randomUUID();
   const assistantMessage: ChatMessage = {
@@ -62,7 +64,13 @@ export async function executeSendMessage(params: ExecuteSendMessageParams): Prom
     timestamp: Date.now(),
     isStreaming: true,
   };
-  setMessages((prev) => [...prev, assistantMessage]);
+
+  if (initialMessages !== undefined) {
+    setMessages([...initialMessages, userMessage, assistantMessage]);
+  } else {
+    setMessages((prev) => [...prev, userMessage]);
+    setMessages((prev) => [...prev, assistantMessage]);
+  }
 
   setStreaming(true);
   streamingContentRef.current = "";
@@ -96,7 +104,8 @@ export async function executeSendMessage(params: ExecuteSendMessageParams): Prom
   const modelDisplayName = selectedModel?.displayName ?? effectiveModel;
 
   const context = contextEnabled ? pageContext : null;
-  const allRefsInConversation = [...currentMessages, userMessage].flatMap(
+  const baseMessages = initialMessages ?? currentMessages;
+  const allRefsInConversation = [...baseMessages, userMessage].flatMap(
     (m) => m.referencedPages ?? [],
   );
   const uniqueRefs = allRefsInConversation.filter(
@@ -104,7 +113,7 @@ export async function executeSendMessage(params: ExecuteSendMessageParams): Prom
   );
   const systemPrompt = buildSystemPrompt(context, existingPageTitles, uniqueRefs);
 
-  const allMessages = [...currentMessages, userMessage];
+  const allMessages = [...baseMessages, userMessage];
   const apiMessages: AIServiceRequest["messages"] = [
     { role: "system", content: systemPrompt },
     ...allMessages.map((m) => ({ role: m.role, content: m.content })),

--- a/src/i18n/locales/en/aiChat.json
+++ b/src/i18n/locales/en/aiChat.json
@@ -12,7 +12,9 @@
     "editAndCreate": "Edit & Create",
     "appendToPage": "Append",
     "createMultiple": "Create All",
-    "addLink": "Add Link"
+    "addLink": "Add Link",
+    "copyCode": "Copy code",
+    "copiedCode": "Copied"
   },
   "placeholders": {
     "default": "Type a message...",

--- a/src/i18n/locales/en/aiChat.json
+++ b/src/i18n/locales/en/aiChat.json
@@ -4,6 +4,8 @@
     "close": "Close",
     "newConversation": "New Conversation",
     "conversationList": "Conversations",
+    "cancel": "Cancel",
+    "resend": "Resend",
     "send": "Send",
     "stop": "Stop",
     "createPage": "Create",

--- a/src/i18n/locales/ja/aiChat.json
+++ b/src/i18n/locales/ja/aiChat.json
@@ -12,7 +12,9 @@
     "editAndCreate": "編集してから作成",
     "appendToPage": "追記する",
     "createMultiple": "まとめて作成",
-    "addLink": "リンクを追加"
+    "addLink": "リンクを追加",
+    "copyCode": "コードをコピー",
+    "copiedCode": "コピーしました"
   },
   "placeholders": {
     "default": "メッセージを入力...",

--- a/src/i18n/locales/ja/aiChat.json
+++ b/src/i18n/locales/ja/aiChat.json
@@ -4,6 +4,8 @@
     "close": "閉じる",
     "newConversation": "新規会話",
     "conversationList": "会話一覧",
+    "cancel": "キャンセル",
+    "resend": "再送信",
     "send": "送信",
     "stop": "停止",
     "createPage": "作成する",

--- a/src/lib/aiChatActions.ts
+++ b/src/lib/aiChatActions.ts
@@ -1,14 +1,19 @@
 import { ChatAction } from "../types/aiChat";
 
+/** アクションブロック検出用正規表現（複数行・空白のゆらぎに対応） */
+const ACTION_BLOCK_REGEX =
+  /<!--\s*zedi-action:(\w[\w-]*)\s*-->\s*([\s\S]*?)\s*<!--\s*\/zedi-action\s*-->/g;
+
 /** AI応答テキストからアクションカードを抽出 */
 export function parseActions(content: string): ChatAction[] {
-  const regex = /<!-- zedi-action:(\w[\w-]*) -->\n([\s\S]*?)\n<!-- \/zedi-action -->/g;
   const actions: ChatAction[] = [];
   let match;
+  ACTION_BLOCK_REGEX.lastIndex = 0;
 
-  while ((match = regex.exec(content)) !== null) {
+  while ((match = ACTION_BLOCK_REGEX.exec(content)) !== null) {
     try {
-      const action = JSON.parse(match[2]) as ChatAction;
+      const raw = match[2].trim();
+      const action = JSON.parse(raw) as ChatAction;
       actions.push(action);
     } catch {
       console.warn("Failed to parse action:", match[2]);
@@ -20,5 +25,7 @@ export function parseActions(content: string): ChatAction[] {
 
 /** アクションカードのコンテンツを除いた表示用テキスト */
 export function getDisplayContent(content: string): string {
-  return content.replace(/<!-- zedi-action:[\w-]+ -->[\s\S]*?<!-- \/zedi-action -->/g, "").trim();
+  return content
+    .replace(/<!--\s*zedi-action:[\w-]+\s*-->[\s\S]*?<!--\s*\/zedi-action\s*-->/g, "")
+    .trim();
 }

--- a/src/lib/aiChatPrompt.ts
+++ b/src/lib/aiChatPrompt.ts
@@ -64,9 +64,9 @@ Zedi はナレッジネットワークツールで、ユーザーの思考を[[W
 {"type":"create-page","title":"ページタイトル","content":"Markdown内容...","suggestedLinks":["関連キーワード"],"reason":"提案理由"}
 <!-- /zedi-action -->
 
-(2) 既存ページへの追記提案（pageIdは既存ページのID）:
+(2) 既存ページへの追記提案（pageTitleで指定。上記タイトル一覧と一致させる）:
 <!-- zedi-action:append-to-page -->
-{"type":"append-to-page","pageId":"既存ページID","pageTitle":"ページタイトル","content":"追記するMarkdown","reason":"提案理由"}
+{"type":"append-to-page","pageTitle":"ページタイトル","content":"追記するMarkdown","reason":"提案理由"}
 <!-- /zedi-action -->
 
 (3) 複数ページの一括作成提案:
@@ -74,9 +74,9 @@ Zedi はナレッジネットワークツールで、ユーザーの思考を[[W
 {"type":"create-multiple-pages","pages":[{"title":"タイトル1","content":"内容1","suggestedLinks":[]},{"title":"タイトル2","content":"内容2","suggestedLinks":[]}],"linkStructure":[{"from":"タイトル1","to":"タイトル2"}],"reason":"提案理由"}
 <!-- /zedi-action -->
 
-(4) 既存ページへのWikiLink提案:
+(4) 既存ページへのWikiLink提案（existingPageTitleで指定。上記タイトル一覧と一致させる）:
 <!-- zedi-action:suggest-wiki-links -->
-{"type":"suggest-wiki-links","links":[{"keyword":"キーワード","existingPageId":"既存の場合はID","existingPageTitle":"既存の場合はタイトル"}],"reason":"提案理由"}
+{"type":"suggest-wiki-links","links":[{"keyword":"キーワード","existingPageTitle":"既存ページのタイトル"}],"reason":"提案理由"}
 <!-- /zedi-action -->
 
 提案のタイミング:

--- a/src/lib/aiChatPrompt.ts
+++ b/src/lib/aiChatPrompt.ts
@@ -56,24 +56,40 @@ Zedi はナレッジネットワークツールで、ユーザーの思考を[[W
 - Markdown形式で回答する
 - 簡潔で実用的な回答を心がける
 
-## ページ作成の提案
-会話の中で十分な情報が蓄積されたと判断した場合、以下のフォーマットでページ作成を提案してください:
+## アクション提案のフォーマット（必須）
+提案するときは、応答本文の末尾に以下のいずれかのブロックを必ず1行のJSONで含めてください。コメントのタグは正確に書いてください。
 
+(1) 新規ページ1件の提案:
 <!-- zedi-action:create-page -->
 {"type":"create-page","title":"ページタイトル","content":"Markdown内容...","suggestedLinks":["関連キーワード"],"reason":"提案理由"}
 <!-- /zedi-action -->
 
+(2) 既存ページへの追記提案（pageIdは既存ページのID）:
+<!-- zedi-action:append-to-page -->
+{"type":"append-to-page","pageId":"既存ページID","pageTitle":"ページタイトル","content":"追記するMarkdown","reason":"提案理由"}
+<!-- /zedi-action -->
+
+(3) 複数ページの一括作成提案:
+<!-- zedi-action:create-multiple-pages -->
+{"type":"create-multiple-pages","pages":[{"title":"タイトル1","content":"内容1","suggestedLinks":[]},{"title":"タイトル2","content":"内容2","suggestedLinks":[]}],"linkStructure":[{"from":"タイトル1","to":"タイトル2"}],"reason":"提案理由"}
+<!-- /zedi-action -->
+
+(4) 既存ページへのWikiLink提案:
+<!-- zedi-action:suggest-wiki-links -->
+{"type":"suggest-wiki-links","links":[{"keyword":"キーワード","existingPageId":"既存の場合はID","existingPageTitle":"既存の場合はタイトル"}],"reason":"提案理由"}
+<!-- /zedi-action -->
+
 提案のタイミング:
-- ユーザーが特定のトピックについて詳しく説明した後
-- 議論が一区切りついた時
-- ユーザーが「まとめて」「記録して」等の意図を示した時
-- 複数のトピックが出た場合は create-multiple-pages を使用
+- ユーザーが特定のトピックについて詳しく説明した後 → create-page
+- 議論が一区切りついた時 → create-page
+- ユーザーが「まとめて」「記録して」等の意図を示した時 → create-page または create-multiple-pages
+- 既存ページに関連するキーワードが会話に出た時 → suggest-wiki-links
 
 ## 既存ページとの連携
 ユーザーの既存ページタイトル一覧:
 ${existingPageTitles.map((t) => `- ${t}`).join("\n")}
 
-上記のタイトルに関連するキーワードが会話に出た場合、[[WikiLink]]として参照できることを提案してください。
+上記のタイトルに関連するキーワードが会話に出た場合、suggest-wiki-links で[[WikiLink]]として参照できることを提案してください。
 
 ${context ? buildContextSection(context) : ""}
 ${buildReferencedPagesSection(referencedPages)}

--- a/src/types/aiChat.ts
+++ b/src/types/aiChat.ts
@@ -39,8 +39,8 @@ export interface CreatePageAction {
 
 export interface AppendToPageAction {
   type: "append-to-page";
-  pageId: string;
-  pageTitle: string;
+  pageTitle: string; // クライアントでタイトル→ID解決する
+  pageId?: string; // 既存解決時は省略可
   content: string;
   reason: string;
 }


### PR DESCRIPTION
## 概要

AIチャットに以下を追加・改善しました。(1) AI応答内の `[[タイトル]]` を WikiLink として表示し、既存ページはリンク・未存在はゴースト表示。(2) ユーザーメッセージの長押し／クリックで編集・再送信。(3) ページ単位の会話一覧とメッセージの永続化（読み込み・保存）。(4) AI提案の「ページ作成」「複数ページ作成」アクションの実行。あわせて `AIChatMessage.tsx` を 250 行以下に分割（`aiChatMarkdownHelpers`、`AIChatCodeBlock`、`AIChatUserMessageBubble` に切り出し）。

## 変更点

- **`src/components/ai-chat/`**
  - `AIChatWikiLink.tsx` 新規: WikiLink 表示（既存ページは `/page/:id`、未存在はゴースト）
  - `aiChatMarkdownHelpers.ts` 新規: `replaceWikiLinksInMarkdown`（`[[Title]]` → `[Title](wiki:Title)`）
  - `AIChatCodeBlock.tsx` 新規: コードブロック＋コピーボタン
  - `AIChatUserMessageBubble.tsx` 新規: ユーザーメッセージ編集 UI と `renderUserContent`
  - `AIChatMessage.tsx`: 上記を import して集約（行数削減）、WikiLink 用カスタム `a` コンポーネント
  - `AIChatMessages.tsx`: `onEditMessage` / `isStreaming` を子に渡す
  - `AIChatPanel.tsx`: 会話作成・選択・削除、ページ切り替え時のリセット、`editAndResend` / アクション実行のハンドラ接続
- **`src/hooks/`**
  - `useAIChat.ts`: `editAndResend`、`loadMessages`、`sendMessage` の `initialMessages` 対応
  - `useAIChatExecute.ts`: システムプロンプト・参照ページ・モデル表示名、アクション解析の組み込み
- **`src/lib/`**
  - `aiChatActions.ts`: アクションブロック正規表現の微調整、`getDisplayContent` で表示用テキストからアクション除去
  - `aiChatPrompt.ts`: アクション提案フォーマット（create-page / append-to-page / create-multiple-pages / suggest-wiki-links）と既存ページ連携の説明を追加
- **`src/i18n/locales/`**
  - `en/aiChat.json`, `ja/aiChat.json`: 参照ページまわりキー追加（added, alreadyAdded, limitReached, dragHint, dropHint, welcomeHint, addToChat, mentionHint, noResults）
- **`docs/reviews/`**
  - `review-develop-20250308-2.md`: 当該変更のセルフレビューレポート

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [x] 📝 ドキュメント (Documentation)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run dev` で起動し、AIチャットを開く。
2. **WikiLink**: AIに「〇〇について書いて」などと送り、応答に `[[ページ名]]` が含まれることを確認。既存ページはリンク、未存在はゴースト表示になることを確認。
3. **編集・再送**: 自分のメッセージを長押しまたはクリックで編集モードにし、内容を変えて再送信。そのメッセージ以降が消え、新しい内容でAIが応答することを確認。
4. **会話履歴**: 同じページで複数回やりとりし、会話一覧から別会話を選んで切り替え、戻ってメッセージが復元されることを確認。ページを切り替えると新規チャットになることを確認。
5. **アクション実行**: AIが「ページを作成」等を提案したとき、カードの「作成する」等でページが作成され、遷移または一覧に反映されることを確認。
6. 単体: `bun run test:run -- src/lib/aiChatActions.test.ts src/lib/aiChatPrompt.test.ts` が通ることを確認。

## チェックリスト

- [x] テストがすべてパスする（上記単体テスト）
- [x] Lint エラーがない（warning のみ）
- [x] 必要に応じてドキュメントを更新した（レビュードキュメント）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

<!-- AIチャットのWikiLink表示・編集UI・会話一覧・アクションカードの Before/After を追加するとよい -->

## 関連 Issue

<!-- 特になし -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ユーザーメッセージの編集と再送機能を追加
  * WikiLink形式のマークダウン変換と既存ページへのリンク表示を実装
  * メッセージ内コードブロックにコピー機能を追加（クリップボードにワンクリックでコピー）
* **ドキュメント**
  * AIチャットの自己レビューと提案フォーマットに関する文書を追加
* **国際化**
  * 編集／再送／コードコピーに関する翻訳キーを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->