### PR TITLE
chore: address review Critical and Warnings (develop vs main)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ POLAR_PRO_YEARLY_PRODUCT_ID=YOUR_POLAR_YEARLY_PRODUCT_ID
 # Get a key at https://openrouter.ai/keys — if unset, all models use default cost units.
 # OPENROUTER_API_KEY=
 
+# API server (production): set CORS_ORIGIN so CSRF origin check is active (see server middleware/csrfOrigin).
+# Comma-separated allowed origins, e.g. https://zedi-note.app,https://admin.zedi-note.app
+# CORS_ORIGIN=
+
 # Docker Compose (docker-compose.dev.yml)
 # Override defaults for local dev; required in shared/production. Do not commit real secrets.
 # POSTGRES_USER=zedi

--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ POLAR_PRO_YEARLY_PRODUCT_ID=YOUR_POLAR_YEARLY_PRODUCT_ID
 # Get a key at https://openrouter.ai/keys — if unset, all models use default cost units.
 # OPENROUTER_API_KEY=
 
-# API server (production): set CORS_ORIGIN so CSRF origin check is active (see server middleware/csrfOrigin).
+# API server (production): set CORS_ORIGIN so CSRF origin check is active (see server/api/src/middleware/csrfOrigin.ts and server/api/src/lib/cors.ts).
 # Comma-separated allowed origins, e.g. https://zedi-note.app,https://admin.zedi-note.app
 # CORS_ORIGIN=
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -55,6 +55,7 @@ jobs:
           VITE_POLAR_PRO_MONTHLY_PRODUCT_ID: ${{ vars.POLAR_MONTHLY_ID }}
           VITE_POLAR_PRO_YEARLY_PRODUCT_ID: ${{ vars.POLAR_YEARLY_ID }}
       # Retry on transient Cloudflare Pages API 5xx (e.g. 503 no healthy upstream).
+      # wrangler CLI reads CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID from env (see wrangler docs).
       - name: Deploy to Cloudflare Pages
         uses: nick-fields/retry@v2
         env:
@@ -103,6 +104,7 @@ jobs:
       - name: Install root dependencies (for wrangler)
         run: bun install --frozen-lockfile
       # Retry on transient Cloudflare Pages API 5xx (e.g. 503 no healthy upstream).
+      # wrangler CLI reads CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID from env (see wrangler docs).
       - name: Deploy Admin to Cloudflare Pages
         uses: nick-fields/retry@v2
         env:

