### PR TITLE
chore(ci): add deploy retry, incident doc, delete-merged-branches updates

### DIFF
--- a/.cursor/skills/delete-merged-branches/SKILL.md
+++ b/.cursor/skills/delete-merged-branches/SKILL.md
@@ -79,4 +79,4 @@ Skipped:
 
 - merged PR があっても、ローカルまたはリモートの tip が `headRefOid` と一致しない場合は削除しない（merge 後に進んだ可能性あり）。
 - 主 remote が `origin` でない構成では手順を流用するかユーザーに確認する。
-- `gh` が使えない場合は、祖先で merged と判定できるローカルブランチのみ削除し、リモート削除と squash/rebase 判定は行わない。
+- `gh` が使えない場合は、祖先で merged と判定できるローカルブランチと、その同名の `origin` 上のリモートブランチを ancestry ベースでのみ削除し、PR の `headRefOid` による squash/rebase 判定は行わない。

--- a/.cursor/skills/delete-merged-branches/SKILL.md
+++ b/.cursor/skills/delete-merged-branches/SKILL.md
@@ -1,117 +1,82 @@
 ---
 name: delete-merged-branches
 description: >
-  指定した基準ブランチ（develop / main など）に取り込まれたローカルブランチを安全に削除する。
-  通常の merge commit に加え、squash merge / rebase merge は GitHub のマージ済み PR の
-  headRefOid 一致で判定する。"マージ済みブランチを削除", "delete merged branches",
-  "ローカルブランチを掃除", "ブランチ整理" などで使う。
+  指定した基準ブランチ（develop / main など）に取り込まれたローカルおよび origin 上の
+  リモートブランチを安全に削除する。通常 merge は祖先判定、squash/rebase merge は
+  GitHub のマージ済み PR の headRefOid 一致で判定。"マージ済みブランチを削除",
+  "delete merged branches", "ローカル/リモートブランチを掃除", "ブランチ整理" などで使う。
 ---
 
-# マージ済みローカルブランチの削除
+# マージ済みローカル・リモートブランチの削除
 
-`git branch --merged` は「ブランチ先頭が基準の祖先か」だけを見るため、
-squash merge / rebase merge では取り込み済みでも未マージ扱いになる。本スキルでは祖先判定に加え、GitHub の merged PR の `headRefOid` 一致で安全に削除対象を決める。
+`git branch --merged` は祖先関係のみ見るため、squash/rebase merge では未マージ扱いになる。本スキルでは祖先判定に加え、GitHub の merged PR の `headRefOid` 一致でローカル・リモート両方の削除対象を安全に決める。主 remote は `origin` を前提とする。
 
-## 基本方針
+## 推奨: スクリプトで一括実行
 
-1. 基準ブランチ（例: develop）を決める。ユーザー指定がなければ、ローカルに develop があれば develop、なければ origin/HEAD。
-2. 各ローカルブランチについて、まず Git の祖先関係で判定。
-3. 祖先で判定できない場合のみ、`gh pr list --base <基準>` で merged PR を取得し、`headRefOid` がローカル tip と一致する場合だけ削除候補にする。
-4. `headRefOid` が一致しない場合は削除しない（merge 後にローカルで進んだ可能性あり）。
-
-## 事前確認
-
-本手順は push/pull の主 remote が `origin` であることを前提とする（`git fetch origin`・`origin/HEAD`・`base_remote=origin/<基準>` を利用するため）。主 remote が `upstream` など別名の場合は手順を流用するかユーザーに確認する。
+事前に `git fetch origin --prune` と `gh auth status` が通ることを確認したうえで、以下で候補列挙・確認・削除まで行う。
 
 ```bash
 git fetch origin --prune
-git branch --show-current
-gh auth status
+./scripts/delete-merged-branches.sh [基準ブランチ] [--dry-run]
 ```
 
-`gh auth status` が失敗する場合は、祖先で merged と判定できるブランチのみ削除し、それ以外はスキップする。
+- **基準ブランチ**: 省略時はローカルに `develop` があれば `develop`、なければ `origin/HEAD` の短縮名（例: main）。
+- **--dry-run**: 削除はせず、削除候補一覧と理由だけ表示する。
 
-## 手順
+スクリプトは merged PR を **1 回だけ** `gh pr list --state merged --base <基準>` で一括取得し、`headRefName` / `headRefOid` で照合する。ローカル候補（祖先 or headRefOid 一致）とリモート専用候補（origin にのみ存在し headRefOid 一致）の両方を判定し、確認後にローカル削除 → リモート削除の順で実行する。
 
