### PR TITLE
feat(editor): wiki link bubble menu for Tiptap editor

### DIFF
--- a/docs/plans/wiki-link-bubble-menu.md
+++ b/docs/plans/wiki-link-bubble-menu.md
@@ -25,7 +25,18 @@
 - **`[[` 入力時のサジェスト**: `wikiLinkSuggestionPlugin` が `[[` を検知 → `WikiLinkSuggestion` でページ候補表示 → 選択時に `useSuggestionEffects.handleSuggestionSelect` で挿入。
 - **挿入処理**（`useSuggestionEffects.ts` 94–108 行）:
   - `deleteRange({ from, to })` で `[[` とクエリ部分を削除
-  - `insertContent([{ type: "text", marks: [{ type: "wikiLink", attrs: { title, exists, referenced } }], text: `[[${title}]]` }])` で WikiLink ノードを挿入
+  - 以下で WikiLink ノードを挿入:
+
+    ```ts
+    insertContent([
+      {
+        type: "text",
+        marks: [{ type: "wikiLink", attrs: { title, exists, referenced } }],
+        text: `[[${title}]]`,
+      },
+    ]);
+    ```
+
   - 新規ページ（`exists: false`）のときは `checkReferenced(title, pageId)` で `referenced` を取得してから挿入。
 
 ### 4. エディター構成
@@ -84,7 +95,23 @@
    - `const text = editor.state.doc.textBetween(from, to, null, "\ufffc").trim();`
    - `if (!text) return;`
    - （任意）`pageId` がある場合: `checkReferenced(text, pageId)` で `referenced` を取得。
-   - `editor.chain().focus().deleteRange({ from, to }).insertContent([{ type: "text", marks: [{ type: "wikiLink", attrs: { title: text, exists: false, referenced } }], text: `[[${text}]]` }]).run();`
+   - 挿入例:
+
+     ```ts
+     editor
+       .chain()
+       .focus()
+       .deleteRange({ from, to })
+       .insertContent([
+         {
+           type: "text",
+           marks: [{ type: "wikiLink", attrs: { title: text, exists: false, referenced } }],
+           text: `[[${text}]]`,
+         },
+       ])
+       .run();
+     ```
+
    - `referenced` を使わない場合は `referenced: false` 固定。
 
 4. **既存 WikiLink 選択時**

--- a/docs/plans/wiki-link-bubble-menu.md
+++ b/docs/plans/wiki-link-bubble-menu.md
@@ -1,0 +1,114 @@
+# BubbleMenu から範囲選択で WikiLink を作成する機能 - 調査・提案
+
+## 目的
+
+- テキストを範囲選択したときに表示される **BubbleMenu** から、選択テキストを `[[タイトル]]` 形式の WikiLink（アプリ内リンク）に変換できるようにする。
+
+## 現在の実装状況
+
+### 1. BubbleMenu（EditorBubbleMenu）
+
+- **場所**: `src/components/editor/TiptapEditor/EditorBubbleMenu.tsx`
+- **表示条件**: `shouldShow` で「選択が空でない」「codeBlock 内でない」ときに表示。
+- **既存ボタン**: 太字・イタリック・取り消し線・コード・ハイライト、箇条書き・番号付き・タスクリスト、テーブル挿入、文字色。
+- **WikiLink 用のボタンは未実装。**
+
+### 2. WikiLink の表現
+
+- **拡張**: `src/components/editor/extensions/WikiLinkExtension.ts`
+- **Mark**: `wikiLink`。属性は `title`, `exists`, `referenced`。
+- **既存コマンド**: `setWikiLink({ title, exists })`, `unsetWikiLink()`。
+- **保存形式**: Tiptap JSON ではテキストが `[[タイトル]]`、marks に `{ type: "wikiLink", attrs: { title, exists, referenced } }` を付与。
+
+### 3. WikiLink の挿入（既存パターン）
+
+- **`[[` 入力時のサジェスト**: `wikiLinkSuggestionPlugin` が `[[` を検知 → `WikiLinkSuggestion` でページ候補表示 → 選択時に `useSuggestionEffects.handleSuggestionSelect` で挿入。
+- **挿入処理**（`useSuggestionEffects.ts` 94–108 行）:
+  - `deleteRange({ from, to })` で `[[` とクエリ部分を削除
+  - `insertContent([{ type: "text", marks: [{ type: "wikiLink", attrs: { title, exists, referenced } }], text: `[[${title}]]` }])` で WikiLink ノードを挿入
+  - 新規ページ（`exists: false`）のときは `checkReferenced(title, pageId)` で `referenced` を取得してから挿入。
+
+### 4. エディター構成
+
+- **TiptapEditor**: `pageId` を受け取り、`EditorBubbleMenu` には現状 `editor` のみ渡している。
+- **WikiLink 状態同期**: `useWikiLinkStatusSync` でコンテンツ内の WikiLink の `exists` / `referenced` を更新。保存時は `extractWikiLinksFromContent` でリンク一覧を取得し `syncWikiLinks` に渡している。
+
+### 5. システムの範囲選択メニューと BubbleMenu の表示関係
+
+- **「通常のツールバー」**: ここではスマホなどでテキストを範囲選択したときに表示される**システム標準のメニューバー**（コピー・貼り付け・全選択など）を指す。
+- **EditorBubbleMenu**: 当アプリが表示する**独自の**範囲選択用メニュー（太字・イタリック・WikiLink 等）。選択位置付近に浮いて表示する。
+- **結論**: システムの選択メニューと EditorBubbleMenu は**別物**のため、**両方とも同時に表示され得る**。特にスマホでは、範囲選択時にネイティブの選択メニューと当方の BubbleMenu の両方が出る可能性があり、配置が重なる・窮屈になる場合は、実装や配置（`placement`）の調整を検討する。
+
+---
+
+## 実装方針
+
+### 方針 A: EditorBubbleMenu に「WikiLink にする」ボタンを追加（推奨）
+
+- **やること**
+  1. **EditorBubbleMenu** に「WikiLink にする」ボタン（例: リンクアイコン + ツールチップ「WikiLink」）を追加する。
+  2. **表示条件**
+     - 既存の BubbleMenu 表示条件（選択あり・codeBlock 外）に加え、
+     - 選択範囲が **既に wikiLink マークのみ** のときはこのボタンを非表示（または「WikiLink を解除」に切り替え）にする。
+  3. **クリック時の処理**
+     - 選択範囲のテキスト `selectedText = editor.state.doc.textBetween(from, to).trim()` を取得。
+     - `selectedText` が空なら何もしない。
+     - 既存の `[[` サジェスト挿入と同じ形で、`deleteRange` → `insertContent` で `[[${selectedText}]]` と wikiLink マークを挿入。
+     - 新規リンク（`exists: false`）にする場合、`referenced` を揃えたいなら `useCheckGhostLinkReferenced` を利用する（後述）。
+
+- **参照の一貫性（任意）**
+  - `[[` サジェストでは `checkReferenced(item.title, pageId)` で `referenced` を設定している。
+  - BubbleMenu から作成する場合も同じにしたいなら、**EditorBubbleMenu に `pageId` をオプションで渡し**、`useCheckGhostLinkReferenced` を呼んでから `insertContent` する。
+  - 初回は `referenced: false` 固定でもよい。保存後や他ページ編集時に `useWikiLinkStatusSync` が `referenced` を更新するため、挙動は遅れても揃う。
+
+### 方針 B: 選択範囲が既に WikiLink のとき
+
+- 選択全体が `wikiLink` マークのみの場合:
+  - 「WikiLink にする」の代わりに「WikiLink を解除」ボタンを出し、`unsetWikiLink()` でマークだけ外す（表示テキスト `[[...]]` はそのまま残すか、外すかは仕様次第）。
+- または、WikiLink 選択時は WikiLink 用ボタンを出さないだけにしてもよい。
+
+---
+
+## 推奨実装ステップ
+
+1. **EditorBubbleMenu の props 拡張**
+   - `pageId?: string` を追加（BubbleMenu は `TiptapEditor` から渡す）。
+
+2. **「WikiLink にする」ボタン追加**
+   - アイコン: `Link2`（lucide-react）など。
+   - `shouldShow` は既存のまま（選択あり・codeBlock 外）でよい。
+   - ボタン表示条件: 選択が空でない **かつ** 選択範囲が `wikiLink` のみでない（`!editor.isActive("wikiLink")` などで判定。範囲選択時は `editor.state.selection` から範囲を取得し、その範囲のマークを確認する必要がある場合は、`doc.rangeHasMark(from, to, wikiLinkType)` のような判定を検討）。
+
+3. **クリックハンドラ**
+   - `const { from, to } = editor.state.selection;`
+   - `const text = editor.state.doc.textBetween(from, to, null, "\ufffc").trim();`
+   - `if (!text) return;`
+   - （任意）`pageId` がある場合: `checkReferenced(text, pageId)` で `referenced` を取得。
+   - `editor.chain().focus().deleteRange({ from, to }).insertContent([{ type: "text", marks: [{ type: "wikiLink", attrs: { title: text, exists: false, referenced } }], text: `[[${text}]]` }]).run();`
+   - `referenced` を使わない場合は `referenced: false` 固定。
+
+4. **既存 WikiLink 選択時**
+   - 選択範囲がすべて wikiLink のときは「WikiLink にする」を非表示にするか、「WikiLink を解除」を表示する。解除時は `editor.chain().focus().unsetWikiLink().run()` でマークのみ解除（テキスト `[[...]]` は残る）。
+
+5. **TiptapEditor の修正**
+   - `<EditorBubbleMenu editor={editor} pageId={pageId} />` のように `pageId` を渡す。
+
+6. **テスト**
+   - 範囲選択 → BubbleMenu の WikiLink ボタン表示 → クリックで `[[選択テキスト]]` に変換されることを確認。
+   - codeBlock 内では BubbleMenu 自体が出ないことを確認。
+   - 既存の `[[` サジェスト・保存・WikiLink 同期（syncWikiLinks / useWikiLinkStatusSync）が従来どおり動くことを確認。
+
+---
+
+## 補足
+
+- **インラインコード内**: 現在の `shouldShow` では codeBlock だけ除外している。インラインコード（`code` mark）内の選択でも BubbleMenu は出る。WikiLink を code 内に作らせないなら、`shouldShow` で `editor.isActive("code")` のときも false にするか、WikiLink ボタンだけ「code 内では無効」にすることができる。
+- **既存データとの整合**: 挿入形式は `useSuggestionEffects.handleSuggestionSelect` と同一にしてあるため、`extractWikiLinksFromContent` や `updateWikiLinkAttributes` はそのまま利用できる。
+
+---
+
+## まとめ
+
+- **現状**: BubbleMenu はテキスト選択時に表示されるが、WikiLink 用の操作はない。WikiLink は `[[` 入力＋サジェストでのみ作成可能。
+- **提案**: EditorBubbleMenu に「WikiLink にする」ボタンを追加し、選択テキストを `deleteRange` + `insertContent` で `[[選択テキスト]]` の wikiLink マーク付きテキストに置き換える。既存の WikiLink 挿入処理（useSuggestionEffects）と同じ形式に揃え、必要なら `pageId` を渡して `referenced` も設定する。
+- **実装量**: EditorBubbleMenu の変更＋TiptapEditor で `pageId` を渡すだけなので、小〜中規模で実現可能。

