### PR TITLE
fix: frontend auth, profile, keepalive and callback reliability (#123)

### DIFF
--- a/src/components/editor/TiptapEditor/thumbnailApiHelpers.test.ts
+++ b/src/components/editor/TiptapEditor/thumbnailApiHelpers.test.ts
@@ -17,9 +17,9 @@ describe("thumbnailApiHelpers", () => {
       expect(getThumbnailApiBaseUrl()).toBe("https://api.example.com");
     });
 
-    it("returns empty string when VITE_API_BASE_URL is undefined", () => {
+    it("falls back to window.location.origin when VITE_API_BASE_URL is undefined (browser)", () => {
       vi.stubEnv("VITE_API_BASE_URL", undefined);
-      expect(getThumbnailApiBaseUrl()).toBe("");
+      expect(getThumbnailApiBaseUrl()).toBe(window.location.origin);
     });
   });
 });

--- a/src/components/editor/TiptapEditor/thumbnailApiHelpers.ts
+++ b/src/components/editor/TiptapEditor/thumbnailApiHelpers.ts
@@ -1,3 +1,6 @@
-/** Uses same base URL as REST API (VITE_API_BASE_URL). Strips trailing slash for path concatenation. */
-export const getThumbnailApiBaseUrl = () =>
-  ((import.meta.env.VITE_API_BASE_URL as string) ?? "").replace(/\/$/, "");
+/** Uses same base URL as REST API (VITE_API_BASE_URL). Strips trailing slash. Falls back to window.location.origin when unset. */
+export const getThumbnailApiBaseUrl = (): string => {
+  const env = import.meta.env.VITE_API_BASE_URL;
+  if (typeof env === "string" && env.trim() !== "") return env.trim().replace(/\/$/, "");
+  return typeof window !== "undefined" ? window.location.origin : "";
+};