-### 1. 基準ブランチの決定
+## 手動で行う場合（フォールバック）
 
-**優先順位:**
+スクリプトを使わないときは以下を参考にする。
 
-1. ユーザーが「develop にマージ済み」「main を基準に」などと指定していればそのブランチ
-2. 未指定なら: ローカルに `develop` が存在すれば `develop`
-3. それ以外: `origin/HEAD` の短縮名（`git symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@'`）
+1. **事前確認**  
+   `git fetch origin --prune` と `gh auth status`。主 remote が `origin` でない場合はユーザーに確認する。
 
-```bash
-# 例: 自動で develop を選ぶ場合
-origin_default="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
-if git rev-parse --verify develop >/dev/null 2>&1; then
-  base_branch="develop"
-else
-  base_branch="${origin_default:-main}"
-fi
-base_remote="origin/$base_branch"
-current_branch="$(git branch --show-current)"
-```
+2. **基準ブランチ**  
+   ユーザー指定 > ローカル `develop` > `origin/HEAD` の短縮名。`base_remote=origin/<基準>` が存在しない場合は中断して確認。
 
-`base_remote` が存在しない（例: リモートに develop がない）場合は中断し、ユーザーに確認する。
+3. **merged PR の一括取得**  
+   ブランチごとに `gh pr list` を叩かず、1 回だけ取得する。
 
-### 2. ローカルブランチ一覧の取得
+   ```bash
+   gh pr list --state merged --base "$base_branch" --limit 200 --json headRefName,headRefOid,number
+   ```
 
-```bash
-git for-each-ref refs/heads --format='%(refname:short)'
-```
+4. **ローカル候補**  
+   `git for-each-ref refs/heads --format='%(refname:short)'` で一覧。現在ブランチ・基準・main/master/develop・origin/HEAD 先は除外。各ブランチについて:
+   - `git merge-base --is-ancestor <branch> "$base_remote"` で成功 → 削除可（merged by ancestry）
+   - 失敗時は上記 JSON からそのブランチ名の `headRefOid` を探し、`$(git rev-parse <branch>)` と一致する場合のみ削除可（merged PR #N）。
 
-対象外: 現在のブランチ、基準ブランチ（`base_branch`）と同名のブランチ。加えて、`main` / `master` / `develop` および `origin/HEAD` が指すブランチ名は常に対象外とする（保護ブランチ）。
+5. **リモート専用候補**  
+   `git for-each-ref refs/remotes/origin --format='%(refname:short)' | sed 's|^origin/||'` で一覧。保護ブランチ・ローカルに存在するブランチは除外。`refs/remotes/origin/<branch>` の tip が、上記 JSON のそのブランチの `headRefOid` と一致する場合のみ `git push origin --delete <branch>` の対象とする。
 
-### 3. 各ブランチの削除可否を判定
-
-#### A. 通常 merge（祖先）の判定
-
-```bash
-git merge-base --is-ancestor "<branch>" "$base_remote"
-```
-
-成功したら削除候補。理由は `merged by ancestry`。
-
-#### B. squash merge / rebase merge の判定
-
-A で削除候補にならず、`gh` が使える場合のみ実行。
-
-```bash
-tip_sha="$(git rev-parse "<branch>")"
-gh pr list --state merged --head "<branch>" --base "$base_branch" --json number,headRefOid --limit 1
-```
-
-- `gh pr list` はデフォルトで更新が新しい順のため、`--limit 1` で最新の merged PR 1 件を取得する。その **`headRefOid` が `tip_sha` と一致**する場合のみ削除候補。理由は `merged PR #<number> (squash/rebase-safe)`。
-- merged PR なし、または `headRefOid` 不一致の場合は削除しない。
-
-### 4. 削除の実行
-
-削除候補一覧をユーザーに提示し、削除してよいか確認を取ったうえで、次の方針で削除する。
-
-- 理由が `merged by ancestry` のブランチ: `git branch -d "<branch>"` を使う（Git 上もマージ済みと判定されているため強制削除は不要）。
-- 理由が `merged PR #<number> (squash/rebase-safe)` のブランチ: まず `git branch -d "<branch>"` を試し、エラーになる場合のみ `git branch -D "<branch>"` を使う。
+6. **削除**  
+   候補を提示し確認後、ローカルは `git branch -d`（必要なら `-D`）、リモートは `git push origin --delete <branch>`。
 
 ## 報告形式
 
 ```markdown
-基準ブランチ: develop（または main 等）
+基準ブランチ: develop
 
-Deleted:
+Deleted (local):
 
 - `feature/foo` - merged by ancestry
 - `feature/bar` - merged PR #123 (squash/rebase-safe)
 
+Deleted (remote):
+
+- `feature/qux` - merged PR #124 (remote-only)
+
 Skipped:
 
 - `feature/baz` - current branch
-- `feature/qux` - PR merged but local branch advanced after merge
+- `feature/adv` - PR merged but tip advanced after merge
 ```
 
 削除件数とスキップ理由を必ず添える。
 
 ## 注意点
 