--- a/docs/reviews/review-develop-20250311-1.md
+++ b/docs/reviews/review-develop-20250311-1.md
@@ -1,8 +1,9 @@
-# セルフレビュー: develop（未コミット変更）
+# セルフレビュー: PR #308（wiki link bubble menu）
 
-**日時**: 2025-03-11
-**ベース**: develop（手元の未コミット変更）
-**変更ファイル数**: 2 files（+ 未追跡 1: 計画ドキュメント）
+**日時**: 2026-03-11
+**ベース**: develop
+**対象**: PR #308 feat(editor): wiki link bubble menu for Tiptap editor
+**変更ファイル数**: 複数（EditorBubbleMenu リファクタ、useBubbleMenuWikiLink、ツールバー・テスト・ドキュメント含む）
 **関連ファイル数**: 6 files
 
 ## サマリー
@@ -11,10 +12,10 @@ BubbleMenu から選択テキストを WikiLink（`[[タイトル]]`）に変換
 
 ## ファイルサイズ
 
-| ファイル                                                | 行数 | 判定                           |
-| ------------------------------------------------------- | ---- | ------------------------------ |
-| src/components/editor/TiptapEditor.tsx                  | 156  | OK                             |
-| src/components/editor/TiptapEditor/EditorBubbleMenu.tsx | 321  | Warning: 250行超（分割を推奨） |
+| ファイル                                                | 行数 | 判定                   |
+| ------------------------------------------------------- | ---- | ---------------------- |
+| src/components/editor/TiptapEditor.tsx                  | 156  | OK                     |
+| src/components/editor/TiptapEditor/EditorBubbleMenu.tsx | 30   | OK（リファクタで短縮） |
 
 ## 指摘事項
 
@@ -26,30 +27,29 @@ BubbleMenu から選択テキストを WikiLink（`[[タイトル]]`）に変換
 
 ### 🟡 Warning（修正を推奨）
 
-| #   | ファイル             | 行  | 観点             | 指摘内容                                                        | 推奨修正                                                                                                                           |
-| --- | -------------------- | --- | ---------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | EditorBubbleMenu.tsx | 39  | 可読性・保守性   | アロー関数が 224 行で 150 行超（ESLint max-lines-per-function） | ツールバーボタン群を子コンポーネントや `*Items` 配列に切り出す、WikiLink まわりを `useBubbleMenuWikiLink` のような hook に分離する |
-| 2   | EditorBubbleMenu.tsx | -   | 可読性・保守性   | ファイル 321 行で 250 行超                                      | 上記に加え、`BubbleButton` を別ファイルへ移動、PRESET_COLORS を `*Config.ts` に分離するなどで行数削減を検討                        |
-| 3   | EditorBubbleMenu.tsx | 295 | プロジェクト規約 | 1 ファイルに複数コンポーネント（react/no-multi-comp）           | `BubbleButton` を `BubbleMenuButton.tsx` などに切り出し                                                                            |
+| #   | ファイル             | 行  | 観点           | 指摘内容                                                                                         | 推奨修正 |
+| --- | -------------------- | --- | -------------- | ------------------------------------------------------------------------------------------------ | -------- |
+| 1–3 | （PR #308 で対応済） | -   | 可読性・保守性 | EditorBubbleMenu をリファクタし、ツールバー・hook・BubbleMenuButton・bubbleMenuConfig に分割済み | -        |
 
 ### 🟢 Info（任意の改善提案）
 
-| #   | ファイル             | 行    | 観点               | 指摘内容                                                                        | 推奨修正                                                                                       |
-| --- | -------------------- | ----- | ------------------ | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| 1   | EditorBubbleMenu.tsx | 91-98 | パフォーマンス・UX | `convertToWikiLink` が async の間、ボタンが無防備で連打可能                     | クリック時に loading 状態を set してボタンを disabled にするか、一度だけ実行するガードを入れる |
-| 2   | EditorBubbleMenu.tsx | 89    | 可読性             | `isWikiLinkSelection` がレンダーごとに `editor.isActive("wikiLink")` を呼ぶだけ | 現状でも軽いが、必要なら useMemo で editor と selection に紐づけてメモ化可能                   |
+| #   | ファイル              | 行  | 観点               | 指摘内容                                                                             | 推奨修正 |
+| --- | --------------------- | --- | ------------------ | ------------------------------------------------------------------------------------ | -------- |
+| 1   | useBubbleMenuWikiLink | -   | パフォーマンス・UX | `convertToWikiLink` の二重クリック防止 → PR レビュー対応で `isConverting` を追加済み | -        |
+| 2   | useEditorBubbleMenu   | -   | 可読性             | hasTable / hasTaskList → PR レビュー対応で useMemo 化済み                            | -        |
 
 ## テストカバレッジ
 
-| 変更ファイル         | テストファイル | 状態                                                                                                         |
-| -------------------- | -------------- | ------------------------------------------------------------------------------------------------------------ |
-| TiptapEditor.tsx     | -              | ⚠️ 本体の単体テストはなし（既存どおり）                                                                      |
-| EditorBubbleMenu.tsx | -              | ⚠️ EditorBubbleMenu 専用テストなし。useSuggestionEffects.test.ts で checkReferenced 利用パターンはテスト済み |
+| 変更ファイル                                     | テストファイル            | 状態                                                                               |
+| ------------------------------------------------ | ------------------------- | ---------------------------------------------------------------------------------- |
+| TiptapEditor.tsx                                 | -                         | ⚠️ 本体の単体テストはなし（既存どおり）                                            |
+| EditorBubbleMenu.tsx                             | EditorBubbleMenu.test.tsx | ✅ リファクタ後の BubbleMenu 表示・ツールバー・pageId・shouldShow 分岐をテスト済み |
+| useBubbleMenuWikiLink / useEditorBubbleMenu / 他 | 各対応 \*.test.ts(x)      | ✅ 単体テストあり                                                                  |
 
 ## Lint / Format チェック
 
-- **lint**: `bun run lint` → 0 errors, 85 warnings（プロジェクト全体）。変更ファイルでは `EditorBubbleMenu.tsx` に `max-lines-per-function`（39 行目・224 行）と `react/no-multi-comp`（295 行目）の warning が該当。
-- **format**: `bun run format:check` → 288 ファイルで warn（プロジェクト全体）。変更した 2 ファイルもリストに含まれる。本変更に起因するフォーマット崩れかは未確認のため、必要なら `bun run format` で変更ファイルのみ整形してからコミット推奨。
+- **lint**: `bun run lint` → 0 errors（変更ファイルで新規エラーなし）。
+- **format**: `bun run format:check` で変更ファイルを整形済み。
 
 ## 統計
 

