### PR TITLE
feat(web-clipper): auto-parse on paste, remove citation block, embed OGP thumbnail (#339)

### DIFF
--- a/src/components/editor/TiptapEditor/useThumbnailCommit.ts
+++ b/src/components/editor/TiptapEditor/useThumbnailCommit.ts
@@ -5,16 +5,8 @@ import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@zedi/ui";
 import { getStorageProvider, getSettingsForUpload, convertToWebP } from "@/lib/storage";
 import type { StorageSettings } from "@/types/storage";
+import { commitThumbnailFromUrl, AuthRedirectError } from "@/lib/thumbnailCommit";
 import { getThumbnailApiBaseUrl } from "./thumbnailApiHelpers";
-
-/** 401 時にサインインへリダイレクトするための印。catch 側で navigate("/sign-in") する。 */
-export class AuthRedirectError extends Error {
-  readonly redirectToSignIn = true;
-  constructor(message?: string) {
-    super(message);
-    this.name = "AuthRedirectError";
-  }
-}
 
 function isAuthRedirectError(err: unknown): err is AuthRedirectError {
   return err instanceof AuthRedirectError;
@@ -44,45 +36,6 @@ async function fetchImageAsFile(imageUrl: string, fallbackUrl?: string): Promise
     }
     throw err;
   }