--- a/docs/reviews/review-develop-20250312-1.md
+++ b/docs/reviews/review-develop-20250312-1.md
@@ -1,0 +1,81 @@
+# セルフレビュー: develop（main との差分）
+
+**日時**: 2025-03-12
+**ベース**: main
+**変更ファイル数**: 41 files
+**関連ファイル数**: 変更含め多数（knip/CI/incident 含む）
+
+## サマリー
+
+develop は main に対し、(1) **セキュリティ**: CSRF Origin チェック追加・docker-compose のインライン認証情報削除、(2) **デプロイ耐性**: Cloudflare Pages デプロイのリトライとログ収集、(3) **フロント認証・信頼性**: サインインコールバックのタイムアウト・エラー表示、サインイン失敗時の UI、API base URL のフォールバック（`window.location.origin`）、(4) **knip 導入**: 未使用コード検出と CI ジョブ追加、(5) **大量の未使用コード削除**（noteRepository, copilotSyncSettings, NotesSection, WelcomeModal, SyncIndicator, AIChatSuggestions 等）、(6) **コンテキストメニュー削除時のホーム凍結修正**（PageCard の modal と onSelect 遅延、E2E 追加）、(7) **CollaborationManager の keepalive ペイロード制限** 対応、を反映している。設計・セキュリティ・運用の改善が中心で、破壊的変更は削除されたモジュールを参照していた箇所の整理（knip ベース）に限定されている。
+
+## ファイルサイズ
+
+| ファイル                                | 行数（差分後） | 判定                       |
+| --------------------------------------- | -------------- | -------------------------- |
+| server/api/src/middleware/csrfOrigin.ts | 50             | OK                         |
+| scripts/delete-merged-branches.sh       | 増加           | OK（既存スクリプト拡張）   |
+| knip.json                               | 95             | OK（新規設定）             |
+| その他変更ファイル                      | -              | 削除が多いため行数増加なし |
+
+※ 削除されたファイル（noteRepository.ts 等）は 250 行超だったが、削除により解消。
+
+## 指摘事項
+
+### 🔴 Critical（マージ前に修正必須）
+
+| #   | ファイル | 行  | 観点             | 指摘内容                                                                                                 | 推奨修正                                                        | 対応                         |
+| --- | -------- | --- | ---------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------- |
+| 1   | （複数） | -   | プロジェクト規約 | develop ブランチで `bun run format:check` が失敗している。変更の入った 10 ファイルで Prettier が未適用。 | `bun run format` を実行し、該当ファイルを整形してコミットする。 | ✅ `bun run format` 実行済み |
+
+**対象ファイル（format:check で指摘）**:
+
+- `src/components/editor/TiptapEditor/thumbnailApiHelpers.test.ts`
+- `src/components/editor/TiptapEditor/thumbnailApiHelpers.ts`
+- `src/components/editor/TiptapEditor/useThumbnailCommit.ts`
+- `src/hooks/useProfile.ts`
+- `src/i18n/locales/en/auth.json`
+- `src/i18n/locales/ja/auth.json`
+- `src/lib/auth/authClient.ts`
+- `src/lib/collaboration/CollaborationManager.ts`
+- `src/pages/AuthCallback.tsx`
+- `src/pages/SignIn.tsx`
+
+### 🟡 Warning（修正を推奨）
+
+| #   | ファイル              | 行  | 観点         | 指摘内容                                                                                                                                                                                                                                   | 推奨修正                                                                                                                                     | 対応                                                   |
+| --- | --------------------- | --- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| 1   | deploy-prod.yml       | -   | 運用         | Cloudflare のデプロイが `cloudflare/wrangler-action@v3` から `nick-fields/retry` + `bunx wrangler pages deploy` に変更されている。リトライとログ収集は良いが、`apiToken`/`accountId` は `env` で渡すと wrangler が環境変数で読むか要確認。 | Wrangler のドキュメントで CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID の読み方を確認し、必要なら `env` で渡す現状を明示するコメントを残す。 | ✅ コメント追加（wrangler が env から読む旨）          |
+| 2   | csrfOrigin.ts         | 39  | セキュリティ | `getAllowedOrigins()` が空配列を返す場合（CORS ワイルドカード等）は CSRF チェックをスキップしている。本番で CORS_ORIGIN 未設定だと保護が無効になる。                                                                                       | 本番では CORS_ORIGIN を必ず設定する旨を .env.example やドキュメントで明記する。                                                              | ✅ .env.example に本番用 CORS_ORIGIN 説明を追加        |
+| 3   | useThumbnailCommit.ts | -   | 保守性       | 401 時に `redirectToSignIn` を付与した Error を throw し、catch 側で `navigate("/sign-in")` している。カスタムプロパティ付き Error はやや読みにくい。                                                                                      | 定数または専用の小さな型（例: `AuthRedirectError`）でラベル付けし、コメントで意図を書く。                                                    | ✅ `AuthRedirectError` 型と `isAuthRedirectError` 追加 |
+
+### 🟢 Info（任意の改善提案）
+
+| #   | ファイル                               | 行  | 観点           | 指摘内容                                                                                                               | 推奨修正                                                                                        |
+| --- | -------------------------------------- | --- | -------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| 1   | CollaborationManager.ts                | -   | パフォーマンス | `fireAndForgetSave` で body サイズに応じて `keepalive` を切り替えている。63 KiB の閾値は適切。                         | 定数 `KEEPALIVE_PAYLOAD_LIMIT` に「64 KiB 制限」のコメントがあり良好。特になし。                |
+| 2   | authClient.ts / thumbnailApiHelpers.ts | -   | 可読性         | `getAuthBaseUrl()` と `getThumbnailApiBaseUrl()` で同様の「VITE_API_BASE_URL が空なら origin」ロジックが重複している。 | 共通化する場合は `src/lib/apiBaseUrl.ts` のようなユーティリティにまとめると DRY。必須ではない。 |
+| 3   | lib/collaboration/index.ts             | -   | アーキテクチャ | バレルファイルが削除され、呼び出し元は `CollaborationManager` や `types` を直接 import している。                      | 既存の import パスが直接指定のため問題なし。削除でよい。                                        |
+
+## テストカバレッジ
+
+| 変更ファイル                            | テストファイル              | 状態                                                                      |
+| --------------------------------------- | --------------------------- | ------------------------------------------------------------------------- |
+| server/api/src/middleware/csrfOrigin.ts | -                           | ⚠️ テスト未作成（ミドルウェア単体テストがあると安心）                     |
+| thumbnailApiHelpers.ts                  | thumbnailApiHelpers.test.ts | ✅ 既存テストあり（差分で微修正）                                         |
+| useThumbnailCommit.ts                   | -                           | ⚠️ 直接の単体テストは未確認（E2E で画像保存はカバーされている可能性あり） |
+| useProfile.ts                           | useProfile.test.ts          | ✅ 既存テストあり                                                         |
+| AuthCallback.tsx / SignIn.tsx           | -                           | ⚠️ 認証フローは E2E または手動確認推奨                                    |
+| PageCard.tsx                            | -                           | ✅ E2E page-editor.spec.ts でコンテキストメニュー削除を追加               |
+| CollaborationManager.ts                 | -                           | 既存テストの有無は未確認                                                  |
+
+## Lint / Format チェック
+
+- **Lint**: `bun run lint` → **0 errors**, 79 warnings（既存の max-lines-per-function 等。今回の変更に起因するエラーなし）
+- **Format**: `bun run format:check` → **通過**（対応後に `bun run format` 実行済み）
+
+## 統計
+
+- Critical: 1 件 → **対応済み**
+- Warning: 3 件 → **対応済み**
+- Info: 3 件（任意）

