### PR TITLE
fix: prevent home page freeze after context-menu delete (#313)

### DIFF
--- a/e2e/page-editor.spec.ts
+++ b/e2e/page-editor.spec.ts
@@ -296,7 +296,10 @@ test.describe("Page Editor", () => {
     }) => {
       await helpers.createNewPage(page);
       const syncPromise = page.waitForResponse(
-        (res) => res.url().includes("/api/sync/pages") && res.ok(),
+        (res) => {
+          const req = res.request();
+          return req.method() === "POST" && res.url().includes("/api/sync/pages") && res.ok();
+        },
         { timeout: 10000 },
       );
       await page.getByPlaceholder("タイトルを入力").fill("Context Menu Delete Test");
@@ -328,9 +331,7 @@ test.describe("Page Editor", () => {
 
       const fab = page.locator("[data-tour-id=tour-fab]");
       await fab.click();
-      await expect(
-        page.getByRole("button", { name: /URLから作成|新規作成|画像から作成/ }),
-      ).toBeVisible({ timeout: 3000 });
+      await expect(page.getByRole("button", { name: /新規作成/ })).toBeVisible({ timeout: 3000 });
     });
   });
 });

--- a/e2e/page-editor.spec.ts
+++ b/e2e/page-editor.spec.ts
@@ -288,4 +288,37 @@ test.describe("Page Editor", () => {
       }
     });
   });
+
+  test.describe("Home page context menu delete", () => {
+    test("should delete page via context menu and keep UI interactive (fix #313)", async ({
+      page,
+      helpers,
+    }) => {
+      await helpers.createNewPage(page);
+      await page.getByPlaceholder("タイトルを入力").fill("Context Menu Delete Test");
+      await page.waitForTimeout(1500);
+
+      await page.goto("/home");
+      await page.waitForLoadState("networkidle");
+      await page.waitForTimeout(500);
+
+      const card = page.locator(".page-card").first();
+      await expect(card).toBeVisible({ timeout: 10000 });
+
+      await card.click({ button: "right" });
+      await page.getByRole("menuitem", { name: "削除" }).click();
+
+      await expect(page.getByRole("alertdialog")).toBeVisible({ timeout: 5000 });
+      await page.getByRole("alertdialog").getByRole("button", { name: "削除" }).click();
+
+      await expect(page.getByRole("alertdialog")).not.toBeVisible({ timeout: 5000 });
+      await expect(page).toHaveURL("/home");
+
+      const fab = page.locator("[data-tour-id=tour-fab]");
+      await fab.click();
+      await expect(
+        page.getByRole("button", { name: /URLから作成|新規作成|画像から作成/ }),
+      ).toBeVisible({ timeout: 3000 });
+    });
+  });
 });

--- a/e2e/page-editor.spec.ts
+++ b/e2e/page-editor.spec.ts
@@ -295,24 +295,36 @@ test.describe("Page Editor", () => {
       helpers,
     }) => {
       await helpers.createNewPage(page);
+      const syncPromise = page.waitForResponse(
+        (res) => res.url().includes("/api/sync/pages") && res.ok(),
+        { timeout: 10000 },
+      );
       await page.getByPlaceholder("タイトルを入力").fill("Context Menu Delete Test");
-      await page.waitForTimeout(1500);
+      await syncPromise;
 
       await page.goto("/home");
       await page.waitForLoadState("networkidle");
-      await page.waitForTimeout(500);
 
-      const card = page.locator(".page-card").first();
+      const card = page.locator(".page-card", { hasText: "Context Menu Delete Test" });
       await expect(card).toBeVisible({ timeout: 10000 });
 
       await card.click({ button: "right" });
       await page.getByRole("menuitem", { name: "削除" }).click();
 
       await expect(page.getByRole("alertdialog")).toBeVisible({ timeout: 5000 });
+      const deletePromise = page.waitForResponse(
+        (res) => {
+          const req = res.request();
+          return req.method() === "DELETE" && res.url().includes("/api/pages") && res.ok();
+        },
+        { timeout: 10000 },
+      );
       await page.getByRole("alertdialog").getByRole("button", { name: "削除" }).click();
+      await deletePromise;
 
       await expect(page.getByRole("alertdialog")).not.toBeVisible({ timeout: 5000 });
       await expect(page).toHaveURL("/home");
+      await expect(card).toHaveCount(0);
 
       const fab = page.locator("[data-tour-id=tour-fab]");
       await fab.click();

--- a/src/components/page/PageCard.tsx
+++ b/src/components/page/PageCard.tsx
@@ -137,9 +137,15 @@ const PageCard: React.FC<PageCardProps> = ({ page, index = 0 }) => {
     });
   };
 
+  const openDeleteDialogAfterMenuClose = useCallback(() => {
+    requestAnimationFrame(() => {
+      setIsDeleteDialogOpen(true);
+    });
+  }, []);
+
   return (
     <>
-      <ContextMenu>
+      <ContextMenu modal={false}>
         <ContextMenuTrigger asChild>
           <button
             draggable={!isMobile}
@@ -205,7 +211,7 @@ const PageCard: React.FC<PageCardProps> = ({ page, index = 0 }) => {
           </ContextMenuItem>
           <ContextMenuSeparator />
           <ContextMenuItem
-            onClick={() => setIsDeleteDialogOpen(true)}
+            onSelect={openDeleteDialogAfterMenuClose}
             className="text-destructive focus:text-destructive"
           >
             <Trash2 className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## 概要

ページ一覧（`/home`）でコンテキストメニューからページ削除後にアプリ全体が操作不能になる不具合を修正しました（Issue #313）。

## 変更点

- **PageCard.tsx**: 削除メニューで `onClick` の代わりに `onSelect` を使用し、`requestAnimationFrame` でコンテキストメニューが閉じてから AlertDialog を開くように変更
- **PageCard.tsx**: `ContextMenu` に `modal={false}` を指定し、AlertDialog とのオーバーレイ競合を回避
- **e2e/page-editor.spec.ts**: `/home` でコンテキストメニューから削除した後も UI が操作可能であることを検証する E2E テストを追加

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `/home` を開く
2. ページカードを右クリック → 「削除」→ 確認ダイアログで「削除」をクリック
3. 削除後、ページ一覧やヘッダーが通常通り操作できることを確認
4. `bun run lint` および `bun run test:run` が通ることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #313

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * コンテキストメニューからページを削除した際、確認ダイアログがメニュー閉鎖後に適切なタイミングで表示されるようUI挙動を改善。

* **Tests**
  * ホーム画面のコンテキストメニューによるページ削除を検証するエンドツーエンドテストを追加。削除確認、同期応答、ページ一覧更新、FABの新規作成オプション表示を確認。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->