-}
-
-async function commitViaServerS3(
-  imageUrl: string,
-  altText: string,
-  previewUrl: string | undefined,
-  baseUrl: string,
-): Promise<{ imageUrl: string; provider: string }> {
-  const response = await fetch(`${baseUrl}/api/thumbnail/commit`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    credentials: "include",
-    body: JSON.stringify({
-      sourceUrl: imageUrl,
-      fallbackUrl: previewUrl,
-      title: altText,
-    }),
-  });
-
-  if (response.status === 401) {
-    throw new AuthRedirectError("ログインが必要です");
-  }
-  if (!response.ok) {
-    let message = `画像の保存に失敗しました: ${response.status}`;
-    try {
-      const data = (await response.json()) as { error?: string; message?: string };
-      if (data?.message) message = data.message;
-      else if (data?.error) message = data.error;
-    } catch {
-      // ignore parse errors
-    }
-    throw new Error(message);
-  }
-
-  const data = (await response.json()) as { imageUrl?: string; provider?: string };
-  if (!data.imageUrl) throw new Error("画像のURLが取得できませんでした");
-  return { imageUrl: data.imageUrl, provider: data.provider ?? "s3" };
 }
 
 export function useThumbnailCommit({
@@ -121,12 +74,11 @@ export function useThumbnailCommit({
           if (!thumbnailApiBaseUrl) {
             throw new Error("APIのURLが設定されていません");
           }
-          const result = await commitViaServerS3(
-            imageUrl,
-            altText,
-            previewUrl,
-            thumbnailApiBaseUrl,
-          );
+          const result = await commitThumbnailFromUrl(imageUrl, {
+            baseUrl: thumbnailApiBaseUrl,
+            fallbackUrl: previewUrl,
+            title: altText,
+          });
           finalUrl = result.imageUrl;
           providerId = result.provider;
         } else {

--- a/src/components/editor/WebClipperDialog.tsx
+++ b/src/components/editor/WebClipperDialog.tsx
@@ -11,13 +11,19 @@ import {
   DialogTitle,
 } from "@zedi/ui";
 import { Alert, AlertDescription } from "@zedi/ui";
+import { useNavigate } from "react-router-dom";
 import { useWebClipper, type WebClipperStatus } from "@/hooks/useWebClipper";
 import { isValidUrl } from "@/lib/webClipper";
 import { useAuth } from "@/hooks/useAuth";
 import { createApiClient } from "@/lib/api";
 import { useDebouncedCallback } from "@/hooks/useDebouncedCallback";
-import { commitThumbnailFromUrl } from "@/lib/thumbnailCommit";
+import { commitThumbnailFromUrl, AuthRedirectError } from "@/lib/thumbnailCommit";
 import { getThumbnailApiBaseUrl } from "@/components/editor/TiptapEditor/thumbnailApiHelpers";
+import { useToast } from "@zedi/ui";
+
+function isAuthRedirectError(err: unknown): err is AuthRedirectError {
+  return err instanceof AuthRedirectError;
+}
 
 interface WebClipperDialogProps {
   open: boolean;
@@ -50,13 +56,24 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
   const { status, clippedContent, error, clip, reset, getTiptapContent } = useWebClipper({ api });
   const lastClippedUrlRef = useRef<string>("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { toast } = useToast();
+  const navigate = useNavigate();
 
-  // URL変更時に前回の解析結果をリセット
+  // URL変更時に前回の解析結果をリセット（進行中の clip は潰さない）
   useEffect(() => {
-    if (url) {
+    if (!url) {
+      reset();
+    } else if (status === "completed" || status === "error") {
       reset();
     }
-  }, [url, reset]);
+  }, [url, status, reset]);
+
+  // エラー時に lastClippedUrlRef をクリアして同一URLのリトライを可能に
+  useEffect(() => {
+    if (status === "error") {
+      lastClippedUrlRef.current = "";
+    }
+  }, [status]);
 
   // 有効なURLを検知したら自動で clip を実行（debounce 500ms）
   const triggerAutoClip = useDebouncedCallback(
@@ -109,31 +126,49 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
 
     setIsSubmitting(true);
     let committedThumbnail: string | undefined;
-    if (clippedContent.thumbnailUrl) {
-      try {
-        const baseUrl = getThumbnailApiBaseUrl();
-        if (baseUrl) {
-          const result = await commitThumbnailFromUrl(clippedContent.thumbnailUrl, {
-            baseUrl,
-            title: clippedContent.title,
+    try {
+      if (clippedContent.thumbnailUrl) {
+        try {
+          const baseUrl = getThumbnailApiBaseUrl();
+          if (baseUrl) {
+            const result = await commitThumbnailFromUrl(clippedContent.thumbnailUrl, {
+              baseUrl,
+              title: clippedContent.title,
+            });
+            committedThumbnail = result.imageUrl;
+          }
+        } catch (err) {
+          if (isAuthRedirectError(err)) {
+            toast({
+              title: "ログインが必要です",
+              description: "再度ログインしてください",
+              variant: "destructive",
+            });
+            navigate("/sign-in", { replace: true });
+            return;
+          }
+          console.error("Failed to commit thumbnail:", err);
+          toast({
+            title: "サムネイルの保存に失敗しました",
+            description: "コンテンツはそのまま取り込みます。",
+            variant: "destructive",
           });
-          committedThumbnail = result.imageUrl;
+          committedThumbnail = undefined;
         }
-      } catch {
-        committedThumbnail = undefined;
       }
+      const tiptapContent = getTiptapContent(committedThumbnail);
+      if (tiptapContent) {
+        onClipped(
+          clippedContent.title,
+          tiptapContent,
+          clippedContent.sourceUrl,
+          committedThumbnail ?? undefined,
+        );
+        onOpenChange(false);
+      }
+    } finally {
+      setIsSubmitting(false);
     }
-    const tiptapContent = getTiptapContent(committedThumbnail);
-    if (tiptapContent) {
-      onClipped(
-        clippedContent.title,
-        tiptapContent,
-        clippedContent.sourceUrl,
-        committedThumbnail ?? undefined,
-      );
-      onOpenChange(false);
-    }
-    setIsSubmitting(false);
   };
 
   // Enterキーで実行
@@ -173,7 +208,7 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
               }}
               onPaste={handlePaste}
               onKeyDown={handleKeyDown}
-              disabled={isProcessing}
+              disabled={isBusy}
               className="font-mono text-sm"
               autoFocus
             />

--- a/src/components/editor/WebClipperDialog.tsx
+++ b/src/components/editor/WebClipperDialog.tsx
@@ -60,13 +60,15 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
   const navigate = useNavigate();
 
   // URL変更時に前回の解析結果をリセット（進行中の clip は潰さない）
+  // status を deps に含めると完了/エラー直後に自ら結果を消してしまうため、url 変更時のみ判定
   useEffect(() => {
     if (!url) {
+      lastClippedUrlRef.current = "";
       reset();
-    } else if (status === "completed" || status === "error") {
+    } else if (url !== lastClippedUrlRef.current) {
       reset();
     }
-  }, [url, status, reset]);
+  }, [url, reset]);
 
   // エラー時に lastClippedUrlRef をクリアして同一URLのリトライを可能に
   useEffect(() => {
@@ -126,6 +128,7 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
 
     setIsSubmitting(true);
     let committedThumbnail: string | undefined;
+    let commitAttemptedAndFailed = false;
     try {
       if (clippedContent.thumbnailUrl) {
         try {
@@ -153,10 +156,12 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
             description: "コンテンツはそのまま取り込みます。",
             variant: "destructive",
           });
-          committedThumbnail = undefined;
+          commitAttemptedAndFailed = true;
         }
       }
-      const tiptapContent = getTiptapContent(committedThumbnail);
+      const thumbnailForContent =
+        committedThumbnail ?? (commitAttemptedAndFailed ? "" : clippedContent.thumbnailUrl);
+      const tiptapContent = getTiptapContent(thumbnailForContent);
       if (tiptapContent) {
         onClipped(
           clippedContent.title,

--- a/src/components/editor/WebClipperDialog.tsx
+++ b/src/components/editor/WebClipperDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Link2, Loader2, AlertCircle, Check, ExternalLink } from "lucide-react";
 import { Button } from "@zedi/ui";
 import { Input } from "@zedi/ui";
@@ -15,6 +15,9 @@ import { useWebClipper, type WebClipperStatus } from "@/hooks/useWebClipper";
 import { isValidUrl } from "@/lib/webClipper";
 import { useAuth } from "@/hooks/useAuth";
 import { createApiClient } from "@/lib/api";
+import { useDebouncedCallback } from "@/hooks/useDebouncedCallback";
+import { commitThumbnailFromUrl } from "@/lib/thumbnailCommit";
+import { getThumbnailApiBaseUrl } from "@/components/editor/TiptapEditor/thumbnailApiHelpers";
 
 interface WebClipperDialogProps {
   open: boolean;
@@ -45,6 +48,48 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
   const [url, setUrl] = useState("");
   const [urlError, setUrlError] = useState<string | null>(null);
   const { status, clippedContent, error, clip, reset, getTiptapContent } = useWebClipper({ api });
+  const lastClippedUrlRef = useRef<string>("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // URL変更時に前回の解析結果をリセット
+  useEffect(() => {
+    if (url) {
+      reset();
+    }
+  }, [url, reset]);
+
+  // 有効なURLを検知したら自動で clip を実行（debounce 500ms）
+  const triggerAutoClip = useDebouncedCallback(
+    useCallback(() => {
+      const trimmed = url.trim();
+      if (!trimmed || !isValidUrl(trimmed)) return;
+      if (trimmed === lastClippedUrlRef.current) return;
+      lastClippedUrlRef.current = trimmed;
+      clip(trimmed);
+    }, [url, clip]),
+    500,
+  );
+
+  useEffect(() => {
+    triggerAutoClip();
+  }, [url, triggerAutoClip]);
+
+  // 貼り付け時に有効なURLなら即時 clip
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      const text = e.clipboardData.getData("text").trim();
+      if (text && isValidUrl(text)) {
+        e.preventDefault();
+        setUrl(text);
+        setUrlError(null);
+        if (text !== lastClippedUrlRef.current) {
+          lastClippedUrlRef.current = text;
+          clip(text);
+        }
+      }
+    },
+    [clip],
+  );
 
   // ダイアログを閉じたときにリセット
   useEffect(() => {
@@ -53,42 +98,47 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
         setUrl("");
         setUrlError(null);
       });
+      lastClippedUrlRef.current = "";
       reset();
     }
   }, [open, reset]);
 
-  // URL入力のバリデーション
-  const validateUrl = useCallback((value: string): boolean => {
-    if (!value.trim()) {
-      setUrlError("URLを入力してください");
-      return false;
-    }
-    if (!isValidUrl(value)) {
-      setUrlError("有効なURLを入力してください（http:// または https://）");
-      return false;
-    }
-    setUrlError(null);
-    return true;
-  }, []);
-
-  // 取り込み実行
+  // 取り込み実行（clippedContent をそのまま使用、再 fetch なし）
   const handleClip = async () => {
-    if (!validateUrl(url)) return;
+    if (!clippedContent) return;
 
-    const result = await clip(url);
-
-    if (result) {
-      const tiptapContent = getTiptapContent();
-      if (tiptapContent) {
-        onClipped(result.title, tiptapContent, result.sourceUrl, result.thumbnailUrl);
-        onOpenChange(false);
+    setIsSubmitting(true);
+    let committedThumbnail: string | undefined;
+    if (clippedContent.thumbnailUrl) {
+      try {
+        const baseUrl = getThumbnailApiBaseUrl();
+        if (baseUrl) {
+          const result = await commitThumbnailFromUrl(clippedContent.thumbnailUrl, {
+            baseUrl,
+            title: clippedContent.title,
+          });
+          committedThumbnail = result.imageUrl;
+        }
+      } catch {
+        committedThumbnail = undefined;
       }
     }
+    const tiptapContent = getTiptapContent(committedThumbnail);
+    if (tiptapContent) {
+      onClipped(
+        clippedContent.title,
+        tiptapContent,
+        clippedContent.sourceUrl,
+        committedThumbnail ?? undefined,
+      );
+      onOpenChange(false);
+    }
+    setIsSubmitting(false);
   };
 
   // Enterキーで実行
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && status === "idle") {
+    if (e.key === "Enter" && clippedContent && !isSubmitting) {
       e.preventDefault();
       handleClip();
     }
@@ -96,6 +146,7 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
 
   const isProcessing = status === "fetching" || status === "extracting";
   const isCompleted = status === "completed";
+  const isBusy = isProcessing || isSubmitting;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -120,6 +171,7 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
                 setUrl(e.target.value);
                 if (urlError) setUrlError(null);
               }}
+              onPaste={handlePaste}
               onKeyDown={handleKeyDown}
               disabled={isProcessing}
               className="font-mono text-sm"
@@ -166,11 +218,11 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
         </div>
 
         <DialogFooter className="gap-2 sm:gap-0">
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isProcessing}>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isBusy}>
             キャンセル
           </Button>
-          <Button onClick={handleClip} disabled={isProcessing || !url.trim()}>
-            {isProcessing ? (
+          <Button onClick={handleClip} disabled={isBusy || !clippedContent}>
+            {isBusy ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 取り込み中...

--- a/src/hooks/useWebClipper.test.ts
+++ b/src/hooks/useWebClipper.test.ts
@@ -106,6 +106,7 @@ describe("useWebClipper", () => {
       fakeContent.sourceUrl,
       fakeContent.siteName,
       fakeContent.thumbnailUrl,
+      fakeContent.title,
     );
   });
 
@@ -124,6 +125,7 @@ describe("useWebClipper", () => {
       fakeContent.sourceUrl,
       fakeContent.siteName,
       "https://committed.com/thumb.png",
+      fakeContent.title,
     );
   });
 });

--- a/src/hooks/useWebClipper.test.ts
+++ b/src/hooks/useWebClipper.test.ts
@@ -105,6 +105,25 @@ describe("useWebClipper", () => {
       fakeContent.content,
       fakeContent.sourceUrl,
       fakeContent.siteName,
+      fakeContent.thumbnailUrl,
+    );
+  });
+
+  it("getTiptapContent passes thumbnailUrl override when provided", async () => {
+    mockClipWebPage.mockResolvedValue(fakeContent);
+    mockFormatClippedContentAsTiptap.mockReturnValue({ type: "doc", content: [] });
+    const { result } = renderHook(() => useWebClipper());
+
+    await act(async () => {
+      await result.current.clip("https://example.com");
+    });
+
+    result.current.getTiptapContent("https://committed.com/thumb.png");
+    expect(mockFormatClippedContentAsTiptap).toHaveBeenCalledWith(
+      fakeContent.content,
+      fakeContent.sourceUrl,
+      fakeContent.siteName,
+      "https://committed.com/thumb.png",
     );
   });
 });