--- a/src/components/editor/TiptapEditor/useThumbnailCommit.ts
+++ b/src/components/editor/TiptapEditor/useThumbnailCommit.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import type { Editor } from "@tiptap/core";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@zedi/ui";
@@ -53,7 +54,9 @@ async function commitViaServerS3(
   });
 
   if (response.status === 401) {
-    throw new Error("ログインが必要です");
+    const err = new Error("ログインが必要です") as Error & { redirectToSignIn?: boolean };
+    err.redirectToSignIn = true;
+    throw err;
   }
   if (!response.ok) {
     let message = `画像の保存に失敗しました: ${response.status}`;
@@ -77,14 +80,16 @@ export function useThumbnailCommit({
   pageTitle,
   storageSettings,
 }: UseThumbnailCommitOptions) {
-  const { isSignedIn } = useAuth();
+  const { isSignedIn, isLoaded } = useAuth();
   const { toast } = useToast();
+  const navigate = useNavigate();
   const thumbnailApiBaseUrl = getThumbnailApiBaseUrl();
 
   const handleInsertThumbnailImage = useCallback(
     async (imageUrl: string, alt: string, previewUrl?: string) => {
       const editor = editorRef.current;
       if (!editor) return;
+      if (!isLoaded) return;
       if (!isSignedIn) {
         toast({
           title: "ログインが必要です",
@@ -142,6 +147,16 @@ export function useThumbnailCommit({
           })
           .run();
       } catch (error) {
+        const err = error as Error & { redirectToSignIn?: boolean };
+        if (err.redirectToSignIn) {
+          toast({
+            title: "ログインが必要です",
+            description: "再度ログインしてください",
+            variant: "destructive",
+          });
+          navigate("/sign-in", { replace: true });
+          return;
+        }
         const isFetchError =
           error instanceof TypeError ||
           (error instanceof Error &&
@@ -155,7 +170,16 @@ export function useThumbnailCommit({
         });
       }
     },
-    [editorRef, isSignedIn, thumbnailApiBaseUrl, pageTitle, toast, storageSettings],
+    [
+      editorRef,
+      isSignedIn,
+      isLoaded,
+      thumbnailApiBaseUrl,
+      pageTitle,
+      toast,
+      storageSettings,
+      navigate,
+    ],
   );
 
   return { handleInsertThumbnailImage };

--- a/src/components/editor/TiptapEditor/useThumbnailCommit.ts
+++ b/src/components/editor/TiptapEditor/useThumbnailCommit.ts
@@ -5,8 +5,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@zedi/ui";
 import { getStorageProvider, getSettingsForUpload, convertToWebP } from "@/lib/storage";
 import type { StorageSettings } from "@/types/storage";
-
-const getThumbnailApiBaseUrl = () => (import.meta.env.VITE_API_BASE_URL as string) ?? "";
+import { getThumbnailApiBaseUrl } from "./thumbnailApiHelpers";
 
 interface UseThumbnailCommitOptions {
   editorRef: React.RefObject<Editor | null>;

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -27,6 +27,21 @@ interface UseProfileReturn {
 
 const PROFILE_CACHE_KEY = "zedi-profile-cache";
 
+/** /api/users/me のレスポンス形状。サーバーは { user: { name, image, ... } } を返す。 */
+interface ApiMeResponse {
+  user?: {
+    name?: string | null;
+    image?: string | null;
+  };
+}
+
+function parseDisplayNameAndAvatar(data: unknown): { displayName: string; avatarUrl: string } {
+  const r = data as ApiMeResponse;
+  const name = typeof r?.user?.name === "string" ? r.user.name : "";
+  const image = typeof r?.user?.image === "string" ? r.user.image : "";
+  return { displayName: name.trim(), avatarUrl: image };
+}
+
 function loadCachedProfile(): ProfileData | null {
   try {
     const cached = localStorage.getItem(PROFILE_CACHE_KEY);
@@ -72,13 +87,11 @@ export function useProfile(): UseProfileReturn {
           credentials: "include",
         });
         if (res.ok) {
-          const data = (await res.json()) as {
-            user?: { name?: string; image?: string };
-          };
-          const rawDisplayName = data?.user?.name ?? "";
-          const rawAvatarUrl = data?.user?.image ?? "";
+          const data: unknown = await res.json();
+          const { displayName: rawDisplayName, avatarUrl: rawAvatarUrl } =
+            parseDisplayNameAndAvatar(data);
           const displayName =
-            rawDisplayName.trim() !== ""
+            rawDisplayName !== ""
               ? rawDisplayName
               : (user?.fullName ?? user?.username ?? "").trim();
           const fetched: ProfileData = {

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -5,6 +5,8 @@
     "title": "Sign in",
     "subtitle": "Sign in to your account to continue",
     "google": "Sign in with Google",
-    "github": "Sign in with GitHub"
-  }
+    "github": "Sign in with GitHub",
+    "error": "Sign-in failed. Please try again."
+  },
+  "callbackTimeout": "Could not complete sign-in. Please try again."
 }

--- a/src/i18n/locales/ja/auth.json
+++ b/src/i18n/locales/ja/auth.json
@@ -5,6 +5,8 @@
     "title": "サインイン",
     "subtitle": "アカウントにサインインして続行",
     "google": "Google でサインイン",
-    "github": "GitHub でサインイン"
-  }
+    "github": "GitHub でサインイン",
+    "error": "サインインに失敗しました。再度お試しください。"
+  },
+  "callbackTimeout": "サインインの完了を確認できませんでした。再度お試しください。"
 }

--- a/src/lib/auth/authClient.ts
+++ b/src/lib/auth/authClient.ts
@@ -1,7 +1,14 @@
 import { createAuthClient } from "better-auth/react";
 
+function getAuthBaseUrl(): string {
+  const env = import.meta.env.VITE_API_BASE_URL;
+  if (typeof env === "string" && env.trim() !== "") return env.trim().replace(/\/$/, "");
+  if (typeof window !== "undefined") return window.location.origin;
+  return "";
+}
+
 export const authClient = createAuthClient({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL: getAuthBaseUrl(),
 });
 
 export const { signIn, signOut, signUp, useSession, getSession } = authClient;

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -458,7 +458,8 @@ export class CollaborationManager {
     const keepaliveLimit = 63 * 1024;
     const useKeepalive = bodyByteLength <= keepaliveLimit;
 
-    const baseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
+    const rawBaseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
+    const baseUrl = rawBaseUrl.replace(/\/$/, "");
     const origin = baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
     const url = `${origin}/api/pages/${encodeURIComponent(this.pageId)}/content`;
 

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -20,6 +20,9 @@ const API_SAVE_DEBOUNCE_MS = 2000;
 /** 二重化検知: マージ後テキストがこの倍率を超えて増加したら二重化とみなす */
 const DUPLICATION_RATIO_THRESHOLD = 1.5;
 
+/** ブラウザの keepalive ペイロード制限（64 KiB）より少し小さい安全な上限（バイト） */
+const KEEPALIVE_PAYLOAD_LIMIT = 63 * 1024;
+
 export class CollaborationManager {
   private ydoc: Y.Doc;
   private wsProvider: HocuspocusProvider | null = null;
@@ -455,8 +458,7 @@ export class CollaborationManager {
     });
     const bodyByteLength =
       typeof TextEncoder !== "undefined" ? new TextEncoder().encode(body).length : body.length * 2;
-    const keepaliveLimit = 63 * 1024;
-    const useKeepalive = bodyByteLength <= keepaliveLimit;
+    const useKeepalive = bodyByteLength <= KEEPALIVE_PAYLOAD_LIMIT;
 
     const rawBaseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
     const baseUrl = rawBaseUrl.replace(/\/$/, "");

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -439,6 +439,7 @@ export class CollaborationManager {
   /**
    * 破棄後の最終保存。エンコード済みステートを受け取り、ydoc に依存しない。
    * keepalive: true でページ離脱後もリクエストが完了するようにする。
+   * ブラウザの keepalive ペイロード制限（約 64 KiB）を超える場合は keepalive なしで送信する。
    */
   private fireAndForgetSave(state: Uint8Array, contentText: string): void {
     let b64 = "";
@@ -448,21 +449,27 @@ export class CollaborationManager {
     }
     b64 = btoa(b64);
 
+    const body = JSON.stringify({
+      ydoc_state: b64,
+      content_text: contentText,
+    });
+    const bodyByteLength =
+      typeof TextEncoder !== "undefined" ? new TextEncoder().encode(body).length : body.length * 2;
+    const keepaliveLimit = 63 * 1024;
+    const useKeepalive = bodyByteLength <= keepaliveLimit;
+
     const baseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
     const origin = baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
     const url = `${origin}/api/pages/${encodeURIComponent(this.pageId)}/content`;
 
     fetch(url, {
       method: "PUT",
-      keepalive: true,
+      keepalive: useKeepalive,
       headers: {
         "Content-Type": "application/json",
       },
       credentials: "include",
-      body: JSON.stringify({
-        ydoc_state: b64,
-        content_text: contentText,
-      }),
+      body,
     }).catch(() => {
       // 最終保存の失敗は無視（ページ離脱中のため処理不能）
     });

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -2,15 +2,19 @@
  * OAuth callback page.
  * Better Auth handles the code exchange server-side; this page simply waits
  * for the session to become available and then redirects to /home.
+ * セッションが取得できない場合はタイムアウト後にエラー表示し、サインインへ戻れるようにする。
  */
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useSession } from "@/lib/auth/authClient";
+
+const SESSION_WAIT_TIMEOUT_MS = 15_000;
 
 export default function AuthCallback() {
   const { t } = useTranslation();
   const { data: session, isPending } = useSession();
   const [error, setError] = useState<string | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -23,9 +27,28 @@ export default function AuthCallback() {
     }
 
     if (!isPending && session) {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
       window.location.assign("/home");
+      return;
     }
-  }, [session, isPending]);
+
+    if (!isPending && !session && !timeoutRef.current) {
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = null;
+        setError(t("auth.callbackTimeout"));
+      }, SESSION_WAIT_TIMEOUT_MS);
+    }
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, [session, isPending, t]);
 
   if (error) {
     return (

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -9,24 +9,17 @@ const SignIn: React.FC = () => {
   const [socialError, setSocialError] = useState<string | null>(null);
 
   const callbackURL = `${window.location.origin}/home`;
-  const handleGoogle = async () => {
+  const handleSocialSignIn = (provider: "google" | "github") => async () => {
     setSocialError(null);
     try {
-      await signIn.social({ provider: "google", callbackURL });
+      await signIn.social({ provider, callbackURL });
     } catch (err) {
-      const message = err instanceof Error ? err.message : t("auth.signIn.error");
-      setSocialError(message);
+      if (err instanceof Error) console.warn("Social sign-in failed:", err.message);
+      setSocialError(t("auth.signIn.error"));
     }
   };
-  const handleGitHub = async () => {
-    setSocialError(null);
-    try {
-      await signIn.social({ provider: "github", callbackURL });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : t("auth.signIn.error");
-      setSocialError(message);
-    }
-  };
+  const handleGoogle = handleSocialSignIn("google");
+  const handleGitHub = handleSocialSignIn("github");
 
   return (
     <div className="flex min-h-screen flex-col bg-background">

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { signIn } from "@/lib/auth";
@@ -6,11 +6,26 @@ import { Button } from "@zedi/ui";
 
 const SignIn: React.FC = () => {
   const { t } = useTranslation();
-  const handleGoogle = () => {
-    signIn.social({ provider: "google", callbackURL: `${window.location.origin}/home` });
+  const [socialError, setSocialError] = useState<string | null>(null);
+
+  const callbackURL = `${window.location.origin}/home`;
+  const handleGoogle = async () => {
+    setSocialError(null);
+    try {
+      await signIn.social({ provider: "google", callbackURL });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t("auth.signIn.error");
+      setSocialError(message);
+    }
   };
-  const handleGitHub = () => {
-    signIn.social({ provider: "github", callbackURL: `${window.location.origin}/home` });
+  const handleGitHub = async () => {
+    setSocialError(null);
+    try {
+      await signIn.social({ provider: "github", callbackURL });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t("auth.signIn.error");
+      setSocialError(message);
+    }
   };
 
   return (
@@ -32,6 +47,11 @@ const SignIn: React.FC = () => {
             <h1 className="mb-2 text-2xl font-bold text-foreground">{t("auth.signIn.title")}</h1>
             <p className="text-foreground/70">{t("auth.signIn.subtitle")}</p>
           </div>
+          {socialError && (
+            <p className="mb-4 text-sm text-destructive" role="alert">
+              {socialError}
+            </p>
+          )}
           <div className="space-y-3">
             <button
               type="button"

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -8,7 +8,7 @@ const SignIn: React.FC = () => {
   const { t } = useTranslation();
   const [socialError, setSocialError] = useState<string | null>(null);
 
-  const callbackURL = `${window.location.origin}/home`;
+  const callbackURL = `${window.location.origin}/auth/callback`;
   const handleSocialSignIn = (provider: "google" | "github") => async () => {
     setSocialError(null);
     try {


### PR DESCRIPTION
## 概要

Issue #123 の対応です。認証フロー・プロファイル取得・keepalive 最終保存・コールバックページの信頼性を上げる変更です。

## 変更点

- **CollaborationManager.ts**
  - `fireAndForgetSave`: ペイロードを UTF-8 バイト長でチェックし、63 KiB 超の場合は `keepalive: false` で送信（ブラウザの keepalive 制限対策）。
- **useThumbnailCommit.ts**
  - 認証ローディング中（`!isLoaded`）は処理しない。401 時はトースト表示のうえ `/sign-in` へリダイレクト。
- **useProfile.ts**
  - `/api/users/me` 用に `ApiMeResponse` 型と `parseDisplayNameAndAvatar` を追加し、レスポンス形状を安全にパース。
- **authClient.ts**
  - `VITE_API_BASE_URL` 未設定時は `window.location.origin` を baseURL に使用。
- **SignIn.tsx**
  - Google/GitHub の `signIn.social()` を try/catch で囲み、失敗時に `socialError` 表示と `auth.signIn.error` の i18n を利用。
- **AuthCallback.tsx**
  - セッションが取れない場合に 15 秒でタイムアウトし、`auth.callbackTimeout` を表示してサインインへ戻るリンクを表示。
- **i18n (ja/en auth.json)**
  - `auth.signIn.error` と `auth.callbackTimeout` を追加。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. **keepalive**: 大きなドキュメントでページを閉じ、ネットワークで PUT が keepalive なしで送られていることを確認（ペイロードが 63 KiB 超の場合）。
2. **サムネイル**: 未ログインでサムネイル挿入は「ログインが必要」トースト。ログイン期限切れで 401 の場合はサインインへリダイレクト。
3. **プロファイル**: 設定画面で表示名・アバターが API と一致することを確認。
4. **SignIn**: ソーシャルログインを故意に失敗させ、エラーメッセージが表示されることを確認。
5. **AuthCallback**: セッションが付与されない状態でコールバック URL を開き、15 秒後にタイムアウトメッセージとサインインリンクが出ることを確認。

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した（i18n）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #123

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ソーシャルサインイン失敗時にユーザー向けのエラーメッセージを表示するようにしました。
  * 画像挿入時に未認証ならログインが促され、ログイン画面へ遷移するフローを追加しました。

* **バグ修正**
  * 認証関連のタイムアウトと401エラー処理を改善し、サインイン遷移がより確実になりました。
  * コールバック処理のタイムアウト（15秒）を追加し、セッション待機の挙動を安定化しました。

* **ドキュメント**
  * サインイン関連の翻訳キー（エラー／コールバックタイムアウト）を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->