### PR TITLE
fix: address PR #311 review comments

### DIFF
--- a/e2e/page-editor.spec.ts
+++ b/e2e/page-editor.spec.ts
@@ -110,6 +110,20 @@ test.describe("Page Editor", () => {
       // The content error banner should not be visible for normal content
       await expect(page.locator(".bg-amber-500\\/10")).not.toBeVisible();
     });
+
+    test("should apply bold via bubble menu when text is selected", async ({ page, helpers }) => {
+      await helpers.createNewPage(page);
+
+      const editor = page.locator(".tiptap");
+      await editor.click();
+      await page.keyboard.type("Bold test");
+      await page.keyboard.press("Mod+a");
+
+      await expect(page.getByRole("button", { name: "太字" })).toBeVisible({ timeout: 3000 });
+      await page.getByRole("button", { name: "太字" }).click();
+
+      await expect(editor.locator("strong")).toContainText("Bold test");
+    });
   });
 
   test.describe("Wiki Generator", () => {

--- a/src/components/editor/TiptapEditor/BubbleMenuButton.tsx
+++ b/src/components/editor/TiptapEditor/BubbleMenuButton.tsx
@@ -10,17 +10,27 @@ export interface BubbleMenuButtonProps extends Omit<
   children: React.ReactNode;
 }
 
+/** Keep editor focus when clicking the button so BubbleMenu shouldShow(hasFocus) does not hide the menu before click fires. */
+function handleMouseDown(e: React.MouseEvent<HTMLButtonElement>) {
+  e.preventDefault();
+}
+
 /** Small toolbar button for the bubble menu */
 export function BubbleMenuButton({
   onClick,
   isActive,
   children,
   className,
+  onMouseDown: onMouseDownProp,
   ...props
 }: BubbleMenuButtonProps) {
   return (
     <button
       type="button"
+      onMouseDown={(e) => {
+        handleMouseDown(e);
+        onMouseDownProp?.(e);
+      }}
       onClick={onClick}
       className={cn(
         "rounded-md p-1.5 transition-colors",

--- a/src/components/editor/TiptapEditor/EditorBubbleMenu.test.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenu.test.tsx
@@ -6,10 +6,18 @@ import type { Editor } from "@tiptap/core";
 
 let shouldShowArgs: {
   state: { selection: { empty: boolean } };
-  editor: { isActive: (name: string) => boolean };
+  editor: {
+    isActive: (name: string) => boolean;
+    view?: { hasFocus?: () => boolean };
+    isEditable?: boolean;
+  };
 } = {
   state: { selection: { empty: false } },
-  editor: { isActive: () => false },
+  editor: {
+    isActive: () => false,
+    view: { hasFocus: () => true },
+    isEditable: true,
+  },
 };
 
 vi.mock("@tiptap/react/menus", () => ({
@@ -20,7 +28,11 @@ vi.mock("@tiptap/react/menus", () => ({
     children: React.ReactNode;
     shouldShow: (opts: {
       state: { selection: { empty: boolean } };
-      editor: { isActive: (name: string) => boolean };
+      editor: {
+        isActive: (name: string) => boolean;
+        view?: { hasFocus?: () => boolean };
+        isEditable?: boolean;
+      };
     }) => boolean;
   }) => {
     const show = shouldShow(shouldShowArgs);
@@ -69,7 +81,11 @@ describe("EditorBubbleMenu", () => {
   it("shows menu when selection is empty but cursor is on wikiLink", () => {
     shouldShowArgs = {
       state: { selection: { empty: true } },
-      editor: { isActive: (name: string) => name === "wikiLink" },
+      editor: {
+        isActive: (name: string) => name === "wikiLink",
+        view: { hasFocus: () => true },
+        isEditable: true,
+      },
     };
     const { getByTestId } = render(<EditorBubbleMenu editor={mockEditor} />);
     expect(getByTestId("bubble-menu")).toBeInTheDocument();
@@ -78,7 +94,11 @@ describe("EditorBubbleMenu", () => {
   it("hides menu when in codeBlock", () => {
     shouldShowArgs = {
       state: { selection: { empty: false } },
-      editor: { isActive: (name: string) => name === "codeBlock" },
+      editor: {
+        isActive: (name: string) => name === "codeBlock",
+        view: { hasFocus: () => true },
+        isEditable: true,
+      },
     };
     const { queryByTestId } = render(<EditorBubbleMenu editor={mockEditor} />);
     expect(queryByTestId("bubble-menu")).not.toBeInTheDocument();
@@ -87,7 +107,11 @@ describe("EditorBubbleMenu", () => {
   it("hides menu when selection is empty and not on wikiLink", () => {
     shouldShowArgs = {
       state: { selection: { empty: true } },
-      editor: { isActive: () => false },
+      editor: {
+        isActive: () => false,
+        view: { hasFocus: () => true },
+        isEditable: true,
+      },
     };
     const { queryByTestId } = render(<EditorBubbleMenu editor={mockEditor} />);
     expect(queryByTestId("bubble-menu")).not.toBeInTheDocument();

--- a/src/components/editor/TiptapEditor/EditorBubbleMenu.test.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenu.test.tsx
@@ -116,4 +116,30 @@ describe("EditorBubbleMenu", () => {
     const { queryByTestId } = render(<EditorBubbleMenu editor={mockEditor} />);
     expect(queryByTestId("bubble-menu")).not.toBeInTheDocument();
   });
+
+  it("hides menu when editor has no focus", () => {
+    shouldShowArgs = {
+      state: { selection: { empty: false } },
+      editor: {
+        isActive: () => false,
+        view: { hasFocus: () => false },
+        isEditable: true,
+      },
+    };
+    const { queryByTestId } = render(<EditorBubbleMenu editor={mockEditor} />);
+    expect(queryByTestId("bubble-menu")).not.toBeInTheDocument();
+  });
+
+  it("hides menu when editor is not editable", () => {
+    shouldShowArgs = {
+      state: { selection: { empty: false } },
+      editor: {
+        isActive: () => false,
+        view: { hasFocus: () => true },
+        isEditable: false,
+      },
+    };
+    const { queryByTestId } = render(<EditorBubbleMenu editor={mockEditor} />);
+    expect(queryByTestId("bubble-menu")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/editor/TiptapEditor/EditorBubbleMenu.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenu.tsx
@@ -20,6 +20,8 @@ export const EditorBubbleMenu: React.FC<EditorBubbleMenuProps> = ({ editor, page
       pluginKey={PLUGIN_KEYS.EDITOR_BUBBLE_MENU}
       options={{ placement: "top" }}
       shouldShow={({ editor, state: menuState }) => {
+        if (!editor.view?.hasFocus?.()) return false;
+        if (!editor.isEditable) return false;
         if (menuState.selection.empty && !editor.isActive("wikiLink")) return false;
         if (editor.isActive("codeBlock")) return false;
         return true;

--- a/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.test.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.test.tsx
@@ -24,6 +24,7 @@ function createMockState(overrides?: Partial<EditorBubbleMenuState>): EditorBubb
     isWikiLinkSelection: false,
     convertToWikiLink: vi.fn(),
     unsetWikiLink: vi.fn(),
+    isConverting: false,
     ...overrides,
   };
 }

--- a/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.test.ts
+++ b/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.test.ts
@@ -183,4 +183,39 @@ describe("useBubbleMenuWikiLink", () => {
     expect(editor.chainReturn.unsetWikiLink).toHaveBeenCalled();
     expect(editor.chainReturn.run).toHaveBeenCalled();
   });
+
+  it("convertToWikiLink ignores second call until first resolves (re-entrancy guard)", async () => {
+    const deferred: {
+      resolve: (v: { pageTitles: Set<string>; referencedTitles: Set<string> }) => void;
+    } = { resolve: () => {} };
+    const checkPromise = new Promise<{ pageTitles: Set<string>; referencedTitles: Set<string> }>(
+      (r) => {
+        deferred.resolve = r;
+      },
+    );
+    mockCheckExistence.mockReturnValue(checkPromise);
+
+    const editor = createMockEditor({ textBetween: "Foo" });
+    const { result } = renderHook(() => useBubbleMenuWikiLink({ editor, pageId: "page-1" }));
+
+    let firstCall: Promise<void> | undefined;
+    await act(async () => {
+      firstCall = result.current.convertToWikiLink();
+      result.current.convertToWikiLink();
+      result.current.convertToWikiLink();
+    });
+
+    expect(mockCheckExistence).toHaveBeenCalledTimes(1);
+    expect(editor.chain).not.toHaveBeenCalled();
+
+    if (firstCall === undefined) throw new Error("expected firstCall");
+    await act(async () => {
+      deferred.resolve({ pageTitles: new Set(), referencedTitles: new Set() });
+      await firstCall;
+    });
+
+    expect(mockCheckExistence).toHaveBeenCalledTimes(1);
+    expect(editor.chain).toHaveBeenCalledTimes(1);
+    expect(result.current.isConverting).toBe(false);
+  });
 });

--- a/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.ts
+++ b/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { Editor } from "@tiptap/core";
 import { useWikiLinkExistsChecker } from "@/hooks/usePageQueries";
 
@@ -10,16 +10,18 @@ export interface UseBubbleMenuWikiLinkOptions {
 export function useBubbleMenuWikiLink({ editor, pageId }: UseBubbleMenuWikiLinkOptions) {
   const { checkExistence } = useWikiLinkExistsChecker();
   const [isConverting, setIsConverting] = useState(false);
+  const convertingRef = useRef(false);
 
   const isWikiLinkSelection = editor.isActive("wikiLink");
 
   const convertToWikiLink = useCallback(async () => {
-    if (isConverting) return;
+    if (convertingRef.current) return;
 
     const { from, to } = editor.state.selection;
     const text = editor.state.doc.textBetween(from, to, null, "\ufffc").trim();
     if (!text) return;
 
+    convertingRef.current = true;
     setIsConverting(true);
     try {
       let exists = false;
@@ -55,9 +57,10 @@ export function useBubbleMenuWikiLink({ editor, pageId }: UseBubbleMenuWikiLinkO
         ])
         .run();
     } finally {
+      convertingRef.current = false;
       setIsConverting(false);
     }
-  }, [editor, pageId, checkExistence, isConverting]);
+  }, [editor, pageId, checkExistence]);
 
   const unsetWikiLink = useCallback(() => {
     editor.chain().focus().unsetWikiLink().run();

--- a/src/components/editor/TiptapEditor/useContentSanitizer.ts
+++ b/src/components/editor/TiptapEditor/useContentSanitizer.ts
@@ -42,6 +42,7 @@ export function useContentSanitizer({
     // コラボモード時は Y.Doc が唯一のソースのため sanitization と setContent を行わない（二重化防止・CPU 節約）
     if (isCollaborationMode) {
       if (!content && onError) onError(null);
+      onContentUpdated?.(true);
       return;
     }
 

--- a/src/components/layout/Header/AIChatButton.tsx
+++ b/src/components/layout/Header/AIChatButton.tsx
@@ -31,23 +31,26 @@ export function AIChatButton() {
   };
 
   return (
-    <div className={`rounded-md bg-gradient-to-r ${AI_BUTTON_GRADIENT} p-[2px]`}>
+    <div
+      className={`flex h-10 shrink-0 items-center rounded-md bg-gradient-to-r ${AI_BUTTON_GRADIENT} p-[2px] transition-shadow duration-300 hover:shadow-[0_0_12px_-2px_rgba(139,92,246,0.35)]`}
+    >
       <button
         type="button"
         onClick={handleClick}
         aria-label={t("aiChat.title")}
         aria-pressed={isOpen}
-        className={`group relative flex items-center gap-1.5 rounded-sm px-3 py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+        className={`group relative flex h-full min-h-0 w-full items-center justify-center gap-1 rounded-[calc(theme(borderRadius.md)-1px)] px-3 transition-colors duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
           isOpen
-            ? `bg-gradient-to-r ${AI_BUTTON_GRADIENT} text-white shadow-sm`
-            : "bg-background text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+            ? `bg-gradient-to-r ${AI_BUTTON_GRADIENT} text-white shadow-md`
+            : "bg-background text-muted-foreground hover:text-white"
         }`}
         title={`${t("aiChat.title")} (Ctrl+Shift+A)`}
       >
-        {/* ホバー時の背景グロー効果 (開いていない時のみ) */}
+        {/* ホバー時: オープン時と同じグラデーション背景を透過で重ねて滑らかに表示 */}
         {!isOpen && (
           <div
-            className={`absolute inset-0 rounded-sm bg-gradient-to-r ${AI_BUTTON_GRADIENT} opacity-0 blur transition-opacity duration-500 group-hover:opacity-10`}
+            className={`pointer-events-none absolute inset-0 rounded-[calc(theme(borderRadius.md)-1px)] bg-gradient-to-r ${AI_BUTTON_GRADIENT} opacity-0 transition-opacity duration-300 ease-out group-hover:opacity-100`}
+            aria-hidden
           />
         )}
 
@@ -85,14 +88,29 @@ export function AIChatButton() {
           </svg>
         )}
 
-        <Sparkles
-          className={`relative h-6 w-6 ${isStreaming ? "animate-pulse" : ""}`}
-          style={isOpen ? { stroke: "currentColor" } : { stroke: `url(#${gradientId})` }}
-          aria-hidden="true"
-        />
+        {isOpen ? (
+          <Sparkles
+            className={`relative h-6 w-6 ${isStreaming ? "animate-pulse" : ""}`}
+            style={{ stroke: "currentColor" }}
+            aria-hidden="true"
+          />
+        ) : (
+          <span className="relative inline-block h-6 w-6">
+            <Sparkles
+              className="h-6 w-6 opacity-100 transition-opacity duration-300 ease-out group-hover:opacity-0"
+              style={{ stroke: `url(#${gradientId})` }}
+              aria-hidden="true"
+            />
+            <Sparkles
+              className={`absolute inset-0 h-6 w-6 opacity-0 transition-opacity duration-300 ease-out group-hover:opacity-100 ${isStreaming ? "animate-pulse" : ""}`}
+              style={{ stroke: "currentColor" }}
+              aria-hidden="true"
+            />
+          </span>
+        )}
         <span
-          className={`relative text-sm font-medium ${
-            !isOpen ? `bg-gradient-to-r ${AI_BUTTON_GRADIENT} bg-clip-text text-transparent` : ""
+          className={`text-md relative bg-transparent font-medium transition-colors duration-300 ease-out ${
+            !isOpen ? "text-muted-foreground group-hover:text-white" : ""
           }`}
         >
           AI

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -216,10 +216,8 @@ export class CollaborationManager {
     const ratio = afterText.length / beforeText.length;
     if (ratio < DUPLICATION_RATIO_THRESHOLD) return;
 
-    const firstMatch = afterText.indexOf(beforeText);
-    const secondMatch =
-      firstMatch === -1 ? -1 : afterText.indexOf(beforeText, firstMatch + beforeText.length);
-    if (secondMatch === -1) return;
+    const occurrences = afterText.split(beforeText).length - 1;
+    if (occurrences < 2) return;
 
     console.error(
       `[Collab] Content duplication detected after ${phase} (page: ${this.pageId.slice(0, 8)})`,

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -184,7 +184,7 @@ export class CollaborationManager {
         credentials: "include",
         body: JSON.stringify({
           ydoc_state: b64,
-          content_text: contentText,
+          content_text: contentText, // 全文検索用プレーンテキスト
         }),
       });
 
@@ -215,6 +215,11 @@ export class CollaborationManager {
 
     const ratio = afterText.length / beforeText.length;
     if (ratio < DUPLICATION_RATIO_THRESHOLD) return;
+
+    const firstMatch = afterText.indexOf(beforeText);
+    const secondMatch =
+      firstMatch === -1 ? -1 : afterText.indexOf(beforeText, firstMatch + beforeText.length);
+    if (secondMatch === -1) return;
 
     console.error(
       `[Collab] Content duplication detected after ${phase} (page: ${this.pageId.slice(0, 8)})`,


### PR DESCRIPTION
## 概要

PR #311（develop → main リリース）に対するレビューコメントの対応を develop に取り込むための PR です。EditorBubbleMenu の shouldShow ガード追加、コラボモード時の初期化通知、二重化検知の誤検知抑制、useBubbleMenuWikiLink の re-entrancy ガードなどを行いました。

## 変更点

- **EditorBubbleMenu**: `shouldShow` に `editor.view?.hasFocus?.()` と `editor.isEditable` を追加し、フォーカス外・非編集時はメニューを非表示に
- **EditorBubbleMenu.test.tsx**: 上記に合わせてモックに `view` / `isEditable` を追加
- **EditorBubbleMenuToolbar.test.tsx**: `createMockState` に `isConverting: false` を追加
- **useContentSanitizer**: コラボモード時も `onContentUpdated?.(true)` を呼び、初期化完了を通知
- **CollaborationManager**: `content_text` に全文検索用のコメントを追加；`detectContentDuplication` で `beforeText` が `afterText` に2回以上現れる場合のみ `console.error` するよう変更
- **useBubbleMenuWikiLink**: 並行実行ガードに `convertingRef`（useRef）を追加

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run lint` / `bun run format:check` / `bun run test:run` が通ること
2. エディタで BubbleMenu がフォーカス外で非表示になること
3. コラボ編集時にエディタが初期化完了すること

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Related to #311

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * バブルメニューが「エディタにフォーカスがあり、編集可能な場合」にのみ表示されるようになりました。
  * バブルメニューのボタンがクリック時にエディタのフォーカスを保持するよう改善されました。

* **バグ修正**
  * Wikiリンク変換の重複実行を防ぐ再入防止を強化しました（処理中は追加実行を抑制）。
  * コラボレーション時のコンテンツ重複検出に下限チェックを追加。
  * 協調モードで空コンテンツ時に更新コールバックを通知するようにしました。

* **テスト**
  * 複数のユニット／E2Eテストを追加・更新し、上記挙動を検証しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->