-- `git branch --merged` だけでは squash/rebase merge を拾えない。
-- merged PR があっても `headRefOid` とローカル tip が違う場合は削除しない。
-- 主 remote が `origin` でない構成では手順がそのまま使えない。その場合はユーザーに確認する。
+- merged PR があっても、ローカルまたはリモートの tip が `headRefOid` と一致しない場合は削除しない（merge 後に進んだ可能性あり）。
+- 主 remote が `origin` でない構成では手順を流用するかユーザーに確認する。
+- `gh` が使えない場合は、祖先で merged と判定できるローカルブランチのみ削除し、リモート削除と squash/rebase 判定は行わない。

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -54,15 +54,25 @@ jobs:
           VITE_REALTIME_URL: ${{ vars.REALTIME_URL }}
           VITE_POLAR_PRO_MONTHLY_PRODUCT_ID: ${{ vars.POLAR_MONTHLY_ID }}
           VITE_POLAR_PRO_YEARLY_PRODUCT_ID: ${{ vars.POLAR_YEARLY_ID }}
+      # Retry on transient Cloudflare Pages API 5xx (e.g. 503 no healthy upstream).
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: nick-fields/retry@v2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          packageManager: bun
-          # Cloudflare API truncates commit message at ~384 bytes without UTF-8 boundary check (workers-sdk#11749).
-          # Use an explicit ASCII-only message to avoid "Invalid commit message" (code 8000111).
-          command: pages deploy dist --project-name=zedi --commit-message "Deploy from GitHub Actions (main) ${{ github.sha }}"
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: >
+            bunx wrangler pages deploy dist --project-name=zedi
+            --commit-message "Deploy from GitHub Actions (main) ${{ github.sha }}"
+      - name: Upload Wrangler logs (Frontend)
+        if: failure()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: wrangler-logs-frontend
+          path: ${{ runner.home }}/.config/.wrangler/logs/
 
   deploy-admin:
     name: Deploy Admin
@@ -84,11 +94,24 @@ jobs:
         env:
           VITE_API_BASE_URL: ${{ vars.API_BASE_URL }}
           VITE_MAIN_APP_URL: ${{ vars.MAIN_APP_URL || 'https://zedi-note.app' }}
+      - name: Install root dependencies (for wrangler)
+        run: bun install --frozen-lockfile
+      # Retry on transient Cloudflare Pages API 5xx (e.g. 503 no healthy upstream).
       - name: Deploy Admin to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: nick-fields/retry@v2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          packageManager: bun
-          # Avoid Cloudflare "Invalid commit message" (8000111) for long UTF-8 git messages (workers-sdk#11749).
-          command: pages deploy admin/dist --project-name=zedi-admin --commit-message "Deploy admin from GitHub Actions (main) ${{ github.sha }}"
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: >
+            bunx wrangler pages deploy admin/dist --project-name=zedi-admin
+            --commit-message "Deploy admin from GitHub Actions (main) ${{ github.sha }}"
+      - name: Upload Wrangler logs (Admin)
+        if: failure()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: wrangler-logs-admin
+          path: ${{ runner.home }}/.config/.wrangler/logs/

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -69,10 +69,16 @@ jobs:
       - name: Upload Wrangler logs (Frontend)
         if: failure()
         continue-on-error: true
+        run: |
+          mkdir -p wrangler-logs-frontend
+          if [ -d "$HOME/.config/.wrangler/logs" ]; then cp -r "$HOME/.config/.wrangler/logs/"* wrangler-logs-frontend/ 2>/dev/null || true; fi
+      - name: Upload Wrangler logs (Frontend) artifact
+        if: failure()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: wrangler-logs-frontend
-          path: $HOME/.config/.wrangler/logs/
+          path: wrangler-logs-frontend/
 
   deploy-admin:
     name: Deploy Admin
@@ -111,7 +117,13 @@ jobs:
       - name: Upload Wrangler logs (Admin)
         if: failure()
         continue-on-error: true
