### PR TITLE
fix(editor): color swatch mouseDown preventDefault for BubbleMenu

### DIFF
--- a/.cursor/skills/handle-pr-review/SKILL.md
+++ b/.cursor/skills/handle-pr-review/SKILL.md
@@ -97,7 +97,24 @@ gh api -X POST repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies
 
 ## Step 5: 再レビュー依頼
 
-修正コミットを push し、再レビューを依頼:
+修正コミットを push し、再レビューを依頼する。
+
+### 対象 PR が develop → main（リリース PR）の場合
+
+**develop に直接 push できない場合は、作業ブランチを作成し develop 向け PR を出す。**
+
+1. 修正をコミットした状態で、main や develop とは別の作業ブランチを作成する:
+   ```bash
+   git checkout -b fix/pr-{number}-review-comment
+   ```
+2. そのブランチを push し、**develop** をベースに PR を作成する:
+   ```bash
+   git push -u origin fix/pr-{number}-review-comment
+   gh pr create --base develop --head fix/pr-{number}-review-comment --title "fix: address PR #{number} review comments" --body "..."
+   ```
+3. 元のリリース PR（#311 など）には「レビュー対応は別 PR で develop に出す予定です」などとコメントし、必要ならその PR の再レビュー依頼は develop にマージ後に行う。
+
+### 通常（feature ブランチなど）の場合
 
 ```bash
 git push origin HEAD

--- a/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.tsx
@@ -177,6 +177,7 @@ export function EditorBubbleMenuToolbar({ editor, state }: EditorBubbleMenuToolb
                 <button
                   type="button"
                   key={color.value || "default"}
+                  // Keep editor focus so BubbleMenu does not close before setColor runs.
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => setColor(color.value)}
                   title={color.label}

--- a/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.tsx
@@ -177,6 +177,7 @@ export function EditorBubbleMenuToolbar({ editor, state }: EditorBubbleMenuToolb
                 <button
                   type="button"
                   key={color.value || "default"}
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => setColor(color.value)}
                   title={color.label}
                   aria-label={color.label}


### PR DESCRIPTION
## 概要

PR #311（develop → main リリース）のレビューコメント対応。カラーピッカーのスウォッチボタンに `onMouseDown` の `preventDefault` を追加し、クリック時にバブルメニューが消えて `setColor` が発火しない問題を修正する。

## 変更点

- EditorBubbleMenuToolbar: カラースウォッチ `<button>` に `onMouseDown={(e) => e.preventDefault()}` を追加（BubbleMenuButton と同様にエディタフォーカスを維持）

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)

## テスト方法

1. `bun run lint` / `bun run format:check` / `bun run test:run` が通ること
2. エディタでテキスト選択 → バブルメニュー「文字色」→ プリセット色のスウォッチをクリックし、色が適用されること

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

PR #311 の Devin レビュー指摘対応

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * PR レビュープロセスに関するドキュメントを更新。修正コミットの push 手順に関する表現を改善し、開発ブランチからメインブランチへのリリース PR に対応するワークフローガイダンスを追加しました。

* **Bug Fixes**
  * エディターのカラーピッカー機能を改善。色を選択する際にエディターのフォーカスが失われないようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->