--- a/docs/reviews/review-develop-20250311-1.md
+++ b/docs/reviews/review-develop-20250311-1.md
@@ -1,0 +1,58 @@
+# セルフレビュー: develop（未コミット変更）
+
+**日時**: 2025-03-11
+**ベース**: develop（手元の未コミット変更）
+**変更ファイル数**: 2 files（+ 未追跡 1: 計画ドキュメント）
+**関連ファイル数**: 6 files
+
+## サマリー
+
+BubbleMenu から選択テキストを WikiLink（`[[タイトル]]`）に変換する機能を追加した変更。`EditorBubbleMenu` に `pageId` を渡し、`useCheckGhostLinkReferenced` で referenced を取得してから WikiLink を挿入。既に WikiLink 選択時は「WikiLinkを解除」ボタンを表示する分岐を追加している。既存の `useSuggestionEffects` の挿入パターンと整合している。
+
+## ファイルサイズ
+
+| ファイル                                                | 行数 | 判定                           |
+| ------------------------------------------------------- | ---- | ------------------------------ |
+| src/components/editor/TiptapEditor.tsx                  | 156  | OK                             |
+| src/components/editor/TiptapEditor/EditorBubbleMenu.tsx | 321  | Warning: 250行超（分割を推奨） |
+
+## 指摘事項
+
+### 🔴 Critical（マージ前に修正必須）
+
+| #        | ファイル | 行  | 観点 | 指摘内容 | 推奨修正 |
+| -------- | -------- | --- | ---- | -------- | -------- |
+| （なし） | -        | -   | -    | -        | -        |
+
+### 🟡 Warning（修正を推奨）
+
+| #   | ファイル             | 行  | 観点             | 指摘内容                                                        | 推奨修正                                                                                                                           |
+| --- | -------------------- | --- | ---------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | EditorBubbleMenu.tsx | 39  | 可読性・保守性   | アロー関数が 224 行で 150 行超（ESLint max-lines-per-function） | ツールバーボタン群を子コンポーネントや `*Items` 配列に切り出す、WikiLink まわりを `useBubbleMenuWikiLink` のような hook に分離する |
+| 2   | EditorBubbleMenu.tsx | -   | 可読性・保守性   | ファイル 321 行で 250 行超                                      | 上記に加え、`BubbleButton` を別ファイルへ移動、PRESET_COLORS を `*Config.ts` に分離するなどで行数削減を検討                        |
+| 3   | EditorBubbleMenu.tsx | 295 | プロジェクト規約 | 1 ファイルに複数コンポーネント（react/no-multi-comp）           | `BubbleButton` を `BubbleMenuButton.tsx` などに切り出し                                                                            |
+
+### 🟢 Info（任意の改善提案）
+
+| #   | ファイル             | 行    | 観点               | 指摘内容                                                                        | 推奨修正                                                                                       |
+| --- | -------------------- | ----- | ------------------ | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| 1   | EditorBubbleMenu.tsx | 91-98 | パフォーマンス・UX | `convertToWikiLink` が async の間、ボタンが無防備で連打可能                     | クリック時に loading 状態を set してボタンを disabled にするか、一度だけ実行するガードを入れる |
+| 2   | EditorBubbleMenu.tsx | 89    | 可読性             | `isWikiLinkSelection` がレンダーごとに `editor.isActive("wikiLink")` を呼ぶだけ | 現状でも軽いが、必要なら useMemo で editor と selection に紐づけてメモ化可能                   |
+
+## テストカバレッジ
+
+| 変更ファイル         | テストファイル | 状態                                                                                                         |
+| -------------------- | -------------- | ------------------------------------------------------------------------------------------------------------ |
+| TiptapEditor.tsx     | -              | ⚠️ 本体の単体テストはなし（既存どおり）                                                                      |
+| EditorBubbleMenu.tsx | -              | ⚠️ EditorBubbleMenu 専用テストなし。useSuggestionEffects.test.ts で checkReferenced 利用パターンはテスト済み |
+
+## Lint / Format チェック
+
+- **lint**: `bun run lint` → 0 errors, 85 warnings（プロジェクト全体）。変更ファイルでは `EditorBubbleMenu.tsx` に `max-lines-per-function`（39 行目・224 行）と `react/no-multi-comp`（295 行目）の warning が該当。
+- **format**: `bun run format:check` → 288 ファイルで warn（プロジェクト全体）。変更した 2 ファイルもリストに含まれる。本変更に起因するフォーマット崩れかは未確認のため、必要なら `bun run format` で変更ファイルのみ整形してからコミット推奨。
+
+## 統計
+
+- Critical: 0 件
+- Warning: 3 件
+- Info: 2 件

--- a/src/components/editor/TiptapEditor.tsx
+++ b/src/components/editor/TiptapEditor.tsx
@@ -101,7 +101,7 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
       <EditorContent editor={editor} />
       {editor && !isReadOnly && (
         <>
-          <EditorBubbleMenu editor={editor} />
+          <EditorBubbleMenu editor={editor} pageId={pageId} />
           <TableBubbleMenu editor={editor} />
         </>
       )}

--- a/src/components/editor/TiptapEditor/BubbleMenuButton.test.tsx
+++ b/src/components/editor/TiptapEditor/BubbleMenuButton.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BubbleMenuButton } from "./BubbleMenuButton";
+
+describe("BubbleMenuButton", () => {
+  it("renders children and calls onClick when clicked", () => {
+    const onClick = vi.fn();
+
+    render(
+      <BubbleMenuButton onClick={onClick} isActive={false}>
+        <span data-testid="icon">Icon</span>
+      </BubbleMenuButton>,
+    );
+
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies active styles when isActive is true", () => {
+    const { container } = render(
+      <BubbleMenuButton onClick={vi.fn()} isActive={true}>
+        Bold
+      </BubbleMenuButton>,
+    );
+    const button = container.querySelector("button");
+    expect(button).toHaveClass("bg-accent", "text-accent-foreground");
+  });
+
+  it("applies inactive styles when isActive is false", () => {
+    const { container } = render(
+      <BubbleMenuButton onClick={vi.fn()} isActive={false}>
+        Bold
+      </BubbleMenuButton>,
+    );
+    const button = container.querySelector("button");
+    expect(button).toHaveClass("text-muted-foreground");
+  });
+
+  it("forwards aria-label and title", () => {
+    render(
+      <BubbleMenuButton onClick={vi.fn()} isActive={false} aria-label="太字" title="太字 (Ctrl+B)">
+        B
+      </BubbleMenuButton>,
+    );
+    const button = screen.getByRole("button", { name: "太字" });
+    expect(button).toHaveAttribute("title", "太字 (Ctrl+B)");
+  });
+});

--- a/src/components/editor/TiptapEditor/BubbleMenuButton.tsx
+++ b/src/components/editor/TiptapEditor/BubbleMenuButton.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { cn } from "@zedi/ui";
 
-export interface BubbleMenuButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  onClick: () => void;
+export interface BubbleMenuButtonProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "onClick"
+> {
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
   isActive: boolean;
   children: React.ReactNode;
 }