--- a/src/hooks/useWebClipper.ts
+++ b/src/hooks/useWebClipper.ts
@@ -2,7 +2,7 @@
  * Web Clipper フック - URLからWebページを取り込む
  * api を渡すとサーバー側で HTML 取得（CORS 回避）。未指定時は CORS プロキシにフォールバック。
  */
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { clipWebPage, getClipErrorMessage, type ClippedContent } from "@/lib/webClipper";
 import { formatClippedContentAsTiptap } from "@/lib/htmlToTiptap";
 import type { ApiClient } from "@/lib/api/apiClient";
@@ -25,6 +25,7 @@ export interface UseWebClipperReturn {
 
 export function useWebClipper(options: UseWebClipperOptions = {}): UseWebClipperReturn {
   const { api } = options;
+  const clipIdRef = useRef(0);
   const [status, setStatus] = useState<WebClipperStatus>("idle");
   const [clippedContent, setClippedContent] = useState<ClippedContent | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -36,6 +37,9 @@ export function useWebClipper(options: UseWebClipperOptions = {}): UseWebClipper
 
   const clip = useCallback(
     async (url: string): Promise<ClippedContent | null> => {
+      clipIdRef.current += 1;
+      const currentId = clipIdRef.current;
+
       setStatus("fetching");
       setError(null);
       setClippedContent(null);
@@ -44,10 +48,14 @@ export function useWebClipper(options: UseWebClipperOptions = {}): UseWebClipper
         setStatus("extracting");
         const content = await clipWebPage(url, api ? fetchHtmlFn : undefined);
 
+        if (currentId !== clipIdRef.current) return null;
+
         setClippedContent(content);
         setStatus("completed");
         return content;
       } catch (err) {
+        if (currentId !== clipIdRef.current) return null;
+
         const errorMessage = getClipErrorMessage(err);
         setError(errorMessage);
         setStatus("error");
@@ -72,6 +80,7 @@ export function useWebClipper(options: UseWebClipperOptions = {}): UseWebClipper
         clippedContent.sourceUrl,
         clippedContent.siteName,
         thumbnailUrl ?? clippedContent.thumbnailUrl,
+        clippedContent.title,
       );
 
       return JSON.stringify(tiptapDoc);

--- a/src/hooks/useWebClipper.ts
+++ b/src/hooks/useWebClipper.ts
@@ -20,7 +20,7 @@ export interface UseWebClipperReturn {
   error: string | null;
   clip: (url: string) => Promise<ClippedContent | null>;
   reset: () => void;
-  getTiptapContent: () => string | null;
+  getTiptapContent: (thumbnailUrl?: string | null) => string | null;
 }
 
 export function useWebClipper(options: UseWebClipperOptions = {}): UseWebClipperReturn {
@@ -63,17 +63,21 @@ export function useWebClipper(options: UseWebClipperOptions = {}): UseWebClipper
     setError(null);
   }, []);
 
-  const getTiptapContent = useCallback((): string | null => {
-    if (!clippedContent) return null;
+  const getTiptapContent = useCallback(
+    (thumbnailUrl?: string | null): string | null => {
+      if (!clippedContent) return null;
 
-    const tiptapDoc = formatClippedContentAsTiptap(
-      clippedContent.content,
-      clippedContent.sourceUrl,
-      clippedContent.siteName,
-    );
+      const tiptapDoc = formatClippedContentAsTiptap(
+        clippedContent.content,
+        clippedContent.sourceUrl,
+        clippedContent.siteName,
+        thumbnailUrl ?? clippedContent.thumbnailUrl,
+      );
 
-    return JSON.stringify(tiptapDoc);
-  }, [clippedContent]);
+      return JSON.stringify(tiptapDoc);
+    },
+    [clippedContent],
+  );
 
   return {
     status,

--- a/src/lib/htmlToTiptap.test.ts
+++ b/src/lib/htmlToTiptap.test.ts
@@ -30,20 +30,27 @@ describe("formatClippedContentAsTiptap", () => {
       "https://example.com",
       "Example",
       "https://cdn.example.com/thumb.png",
+      "Page Title",
     );
     expect(result.type).toBe("doc");
     const first = result.content?.[0];
     expect(first?.type).toBe("image");
     expect(first).toMatchObject({
       type: "image",
-      attrs: { src: "https://cdn.example.com/thumb.png", alt: "OGP thumbnail" },
+      attrs: { src: "https://cdn.example.com/thumb.png", alt: "Page Title" },
     });
     const second = result.content?.[1];
     expect(second?.type).toBe("paragraph");
   });
 
   it("omits image when thumbnailUrl is empty string", () => {
-    const result = formatClippedContentAsTiptap("<p>Body</p>", "https://example.com", null, "");
+    const result = formatClippedContentAsTiptap(
+      "<p>Body</p>",
+      "https://example.com",
+      null,
+      "",
+      null,
+    );
     const first = result.content?.[0];
     expect(first?.type).toBe("paragraph");
     expect(first?.type).not.toBe("image");

--- a/src/lib/htmlToTiptap.test.ts
+++ b/src/lib/htmlToTiptap.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { formatClippedContentAsTiptap } from "./htmlToTiptap";
+
+describe("formatClippedContentAsTiptap", () => {
+  it("returns main content without citation block or thumbnail when thumbnailUrl is omitted", () => {
+    const result = formatClippedContentAsTiptap(
+      "<p>Hello world</p>",
+      "https://example.com",
+      "Example",
+    );
+    expect(result.type).toBe("doc");
+    expect(result.content).toBeDefined();
+    expect(Array.isArray(result.content)).toBe(true);
+    // No citation block (📎 引用元), no horizontalRule, no image
+    const hasCitationBlock = JSON.stringify(result).includes("引用元");
+    expect(hasCitationBlock).toBe(false);
+    const hasHorizontalRule = result.content?.some((n) => n.type === "horizontalRule");
+    expect(hasHorizontalRule).toBe(false);
+    const hasImage = result.content?.some((n) => n.type === "image");
+    expect(hasImage).toBe(false);
+    // Main content present
+    expect(result.content?.length).toBeGreaterThan(0);
+    const first = result.content?.[0];
+    expect(first?.type).toBe("paragraph");
+  });
+
+  it("prepends image node when thumbnailUrl is provided", () => {
+    const result = formatClippedContentAsTiptap(
+      "<p>Body text</p>",
+      "https://example.com",
+      "Example",
+      "https://cdn.example.com/thumb.png",
+    );
+    expect(result.type).toBe("doc");
+    const first = result.content?.[0];
+    expect(first?.type).toBe("image");
+    expect(first).toMatchObject({
+      type: "image",
+      attrs: { src: "https://cdn.example.com/thumb.png", alt: "OGP thumbnail" },
+    });
+    const second = result.content?.[1];
+    expect(second?.type).toBe("paragraph");
+  });
+
+  it("omits image when thumbnailUrl is empty string", () => {
+    const result = formatClippedContentAsTiptap("<p>Body</p>", "https://example.com", null, "");
+    const first = result.content?.[0];
+    expect(first?.type).toBe("paragraph");
+    expect(first?.type).not.toBe("image");
+  });
+});

--- a/src/lib/htmlToTiptap.ts
+++ b/src/lib/htmlToTiptap.ts
@@ -156,50 +156,29 @@ export function tiptapJSONToString(json: JSONContent): string {
 
 /**
  * クリップしたコンテンツをTiptap JSONとして整形
- * 引用元情報を含めたフォーマット
+ * 引用元表示は PageEditorContent の SourceUrlBadge が担当
  */
 export function formatClippedContentAsTiptap(
   content: string,
   sourceUrl: string,
   siteName?: string | null,
+  thumbnailUrl?: string | null,
 ): JSONContent {
   const mainContent = htmlToTiptapJSON(content);
+  const baseContent = mainContent.content ?? [];
 
-  let sourceText = siteName ?? sourceUrl;
-  if (!siteName) {
-    try {
-      sourceText = new URL(sourceUrl).hostname;
-    } catch {
-      sourceText = sourceUrl;
-    }
-  }
+  const imageNode: JSONContent | null =
+    thumbnailUrl && thumbnailUrl.trim()
+      ? {
+          type: "image",
+          attrs: { src: thumbnailUrl, alt: "OGP thumbnail" },
+        }
+      : null;
 
-  const sourceInfo: JSONContent = {
-    type: "paragraph",
-    content: [
-      { type: "text", text: "📎 引用元: " },
-      {
-        type: "text",
-        marks: [
-          {
-            type: "link",
-            attrs: {
-              href: sourceUrl,
-              target: "_blank",
-              rel: "noopener noreferrer nofollow",
-              class: null,
-            },
-          },
-        ],
-        text: sourceText,
-      },
-    ],
-  };
-
-  const horizontalRule: JSONContent = { type: "horizontalRule" };
+  const contentNodes: JSONContent[] = imageNode ? [imageNode, ...baseContent] : baseContent;
 
   return {
     type: "doc",
-    content: [sourceInfo, horizontalRule, ...(mainContent.content ?? [])],
+    content: contentNodes,
   };
 }

--- a/src/lib/htmlToTiptap.ts
+++ b/src/lib/htmlToTiptap.ts
@@ -163,17 +163,21 @@ export function formatClippedContentAsTiptap(
   sourceUrl: string,
   siteName?: string | null,
   thumbnailUrl?: string | null,
+  title?: string | null,
 ): JSONContent {
+  void sourceUrl;
+  void siteName;
+
   const mainContent = htmlToTiptapJSON(content);
   const baseContent = mainContent.content ?? [];
 
-  const imageNode: JSONContent | null =
-    thumbnailUrl && thumbnailUrl.trim()
-      ? {
-          type: "image",
-          attrs: { src: thumbnailUrl, alt: "OGP thumbnail" },
-        }
-      : null;
+  const trimmedThumbnail = thumbnailUrl?.trim();
+  const imageNode: JSONContent | null = trimmedThumbnail
+    ? {
+        type: "image",
+        attrs: { src: trimmedThumbnail, alt: title || "OGP thumbnail" },
+      }
+    : null;
 
   const contentNodes: JSONContent[] = imageNode ? [imageNode, ...baseContent] : baseContent;
 

--- a/src/lib/thumbnailCommit.ts
+++ b/src/lib/thumbnailCommit.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared utility to commit an image from a URL to thumbnail storage via the API.
+ * Used by useThumbnailCommit (editor) and WebClipperDialog.
+ */
+
+/** 401 時にサインインへリダイレクトするための印。catch 側で navigate("/sign-in") する。 */
+export class AuthRedirectError extends Error {
+  readonly redirectToSignIn = true;
+  constructor(message?: string) {
+    super(message);
+    this.name = "AuthRedirectError";
+  }
+}
+
+export interface CommitThumbnailResult {
+  imageUrl: string;
+  provider: string;
+}
+
+export interface CommitThumbnailOptions {
+  baseUrl: string;
+  fallbackUrl?: string;
+  title?: string;
+}
+
+/**
+ * Commits an image from sourceUrl to storage via POST /api/thumbnail/commit.
+ * Uses cookie credentials. Throws AuthRedirectError on 401, Error on other failures.
+ */
+export async function commitThumbnailFromUrl(
+  sourceUrl: string,
+  options: CommitThumbnailOptions,
+): Promise<CommitThumbnailResult> {
+  const { baseUrl } = options;
+  if (!baseUrl) {
+    throw new Error("APIのURLが設定されていません");
+  }
+
+  const response = await fetch(`${baseUrl}/api/thumbnail/commit`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify({
+      sourceUrl,
+      fallbackUrl: options?.fallbackUrl,
+      title: options?.title ?? "thumbnail",
+    }),
+  });
+
+  if (response.status === 401) {
+    throw new AuthRedirectError("ログインが必要です");
+  }
+
+  if (!response.ok) {
+    let message = `画像の保存に失敗しました: ${response.status}`;
+    try {
+      const data = (await response.json()) as { error?: string; message?: string };
+      if (data?.message) message = data.message;
+      else if (data?.error) message = data.error;
+    } catch {
+      // ignore parse errors
+    }
+    throw new Error(message);
+  }
+
+  const data = (await response.json()) as { imageUrl?: string; provider?: string };
+  if (!data.imageUrl) throw new Error("画像のURLが取得できませんでした");
+  return { imageUrl: data.imageUrl, provider: data.provider ?? "s3" };
+}


### PR DESCRIPTION
## 概要

Web Clipper（URLから取り込み）の UX を改善。Issue #339 に従い、(1) URL 貼り付け・入力時の自動解析、(2) 引用元ブロックの削除、(3) OGP サムネイルのページ先頭埋め込み（thumbnail/commit API 経由）の 3 点を実装する。

## 変更点

### `src/components/editor/WebClipperDialog.tsx`
- URL 貼り付け時（onPaste）および入力変更時（onChange、debounce 500ms）に有効な URL を検知して自動で `clip()` を実行
- 取り込みボタンは `clippedContent` が存在する場合のみ有効化
- クリック時は再 fetch せず `getTiptapContent()` で生成した内容を `onClipped` に渡す
- OGP サムネイルがある場合は `thumbnail/commit` API で保存してからコンテンツ先頭に埋め込み

### `src/lib/htmlToTiptap.ts`
- `formatClippedContentAsTiptap` から引用元ブロック（📎 引用元段落）と horizontalRule を削除
- 任意の `thumbnailUrl` を受け取り、ある場合は先頭に image ノードを挿入

### `src/hooks/useWebClipper.ts`
- `getTiptapContent(thumbnailUrl?: string | null)` でコミット済み URL を渡せるようにする

### `src/lib/thumbnailCommit.ts`（新規）
- `commitThumbnailFromUrl` 共有ユーティリティ（useThumbnailCommit と WebClipperDialog で利用）

### `src/components/editor/TiptapEditor/useThumbnailCommit.ts`
- 共有の `commitThumbnailFromUrl` を使用するようにリファクタリング

### テスト
- `useWebClipper.test.ts`: `getTiptapContent` の thumbnailUrl 引数に対応
- `htmlToTiptap.test.ts`（新規）: `formatClippedContentAsTiptap` の引用元削除とサムネイル埋め込みのテスト

## 変更の種類

- [x] ✨ 新機能 (New feature)

## テスト方法

1. `bun run dev` で開発サーバーを起動
2. FAB（+）→ URL から取り込み を選択
3. URL を貼り付けると自動で解析が開始され、完了後にプレビューが表示されることを確認
4. 取り込みボタンをクリックするとページが作成され、SourceUrlBadge のみが表示される（引用元ブロックがないこと）を確認
5. OGP サムネイルがある URL の場合、ページ先頭に画像が埋め込まれ、サムネイルとして登録されることを確認

## チェックリスト

- [x] テストがすべてパスする（619 passed）
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

Web Clipper ダイアログの挙動が変わるため、以下を手動で確認推奨：
- URL 貼り付け時の自動解析
- 取り込み後のページ表示（引用元ブロックなし、SourceUrlBadge のみ）

## 関連 Issue

Closes #339

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ペースト時の有効なURLの自動検出・自動クリップ機能
  * URL入力時の自動クリップ（デバウンス）と同一URLの再クリップ防止
  * クリップ結果からのサムネイルをサーバーへコミットする機能

* **Improvements**
  * クリップ中の状態（isSubmitting/isBusy）表示で入力とボタンを無効化
  * 認証エラー時にサインインへの案内と自動リダイレクト、ユーザー向けトースト改善

* **Tests**
  * サムネイル指定時のコンテンツ生成挙動を検証するテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->