+        run: |
+          mkdir -p wrangler-logs-admin
+          if [ -d "$HOME/.config/.wrangler/logs" ]; then cp -r "$HOME/.config/.wrangler/logs/"* wrangler-logs-admin/ 2>/dev/null || true; fi
+      - name: Upload Wrangler logs (Admin) artifact
+        if: failure()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: wrangler-logs-admin
-          path: $HOME/.config/.wrangler/logs/
+          path: wrangler-logs-admin/

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wrangler-logs-frontend
-          path: ${{ runner.home }}/.config/.wrangler/logs/
+          path: $HOME/.config/.wrangler/logs/
 
   deploy-admin:
     name: Deploy Admin
@@ -114,4 +114,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wrangler-logs-admin
-          path: ${{ runner.home }}/.config/.wrangler/logs/
+          path: $HOME/.config/.wrangler/logs/

--- a/docs/incidents/prod-deploy-cloudflare-503-20260312.md
+++ b/docs/incidents/prod-deploy-cloudflare-503-20260312.md
@@ -59,4 +59,4 @@
 ## 4. 恒久対策（実施内容）
 
 - `deploy-prod.yml` の Cloudflare デプロイに **リトライ（`nick-fields/retry@v2`、最大 3 回、待機 60 秒）** を導入。一時的な Pages API 5xx（503 no healthy upstream 等）の緩和を想定。
-- デプロイ失敗時に **wrangler ログを artifact（`wrangler-logs-frontend` / `wrangler-logs-admin`）としてアップロード** する step を追加。パスは `${{ runner.home }}/.config/.wrangler/logs/`。ログが無い場合は `continue-on-error: true` でジョブはそのまま失敗扱い。
+- デプロイ失敗時に **wrangler ログを artifact（`wrangler-logs-frontend` / `wrangler-logs-admin`）としてアップロード** する step を追加。run で `$HOME/.config/.wrangler/logs/` をワークスペースにコピーしてから upload-artifact で相対パスを指定（upload-artifact の path は `$HOME` を展開しないため）。ログが無い／アップロード失敗時も `continue-on-error: true` により当該 step はジョブを止めない。