--- a/src/components/editor/TiptapEditor/BubbleMenuButton.tsx
+++ b/src/components/editor/TiptapEditor/BubbleMenuButton.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { cn } from "@zedi/ui";
+
+export interface BubbleMenuButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  onClick: () => void;
+  isActive: boolean;
+  children: React.ReactNode;
+}
+
+/** Small toolbar button for the bubble menu */
+export function BubbleMenuButton({
+  onClick,
+  isActive,
+  children,
+  className,
+  ...props
+}: BubbleMenuButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-md p-1.5 transition-colors",
+        isActive
+          ? "bg-accent text-accent-foreground"
+          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/editor/TiptapEditor/EditorBubbleMenu.test.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenu.test.tsx
@@ -4,6 +4,14 @@ import { render } from "@testing-library/react";
 import { EditorBubbleMenu } from "./EditorBubbleMenu";
 import type { Editor } from "@tiptap/core";
 
+let shouldShowArgs: {
+  state: { selection: { empty: boolean } };
+  editor: { isActive: (name: string) => boolean };
+} = {
+  state: { selection: { empty: false } },
+  editor: { isActive: () => false },
+};
+
 vi.mock("@tiptap/react/menus", () => ({
   BubbleMenu: ({
     children,
@@ -15,10 +23,7 @@ vi.mock("@tiptap/react/menus", () => ({
       editor: { isActive: (name: string) => boolean };
     }) => boolean;
   }) => {
-    const show = shouldShow({
-      state: { selection: { empty: false } },
-      editor: { isActive: (name: string) => name === "codeBlock" && false },
-    });
+    const show = shouldShow(shouldShowArgs);
     if (!show) return null;
     return <div data-testid="bubble-menu">{children}</div>;
   },
@@ -59,5 +64,32 @@ describe("EditorBubbleMenu", () => {
   it("accepts optional pageId prop", () => {
     const { getByTestId } = render(<EditorBubbleMenu editor={mockEditor} pageId="page-1" />);
     expect(getByTestId("bubble-menu")).toBeInTheDocument();
+  });
+
+  it("shows menu when selection is empty but cursor is on wikiLink", () => {
+    shouldShowArgs = {
+      state: { selection: { empty: true } },
+      editor: { isActive: (name: string) => name === "wikiLink" },
+    };
+    const { getByTestId } = render(<EditorBubbleMenu editor={mockEditor} />);
+    expect(getByTestId("bubble-menu")).toBeInTheDocument();
+  });
+
+  it("hides menu when in codeBlock", () => {
+    shouldShowArgs = {
+      state: { selection: { empty: false } },
+      editor: { isActive: (name: string) => name === "codeBlock" },
+    };
+    const { queryByTestId } = render(<EditorBubbleMenu editor={mockEditor} />);
+    expect(queryByTestId("bubble-menu")).not.toBeInTheDocument();
+  });
+
+  it("hides menu when selection is empty and not on wikiLink", () => {
+    shouldShowArgs = {
+      state: { selection: { empty: true } },
+      editor: { isActive: () => false },
+    };
+    const { queryByTestId } = render(<EditorBubbleMenu editor={mockEditor} />);
+    expect(queryByTestId("bubble-menu")).not.toBeInTheDocument();
   });
 });

--- a/src/components/editor/TiptapEditor/EditorBubbleMenu.test.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenu.test.tsx
@@ -25,7 +25,13 @@ vi.mock("@tiptap/react/menus", () => ({
 }));
 
 vi.mock("@/hooks/usePageQueries", () => ({
-  useCheckGhostLinkReferenced: () => ({ checkReferenced: vi.fn().mockResolvedValue(false) }),
+  useWikiLinkExistsChecker: () =>
+    ({
+      checkExistence: vi.fn().mockResolvedValue({
+        pageTitles: new Set(),
+        referencedTitles: new Set(),
+      }),
+    }) as unknown,
 }));
 
 const mockEditor = {

--- a/src/components/editor/TiptapEditor/EditorBubbleMenu.test.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenu.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { EditorBubbleMenu } from "./EditorBubbleMenu";
+import type { Editor } from "@tiptap/core";
+
+vi.mock("@tiptap/react/menus", () => ({
+  BubbleMenu: ({
+    children,
+    shouldShow,
+  }: {
+    children: React.ReactNode;
+    shouldShow: (opts: {
+      state: { selection: { empty: boolean } };
+      editor: { isActive: (name: string) => boolean };
+    }) => boolean;
+  }) => {
+    const show = shouldShow({
+      state: { selection: { empty: false } },
+      editor: { isActive: (name: string) => name === "codeBlock" && false },
+    });
+    if (!show) return null;
+    return <div data-testid="bubble-menu">{children}</div>;
+  },
+}));
+
+vi.mock("@/hooks/usePageQueries", () => ({
+  useCheckGhostLinkReferenced: () => ({ checkReferenced: vi.fn().mockResolvedValue(false) }),
+}));
+
+const mockEditor = {
+  isActive: vi.fn(() => false),
+  extensionManager: { extensions: [] },
+  state: { selection: { empty: false } },
+  chain: vi.fn(() => ({
+    focus: vi.fn().mockReturnThis(),
+    run: vi.fn(),
+  })),
+} as unknown as Editor;
+
+describe("EditorBubbleMenu", () => {
+  it("renders BubbleMenu with toolbar when shouldShow is true", () => {
+    const { getByTestId } = render(<EditorBubbleMenu editor={mockEditor} />);
+    expect(getByTestId("bubble-menu")).toBeInTheDocument();
+  });
+
+  it("renders toolbar with WikiLink and formatting buttons", () => {
+    const { getByRole } = render(<EditorBubbleMenu editor={mockEditor} />);
+    expect(getByRole("button", { name: "太字" })).toBeInTheDocument();
+    expect(getByRole("button", { name: "WikiLinkにする" })).toBeInTheDocument();
+  });
+
+  it("accepts optional pageId prop", () => {
+    const { getByTestId } = render(<EditorBubbleMenu editor={mockEditor} pageId="page-1" />);
+    expect(getByTestId("bubble-menu")).toBeInTheDocument();
+  });
+});

--- a/src/components/editor/TiptapEditor/EditorBubbleMenu.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenu.tsx
@@ -18,7 +18,7 @@ export const EditorBubbleMenu: React.FC<EditorBubbleMenuProps> = ({ editor, page
       editor={editor}
       options={{ placement: "top" }}
       shouldShow={({ editor, state: menuState }) => {
-        if (menuState.selection.empty) return false;
+        if (menuState.selection.empty && !editor.isActive("wikiLink")) return false;
         if (editor.isActive("codeBlock")) return false;
         return true;
       }}

--- a/src/components/editor/TiptapEditor/EditorBubbleMenu.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenu.tsx
@@ -1,260 +1,29 @@
-import React, { useCallback, useState } from "react";
+import React from "react";
 import { BubbleMenu } from "@tiptap/react/menus";
 import type { Editor } from "@tiptap/core";
-import { cn } from "@zedi/ui";
-import {
-  Bold,
-  Italic,
-  Highlighter,
-  List,
-  ListOrdered,
-  CheckSquare,
-  Table,
-  Palette,
-  Strikethrough,
-  Code,
-} from "lucide-react";
-
-/** Preset text colors for the color picker */
-const PRESET_COLORS = [
-  { label: "デフォルト", value: "" },
-  { label: "グレー", value: "#6b7280" },
-  { label: "赤", value: "#dc2626" },
-  { label: "オレンジ", value: "#ea580c" },
-  { label: "緑", value: "#16a34a" },
-  { label: "青", value: "#2563eb" },
-  { label: "紫", value: "#7c3aed" },
-  { label: "ピンク", value: "#db2777" },
-];
+import { EditorBubbleMenuToolbar } from "./EditorBubbleMenuToolbar";
+import { useEditorBubbleMenu } from "./useEditorBubbleMenu";
 
 interface EditorBubbleMenuProps {
   editor: Editor;
+  /** 現在のページID。WikiLink 作成時の referenced 判定に使用（任意） */
+  pageId?: string;
 }
 
-export const EditorBubbleMenu: React.FC<EditorBubbleMenuProps> = ({ editor }) => {
-  const [showColorPicker, setShowColorPicker] = useState(false);
-
-  const toggleBold = useCallback(() => {
-    editor.chain().focus().toggleBold().run();
-  }, [editor]);
-
-  const toggleItalic = useCallback(() => {
-    editor.chain().focus().toggleItalic().run();
-  }, [editor]);
-
-  const toggleStrike = useCallback(() => {
-    editor.chain().focus().toggleStrike().run();
-  }, [editor]);
-
-  const toggleCode = useCallback(() => {
-    editor.chain().focus().toggleCode().run();
-  }, [editor]);
-
-  const toggleHighlight = useCallback(() => {
-    editor.chain().focus().toggleHighlight().run();
-  }, [editor]);
-
-  const toggleBulletList = useCallback(() => {
-    editor.chain().focus().toggleBulletList().run();
-  }, [editor]);
-
-  const toggleOrderedList = useCallback(() => {
-    editor.chain().focus().toggleOrderedList().run();
-  }, [editor]);
-
-  const toggleTaskList = useCallback(() => {
-    editor.chain().focus().toggleTaskList().run();
-  }, [editor]);
-
-  const insertTable = useCallback(() => {
-    editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
-  }, [editor]);
-
-  const setColor = useCallback(
-    (color: string) => {
-      if (!color) {
-        editor.chain().focus().unsetColor().run();
-      } else {
-        editor.chain().focus().setColor(color).run();
-      }
-      setShowColorPicker(false);
-    },
-    [editor],
-  );
-
-  const hasTable = !!editor.extensionManager.extensions.find((e) => e.name === "table");
-  const hasTaskList = !!editor.extensionManager.extensions.find((e) => e.name === "taskList");
+export const EditorBubbleMenu: React.FC<EditorBubbleMenuProps> = ({ editor, pageId }) => {
+  const state = useEditorBubbleMenu(editor, pageId);
 
   return (
     <BubbleMenu
       editor={editor}
       options={{ placement: "top" }}
-      shouldShow={({ editor, state }) => {
-        // Don't show on empty selections
-        if (state.selection.empty) return false;
-        // Don't show inside code blocks
+      shouldShow={({ editor, state: menuState }) => {
+        if (menuState.selection.empty) return false;
         if (editor.isActive("codeBlock")) return false;
         return true;
       }}
     >
-      <div className="shadow-elevated flex animate-fade-in items-center gap-0.5 rounded-lg border border-border bg-popover p-1">
-        {/* Bold */}
-        <BubbleButton
-          onClick={toggleBold}
-          isActive={editor.isActive("bold")}
-          aria-label="太字"
-          title="太字 (Ctrl+B)"
-        >
-          <Bold className="h-4 w-4" />
-        </BubbleButton>
-
-        {/* Italic */}
-        <BubbleButton
-          onClick={toggleItalic}
-          isActive={editor.isActive("italic")}
-          aria-label="イタリック"
-          title="イタリック (Ctrl+I)"
-        >
-          <Italic className="h-4 w-4" />
-        </BubbleButton>
-
-        {/* Strikethrough */}
-        <BubbleButton
-          onClick={toggleStrike}
-          isActive={editor.isActive("strike")}
-          aria-label="取り消し線"
-          title="取り消し線"
-        >
-          <Strikethrough className="h-4 w-4" />
-        </BubbleButton>
-
-        {/* Code */}
-        <BubbleButton
-          onClick={toggleCode}
-          isActive={editor.isActive("code")}
-          aria-label="インラインコード"
-          title="インラインコード"
-        >
-          <Code className="h-4 w-4" />
-        </BubbleButton>
-
-        {/* Highlight */}
-        <BubbleButton
-          onClick={toggleHighlight}
-          isActive={editor.isActive("highlight")}
-          aria-label="ハイライト"
-          title="ハイライト"
-        >
-          <Highlighter className="h-4 w-4" />
-        </BubbleButton>
-
-        <div className="mx-0.5 h-5 w-px bg-border" />
-
-        {/* Bullet List */}
-        <BubbleButton
-          onClick={toggleBulletList}
-          isActive={editor.isActive("bulletList")}
-          aria-label="箇条書き"
-          title="箇条書き"
-        >
-          <List className="h-4 w-4" />
-        </BubbleButton>
-
-        {/* Ordered List */}
-        <BubbleButton
-          onClick={toggleOrderedList}
-          isActive={editor.isActive("orderedList")}
-          aria-label="番号付きリスト"
-          title="番号付きリスト"
-        >
-          <ListOrdered className="h-4 w-4" />
-        </BubbleButton>
-
-        {/* Task List */}
-        {hasTaskList && (
-          <BubbleButton
-            onClick={toggleTaskList}
-            isActive={editor.isActive("taskList")}
-            aria-label="タスクリスト"
-            title="タスクリスト"
-          >
-            <CheckSquare className="h-4 w-4" />
-          </BubbleButton>
-        )}
-
-        <div className="mx-0.5 h-5 w-px bg-border" />
-
-        {/* Table insert */}
-        {hasTable && (
-          <BubbleButton
-            onClick={insertTable}
-            isActive={false}
-            aria-label="テーブル"
-            title="テーブル挿入"
-          >
-            <Table className="h-4 w-4" />
-          </BubbleButton>
-        )}
-
-        {/* Color picker */}
-        <div className="relative">
-          <BubbleButton
-            onClick={() => setShowColorPicker(!showColorPicker)}
-            isActive={showColorPicker}
-            aria-label="文字色"
-            title="文字色"
-          >
-            <Palette className="h-4 w-4" />
-          </BubbleButton>
-
-          {showColorPicker && (
-            <div className="shadow-elevated absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 animate-fade-in rounded-lg border border-border bg-popover p-2">
-              <div className="grid grid-cols-4 gap-1.5">
-                {PRESET_COLORS.map((color) => (
-                  <button
-                    key={color.value || "default"}
-                    onClick={() => setColor(color.value)}
-                    title={color.label}
-                    className={cn(
-                      "h-6 w-6 rounded-md border border-border transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-ring",
-                      !color.value && "bg-foreground",
-                    )}
-                    style={color.value ? { backgroundColor: color.value } : undefined}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
+      <EditorBubbleMenuToolbar editor={editor} state={state} />
     </BubbleMenu>
   );
 };
-
-/** Small toolbar button for the bubble menu */
-function BubbleButton({
-  onClick,
-  isActive,
-  children,
-  ...props
-}: {
-  onClick: () => void;
-  isActive: boolean;
-  children: React.ReactNode;
-} & React.ButtonHTMLAttributes<HTMLButtonElement>) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "rounded-md p-1.5 transition-colors",
-        isActive
-          ? "bg-accent text-accent-foreground"
-          : "text-muted-foreground hover:bg-muted hover:text-foreground",
-      )}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-}

--- a/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.test.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EditorBubbleMenuToolbar } from "./EditorBubbleMenuToolbar";
+import type { useEditorBubbleMenu } from "./useEditorBubbleMenu";
+
+type EditorBubbleMenuState = ReturnType<typeof useEditorBubbleMenu>;
+
+function createMockState(overrides?: Partial<EditorBubbleMenuState>): EditorBubbleMenuState {
+  return {
+    showColorPicker: false,
+    setShowColorPicker: vi.fn(),
+    setColor: vi.fn(),
+    hasTable: true,
+    hasTaskList: true,
+    toggleBold: vi.fn(),
+    toggleItalic: vi.fn(),
+    toggleStrike: vi.fn(),
+    toggleCode: vi.fn(),
+    toggleHighlight: vi.fn(),
+    toggleBulletList: vi.fn(),
+    toggleOrderedList: vi.fn(),
+    toggleTaskList: vi.fn(),
+    insertTable: vi.fn(),
+    isWikiLinkSelection: false,
+    convertToWikiLink: vi.fn(),
+    unsetWikiLink: vi.fn(),
+    ...overrides,
+  };
+}
+
+const mockEditor = {
+  isActive: vi.fn((_name: string) => false),
+} as unknown as Parameters<typeof EditorBubbleMenuToolbar>[0]["editor"];
+
+describe("EditorBubbleMenuToolbar", () => {
+  it("renders formatting buttons with aria-labels", () => {
+    const state = createMockState();
+    render(<EditorBubbleMenuToolbar editor={mockEditor} state={state} />);
+
+    expect(screen.getByRole("button", { name: "太字" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "イタリック" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "WikiLinkにする" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "箇条書き" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "文字色" })).toBeInTheDocument();
+  });
+
+  it("shows WikiLink解除 button when isWikiLinkSelection is true", () => {
+    const state = createMockState({ isWikiLinkSelection: true });
+    render(<EditorBubbleMenuToolbar editor={mockEditor} state={state} />);
+
+    expect(screen.getByRole("button", { name: "WikiLinkを解除" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "WikiLinkにする" })).not.toBeInTheDocument();
+  });
+
+  it("hides task list button when hasTaskList is false", () => {
+    const state = createMockState({ hasTaskList: false });
+    render(<EditorBubbleMenuToolbar editor={mockEditor} state={state} />);
+
+    expect(screen.queryByRole("button", { name: "タスクリスト" })).not.toBeInTheDocument();
+  });
+
+  it("hides table button when hasTable is false", () => {
+    const state = createMockState({ hasTable: false });
+    render(<EditorBubbleMenuToolbar editor={mockEditor} state={state} />);
+
+    expect(screen.queryByRole("button", { name: "テーブル" })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.tsx
@@ -1,0 +1,192 @@
+import React from "react";
+import type { Editor } from "@tiptap/core";
+import { cn } from "@zedi/ui";
+import {
+  Bold,
+  Italic,
+  Highlighter,
+  List,
+  ListOrdered,
+  CheckSquare,
+  Table,
+  Palette,
+  Strikethrough,
+  Code,
+  Link2,
+  Link2Off,
+} from "lucide-react";
+import { BubbleMenuButton } from "./BubbleMenuButton";
+import { BUBBLE_MENU_PRESET_COLORS } from "./bubbleMenuConfig";
+import type { useEditorBubbleMenu } from "./useEditorBubbleMenu";
+
+type EditorBubbleMenuState = ReturnType<typeof useEditorBubbleMenu>;
+
+interface EditorBubbleMenuToolbarProps {
+  editor: Editor;
+  state: EditorBubbleMenuState;
+}
+
+export function EditorBubbleMenuToolbar({ editor, state }: EditorBubbleMenuToolbarProps) {
+  const {
+    showColorPicker,
+    setShowColorPicker,
+    setColor,
+    hasTable,
+    hasTaskList,
+    toggleBold,
+    toggleItalic,
+    toggleStrike,
+    toggleCode,
+    toggleHighlight,
+    toggleBulletList,
+    toggleOrderedList,
+    toggleTaskList,
+    insertTable,
+    isWikiLinkSelection,
+    convertToWikiLink,
+    unsetWikiLink,
+  } = state;
+
+  return (
+    <div className="shadow-elevated flex animate-fade-in items-center gap-0.5 rounded-lg border border-border bg-popover p-1">
+      <BubbleMenuButton
+        onClick={toggleBold}
+        isActive={editor.isActive("bold")}
+        aria-label="太字"
+        title="太字 (Ctrl+B)"
+      >
+        <Bold className="h-4 w-4" />
+      </BubbleMenuButton>
+
+      <BubbleMenuButton
+        onClick={toggleItalic}
+        isActive={editor.isActive("italic")}
+        aria-label="イタリック"
+        title="イタリック (Ctrl+I)"
+      >
+        <Italic className="h-4 w-4" />
+      </BubbleMenuButton>
+
+      <BubbleMenuButton
+        onClick={toggleStrike}
+        isActive={editor.isActive("strike")}
+        aria-label="取り消し線"
+        title="取り消し線"
+      >
+        <Strikethrough className="h-4 w-4" />
+      </BubbleMenuButton>
+
+      <BubbleMenuButton
+        onClick={toggleCode}
+        isActive={editor.isActive("code")}
+        aria-label="インラインコード"
+        title="インラインコード"
+      >
+        <Code className="h-4 w-4" />
+      </BubbleMenuButton>
+
+      <BubbleMenuButton
+        onClick={toggleHighlight}
+        isActive={editor.isActive("highlight")}
+        aria-label="ハイライト"
+        title="ハイライト"
+      >
+        <Highlighter className="h-4 w-4" />
+      </BubbleMenuButton>
+
+      {!isWikiLinkSelection ? (
+        <BubbleMenuButton
+          onClick={convertToWikiLink}
+          isActive={false}
+          aria-label="WikiLinkにする"
+          title="WikiLink"
+        >
+          <Link2 className="h-4 w-4" />
+        </BubbleMenuButton>
+      ) : (
+        <BubbleMenuButton
+          onClick={unsetWikiLink}
+          isActive={true}
+          aria-label="WikiLinkを解除"
+          title="WikiLinkを解除"
+        >
+          <Link2Off className="h-4 w-4" />
+        </BubbleMenuButton>
+      )}
+
+      <div className="mx-0.5 h-5 w-px bg-border" />
+
+      <BubbleMenuButton
+        onClick={toggleBulletList}
+        isActive={editor.isActive("bulletList")}
+        aria-label="箇条書き"
+        title="箇条書き"
+      >
+        <List className="h-4 w-4" />
+      </BubbleMenuButton>
+
+      <BubbleMenuButton
+        onClick={toggleOrderedList}
+        isActive={editor.isActive("orderedList")}
+        aria-label="番号付きリスト"
+        title="番号付きリスト"
+      >
+        <ListOrdered className="h-4 w-4" />
+      </BubbleMenuButton>
+
+      {hasTaskList && (
+        <BubbleMenuButton
+          onClick={toggleTaskList}
+          isActive={editor.isActive("taskList")}
+          aria-label="タスクリスト"
+          title="タスクリスト"
+        >
+          <CheckSquare className="h-4 w-4" />
+        </BubbleMenuButton>
+      )}
+
+      <div className="mx-0.5 h-5 w-px bg-border" />
+
+      {hasTable && (
+        <BubbleMenuButton
+          onClick={insertTable}
+          isActive={false}
+          aria-label="テーブル"
+          title="テーブル挿入"
+        >
+          <Table className="h-4 w-4" />
+        </BubbleMenuButton>
+      )}
+
+      <div className="relative">
+        <BubbleMenuButton
+          onClick={() => setShowColorPicker(!showColorPicker)}
+          isActive={showColorPicker}
+          aria-label="文字色"
+          title="文字色"
+        >
+          <Palette className="h-4 w-4" />
+        </BubbleMenuButton>
+
+        {showColorPicker && (
+          <div className="shadow-elevated absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 animate-fade-in rounded-lg border border-border bg-popover p-2">
+            <div className="grid grid-cols-4 gap-1.5">
+              {BUBBLE_MENU_PRESET_COLORS.map((color) => (
+                <button
+                  key={color.value || "default"}
+                  onClick={() => setColor(color.value)}
+                  title={color.label}
+                  className={cn(
+                    "h-6 w-6 rounded-md border border-border transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-ring",
+                    !color.value && "bg-foreground",
+                  )}
+                  style={color.value ? { backgroundColor: color.value } : undefined}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.tsx
@@ -45,6 +45,7 @@ export function EditorBubbleMenuToolbar({ editor, state }: EditorBubbleMenuToolb
     isWikiLinkSelection,
     convertToWikiLink,
     unsetWikiLink,
+    isConverting,
   } = state;
 
   return (
@@ -98,6 +99,7 @@ export function EditorBubbleMenuToolbar({ editor, state }: EditorBubbleMenuToolb
         <BubbleMenuButton
           onClick={convertToWikiLink}
           isActive={false}
+          disabled={isConverting}
           aria-label="WikiLinkにする"
           title="WikiLink"
         >
@@ -173,9 +175,11 @@ export function EditorBubbleMenuToolbar({ editor, state }: EditorBubbleMenuToolb
             <div className="grid grid-cols-4 gap-1.5">
               {BUBBLE_MENU_PRESET_COLORS.map((color) => (
                 <button
+                  type="button"
                   key={color.value || "default"}
                   onClick={() => setColor(color.value)}
                   title={color.label}
+                  aria-label={color.label}
                   className={cn(
                     "h-6 w-6 rounded-md border border-border transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-ring",
                     !color.value && "bg-foreground",

--- a/src/components/editor/TiptapEditor/bubbleMenuConfig.test.ts
+++ b/src/components/editor/TiptapEditor/bubbleMenuConfig.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest";
+import { BUBBLE_MENU_PRESET_COLORS } from "./bubbleMenuConfig";
+
+describe("bubbleMenuConfig", () => {
+  it("BUBBLE_MENU_PRESET_COLORS has default and 7 color presets", () => {
+    expect(BUBBLE_MENU_PRESET_COLORS).toHaveLength(8);
+    expect(BUBBLE_MENU_PRESET_COLORS[0]).toEqual({ label: "デフォルト", value: "" });
+    expect(BUBBLE_MENU_PRESET_COLORS[1].label).toBe("グレー");
+    expect(BUBBLE_MENU_PRESET_COLORS.every((c) => "label" in c && "value" in c)).toBe(true);
+  });
+});

--- a/src/components/editor/TiptapEditor/bubbleMenuConfig.ts
+++ b/src/components/editor/TiptapEditor/bubbleMenuConfig.ts
@@ -1,0 +1,11 @@
+/** Preset text colors for the bubble menu color picker */
+export const BUBBLE_MENU_PRESET_COLORS = [
+  { label: "デフォルト", value: "" },
+  { label: "グレー", value: "#6b7280" },
+  { label: "赤", value: "#dc2626" },
+  { label: "オレンジ", value: "#ea580c" },
+  { label: "緑", value: "#16a34a" },
+  { label: "青", value: "#2563eb" },
+  { label: "紫", value: "#7c3aed" },
+  { label: "ピンク", value: "#db2777" },
+];

--- a/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.test.ts
+++ b/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.test.ts
@@ -3,9 +3,9 @@ import { renderHook, act } from "@testing-library/react";
 import { useBubbleMenuWikiLink } from "./useBubbleMenuWikiLink";
 import type { Editor } from "@tiptap/core";
 
-const mockCheckReferenced = vi.fn();
+const mockCheckExistence = vi.fn();
 vi.mock("@/hooks/usePageQueries", () => ({
-  useCheckGhostLinkReferenced: () => ({ checkReferenced: mockCheckReferenced }),
+  useWikiLinkExistsChecker: () => ({ checkExistence: mockCheckExistence }),
 }));
 
 function createMockEditor(options: {
@@ -49,7 +49,7 @@ function createMockEditor(options: {
 describe("useBubbleMenuWikiLink", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCheckReferenced.mockResolvedValue(false);
+    mockCheckExistence.mockResolvedValue({ pageTitles: new Set(), referencedTitles: new Set() });
   });
 
   it("returns isWikiLinkSelection false when editor is not in wikiLink", () => {
@@ -64,6 +64,12 @@ describe("useBubbleMenuWikiLink", () => {
     expect(result.current.isWikiLinkSelection).toBe(true);
   });
 
+  it("returns isConverting false initially", () => {
+    const editor = createMockEditor({ textBetween: "Foo" });
+    const { result } = renderHook(() => useBubbleMenuWikiLink({ editor }));
+    expect(result.current.isConverting).toBe(false);
+  });
+
   it("convertToWikiLink does nothing when selection text is empty", async () => {
     const editor = createMockEditor({ textBetween: "   " });
     const { result } = renderHook(() => useBubbleMenuWikiLink({ editor }));
@@ -72,11 +78,11 @@ describe("useBubbleMenuWikiLink", () => {
       await result.current.convertToWikiLink();
     });
 
-    expect(mockCheckReferenced).not.toHaveBeenCalled();
+    expect(mockCheckExistence).not.toHaveBeenCalled();
     expect(editor.chain).not.toHaveBeenCalled();
   });
 
-  it("convertToWikiLink calls checkReferenced with title and pageId then inserts content", async () => {
+  it("convertToWikiLink calls checkExistence with titles and pageId then inserts content", async () => {
     const editor = createMockEditor({ textBetween: "New Page" });
     const { result } = renderHook(() => useBubbleMenuWikiLink({ editor, pageId: "page-1" }));
 
@@ -84,7 +90,7 @@ describe("useBubbleMenuWikiLink", () => {
       await result.current.convertToWikiLink();
     });
 
-    expect(mockCheckReferenced).toHaveBeenCalledWith("New Page", "page-1");
+    expect(mockCheckExistence).toHaveBeenCalledWith(["New Page"], "page-1");
     expect(editor.chain).toHaveBeenCalled();
     expect(editor.chainReturn.deleteRange).toHaveBeenCalledWith({ from: 0, to: 5 });
     expect(editor.chainReturn.insertContent).toHaveBeenCalledWith([
@@ -102,8 +108,37 @@ describe("useBubbleMenuWikiLink", () => {
     expect(editor.chainReturn.run).toHaveBeenCalled();
   });
 
-  it("convertToWikiLink uses referenced true when checkReferenced returns true", async () => {
-    mockCheckReferenced.mockResolvedValue(true);
+  it("convertToWikiLink uses exists and referenced from checkExistence", async () => {
+    mockCheckExistence.mockResolvedValue({
+      pageTitles: new Set(["existing page"]),
+      referencedTitles: new Set(["existing page"]),
+    });
+    const editor = createMockEditor({ textBetween: "Existing Page" });
+    const { result } = renderHook(() => useBubbleMenuWikiLink({ editor, pageId: "p1" }));
+
+    await act(async () => {
+      await result.current.convertToWikiLink();
+    });
+
+    expect(editor.chainReturn.insertContent).toHaveBeenCalledWith([
+      {
+        type: "text",
+        marks: [
+          {
+            type: "wikiLink",
+            attrs: { title: "Existing Page", exists: true, referenced: true },
+          },
+        ],
+        text: "[[Existing Page]]",
+      },
+    ]);
+  });
+
+  it("convertToWikiLink uses referenced true when only referencedTitles has the title", async () => {
+    mockCheckExistence.mockResolvedValue({
+      pageTitles: new Set(),
+      referencedTitles: new Set(["ghost"]),
+    });
     const editor = createMockEditor({ textBetween: "Ghost" });
     const { result } = renderHook(() => useBubbleMenuWikiLink({ editor, pageId: "p1" }));
 
@@ -125,7 +160,7 @@ describe("useBubbleMenuWikiLink", () => {
     ]);
   });
 
-  it("convertToWikiLink does not call checkReferenced when pageId is undefined", async () => {
+  it("convertToWikiLink does not call checkExistence when pageId is undefined", async () => {
     const editor = createMockEditor({ textBetween: "No Page" });
     const { result } = renderHook(() => useBubbleMenuWikiLink({ editor }));
 
@@ -133,7 +168,7 @@ describe("useBubbleMenuWikiLink", () => {
       await result.current.convertToWikiLink();
     });
 
-    expect(mockCheckReferenced).not.toHaveBeenCalled();
+    expect(mockCheckExistence).not.toHaveBeenCalled();
     expect(editor.chain).toHaveBeenCalled();
   });
 

--- a/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.test.ts
+++ b/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useBubbleMenuWikiLink } from "./useBubbleMenuWikiLink";
+import type { Editor } from "@tiptap/core";
+
+const mockCheckReferenced = vi.fn();
+vi.mock("@/hooks/usePageQueries", () => ({
+  useCheckGhostLinkReferenced: () => ({ checkReferenced: mockCheckReferenced }),
+}));
+
+function createMockEditor(options: {
+  selection?: { from: number; to: number };
+  textBetween?: string;
+  isWikiLink?: boolean;
+}): Editor & {
+  chainReturn: {
+    deleteRange: ReturnType<typeof vi.fn>;
+    insertContent: ReturnType<typeof vi.fn>;
+    unsetWikiLink: ReturnType<typeof vi.fn>;
+    run: ReturnType<typeof vi.fn>;
+  };
+} {
+  const { selection = { from: 0, to: 5 }, textBetween = "Foo", isWikiLink = false } = options;
+  const chainRun = vi.fn();
+  const deleteRange = vi.fn().mockReturnThis();
+  const insertContent = vi.fn().mockReturnThis();
+  const unsetWikiLink = vi.fn().mockReturnThis();
+  const chainReturn = {
+    focus: vi.fn().mockReturnThis(),
+    deleteRange,
+    insertContent,
+    unsetWikiLink,
+    run: chainRun,
+  };
+  const editor = {
+    isActive: vi.fn((name: string) => (name === "wikiLink" ? isWikiLink : false)),
+    state: {
+      selection: { from: selection.from, to: selection.to },
+      doc: { textBetween: vi.fn(() => textBetween) },
+    },
+    chain: vi.fn(() => chainReturn),
+    chainReturn,
+  } as unknown as Editor & {
+    chainReturn: typeof chainReturn;
+  };
+  return editor;
+}
+
+describe("useBubbleMenuWikiLink", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckReferenced.mockResolvedValue(false);
+  });
+
+  it("returns isWikiLinkSelection false when editor is not in wikiLink", () => {
+    const editor = createMockEditor({ isWikiLink: false });
+    const { result } = renderHook(() => useBubbleMenuWikiLink({ editor }));
+    expect(result.current.isWikiLinkSelection).toBe(false);
+  });
+
+  it("returns isWikiLinkSelection true when editor is in wikiLink", () => {
+    const editor = createMockEditor({ isWikiLink: true });
+    const { result } = renderHook(() => useBubbleMenuWikiLink({ editor }));
+    expect(result.current.isWikiLinkSelection).toBe(true);
+  });
+
+  it("convertToWikiLink does nothing when selection text is empty", async () => {
+    const editor = createMockEditor({ textBetween: "   " });
+    const { result } = renderHook(() => useBubbleMenuWikiLink({ editor }));
+
+    await act(async () => {
+      await result.current.convertToWikiLink();
+    });
+
+    expect(mockCheckReferenced).not.toHaveBeenCalled();
+    expect(editor.chain).not.toHaveBeenCalled();
+  });
+
+  it("convertToWikiLink calls checkReferenced with title and pageId then inserts content", async () => {
+    const editor = createMockEditor({ textBetween: "New Page" });
+    const { result } = renderHook(() => useBubbleMenuWikiLink({ editor, pageId: "page-1" }));
+
+    await act(async () => {
+      await result.current.convertToWikiLink();
+    });
+
+    expect(mockCheckReferenced).toHaveBeenCalledWith("New Page", "page-1");
+    expect(editor.chain).toHaveBeenCalled();
+    expect(editor.chainReturn.deleteRange).toHaveBeenCalledWith({ from: 0, to: 5 });
+    expect(editor.chainReturn.insertContent).toHaveBeenCalledWith([
+      {
+        type: "text",
+        marks: [
+          {
+            type: "wikiLink",
+            attrs: { title: "New Page", exists: false, referenced: false },
+          },
+        ],
+        text: "[[New Page]]",
+      },
+    ]);
+    expect(editor.chainReturn.run).toHaveBeenCalled();
+  });
+
+  it("convertToWikiLink uses referenced true when checkReferenced returns true", async () => {
+    mockCheckReferenced.mockResolvedValue(true);
+    const editor = createMockEditor({ textBetween: "Ghost" });
+    const { result } = renderHook(() => useBubbleMenuWikiLink({ editor, pageId: "p1" }));
+
+    await act(async () => {
+      await result.current.convertToWikiLink();
+    });
+
+    expect(editor.chainReturn.insertContent).toHaveBeenCalledWith([
+      {
+        type: "text",
+        marks: [
+          {
+            type: "wikiLink",
+            attrs: { title: "Ghost", exists: false, referenced: true },
+          },
+        ],
+        text: "[[Ghost]]",
+      },
+    ]);
+  });
+
+  it("convertToWikiLink does not call checkReferenced when pageId is undefined", async () => {
+    const editor = createMockEditor({ textBetween: "No Page" });
+    const { result } = renderHook(() => useBubbleMenuWikiLink({ editor }));
+
+    await act(async () => {
+      await result.current.convertToWikiLink();
+    });
+
+    expect(mockCheckReferenced).not.toHaveBeenCalled();
+    expect(editor.chain).toHaveBeenCalled();
+  });
+
+  it("unsetWikiLink calls editor chain unsetWikiLink and run", () => {
+    const editor = createMockEditor({});
+    const { result } = renderHook(() => useBubbleMenuWikiLink({ editor }));
+
+    act(() => {
+      result.current.unsetWikiLink();
+    });
+
+    expect(editor.chainReturn.unsetWikiLink).toHaveBeenCalled();
+    expect(editor.chainReturn.run).toHaveBeenCalled();
+  });
+});

--- a/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.ts
+++ b/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.ts
@@ -1,6 +1,6 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import type { Editor } from "@tiptap/core";
-import { useCheckGhostLinkReferenced } from "@/hooks/usePageQueries";
+import { useWikiLinkExistsChecker } from "@/hooks/usePageQueries";
 
 export interface UseBubbleMenuWikiLinkOptions {
   editor: Editor;
@@ -8,40 +8,60 @@ export interface UseBubbleMenuWikiLinkOptions {
 }
 
 export function useBubbleMenuWikiLink({ editor, pageId }: UseBubbleMenuWikiLinkOptions) {
-  const { checkReferenced } = useCheckGhostLinkReferenced();
+  const { checkExistence } = useWikiLinkExistsChecker();
+  const [isConverting, setIsConverting] = useState(false);
 
   const isWikiLinkSelection = editor.isActive("wikiLink");
 
   const convertToWikiLink = useCallback(async () => {
+    if (isConverting) return;
+
     const { from, to } = editor.state.selection;
     const text = editor.state.doc.textBetween(from, to, null, "\ufffc").trim();
     if (!text) return;
-    let referenced = false;
-    if (pageId) {
-      referenced = await checkReferenced(text, pageId);
+
+    setIsConverting(true);
+    try {
+      let exists = false;
+      let referenced = false;
+      if (pageId !== undefined) {
+        const { pageTitles, referencedTitles } = await checkExistence([text], pageId);
+        const normalized = text.toLowerCase().trim();
+        exists = pageTitles.has(normalized);
+        referenced = referencedTitles.has(normalized);
+      }
+
+      const { from: currentFrom, to: currentTo } = editor.state.selection;
+      const currentText = editor.state.doc
+        .textBetween(currentFrom, currentTo, null, "\ufffc")
+        .trim();
+      if (currentText !== text) return;
+
+      editor
+        .chain()
+        .focus()
+        .deleteRange({ from: currentFrom, to: currentTo })
+        .insertContent([
+          {
+            type: "text",
+            marks: [
+              {
+                type: "wikiLink",
+                attrs: { title: text, exists, referenced },
+              },
+            ],
+            text: `[[${text}]]`,
+          },
+        ])
+        .run();
+    } finally {
+      setIsConverting(false);
     }
-    editor
-      .chain()
-      .focus()
-      .deleteRange({ from, to })
-      .insertContent([
-        {
-          type: "text",
-          marks: [
-            {
-              type: "wikiLink",
-              attrs: { title: text, exists: false, referenced },
-            },
-          ],
-          text: `[[${text}]]`,
-        },
-      ])
-      .run();
-  }, [editor, pageId, checkReferenced]);
+  }, [editor, pageId, checkExistence, isConverting]);
 
   const unsetWikiLink = useCallback(() => {
     editor.chain().focus().unsetWikiLink().run();
   }, [editor]);
 
-  return { isWikiLinkSelection, convertToWikiLink, unsetWikiLink };
+  return { isWikiLinkSelection, convertToWikiLink, unsetWikiLink, isConverting };
 }

--- a/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.ts
+++ b/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.ts
@@ -1,0 +1,47 @@
+import { useCallback } from "react";
+import type { Editor } from "@tiptap/core";
+import { useCheckGhostLinkReferenced } from "@/hooks/usePageQueries";
+
+export interface UseBubbleMenuWikiLinkOptions {
+  editor: Editor;
+  pageId?: string;
+}
+
+export function useBubbleMenuWikiLink({ editor, pageId }: UseBubbleMenuWikiLinkOptions) {
+  const { checkReferenced } = useCheckGhostLinkReferenced();
+
+  const isWikiLinkSelection = editor.isActive("wikiLink");
+
+  const convertToWikiLink = useCallback(async () => {
+    const { from, to } = editor.state.selection;
+    const text = editor.state.doc.textBetween(from, to, null, "\ufffc").trim();
+    if (!text) return;
+    let referenced = false;
+    if (pageId) {
+      referenced = await checkReferenced(text, pageId);
+    }
+    editor
+      .chain()
+      .focus()
+      .deleteRange({ from, to })
+      .insertContent([
+        {
+          type: "text",
+          marks: [
+            {
+              type: "wikiLink",
+              attrs: { title: text, exists: false, referenced },
+            },
+          ],
+          text: `[[${text}]]`,
+        },
+      ])
+      .run();
+  }, [editor, pageId, checkReferenced]);
+
+  const unsetWikiLink = useCallback(() => {
+    editor.chain().focus().unsetWikiLink().run();
+  }, [editor]);
+
+  return { isWikiLinkSelection, convertToWikiLink, unsetWikiLink };
+}

--- a/src/components/editor/TiptapEditor/useEditorBubbleMenu.test.ts
+++ b/src/components/editor/TiptapEditor/useEditorBubbleMenu.test.ts
@@ -4,7 +4,13 @@ import { useEditorBubbleMenu } from "./useEditorBubbleMenu";
 import type { Editor } from "@tiptap/core";
 
 vi.mock("@/hooks/usePageQueries", () => ({
-  useCheckGhostLinkReferenced: () => ({ checkReferenced: vi.fn().mockResolvedValue(false) }),
+  useWikiLinkExistsChecker: () =>
+    ({
+      checkExistence: vi.fn().mockResolvedValue({
+        pageTitles: new Set(),
+        referencedTitles: new Set(),
+      }),
+    }) as unknown,
 }));
 
 function createMockEditor(): Editor & {

--- a/src/components/editor/TiptapEditor/useEditorBubbleMenu.test.ts
+++ b/src/components/editor/TiptapEditor/useEditorBubbleMenu.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useEditorBubbleMenu } from "./useEditorBubbleMenu";
+import type { Editor } from "@tiptap/core";
+
+vi.mock("@/hooks/usePageQueries", () => ({
+  useCheckGhostLinkReferenced: () => ({ checkReferenced: vi.fn().mockResolvedValue(false) }),
+}));
+
+function createMockEditor(): Editor & {
+  chainReturn: {
+    run: ReturnType<typeof vi.fn>;
+    focus: ReturnType<typeof vi.fn>;
+    toggleBold: ReturnType<typeof vi.fn>;
+    setColor: ReturnType<typeof vi.fn>;
+    unsetColor: ReturnType<typeof vi.fn>;
+    insertTable: ReturnType<typeof vi.fn>;
+  };
+} {
+  const run = vi.fn();
+  const chainReturn = {
+    focus: vi.fn().mockReturnThis(),
+    toggleBold: vi.fn().mockReturnThis(),
+    toggleItalic: vi.fn().mockReturnThis(),
+    toggleStrike: vi.fn().mockReturnThis(),
+    toggleCode: vi.fn().mockReturnThis(),
+    toggleHighlight: vi.fn().mockReturnThis(),
+    toggleBulletList: vi.fn().mockReturnThis(),
+    toggleOrderedList: vi.fn().mockReturnThis(),
+    toggleTaskList: vi.fn().mockReturnThis(),
+    setColor: vi.fn().mockReturnThis(),
+    unsetColor: vi.fn().mockReturnThis(),
+    insertTable: vi.fn().mockReturnThis(),
+    run,
+  };
+  const editor = {
+    isActive: vi.fn(() => false),
+    state: {
+      selection: { from: 0, to: 0 },
+      doc: { textBetween: vi.fn(() => "") },
+    },
+    chain: vi.fn(() => chainReturn),
+    extensionManager: {
+      extensions: [{ name: "table" }, { name: "taskList" }],
+    },
+    chainReturn,
+  } as unknown as Editor & { chainReturn: typeof chainReturn };
+  return editor;
+}
+
+describe("useEditorBubbleMenu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns showColorPicker, hasTable, hasTaskList and action callbacks", () => {
+    const editor = createMockEditor();
+    const { result } = renderHook(() => useEditorBubbleMenu(editor));
+
+    expect(result.current.showColorPicker).toBe(false);
+    expect(result.current.hasTable).toBe(true);
+    expect(result.current.hasTaskList).toBe(true);
+    expect(typeof result.current.setShowColorPicker).toBe("function");
+    expect(typeof result.current.toggleBold).toBe("function");
+    expect(typeof result.current.convertToWikiLink).toBe("function");
+    expect(typeof result.current.unsetWikiLink).toBe("function");
+  });
+
+  it("toggleBold calls editor chain toggleBold and run", () => {
+    const editor = createMockEditor();
+    const { result } = renderHook(() => useEditorBubbleMenu(editor));
+
+    act(() => {
+      result.current.toggleBold();
+    });
+
+    expect(editor.chainReturn.toggleBold).toHaveBeenCalled();
+    expect(editor.chainReturn.run).toHaveBeenCalled();
+  });
+
+  it("setColor with empty string calls unsetColor", () => {
+    const editor = createMockEditor();
+    const { result } = renderHook(() => useEditorBubbleMenu(editor));
+
+    act(() => {
+      result.current.setColor("");
+    });
+
+    expect(editor.chainReturn.unsetColor).toHaveBeenCalled();
+    expect(editor.chainReturn.run).toHaveBeenCalled();
+  });
+
+  it("setColor with value calls setColor and run", () => {
+    const editor = createMockEditor();
+    const { result } = renderHook(() => useEditorBubbleMenu(editor));
+
+    act(() => {
+      result.current.setColor("#2563eb");
+    });
+
+    expect(editor.chainReturn.setColor).toHaveBeenCalledWith("#2563eb");
+    expect(editor.chainReturn.run).toHaveBeenCalled();
+  });
+
+  it("insertTable calls editor chain insertTable with 3x3 and run", () => {
+    const editor = createMockEditor();
+    const { result } = renderHook(() => useEditorBubbleMenu(editor));
+
+    act(() => {
+      result.current.insertTable();
+    });
+
+    expect(editor.chainReturn.insertTable).toHaveBeenCalledWith({
+      rows: 3,
+      cols: 3,
+      withHeaderRow: true,
+    });
+    expect(editor.chainReturn.run).toHaveBeenCalled();
+  });
+});

--- a/src/components/editor/TiptapEditor/useEditorBubbleMenu.ts
+++ b/src/components/editor/TiptapEditor/useEditorBubbleMenu.ts
@@ -1,0 +1,77 @@
+import { useCallback, useState } from "react";
+import type { Editor } from "@tiptap/core";
+import { useBubbleMenuWikiLink } from "./useBubbleMenuWikiLink";
+
+export function useEditorBubbleMenu(editor: Editor, pageId?: string) {
+  const [showColorPicker, setShowColorPicker] = useState(false);
+  const wikiLink = useBubbleMenuWikiLink({ editor, pageId });
+
+  const toggleBold = useCallback(() => {
+    editor.chain().focus().toggleBold().run();
+  }, [editor]);
+
+  const toggleItalic = useCallback(() => {
+    editor.chain().focus().toggleItalic().run();
+  }, [editor]);
+
+  const toggleStrike = useCallback(() => {
+    editor.chain().focus().toggleStrike().run();
+  }, [editor]);
+
+  const toggleCode = useCallback(() => {
+    editor.chain().focus().toggleCode().run();
+  }, [editor]);
+
+  const toggleHighlight = useCallback(() => {
+    editor.chain().focus().toggleHighlight().run();
+  }, [editor]);
+
+  const toggleBulletList = useCallback(() => {
+    editor.chain().focus().toggleBulletList().run();
+  }, [editor]);
+
+  const toggleOrderedList = useCallback(() => {
+    editor.chain().focus().toggleOrderedList().run();
+  }, [editor]);
+
+  const toggleTaskList = useCallback(() => {
+    editor.chain().focus().toggleTaskList().run();
+  }, [editor]);
+
+  const insertTable = useCallback(() => {
+    editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
+  }, [editor]);
+
+  const setColor = useCallback(
+    (color: string) => {
+      if (!color) {
+        editor.chain().focus().unsetColor().run();
+      } else {
+        editor.chain().focus().setColor(color).run();
+      }
+      setShowColorPicker(false);
+    },
+    [editor],
+  );
+
+  const hasTable = !!editor.extensionManager.extensions.find((e) => e.name === "table");
+  const hasTaskList = !!editor.extensionManager.extensions.find((e) => e.name === "taskList");
+
+  return {
+    showColorPicker,
+    setShowColorPicker,
+    setColor,
+    hasTable,
+    hasTaskList,
+    toggleBold,
+    toggleItalic,
+    toggleStrike,
+    toggleCode,
+    toggleHighlight,
+    toggleBulletList,
+    toggleOrderedList,
+    toggleTaskList,
+    insertTable,
+    ...wikiLink,
+  };
+}

--- a/src/components/editor/TiptapEditor/useEditorBubbleMenu.ts
+++ b/src/components/editor/TiptapEditor/useEditorBubbleMenu.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { Editor } from "@tiptap/core";
 import { useBubbleMenuWikiLink } from "./useBubbleMenuWikiLink";
 
@@ -54,8 +54,14 @@ export function useEditorBubbleMenu(editor: Editor, pageId?: string) {
     [editor],
   );
 
-  const hasTable = !!editor.extensionManager.extensions.find((e) => e.name === "table");
-  const hasTaskList = !!editor.extensionManager.extensions.find((e) => e.name === "taskList");
+  const hasTable = useMemo(
+    () => !!editor.extensionManager.extensions.find((e) => e.name === "table"),
+    [editor.extensionManager.extensions],
+  );
+  const hasTaskList = useMemo(
+    () => !!editor.extensionManager.extensions.find((e) => e.name === "taskList"),
+    [editor.extensionManager.extensions],
+  );
 
   return {
     showColorPicker,


### PR DESCRIPTION
## 概要

Tiptap エディタでウィキリンクを選択したときに表示するバブルメニューを実装しました。既存の `EditorBubbleMenu` をリファクタし、ウィキリンク用の表示・編集アクション（ページ作成・編集・削除など）をツールバーで提供します。

## 変更点

- **`src/components/editor/TiptapEditor/`**
  - `EditorBubbleMenu.tsx`: ウィキリンク判定とツールバー表示に責務を分割。`EditorBubbleMenuToolbar`・`useEditorBubbleMenu`・`useBubbleMenuWikiLink` を利用する構成に変更。
  - 新規: `EditorBubbleMenuToolbar.tsx`（バブルメニューのツールバーUI）、`BubbleMenuButton.tsx`（ボタンコンポーネント）、`bubbleMenuConfig.ts`（設定）、`useEditorBubbleMenu.ts`（表示制御）、`useBubbleMenuWikiLink.ts`（ウィキリンク用ロジック）および各テスト。
- **`src/components/editor/TiptapEditor.tsx`**
  - バブルメニュー周りの参照を新構成に合わせて調整。
- **`docs/`**
  - `docs/plans/wiki-link-bubble-menu.md`（計画）、`docs/reviews/review-develop-20250311-1.md`（レビュー記録）を追加。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [x] 📝 ドキュメント (Documentation)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. 開発サーバーを起動し、ノートのページエディタを開く。
2. 本文にウィキリンク（`[[ページ名]]`）を挿入する。
3. ウィキリンクのテキストを選択（またはキャレットを置く）し、バブルメニューが表示されることを確認する。
4. ツールバーの「ページを作成」「編集」「削除」等のアクションが期待どおり動作することを確認する。
5. 単体テスト: `bun run test:run` で TiptapEditor 関連のテストが通ることを確認。

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

ウィキリンク選択時に表示されるバブルメニューのスクリーンショットを追加するとよいです。

## 関連 Issue

<!-- 特になし -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * WikiLink変換: エディタの吹き出しメニューから選択したテキストを直接WikiLinkに変換可能に
  * テキスト色ピッカー: 吹き出しメニューのプリセットカラーパレットからテキストに色を適用可能に
  * 強化されたエディタツールバー: 包括的なフォーマットコントロールと改善されたユーザビリティを備えた吹き出しメニュー

<!-- end of auto-generated comment: release notes by coderabbit.ai -->