--- a/src/components/editor/TiptapEditor/useThumbnailCommit.ts
+++ b/src/components/editor/TiptapEditor/useThumbnailCommit.ts
@@ -7,6 +7,13 @@ import { getStorageProvider, getSettingsForUpload, convertToWebP } from "@/lib/s
 import type { StorageSettings } from "@/types/storage";
 import { getThumbnailApiBaseUrl } from "./thumbnailApiHelpers";
 
+/** 401 時にサインインへリダイレクトするための印。catch 側で navigate("/sign-in") する。 */
+export type AuthRedirectError = Error & { redirectToSignIn: true };
+
+function isAuthRedirectError(err: unknown): err is AuthRedirectError {
+  return err instanceof Error && (err as AuthRedirectError).redirectToSignIn === true;
+}
+
 interface UseThumbnailCommitOptions {
   editorRef: React.RefObject<Editor | null>;
   pageTitle: string;
@@ -53,7 +60,7 @@ async function commitViaServerS3(
   });
 
   if (response.status === 401) {
-    const err = new Error("ログインが必要です") as Error & { redirectToSignIn?: boolean };
+    const err = new Error("ログインが必要です") as AuthRedirectError;
     err.redirectToSignIn = true;
     throw err;
   }
@@ -146,8 +153,7 @@ export function useThumbnailCommit({
           })
           .run();
       } catch (error) {
-        const err = error as Error & { redirectToSignIn?: boolean };
-        if (err.redirectToSignIn) {
+        if (isAuthRedirectError(error)) {
           toast({
             title: "ログインが必要です",
             description: "再度ログインしてください",
@@ -156,10 +162,10 @@ export function useThumbnailCommit({
           navigate("/sign-in", { replace: true });
           return;
         }
+        const err = error instanceof Error ? error : new Error(String(error));
         const isFetchError =
           error instanceof TypeError ||
-          (error instanceof Error &&
-            /Failed to fetch|CORS|NetworkError|Image fetch failed/i.test(error.message));
+          /Failed to fetch|CORS|NetworkError|Image fetch failed/i.test(err.message);
         toast({
           title: "画像の保存に失敗しました",
           description: isFetchError

--- a/src/components/editor/TiptapEditor/useThumbnailCommit.ts
+++ b/src/components/editor/TiptapEditor/useThumbnailCommit.ts
@@ -8,10 +8,16 @@ import type { StorageSettings } from "@/types/storage";
 import { getThumbnailApiBaseUrl } from "./thumbnailApiHelpers";
 
 /** 401 時にサインインへリダイレクトするための印。catch 側で navigate("/sign-in") する。 */
-export type AuthRedirectError = Error & { redirectToSignIn: true };
+export class AuthRedirectError extends Error {
+  readonly redirectToSignIn = true;
+  constructor(message?: string) {
+    super(message);
+    this.name = "AuthRedirectError";
+  }
+}
 
 function isAuthRedirectError(err: unknown): err is AuthRedirectError {
-  return err instanceof Error && (err as AuthRedirectError).redirectToSignIn === true;
+  return err instanceof AuthRedirectError;
 }
 
 interface UseThumbnailCommitOptions {
@@ -60,9 +66,7 @@ async function commitViaServerS3(
   });
 
   if (response.status === 401) {
-    const err = new Error("ログインが必要です") as AuthRedirectError;
-    err.redirectToSignIn = true;
-    throw err;
+    throw new AuthRedirectError("ログインが必要です");
   }
   if (!response.ok) {
     let message = `画像の保存に失敗しました: ${response.status}`;
@@ -164,7 +168,7 @@ export function useThumbnailCommit({
         }
         const err = error instanceof Error ? error : new Error(String(error));
         const isFetchError =
-          error instanceof TypeError ||
+          err instanceof TypeError ||
           /Failed to fetch|CORS|NetworkError|Image fetch failed/i.test(err.message);
         toast({
           title: "画像の保存に失敗しました",


### PR DESCRIPTION
## 概要

main と develop の差分に対するセルフレビュー（`docs/reviews/review-develop-20250312-1.md`）で指摘した Critical 1 件・Warning 3 件に対応した変更です。develop 取り込み用のフィードバック対応 PR です。

## 変更点

- **`.env.example`**: 本番で CSRF チェックを有効にするため、API サーバー用の `CORS_ORIGIN` 説明を追加（先頭付近に「API server (production)」セクション）
- **`.github/workflows/deploy-prod.yml`**: Cloudflare デプロイステップ（Frontend / Admin）に、wrangler CLI が `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` を環境変数から読む旨のコメントを追加
- **`src/components/editor/TiptapEditor/useThumbnailCommit.ts`**: 401 時のサインインリダイレクト用に `AuthRedirectError` 型と `isAuthRedirectError` 型ガードを追加し、意図をコメントで明示
- **`docs/reviews/review-develop-20250312-1.md`**: レビューレポートを追加し、Critical・Warning の対応済みステータスを記載

## 変更の種類

- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 📝 ドキュメント (Documentation)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run lint` が通ること
2. `bun run format:check` が通ること
3. （任意）サインイン未済でサムネイル保存を試し、401 時にサインインへリダイレクトされること

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

なし（UI 変更なし）

## 関連 Issue

なし

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Bug Fixes**
  * 認証エラーハンドリングを改善し、サインインフローの信頼性を向上させました。

* **Chores**
  * CORS設定オプションを追加しました。
  * デプロイメント手順のドキュメント注釈を追加しました。

* **Documentation**
  * 開発ブランチのレビュードキュメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->