### PR TITLE
fix(editor): ページコンテンツの二重保存を防止し検知を追加

### DIFF
--- a/src/components/editor/TiptapEditor/useContentSanitizer.ts
+++ b/src/components/editor/TiptapEditor/useContentSanitizer.ts
@@ -18,6 +18,7 @@ interface UseContentSanitizerOptions {
   content: string;
   onError?: (error: ContentError | null) => void;
   onContentUpdated?: (initialized: boolean) => void;
+  isCollaborationMode?: boolean;
 }
 
 /**
@@ -29,6 +30,7 @@ export function useContentSanitizer({
   content,
   onError,
   onContentUpdated,
+  isCollaborationMode = false,
 }: UseContentSanitizerOptions): void {
   const lastSanitizeResultRef = useRef<SanitizeResult | null>(null);
 
@@ -61,7 +63,20 @@ export function useContentSanitizer({
         const currentContent = JSON.stringify(editor.getJSON());
 
         if (currentContent !== sanitizeResult.content) {
-          editor.commands.setContent(parsedContent);
+          if (isCollaborationMode) {
+            // コラボレーションモード時は setContent を呼ばない。
+            // Y.Doc が唯一のコンテンツソースであり、React state の content で
+            // 上書きすると Y.Doc に二重書き込みが発生しコンテンツが複製される。
+            console.error(
+              "[Collab] Blocked setContent in collaboration mode to prevent Y.Doc duplication",
+              {
+                currentContentLength: currentContent.length,
+                incomingContentLength: sanitizeResult.content.length,
+              },
+            );
+          } else {
+            editor.commands.setContent(parsedContent);
+          }
 
           // Notify that content was updated
           if (sanitizeResult.content.length > 50) {
@@ -91,5 +106,5 @@ export function useContentSanitizer({
         onError(null);
       }
     }
-  }, [editor, content, onError, onContentUpdated]);
+  }, [editor, content, onError, onContentUpdated, isCollaborationMode]);
 }

--- a/src/components/editor/TiptapEditor/useContentSanitizer.ts
+++ b/src/components/editor/TiptapEditor/useContentSanitizer.ts
@@ -37,7 +37,15 @@ export function useContentSanitizer({
   // Update editor content when prop changes (e.g., when page data is loaded)
   // This is the only place where sanitization happens to avoid duplicate calls
   useEffect(() => {
-    if (editor && content) {
+    if (!editor) return;
+
+    // コラボモード時は Y.Doc が唯一のソースのため sanitization と setContent を行わない（二重化防止・CPU 節約）
+    if (isCollaborationMode) {
+      if (!content && onError) onError(null);
+      return;
+    }
+
+    if (content) {
       // Sanitize content to remove unsupported node/mark types
       const sanitizeResult = sanitizeTiptapContent(content);
       lastSanitizeResultRef.current = sanitizeResult;
@@ -63,22 +71,8 @@ export function useContentSanitizer({
         const currentContent = JSON.stringify(editor.getJSON());
 
         if (currentContent !== sanitizeResult.content) {
-          if (isCollaborationMode) {
-            // コラボレーションモード時は setContent を呼ばない。
-            // Y.Doc が唯一のコンテンツソースであり、React state の content で
-            // 上書きすると Y.Doc に二重書き込みが発生しコンテンツが複製される。
-            console.error(
-              "[Collab] Blocked setContent in collaboration mode to prevent Y.Doc duplication",
-              {
-                currentContentLength: currentContent.length,
-                incomingContentLength: sanitizeResult.content.length,
-              },
-            );
-          } else {
-            editor.commands.setContent(parsedContent);
-          }
-
-          // Notify that content was updated
+          editor.commands.setContent(parsedContent);
+          // Notify that content was updated (only when we actually applied content)
           if (sanitizeResult.content.length > 50) {
             onContentUpdated?.(true);
           }
@@ -100,7 +94,7 @@ export function useContentSanitizer({
           });
         }
       }
-    } else if (editor && !content) {
+    } else {
       // Clear error if content is empty
       if (onError) {
         onError(null);

--- a/src/components/editor/TiptapEditor/useEditorLifecycle.ts
+++ b/src/components/editor/TiptapEditor/useEditorLifecycle.ts
@@ -80,6 +80,7 @@ export function useEditorLifecycle({
     onContentUpdated: (initialized) => {
       if (initialized) isEditorInitializedRef.current = true;
     },
+    isCollaborationMode: !!collaborationConfig,
   });
 
   useWikiLinkStatusSync({

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -80,6 +80,8 @@ export class CollaborationManager {
       const origin = baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
       const url = `${origin}/api/pages/${encodeURIComponent(this.pageId)}/content`;
 
+      const beforeText = this.getPlainText();
+
       const res = await fetch(url, {
         credentials: "include",
       });
@@ -98,6 +100,7 @@ export class CollaborationManager {
           const binary = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
           if (binary.length > 2) {
             Y.applyUpdate(this.ydoc, binary);
+            this.detectContentDuplication(beforeText, "api-merge");
           }
         }
       } else if (res.status === 401) {
@@ -163,7 +166,6 @@ export class CollaborationManager {
       }
       b64 = btoa(b64);
 
-      // Extract plain text for content_text (for full-text search)
       const fragment = this.ydoc.getXmlFragment("default");
       const contentText = fragment.toJSON() ? this.extractText(fragment) : "";
 
@@ -190,6 +192,37 @@ export class CollaborationManager {
     } catch (err) {
       console.warn("[Collab] API save error:", err);
     }
+  }
+
+  /**
+   * Y.Doc のプレーンテキストを取得するヘルパー
+   */
+  private getPlainText(): string {
+    return this.extractText(this.ydoc.getXmlFragment("default"));
+  }
+
+  /**
+   * コンテンツの二重化を検知する。
+   * マージ前後のテキストを比較し、不自然な増加があれば console.error で報告する。
+   */
+  private detectContentDuplication(beforeText: string, phase: string): void {
+    const afterText = this.getPlainText();
+    if (beforeText.length < 10) return;
+    if (afterText.length <= beforeText.length) return;
+
+    const ratio = afterText.length / beforeText.length;
+    if (ratio < 1.5) return;
+
+    console.error(
+      `[Collab] Content duplication detected after ${phase} (page: ${this.pageId.slice(0, 8)})`,
+      {
+        beforeLength: beforeText.length,
+        afterLength: afterText.length,
+        ratio: ratio.toFixed(2),
+        beforePreview: beforeText.slice(0, 200),
+        afterPreview: afterText.slice(0, 200),
+      },
+    );
   }
 
   /**

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -17,6 +17,9 @@ export type CollaborationManagerMode = "local" | "collaborative";
 /** Debounce timer for saving Y.Doc to API in local mode. */
 const API_SAVE_DEBOUNCE_MS = 2000;
 
