### PR TITLE
fix(editor): add pluginKey to BubbleMenu components

### DIFF
--- a/src/components/editor/TiptapEditor/EditorBubbleMenu.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenu.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BubbleMenu } from "@tiptap/react/menus";
 import type { Editor } from "@tiptap/core";
 import { EditorBubbleMenuToolbar } from "./EditorBubbleMenuToolbar";
+import { PLUGIN_KEYS } from "./pluginKeys";
 import { useEditorBubbleMenu } from "./useEditorBubbleMenu";
 
 interface EditorBubbleMenuProps {
@@ -16,7 +17,7 @@ export const EditorBubbleMenu: React.FC<EditorBubbleMenuProps> = ({ editor, page
   return (
     <BubbleMenu
       editor={editor}
-      pluginKey="editorBubbleMenu"
+      pluginKey={PLUGIN_KEYS.EDITOR_BUBBLE_MENU}
       options={{ placement: "top" }}
       shouldShow={({ editor, state: menuState }) => {
         if (menuState.selection.empty && !editor.isActive("wikiLink")) return false;

--- a/src/components/editor/TiptapEditor/EditorBubbleMenu.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenu.tsx
@@ -16,6 +16,7 @@ export const EditorBubbleMenu: React.FC<EditorBubbleMenuProps> = ({ editor, page
   return (
     <BubbleMenu
       editor={editor}
+      pluginKey="editorBubbleMenu"
       options={{ placement: "top" }}
       shouldShow={({ editor, state: menuState }) => {
         if (menuState.selection.empty && !editor.isActive("wikiLink")) return false;

--- a/src/components/editor/TiptapEditor/TableBubbleMenu.tsx
+++ b/src/components/editor/TiptapEditor/TableBubbleMenu.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BubbleMenu } from "@tiptap/react/menus";
 import type { Editor } from "@tiptap/core";
 import { cn } from "@zedi/ui";
+import { PLUGIN_KEYS } from "./pluginKeys";
 import {
   ArrowUpFromLine,
   ArrowDownFromLine,
@@ -21,7 +22,7 @@ export const TableBubbleMenu: React.FC<TableBubbleMenuProps> = ({ editor }) => {
   return (
     <BubbleMenu
       editor={editor}
-      pluginKey="tableBubbleMenu"
+      pluginKey={PLUGIN_KEYS.TABLE_BUBBLE_MENU}
       options={{ placement: "top" }}
       shouldShow={({ editor }) => {
         return editor.isActive("table");

--- a/src/components/editor/TiptapEditor/TableBubbleMenu.tsx
+++ b/src/components/editor/TiptapEditor/TableBubbleMenu.tsx
@@ -21,6 +21,7 @@ export const TableBubbleMenu: React.FC<TableBubbleMenuProps> = ({ editor }) => {
   return (
     <BubbleMenu
       editor={editor}
+      pluginKey="tableBubbleMenu"
       options={{ placement: "top" }}
       shouldShow={({ editor }) => {
         return editor.isActive("table");

--- a/src/components/editor/TiptapEditor/pluginKeys.ts
+++ b/src/components/editor/TiptapEditor/pluginKeys.ts
@@ -1,0 +1,5 @@
+/** Tiptap BubbleMenu の pluginKey。複数メニューが競合しないよう一意に識別するために使用 */
+export const PLUGIN_KEYS = {
+  EDITOR_BUBBLE_MENU: "editorBubbleMenu",
+  TABLE_BUBBLE_MENU: "tableBubbleMenu",
+} as const;


### PR DESCRIPTION
## 概要

Tiptap の BubbleMenu に `pluginKey` を明示的に指定する修正です。EditorBubbleMenu と TableBubbleMenu の両方に `pluginKey` を追加し、プラグインが一意に識別されるようにしました。

## 変更点

- `src/components/editor/TiptapEditor/EditorBubbleMenu.tsx`: `pluginKey="editorBubbleMenu"` を追加
- `src/components/editor/TiptapEditor/TableBubbleMenu.tsx`: `pluginKey="tableBubbleMenu"` を追加

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. 開発サーバーを起動し、ページエディタを開く
2. テキストを選択し、バブルメニュー（WikiLink 等）が表示されることを確認
3. 表を選択し、表用バブルメニュー（行・列の追加・削除等）が表示されることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

<!-- 見た目の変更はないため不要 -->

## 関連 Issue

<!-- なし -->

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