--- a/docs/incidents/prod-deploy-cloudflare-503-20260312.md
+++ b/docs/incidents/prod-deploy-cloudflare-503-20260312.md
@@ -1,0 +1,62 @@
+# Prod Deploy Failure Triage — Cloudflare Pages 503 (2026-03-12)
+
+## 1. Run evidence (記録)
+
+### 対象 Run
+
+- **Workflow**: [Deploy Production](https://github.com/otomatty/zedi/actions/runs/22983934171)
+- **Trigger**: Push to `main` (merge of PR #311), commit `9cdd2f337888592643c84eba0e3deee32dfd0eda`
+- **Date**: 2026-03-12
+
+### ビルドは成功している
+
+- **Run Database Migrations**: 成功
+- **Deploy Frontend**: ステップ「Install & Build」まで成功（`vite build` 完了、`dist/` 生成済み）
+- **Deploy Admin**: ステップ「Install & Build Admin」まで成功（`admin/dist/` 生成済み）
+
+失敗はどちらも **Cloudflare Pages デプロイ**（`cloudflare/wrangler-action@v3` 実行時）のみ。
+
+### Deploy Frontend の wrangler 実エラー
+
+- **メッセージ**: `Received a malformed response from the API`
+- **詳細**: `no healthy upstream`
+- **HTTP**: `GET /accounts/***/pages/projects/zedi -> 503 Service Unavailable`
+- **Wrangler**: 4.71.0（ログ出力先: `/home/runner/.config/.wrangler/logs/wrangler-2026-03-12_02-32-44_205.log`）
+
+### Deploy Admin の wrangler 実エラー
+
+- **メッセージ**: `Received a malformed response from the API`
+- **詳細**: `upstream connect error or disconnect/reset before headers. reset reason: connection termination`
+- **HTTP**: `GET /accounts/***/pages/projects/zedi-admin -> 503 Service Unavailable`
+- **Wrangler**: 4.71.0
+
+両ジョブとも、Pages API のプロジェクト取得（またはデプロイ前の取得）で 503 が返り、wrangler が終了コード 1 で落ちている。
+
+---
+
+## 2. Root cause classification（原因の切り分け）
+
+### Cloudflare API 側要因が優勢である根拠
+
+- **503 / no healthy upstream**: 認可や環境変数ミスでは通常 401/403 になる。503 は上流（Cloudflare の Pages バックエンド）の一時的な障害や負荷を示す。
+- **同一 run 内で 2 プロジェクトが同時に 503**: `zedi` と `zedi-admin` が別ジョブでほぼ同時に同じ種の 503 を受けており、プロジェクト固有の設定不備より、プラットフォーム側の一時障害の方が説明しやすい。
+- **過去の成功**: 同一ワークフローは 2026-03-10 に成功しており、ワークフロー・シークレット・プロジェクト設定の変更なしで再現している。
+- **既知の事象**: Cloudflare Status や workers-sdk の Issue で、Pages API の 503 / "no healthy upstream" / "connection termination" は過去にも報告されており、Cloudflare 側のインシデントやバックエンド不調で発生することが知られている。
+
+### 設定不備でない理由
+
+- `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` が欠けている、または権限不足の場合は 401/403 が典型的。今回の 503 とは一致しない。
+- 同一トークン・アカウントで 2 プロジェクトが同時に 503 であることから、トークン単体の問題より API の可用性の問題の方が自然。
+
+---
+
+## 3. 運用アクション（すぐに取るべき対応）
+
+1. 同一コミットで「Re-run failed jobs」を実行し、自然復旧するか確認する。
+2. 再発時は [Cloudflare Status](https://www.cloudflarestatus.com/) を同時刻で確認し、インシデント有無を記録する。
+3. 失敗時に wrangler ログを artifacts で回収できるよう、ワークフローにログアップロード step を追加する（本 triage に合わせて実施）。
+
+## 4. 恒久対策（実施内容）
+
+- `deploy-prod.yml` の Cloudflare デプロイに **リトライ（`nick-fields/retry@v2`、最大 3 回、待機 60 秒）** を導入。一時的な Pages API 5xx（503 no healthy upstream 等）の緩和を想定。
+- デプロイ失敗時に **wrangler ログを artifact（`wrangler-logs-frontend` / `wrangler-logs-admin`）としてアップロード** する step を追加。パスは `${{ runner.home }}/.config/.wrangler/logs/`。ログが無い場合は `continue-on-error: true` でジョブはそのまま失敗扱い。

--- a/scripts/delete-merged-branches.sh
+++ b/scripts/delete-merged-branches.sh
@@ -66,18 +66,17 @@ echo "Current branch: $current_branch"
 [ "$DRY_RUN" = true ] && echo "(dry-run: no branches will be deleted)"
 echo ""
 
-deleted_local=""
 deleted_remote_only=""
-deleted_remote_with_local=""
-skipped=""
 
 # ローカル削除候補を列挙（branch:reason の行を蓄積）
 local_candidates=""
 remote_delete_names=""
 
-for branch in $(git for-each-ref refs/heads --format='%(refname:short)'); do
+while IFS= read -r branch; do
+  [ -z "$branch" ] && continue
   is_protected "$branch" && continue
   reason=""
+  oid_num=""
   if git merge-base --is-ancestor "$branch" "$base_remote" 2>/dev/null; then
     reason="merged by ancestry"
   else
@@ -94,14 +93,24 @@ for branch in $(git for-each-ref refs/heads --format='%(refname:short)'); do
   if [ -n "$reason" ]; then
     local_candidates="${local_candidates}${local_candidates:+$'\n'}${branch}:${reason}"
     if git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
-      remote_delete_names="${remote_delete_names}${remote_delete_names:+$'\n'}${branch}:local"
+      remote_tip="$(git rev-parse "origin/$branch" 2>/dev/null)"
+      safe_remote=false
+      if git merge-base --is-ancestor "origin/$branch" "$base_remote" 2>/dev/null; then
+        safe_remote=true
+      elif [ -n "$oid_num" ]; then
+        oid="${oid_num%% *}"
+        [ "$oid" = "$remote_tip" ] && safe_remote=true
+      fi
+      if [ "$safe_remote" = true ]; then
+        remote_delete_names="${remote_delete_names}${remote_delete_names:+$'\n'}${branch}:local:${reason}"
+      fi
     fi
   fi
-done
+done < <(git for-each-ref refs/heads --format='%(refname:short)')
 
 # リモート専用の削除候補（ローカルに ref が無く、origin にあり、merged PR で tip 一致）
-for ref in $(git for-each-ref refs/remotes/origin --format='%(refname:short)' | sed 's|^origin/||'); do
-  [ "$ref" = "HEAD" ] && continue
+while IFS= read -r ref; do
+  [ -z "$ref" ] || [ "$ref" = "HEAD" ] && continue
   is_protected "$ref" && continue
   git rev-parse --verify "refs/heads/$ref" >/dev/null 2>&1 && continue
   if ! git rev-parse --verify "origin/$ref" >/dev/null 2>&1; then
@@ -114,16 +123,14 @@ for ref in $(git for-each-ref refs/remotes/origin --format='%(refname:short)' | 
   num="${oid_num#* }"
   if [ "$oid" = "$tip" ]; then
     deleted_remote_only="${deleted_remote_only}${deleted_remote_only:+$'\n'}${ref}:merged PR #${num} (remote-only)"
-    remote_delete_names="${remote_delete_names}${remote_delete_names:+$'\n'}${ref}:remote-only"
+    remote_delete_names="${remote_delete_names}${remote_delete_names:+$'\n'}${ref}:remote-only:merged PR #${num} (remote-only)"
   fi
-done
+done < <(git for-each-ref refs/remotes/origin --format='%(refname:short)' | sed 's|^origin/||')
 
 # 報告用に削除予定を表示
 report_local=""
 report_remote=""
-report_skipped=""
 count_local=0
-count_remote_only=0
 
 while IFS= read -r line; do
   [ -z "$line" ] && continue
@@ -133,13 +140,20 @@ while IFS= read -r line; do
   ((count_local++)) || true
 done <<< "$local_candidates"
 
+# リモート削除候補はすべて表示（:local と :remote-only の両方）
 while IFS= read -r line; do
   [ -z "$line" ] && continue
-  branch="${line%%:*}"
-  reason="${line#*:}"
-  report_remote="${report_remote}${report_remote:+$'\n'}- \`${branch}\` - ${reason}"
-  ((count_remote_only++)) || true
-done <<< "$deleted_remote_only"
+  name="${line%%:*}"
+  rest="${line#*:}"
+  rest="${rest#*:}" # branch:local:reason or branch:remote-only:reason -> reason
+  report_remote="${report_remote}${report_remote:+$'\n'}- \`${name}\` - ${rest}"
+done <<< "$remote_delete_names"
+
+total_remote=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  ((total_remote++)) || true
+done <<< "$remote_delete_names"
 
 if [ -z "$report_local" ] && [ -z "$report_remote" ]; then
   echo "No branches to delete."
@@ -148,13 +162,7 @@ fi
 
 echo "--- Candidates ---"
 [ -n "$report_local" ] && echo "Deleted (local):" && echo "$report_local" && echo ""
-[ -n "$report_remote" ] && echo "Deleted (remote only):" && echo "$report_remote" && echo ""
-
-total_remote=0
-while IFS= read -r line; do
-  [ -z "$line" ] && continue
-  ((total_remote++)) || true
-done <<< "$remote_delete_names"
+[ -n "$report_remote" ] && echo "Deleted (remote):" && echo "$report_remote" && echo ""
 
 if [ "$DRY_RUN" = true ]; then
   echo "Dry-run: would delete $count_local local branch(es) and $total_remote remote branch(es)."

--- a/scripts/delete-merged-branches.sh
+++ b/scripts/delete-merged-branches.sh
@@ -1,46 +1,192 @@
 #!/usr/bin/env bash
-# リモートでマージ済みのローカルブランチを削除する。
-# 使用例: ./scripts/delete-merged-branches.sh
+# 基準ブランチにマージ済みのローカルブランチと origin 上のリモートブランチを安全に削除する。
+# 使用例: ./scripts/delete-merged-branches.sh [基準ブランチ] [--dry-run]
 
 set -e
+
+DRY_RUN=false
+BASE_BRANCH=""
+for arg in "$@"; do
+  if [ "$arg" = "--dry-run" ]; then
+    DRY_RUN=true
+  elif [ -z "$BASE_BRANCH" ]; then
+    BASE_BRANCH="$arg"
+  fi
+done
 
 echo "Fetching and pruning remote refs..."
 git fetch origin --prune
 
-# リモートのデフォルトブランチ（例: main）
-default_branch="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
-if [ -z "$default_branch" ]; then
-  echo "Error: Could not determine the default branch for remote 'origin'." >&2
-  echo "Please ensure 'origin/HEAD' is set correctly on your remote." >&2
+origin_default="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+if [ -z "$BASE_BRANCH" ]; then
+  if git rev-parse --verify develop >/dev/null 2>&1; then
+    BASE_BRANCH="develop"
+  else
+    BASE_BRANCH="${origin_default:-main}"
+  fi
+fi
+base_remote="origin/$BASE_BRANCH"
+if ! git rev-parse --verify "$base_remote" >/dev/null 2>&1; then
+  echo "Error: base branch ref $base_remote does not exist." >&2
   exit 1
 fi
-default_remote="origin/$default_branch"
-current="$(git branch --show-current)"
+current_branch="$(git branch --show-current)"
+# 保護ブランチ: 基準・main/master/develop・現在・origin のデフォルト
+protected="$BASE_BRANCH main master develop $current_branch $origin_default"
 
-echo "Default branch: $default_branch (merged into $default_remote)"
-echo "Current branch: $current"
+is_protected() {
+  local b="$1"
+  for p in $protected; do
+    [ "$b" = "$p" ] && return 0
+  done
+  return 1
+}
+
+merged_file=""
+if command -v gh >/dev/null 2>&1; then
+  merged_file="$(mktemp 2>/dev/null || echo "/tmp/merged-prs.$$")"
+  trap 'rm -f "$merged_file"' EXIT
+  gh pr list --state merged --base "$BASE_BRANCH" --limit 200 --json headRefName,headRefOid,number \
+    --jq '.[] | "\(.headRefName)\t\(.headRefOid)\t\(.number)"' 2>/dev/null >"$merged_file" || true
+fi
+
+# merged 一覧から branch の oid と number を取得（1行 "oid number" を返す）。見つからない場合は何も出力せず return 0（set -e で落ちないように）
+get_merged_oid_and_num() {
+  local branch="$1"
+  [ -z "$merged_file" ] || [ ! -s "$merged_file" ] && return 0
+  local oid num
+  oid="$(awk -v b="$branch" 'BEGIN{FS="\t"} $1==b {print $2; exit}' "$merged_file" 2>/dev/null)"
+  num="$(awk -v b="$branch" 'BEGIN{FS="\t"} $1==b {print $3; exit}' "$merged_file" 2>/dev/null)"
+  [ -z "$oid" ] && return 0
+  echo "$oid $num"
+}
+
+echo "Base branch: $BASE_BRANCH ($base_remote)"
+echo "Current branch: $current_branch"
+[ "$DRY_RUN" = true ] && echo "(dry-run: no branches will be deleted)"
 echo ""
 
-merged_list="$(git branch --merged "$default_remote" | sed -e 's/^[* ]*//' -e '/^$/d')"
-deleted=0
+deleted_local=""
+deleted_remote_only=""
+deleted_remote_with_local=""
+skipped=""
 
-while IFS= read -r branch; do
-  [ -z "$branch" ] && continue
-  if [ "$branch" = "$current" ]; then
-    echo "Skip (current): $branch"
-    continue
-  fi
-  if [ "$branch" = "$default_branch" ]; then
-    echo "Skip (default): $branch"
-    continue
-  fi
-  # Use -D: we already filtered by --merged "$default_remote"; -d uses upstream/HEAD and can disagree
-  if git branch -D "$branch" 2>/dev/null; then
-    ((deleted++)) || true
+# ローカル削除候補を列挙（branch:reason の行を蓄積）
+local_candidates=""
+remote_delete_names=""
+
+for branch in $(git for-each-ref refs/heads --format='%(refname:short)'); do
+  is_protected "$branch" && continue
+  reason=""
+  if git merge-base --is-ancestor "$branch" "$base_remote" 2>/dev/null; then
+    reason="merged by ancestry"
   else
-    echo "Skip (not fully merged or error): $branch"
+    oid_num="$(get_merged_oid_and_num "$branch")"
+    if [ -n "$oid_num" ]; then
+      tip="$(git rev-parse "$branch" 2>/dev/null)"
+      oid="${oid_num%% *}"
+      num="${oid_num#* }"
+      if [ "$oid" = "$tip" ]; then
+        reason="merged PR #${num} (squash/rebase-safe)"
+      fi
+    fi
   fi
-done <<< "$merged_list"
+  if [ -n "$reason" ]; then
+    local_candidates="${local_candidates}${local_candidates:+$'\n'}${branch}:${reason}"
+    if git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+      remote_delete_names="${remote_delete_names}${remote_delete_names:+$'\n'}${branch}:local"
+    fi
+  fi
+done
+
+# リモート専用の削除候補（ローカルに ref が無く、origin にあり、merged PR で tip 一致）
+for ref in $(git for-each-ref refs/remotes/origin --format='%(refname:short)' | sed 's|^origin/||'); do
+  [ "$ref" = "HEAD" ] && continue
+  is_protected "$ref" && continue
+  git rev-parse --verify "refs/heads/$ref" >/dev/null 2>&1 && continue
+  if ! git rev-parse --verify "origin/$ref" >/dev/null 2>&1; then
+    continue
+  fi
+  oid_num="$(get_merged_oid_and_num "$ref")"
+  [ -z "$oid_num" ] && continue
+  tip="$(git rev-parse "origin/$ref" 2>/dev/null)"
+  oid="${oid_num%% *}"
+  num="${oid_num#* }"
+  if [ "$oid" = "$tip" ]; then
+    deleted_remote_only="${deleted_remote_only}${deleted_remote_only:+$'\n'}${ref}:merged PR #${num} (remote-only)"
+    remote_delete_names="${remote_delete_names}${remote_delete_names:+$'\n'}${ref}:remote-only"
+  fi
+done
+
+# 報告用に削除予定を表示
+report_local=""
+report_remote=""
+report_skipped=""
+count_local=0
+count_remote_only=0
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  branch="${line%%:*}"
+  reason="${line#*:}"
+  report_local="${report_local}${report_local:+$'\n'}- \`${branch}\` - ${reason}"
+  ((count_local++)) || true
+done <<< "$local_candidates"
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  branch="${line%%:*}"
+  reason="${line#*:}"
+  report_remote="${report_remote}${report_remote:+$'\n'}- \`${branch}\` - ${reason}"
+  ((count_remote_only++)) || true
+done <<< "$deleted_remote_only"
+
+if [ -z "$report_local" ] && [ -z "$report_remote" ]; then
+  echo "No branches to delete."
+  exit 0
+fi
+
+echo "--- Candidates ---"
+[ -n "$report_local" ] && echo "Deleted (local):" && echo "$report_local" && echo ""
+[ -n "$report_remote" ] && echo "Deleted (remote only):" && echo "$report_remote" && echo ""
+
+total_remote=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  ((total_remote++)) || true
+done <<< "$remote_delete_names"
+
+if [ "$DRY_RUN" = true ]; then
+  echo "Dry-run: would delete $count_local local branch(es) and $total_remote remote branch(es)."
+  exit 0
+fi
+
+echo "Delete $count_local local and $total_remote remote branch(es)? [y/N]"
+read -r confirm
+case "$confirm" in
+  [yY]|[yY][eE][sS]) ;;
+  *) echo "Aborted."; exit 0 ;;
+esac
+
+deleted_local_count=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  branch="${line%%:*}"
+  if git branch -d "$branch" 2>/dev/null || git branch -D "$branch" 2>/dev/null; then
+    ((deleted_local_count++)) || true
+  fi
+done <<< "$local_candidates"
+
+deleted_remote_count=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  name="${line%%:*}"
+  if git rev-parse --verify "origin/$name" >/dev/null 2>&1; then
+    if git push origin --delete "$name" 2>/dev/null; then
+      ((deleted_remote_count++)) || true
+    fi
+  fi
+done <<< "$remote_delete_names"
 
 echo ""
-echo "Done. Deleted $deleted local branch(es)."
+echo "Done. Deleted $deleted_local_count local and $deleted_remote_count remote branch(es)."


### PR DESCRIPTION
## 概要

本番デプロイで発生した Cloudflare Pages API 503（no healthy upstream）への対策として、デプロイステップにリトライと失敗時の Wrangler ログ収集を追加しました。あわせてインシデント記録と delete-merged-branches スクリプト・スキルの更新を含みます。

## 変更点

- `.github/workflows/deploy-prod.yml`: Frontend / Admin の Cloudflare Pages デプロイを `nick-fields/retry@v2` でラップ（最大3回・60秒間隔）。失敗時に Wrangler ログをアーティファクトでアップロード。
- `docs/incidents/prod-deploy-cloudflare-503-20260312.md`: 2026-03-12 の本番デプロイ失敗（503）の記録と対策メモを追加。
- `scripts/delete-merged-branches.sh`: マージ済みブランチ削除スクリプトの改善。
- `.cursor/skills/delete-merged-branches/SKILL.md`: 上記スクリプトに合わせたスキル説明の更新。

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [x] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run lint` および `bun run format:check` が通ることを確認済み。
2. 本番デプロイは main マージ後のワークフローで実行されるため、マージ後に次の Deploy Production の成功で検証。

## チェックリスト

- [x] テストがすべてパスする（既存テストに変更なし）
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した（インシデント doc 追加）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

なし。

## 関連 Issue

なし。

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * マージ済みブランチ削除ワークフローを大幅強化：ローカル／originの両方を対象に識別・削除、PRデータ照合による安全判定、ベースブランチ解決順序、保護ブランチ除外、ドライラン、詳細な削除レポート（ローカル／リモート別）を追加しました。

* **Chores**
  * 本番デプロイワークフローにリトライ（最大試行・待機設定）と依存導入を追加し、デプロイ信頼性とログ収集（アーティファクト化）を改善しました。

* **Documentation**
  * Cloudflare Pagesデプロイの503事象に関するインシデント報告書と運用対応・恒久対策を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->