+/** 二重化検知: マージ後テキストがこの倍率を超えて増加したら二重化とみなす */
+const DUPLICATION_RATIO_THRESHOLD = 1.5;
+
 export class CollaborationManager {
   private ydoc: Y.Doc;
   private wsProvider: HocuspocusProvider | null = null;
@@ -211,7 +214,7 @@ export class CollaborationManager {
     if (afterText.length <= beforeText.length) return;
 
     const ratio = afterText.length / beforeText.length;
-    if (ratio < 1.5) return;
+    if (ratio < DUPLICATION_RATIO_THRESHOLD) return;
 
     console.error(
       `[Collab] Content duplication detected after ${phase} (page: ${this.pageId.slice(0, 8)})`,
@@ -219,8 +222,6 @@ export class CollaborationManager {
         beforeLength: beforeText.length,
         afterLength: afterText.length,
         ratio: ratio.toFixed(2),
-        beforePreview: beforeText.slice(0, 200),
-        afterPreview: afterText.slice(0, 200),
       },
     );
   }


### PR DESCRIPTION
## 概要

ページ編集画面（`/page/:id`）でコンテンツが二重に保存されてしまう不具合を修正しました。原因はコラボレーションモード（Y.Doc 使用）時に `useContentSanitizer` が React state の `content` とエディタの差分を解消するために `editor.commands.setContent()` を呼び、Y.Doc に同じ内容が二重に書き込まれていたことです。コラボモード時は setContent を呼ばないガードを入れ、あわせて二重化の検知（console.error）を追加しています。

## 変更点

- **`src/components/editor/TiptapEditor/useContentSanitizer.ts`**
  - `isCollaborationMode` オプションを追加。コラボモード時は `setContent` を呼ばず、検知時に `console.error` で報告。
- **`src/components/editor/TiptapEditor/useEditorLifecycle.ts`**
  - `useContentSanitizer` に `isCollaborationMode: !!collaborationConfig` を渡すように変更。
- **`src/lib/collaboration/CollaborationManager.ts`**
  - デバッグ用の console.log を削除。
  - API マージ後にテキスト長が 50% 以上増加した場合に二重化として `console.error` で検知する `detectContentDuplication` を追加。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. 開発サーバーを起動し、既存ページを開く（または新規ページを作成）。
2. テキストを入力し、ページを離脱（ホームなどに遷移）してから再度同じページを開く。
3. コンテンツが二重に表示されず、1回だけ表示されることを確認。
4. コンソールに `[Collab] Blocked setContent in collaboration mode` や `Content duplication detected` のエラーが出ていないことを確認（出た場合は検知が動作している）。

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

<!-- 表示・挙動の変更はなく、バグ修正のみのため不要 -->

## 関連 Issue

<!-- 特になし -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * リアルタイム協作編集モード時のパフォーマンスを向上
  * コンテンツ重複検出機能を追加し、マージ時の問題を自動検出

* **バグ修正**
  * JSON解析失敗時のエラー処理を改善
  * 協作編集時のコンテンツ同期精度を向上
  * エラー発生時の通知ロジックを強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->