### PR TITLE
fix: address review-develop-vs-main Critical and Warning items

### DIFF
--- a/.cursor/skills/handle-pr-review/SKILL.md
+++ b/.cursor/skills/handle-pr-review/SKILL.md
@@ -20,10 +20,12 @@ gh pr list --head "$(git branch --show-current)" --json number,url,title --jq '.
 
 セッション中に既に PR を扱っている場合は、その情報を再利用する。
 
-## Step 1: 未対応コメントのみ取得
+## Step 1: 未返信コメントの取得
 
-**返信済みのコメントを除外し、未対応のものだけを最小フィールドで取得する。**
+**返信済みのコメントを除外し、未返信のトップレベルコメントを取得する。**
 新規チャットでも前回のコンテキスト不要で正しく動作する。
+
+**注意**: この方式は「未返信」を対象とする。GitHub の `Require conversation resolution before merging` は「未解決のスレッド」をブロックするため、返信済みだが未解決のスレッドは検出されない。マージ可否の完全な判定には `gh pr view --json mergeable,reviewDecision` の確認を併用すること。コメントが 30 件超の場合は `?per_page=100` や `--paginate` でページネーションを指定すること。
 
 ```bash
 gh api repos/{owner}/{repo}/pulls/{number}/comments \
@@ -37,8 +39,9 @@ gh api repos/{owner}/{repo}/pulls/{number}/comments \
 
 1. 全コメントから「返信コメント」の `in_reply_to_id` を収集 → `$replied`
 2. トップレベルコメント（`in_reply_to_id == null`）のうち、`$replied` に含まれないもの = 未返信
-3. `body` は先頭 300 文字に切り詰め、全文が必要なら個別に読む
-4. bot の自動コメント（coderabbitai の summary 等）は分析対象外
+3. 「未返信」≠「未解決」。返信済みだがスレッドが未解決の場合はこの方式では検出されない
+4. `body` は先頭 300 文字に切り詰め、全文が必要なら個別に読む
+5. bot の自動コメント（coderabbitai の summary 等）は分析対象外
 
 ## Step 2: コメント分析
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -98,7 +98,7 @@ jobs:
           bun-version: "1.2"
       - name: Install & Build Admin
         working-directory: admin
-        run: bun install && bun run build
+        run: bun install --frozen-lockfile && bun run build
         env:
           VITE_API_BASE_URL: ${{ vars.API_BASE_URL }}
           VITE_MAIN_APP_URL: ${{ vars.MAIN_APP_URL || 'https://zedi-note.app' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,9 @@ bun run test:run       # Vitest 単体テスト
 
 ### 1. 未対応コメントの取得
 
-返信済みコメントを除外し、未対応のものだけ取得する（新規セッションでも動作する）:
+**注意**: 以下は「未返信」のトップレベルコメントを取得する方式。GitHub の `Require conversation resolution before merging` は「未解決のスレッド」をブロックするため、返信済みだが未解決のスレッドはこの方式では検出されない。マージ可否の完全な判定には、PR の `mergeable` 状態や `reviewDecision` の確認を併用すること。
+
+返信済みコメントを除外し、未返信のトップレベルコメントを取得する（新規セッションでも動作する）:
 
 ```bash
 gh api repos/{owner}/{repo}/pulls/{number}/comments \
@@ -59,6 +61,8 @@ gh api repos/{owner}/{repo}/pulls/{number}/comments \
     [.[] | select(.in_reply_to_id == null and (.id | IN($replied[]) | not))]
     | .[] | {id, path, line, body: (.body | .[0:300]), user: .user.login}'
 ```
+
+コメントが 30 件を超える場合は `?per_page=100` や `--paginate` でページネーションを指定すること。
 
 ### 2. PR の自動検出
 

--- a/docs/reviews/review-develop-vs-main-20260314-1.md
+++ b/docs/reviews/review-develop-vs-main-20260314-1.md
@@ -1,0 +1,99 @@
+# セルフレビュー: develop vs main
+
+**日時**: 2026-03-14 00:14
+**ベース**: main
+**変更ファイル数**: 16 files（`main..develop` のツリー差分）
+**関連ファイル数**: 7 files（`docs/guides/branch-strategy.md`, `usePageQueries`, `StorageAdapterPageRepository`, `ImageNodeView`, `StorageImageExtension`, `useMarkdownExport`, `PageEditorContent` を追加確認）
+
+## サマリー
+
+現在の作業ブランチは `develop` のため、`develop..HEAD` にローカル差分はない。レビュー対象は `main` に未反映の `develop` 側 4 コミットで、実質的な変更は Web Clipper の UX 改善、WikiLink サジェスト抑制、PR レビュー運用ドキュメント更新、Cloudflare Pages 本番 deploy retry の 4 つに集中していた。
+
+WikiLink 側の実装と E2E 追加は概ね妥当で、閉じた `[[...]]` 内でサジェストを出さない目的は達成できている。一方で Web Clipper にはゲスト利用を壊す挙動回帰と非同期 race、運用ドキュメントには GitHub の conversation resolution とずれる記述、さらに変更ファイル自身の `format:check` 失敗が残っている。
+
+## 対象コミット
+
+| コミット  | 概要                                                                                               |
+| --------- | -------------------------------------------------------------------------------------------------- |
+| `9472775` | `fix(ci): add timeout_minutes to deploy-prod retry (#346)`                                         |
+| `d5ea28a` | `fix(editor): wikilink 入力補助を閉じた ]] 内では発動させない (#348)`                              |
+| `116e585` | `feat(web-clipper): auto-parse on paste, remove citation block, embed OGP thumbnail (#339) (#350)` |
+| `13a3ba9` | `Merge pull request #345 from otomatty/main`                                                       |
+
+## ファイルサイズ
+
+| ファイル                                                       | 行数 | 判定                           |
+| -------------------------------------------------------------- | ---- | ------------------------------ |
+| `.cursor/skills/handle-pr-review/SKILL.md`                     | 134  | OK                             |
+| `.github/workflows/deploy-prod.yml`                            | 134  | OK                             |
+| `AGENTS.md`                                                    | 97   | OK                             |
+| `docs/investigations/web-clipper-ux-improvements.md`           | 154  | OK                             |
+| `docs/investigations/wikilink-suggestion-closed-brackets.md`   | 139  | OK                             |
+| `docs/reviews/review-wikilink-closed-brackets-20260313.md`     | 56   | OK                             |
+| `e2e/linked-pages.spec.ts`                                     | 206  | OK                             |
+| `src/components/editor/TiptapEditor/useThumbnailCommit.ts`     | 147  | OK                             |
+| `src/components/editor/WebClipperDialog.tsx`                   | 282  | Warning: 250行超（分割を推奨） |
+| `src/components/editor/extensions/WikiLinkSuggestion.tsx`      | 140  | OK                             |
+| `src/components/editor/extensions/wikiLinkSuggestionPlugin.ts` | 160  | OK                             |
+| `src/hooks/useWebClipper.test.ts`                              | 131  | OK                             |
+| `src/hooks/useWebClipper.ts`                                   | 100  | OK                             |
+| `src/lib/htmlToTiptap.test.ts`                                 | 58   | OK                             |
+| `src/lib/htmlToTiptap.ts`                                      | 189  | OK                             |
+| `src/lib/thumbnailCommit.ts`                                   | 71   | OK                             |
+
+## 指摘事項
+
+### 🔴 Critical（マージ前に修正必須）
+
+| #   | ファイル                                                                                                                                                                                                                                                           | 行                                                                                                             | 観点                | 指摘内容                                                                                                                                                                                                                                                                                                                     | 推奨修正                                                                                                                                                                     |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `src/components/editor/WebClipperDialog.tsx`, `src/hooks/usePageQueries.ts`, `src/lib/pageRepository/StorageAdapterPageRepository.ts`                                                                                                                              | `WebClipperDialog.tsx:133-151,166-170` / `usePageQueries.ts:313-329` / `StorageAdapterPageRepository.ts:57-60` | 挙動 / 認証         | Web Clipper が OGP 画像つきページを取り込むたびに `commitThumbnailFromUrl()` を試し、401 だと `/sign-in` へ遷移して処理自体を中断する。`useCreatePage()` と `StorageAdapterPageRepository` は未ログイン時に `local-user` でローカル作成できるのに、今回の変更で「`og:image` があるだけでゲスト取り込み不可」へ後退している。 | 401 時はサインイン誘導を出しても取り込み自体は継続し、元の `thumbnailUrl` またはサムネイルなしへフォールバックする。少なくとも未ログイン時の Web Clipper はブロックしない。  |
+| 2   | `src/hooks/useWebClipper.ts`, `src/components/editor/WebClipperDialog.tsx`                                                                                                                                                                                         | `useWebClipper.ts:68-72` / `WebClipperDialog.tsx:62-71,113-123`                                                | 挙動 / データ整合性 | `reset()` が `clipIdRef` を進めないため、URL変更やダイアログ close 後でも旧リクエストが完了すると stale な `clippedContent` が state に戻る。別 URL のプレビューが再表示されたり、閉じたダイアログを開き直した直後に古い結果が見える race になる。                                                                           | `reset()` でも `clipIdRef.current += 1` して in-flight 応答を無効化する。必要なら `AbortController` を併用し、URL変更・close の両経路で前回 request を確実にキャンセルする。 |
+| 3   | `src/components/editor/TiptapEditor/useThumbnailCommit.ts`, `src/components/editor/WebClipperDialog.tsx`, `src/hooks/useWebClipper.test.ts`, `src/hooks/useWebClipper.ts`, `src/lib/htmlToTiptap.test.ts`, `src/lib/htmlToTiptap.ts`, `src/lib/thumbnailCommit.ts` | `-`                                                                                                            | プロジェクト規約    | `bun run format:check` が今回の変更ファイル 7 件で失敗している。ガイドライン上 `format:check` を通す前提のため、この状態ではマージ基準を満たしていない。                                                                                                                                                                     | 変更ファイルに `prettier --write` を適用し、`bun run format:check` が成功することを確認する。                                                                                |
+
+### 🟡 Warning（修正を推奨）
+
+| #   | ファイル                                                                                                                                                                                                                                    | 行                                                                                                                               | 観点                | 指摘内容                                                                                                                                                                                                                                                                                              | 推奨修正                                                                                                                                                              |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `src/lib/htmlToTiptap.ts`, `src/components/editor/WebClipperDialog.tsx`, `src/components/editor/TiptapEditor/useThumbnailCommit.ts`, `src/components/editor/ImageNodeView.tsx`, `src/components/editor/extensions/StorageImageExtension.ts` | `htmlToTiptap.ts:175-179` / `WebClipperDialog.tsx:137-142` / `useThumbnailCommit.ts:77-83,101-108` / `ImageNodeView.tsx:137-146` | データ整合性 / UX   | Web Clipper 経由で commit したサムネイル画像は `provider` を受け取っているのに、Tiptap の `image` node に `storageProviderId` を入れていない。既存の手動サムネイル挿入では同属性を設定しており、今回の経路だけ「保存先: 不明」表示やストレージ削除導線の判定がずれる。                                | `commitThumbnailFromUrl()` の戻り値 `provider` を `getTiptapContent` 経由で `formatClippedContentAsTiptap` に渡し、`image.attrs.storageProviderId` を付与する。       |
+| 2   | `src/lib/htmlToTiptap.ts`, `src/components/editor/PageEditor/useMarkdownExport.ts`, `src/components/editor/PageEditor/PageEditorContent.tsx`                                                                                                | `htmlToTiptap.ts:157-187` / `useMarkdownExport.ts:13-35` / `PageEditorContent.tsx:130-131`                                       | 挙動 / データ保持   | 引用元ブロックを content から完全に外したため、エディタ画面では `SourceUrlBadge` で見えていても Markdown export / copy では引用元情報が消える。クリップしたページを外部へ持ち出すと attribution が失われる。                                                                                          | 「本文内の重複表示は消すが export では source URL を残す」方針にするか、Markdown export 側で `sourceUrl` を前置するなど、持ち出し時の attribution を保持する。        |
+| 3   | `AGENTS.md`, `.cursor/skills/handle-pr-review/SKILL.md`, `docs/guides/branch-strategy.md`                                                                                                                                                   | `AGENTS.md:51-61` / `.cursor/skills/handle-pr-review/SKILL.md:23-42` / `branch-strategy.md:196-208`                              | 運用 / ドキュメント | 「返信済みコメントを除外 = 未対応コメントのみ取得」という新フローは、GitHub の `Require conversation resolution before merging` と一致していない。返信済みだが未解決の thread を見落としうえ、`gh api repos/.../pulls/{number}/comments` はデフォルト 1 page のため件数が多い PR では後半も欠落する。 | 「未返信」ではなく「未解決 thread」を取得する設計に修正し、少なくとも pagination を明示する。ドキュメント上も “未対応” と “未返信” を同一視しない。                   |
+| 4   | `.github/workflows/deploy-prod.yml`                                                                                                                                                                                                         | `99-106`                                                                                                                         | CI / 再現性         | `deploy-admin` だけ `bun install` を `--frozen-lockfile` なしで実行しており、他 job と再現性ポリシーが揃っていない。`admin/bun.lock` と実際の解決結果がずれても build が通る可能性がある。                                                                                                            | `admin` 側も `bun install --frozen-lockfile` に揃え、lockfile drift を CI で早期検知する。                                                                            |
+| 5   | `src/components/editor/WebClipperDialog.tsx`                                                                                                                                                                                                | `47-281`                                                                                                                         | 可読性・保守性      | コンポーネント全体が 282 行、`bun run lint` でも `max-lines-per-function` warning が出ている。自動解析、paste 処理、thumbnail commit、dialog reset、submit まで単一コンポーネントに責務が集中しており、今回の stale response 問題も追いにくくなっている。                                             | `useWebClipperDialogState` のような hook と、preview / footer / submit 周りの小コンポーネントへ分割する。少なくとも「clip lifecycle」と「submit lifecycle」は分ける。 |
+
+### 🟢 Info（任意の改善提案）
+
+| #   | ファイル                                                                                                                                    | 行             | 観点               | 指摘内容                                                                                                                                                                                                                                                                                                        | 推奨修正                                                                                                                  |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `docs/investigations/web-clipper-ux-improvements.md`                                                                                        | `19-29,97-125` | ドキュメント整合性 | 調査メモの「現在のフロー」が実装前提の記述のままで、`WebClipperDialog` が既に auto-clip と submit 分離へ変わった現状を反映していない。今後この文書を元に追加作業すると認識ズレを招く。                                                                                                                          | 調査メモを「検討時点の前提」と「実装後の現状」で分けるか、現状セクションを更新する。                                      |
+| 2   | `docs/investigations/wikilink-suggestion-closed-brackets.md`                                                                                | `37-43`        | ドキュメント整合性 | `[[A]] [[B]]` の `"B" の途中` を「この例は意図通りでよい」としているが、文書冒頭の要件と現実装はどちらも「閉じた `[[...]]` 内では発動させない」方向。表の 1 行だけ要件と逆になっている。                                                                                                                        | 例表を現在の仕様に合わせて修正する。                                                                                      |
+| 3   | `src/components/editor/WebClipperDialog.tsx`, `src/hooks/useWebClipper.test.ts`, `src/lib/htmlToTiptap.test.ts`, `e2e/linked-pages.spec.ts` | `-`            | テスト             | `useWebClipper` と `htmlToTiptap` の単体テストは追加されているが、今回の高リスク経路である guest clipping、close/URL change race、thumbnail commit の provider 伝播にはテストがない。WikiLink 側も「閉じたリンク内で出ない」は E2E 追加済みだが、同一段落で新しい `[[` を打ったとき再び出る正方向ケースがない。 | Web Clipper は `WebClipperDialog` に統合テストを追加し、WikiLink は positive case を 1 本足して over-suppression を防ぐ。 |
+
+## テストカバレッジ
+
+| 変更ファイル                                                                                            | テストファイル                    | 状態                                            |
+| ------------------------------------------------------------------------------------------------------- | --------------------------------- | ----------------------------------------------- |
+| `src/hooks/useWebClipper.ts`                                                                            | `src/hooks/useWebClipper.test.ts` | ✅ 既存テスト更新あり                           |
+| `src/lib/htmlToTiptap.ts`                                                                               | `src/lib/htmlToTiptap.test.ts`    | ✅ 既存テスト更新あり                           |
+| `src/components/editor/extensions/wikiLinkSuggestionPlugin.ts`                                          | `e2e/linked-pages.spec.ts`        | ✅ E2E 追加あり（単体テストは未作成）           |
+| `src/components/editor/WebClipperDialog.tsx`                                                            | -                                 | ⚠️ 専用テスト未作成                             |
+| `src/components/editor/TiptapEditor/useThumbnailCommit.ts`, `src/lib/thumbnailCommit.ts`                | -                                 | ⚠️ 専用テスト未作成                             |
+| `AGENTS.md`, `.cursor/skills/handle-pr-review/SKILL.md`, `.github/workflows/deploy-prod.yml`, `docs/**` | -                                 | ℹ️ ドキュメント / CI 設定のため自動テスト対象外 |
+
+## Lint / Format チェック
+
+- `bun run lint`: **0 errors, 80 warnings**。今回の変更ファイルで直接目立つものは `src/components/editor/WebClipperDialog.tsx` の `max-lines-per-function` warning。その他の warning は既存ファイルに広く分布している。
+- `bun run format:check`: **失敗**。対象は `src/components/editor/TiptapEditor/useThumbnailCommit.ts`, `src/components/editor/WebClipperDialog.tsx`, `src/hooks/useWebClipper.test.ts`, `src/hooks/useWebClipper.ts`, `src/lib/htmlToTiptap.test.ts`, `src/lib/htmlToTiptap.ts`, `src/lib/thumbnailCommit.ts`。
+- `bun run test:run src/hooks/useWebClipper.test.ts src/lib/htmlToTiptap.test.ts`: **10 tests passed**。ただし `htmlToTiptap.test.ts` 実行時に Tiptap の `Duplicate extension names found: ['link']` warning は出ている。
+
+## セキュリティ・設計メモ
+
+- `htmlToTiptap.ts` は `DOMParser` を使い、`script`, `iframe`, `object`, `embed` などを除去しており、危険な HTML をそのまま editor に渡さない方向性は妥当。
+- `wikiLinkSuggestionPlugin.ts` の `textAfter` 判定は閉じた `[[...]]` 内抑制としてシンプルで、現状の E2E と整合している。今回確認した範囲では即時の回帰は見当たらなかった。
+- Web Clipper の変更は UX 改善意図自体は良いが、「guest も使える local-first 設計」と「storage-aware image node」の既存設計を部分的に外している。既存責務との接続点まで含めて再調整が必要。
+
+## 統計
+
+- Critical: 3 件
+- Warning: 5 件
+- Info: 3 件

--- a/src/components/editor/PageEditor/useMarkdownExport.ts
+++ b/src/components/editor/PageEditor/useMarkdownExport.ts
@@ -10,19 +10,23 @@ interface UseMarkdownExportReturn {
 /**
  * Hook for markdown export functionality
  */
-export function useMarkdownExport(title: string, content: string): UseMarkdownExportReturn {
+export function useMarkdownExport(
+  title: string,
+  content: string,
+  sourceUrl?: string | null,
+): UseMarkdownExportReturn {
   const { toast } = useToast();
 
   const handleExportMarkdown = useCallback(() => {
-    downloadMarkdown(title, content);
+    downloadMarkdown(title, content, sourceUrl);
     toast({
       title: "Markdownファイルをダウンロードしました",
     });
-  }, [title, content, toast]);
+  }, [title, content, sourceUrl, toast]);
 
   const handleCopyMarkdown = useCallback(async () => {
     try {
-      await copyMarkdownToClipboard(title, content);
+      await copyMarkdownToClipboard(title, content, sourceUrl);
       toast({
         title: "Markdownをクリップボードにコピーしました",
       });
@@ -32,7 +36,7 @@ export function useMarkdownExport(title: string, content: string): UseMarkdownEx
         variant: "destructive",
       });
     }
-  }, [title, content, toast]);
+  }, [title, content, sourceUrl, toast]);
 
   return {
     handleExportMarkdown,

--- a/src/components/editor/PageEditor/useMarkdownExport.ts
+++ b/src/components/editor/PageEditor/useMarkdownExport.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { downloadMarkdown, copyMarkdownToClipboard } from "@/lib/markdownExport";
 import { useToast } from "@zedi/ui";
 
@@ -15,28 +16,35 @@ export function useMarkdownExport(
   content: string,
   sourceUrl?: string | null,
 ): UseMarkdownExportReturn {
+  const { t } = useTranslation();
   const { toast } = useToast();
 
   const handleExportMarkdown = useCallback(() => {
-    downloadMarkdown(title, content, sourceUrl);
-    toast({
-      title: "Markdownファイルをダウンロードしました",
+    downloadMarkdown(title, content, sourceUrl, {
+      defaultTitle: t("notes.untitledPage"),
+      attributionLabel: t("editor.markdownExport.sourceAttribution"),
     });
-  }, [title, content, sourceUrl, toast]);
+    toast({
+      title: t("editor.markdownExport.downloaded"),
+    });
+  }, [title, content, sourceUrl, toast, t]);
 
   const handleCopyMarkdown = useCallback(async () => {
     try {
-      await copyMarkdownToClipboard(title, content, sourceUrl);
+      await copyMarkdownToClipboard(title, content, sourceUrl, {
+        defaultTitle: t("notes.untitledPage"),
+        attributionLabel: t("editor.markdownExport.sourceAttribution"),
+      });
       toast({
-        title: "Markdownをクリップボードにコピーしました",
+        title: t("editor.markdownExport.copied"),
       });
     } catch {
       toast({
-        title: "コピーに失敗しました",
+        title: t("editor.markdownExport.copyFailed"),
         variant: "destructive",
       });
     }
-  }, [title, content, sourceUrl, toast]);
+  }, [title, content, sourceUrl, toast, t]);
 
   return {
     handleExportMarkdown,

--- a/src/components/editor/PageEditor/usePageEditorStateAndSync.ts
+++ b/src/components/editor/PageEditor/usePageEditorStateAndSync.ts
@@ -86,7 +86,7 @@ export function usePageEditorStateAndSync() {
     shouldBlockSave,
   });
 
-  const { handleExportMarkdown, handleCopyMarkdown } = useMarkdownExport(title, content);
+  const { handleExportMarkdown, handleCopyMarkdown } = useMarkdownExport(title, content, sourceUrl);
   usePageEditorKeyboard({ onBack: handleBack });
 
   const {

--- a/src/components/editor/WebClipperDialog.tsx
+++ b/src/components/editor/WebClipperDialog.tsx
@@ -1,25 +1,18 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
-import { Link2, Loader2, AlertCircle, Check, ExternalLink } from "lucide-react";
-import { Button } from "@zedi/ui";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
+import { Link2, Loader2, AlertCircle } from "lucide-react";
 import { Input } from "@zedi/ui";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@zedi/ui";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@zedi/ui";
 import { Alert, AlertDescription } from "@zedi/ui";
 import { useNavigate } from "react-router-dom";
 import { useWebClipper, type WebClipperStatus } from "@/hooks/useWebClipper";
-import { isValidUrl } from "@/lib/webClipper";
 import { useAuth } from "@/hooks/useAuth";
 import { createApiClient } from "@/lib/api";
-import { useDebouncedCallback } from "@/hooks/useDebouncedCallback";
 import { commitThumbnailFromUrl, AuthRedirectError } from "@/lib/thumbnailCommit";
 import { getThumbnailApiBaseUrl } from "@/components/editor/TiptapEditor/thumbnailApiHelpers";
 import { useToast } from "@zedi/ui";
+import { useWebClipperDialogState } from "./useWebClipperDialogState";
+import { WebClipperDialogPreview } from "./WebClipperDialogPreview";
+import { WebClipperDialogFooter } from "./WebClipperDialogFooter";
 
 function isAuthRedirectError(err: unknown): err is AuthRedirectError {
   return err instanceof AuthRedirectError;
@@ -51,83 +44,25 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
 }) => {
   const { getToken } = useAuth();
   const api = useMemo(() => createApiClient({ getToken }), [getToken]);
-  const [url, setUrl] = useState("");
-  const [urlError, setUrlError] = useState<string | null>(null);
   const { status, clippedContent, error, clip, reset, getTiptapContent } = useWebClipper({ api });
-  const lastClippedUrlRef = useRef<string>("");
+  const { url, setUrl, urlError, setUrlError, lastClippedUrlRef, handlePaste } =
+    useWebClipperDialogState({ open, clip, reset });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
   const navigate = useNavigate();
 
-  // URL変更時に前回の解析結果をリセット（進行中の clip は潰さない）
-  // status を deps に含めると完了/エラー直後に自ら結果を消してしまうため、url 変更時のみ判定
-  useEffect(() => {
-    if (!url) {
-      lastClippedUrlRef.current = "";
-      reset();
-    } else if (url !== lastClippedUrlRef.current) {
-      reset();
-    }
-  }, [url, reset]);
-
-  // エラー時に lastClippedUrlRef をクリアして同一URLのリトライを可能に
   useEffect(() => {
     if (status === "error") {
       lastClippedUrlRef.current = "";
     }
-  }, [status]);
+  }, [status, lastClippedUrlRef]);
 
-  // 有効なURLを検知したら自動で clip を実行（debounce 500ms）
-  const triggerAutoClip = useDebouncedCallback(
-    useCallback(() => {
-      const trimmed = url.trim();
-      if (!trimmed || !isValidUrl(trimmed)) return;
-      if (trimmed === lastClippedUrlRef.current) return;
-      lastClippedUrlRef.current = trimmed;
-      clip(trimmed);
-    }, [url, clip]),
-    500,
-  );
-
-  useEffect(() => {
-    triggerAutoClip();
-  }, [url, triggerAutoClip]);
-
-  // 貼り付け時に有効なURLなら即時 clip
-  const handlePaste = useCallback(
-    (e: React.ClipboardEvent) => {
-      const text = e.clipboardData.getData("text").trim();
-      if (text && isValidUrl(text)) {
-        e.preventDefault();
-        setUrl(text);
-        setUrlError(null);
-        if (text !== lastClippedUrlRef.current) {
-          lastClippedUrlRef.current = text;
-          clip(text);
-        }
-      }
-    },
-    [clip],
-  );
-
-  // ダイアログを閉じたときにリセット
-  useEffect(() => {
-    if (!open) {
-      queueMicrotask(() => {
-        setUrl("");
-        setUrlError(null);
-      });
-      lastClippedUrlRef.current = "";
-      reset();
-    }
-  }, [open, reset]);
-
-  // 取り込み実行（clippedContent をそのまま使用、再 fetch なし）
-  const handleClip = async () => {
+  const handleClip = useCallback(async () => {
     if (!clippedContent) return;
 
     setIsSubmitting(true);
     let committedThumbnail: string | undefined;
+    let committedProvider: string | undefined;
     let commitAttemptedAndFailed = false;
     try {
       if (clippedContent.thumbnailUrl) {
@@ -139,6 +74,7 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
               title: clippedContent.title,
             });
             committedThumbnail = result.imageUrl;
+            committedProvider = result.provider;
           }
         } catch (err) {
           if (isAuthRedirectError(err)) {
@@ -161,7 +97,7 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
       }
       const thumbnailForContent =
         committedThumbnail ?? (commitAttemptedAndFailed ? "" : clippedContent.thumbnailUrl);
-      const tiptapContent = getTiptapContent(thumbnailForContent);
+      const tiptapContent = getTiptapContent(thumbnailForContent, committedProvider);
       if (tiptapContent) {
         onClipped(
           clippedContent.title,
@@ -174,18 +110,19 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
     } finally {
       setIsSubmitting(false);
     }
-  };
+  }, [clippedContent, getTiptapContent, navigate, onClipped, onOpenChange, toast]);
 
-  // Enterキーで実行
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && clippedContent && !isSubmitting) {
-      e.preventDefault();
-      handleClip();
-    }
-  };
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && clippedContent && !isSubmitting) {
+        e.preventDefault();
+        handleClip();
+      }
+    },
+    [clippedContent, isSubmitting, handleClip],
+  );
 
   const isProcessing = status === "fetching" || status === "extracting";
-  const isCompleted = status === "completed";
   const isBusy = isProcessing || isSubmitting;
 
   return (
@@ -202,7 +139,6 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
         </DialogHeader>
 
         <div className="space-y-4 py-4">
-          {/* URL入力 */}
           <div className="space-y-2">
             <Input
               placeholder="https://example.com/article"
@@ -220,7 +156,6 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
             {urlError && <p className="text-sm text-destructive">{urlError}</p>}
           </div>
 
-          {/* ステータス表示 */}
           {isProcessing && (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
@@ -228,22 +163,10 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
             </div>
           )}
 
-          {/* 成功時のプレビュー */}
-          {isCompleted && clippedContent && (
-            <Alert className="border-green-500/50 bg-green-50 dark:bg-green-950/20">
-              <Check className="h-4 w-4 text-green-600" />
-              <AlertDescription className="text-green-800 dark:text-green-200">
-                <div className="space-y-1">
-                  <div className="font-medium">{clippedContent.title}</div>
-                  {clippedContent.siteName && (
-                    <div className="text-xs opacity-70">{clippedContent.siteName}</div>
-                  )}
-                </div>
-              </AlertDescription>
-            </Alert>
+          {status === "completed" && clippedContent && (
+            <WebClipperDialogPreview clippedContent={clippedContent} />
           )}
 
-          {/* エラー表示 */}
           {error && (
             <Alert variant="destructive">
               <AlertCircle className="h-4 w-4" />
@@ -251,30 +174,17 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
             </Alert>
           )}
 
-          {/* 注意書き */}
           <p className="text-xs text-muted-foreground">
             💡 対応していないページもあります。著作権にご注意ください。
           </p>
         </div>
 
-        <DialogFooter className="gap-2 sm:gap-0">
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isBusy}>
-            キャンセル
-          </Button>
-          <Button onClick={handleClip} disabled={isBusy || !clippedContent}>
-            {isBusy ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                取り込み中...
-              </>
-            ) : (
-              <>
-                <ExternalLink className="mr-2 h-4 w-4" />
-                取り込み
-              </>
-            )}
-          </Button>
-        </DialogFooter>
+        <WebClipperDialogFooter
+          isBusy={isBusy}
+          hasContent={Boolean(clippedContent)}
+          onCancel={() => onOpenChange(false)}
+          onSubmit={handleClip}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/editor/WebClipperDialog.tsx
+++ b/src/components/editor/WebClipperDialog.tsx
@@ -48,8 +48,8 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
   const { getToken } = useAuth();
   const api = useMemo(() => createApiClient({ getToken }), [getToken]);
   const { status, clippedContent, error, clip, reset, getTiptapContent } = useWebClipper({ api });
-  const { url, setUrl, urlError, setUrlError, lastClippedUrlRef, handlePaste } =
-    useWebClipperDialogState({ open, clip, reset });
+  const { url, setUrl, urlError, setUrlError, lastClippedUrlRef, handlePaste, resetDialogState } =
+    useWebClipperDialogState({ clip, reset });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
 
@@ -58,6 +58,16 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
       lastClippedUrlRef.current = "";
     }
   }, [status, lastClippedUrlRef]);
+
+  const handleDialogOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        resetDialogState();
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange, resetDialogState],
+  );
 
   const handleClip = useCallback(async () => {
     if (!clippedContent) return;
@@ -112,12 +122,12 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
           clippedContent.sourceUrl,
           committedThumbnail ?? undefined,
         );
-        onOpenChange(false);
+        handleDialogOpenChange(false);
       }
     } finally {
       setIsSubmitting(false);
     }
-  }, [clippedContent, getTiptapContent, onClipped, onOpenChange, toast, t]);
+  }, [clippedContent, getTiptapContent, onClipped, handleDialogOpenChange, toast, t]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -133,7 +143,7 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
   const isBusy = isProcessing || isSubmitting;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
@@ -185,7 +195,7 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
         <WebClipperDialogFooter
           isBusy={isBusy}
           hasContent={Boolean(clippedContent)}
-          onCancel={() => onOpenChange(false)}
+          onCancel={() => handleDialogOpenChange(false)}
           onSubmit={handleClip}
         />
       </DialogContent>

--- a/src/components/editor/WebClipperDialog.tsx
+++ b/src/components/editor/WebClipperDialog.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { Link2, Loader2, AlertCircle } from "lucide-react";
 import { Input } from "@zedi/ui";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@zedi/ui";
 import { Alert, AlertDescription } from "@zedi/ui";
-import { useNavigate } from "react-router-dom";
 import { useWebClipper, type WebClipperStatus } from "@/hooks/useWebClipper";
 import { useAuth } from "@/hooks/useAuth";
 import { createApiClient } from "@/lib/api";
@@ -29,19 +29,22 @@ interface WebClipperDialogProps {
   ) => void;
 }
 
-const statusMessages: Record<WebClipperStatus, string> = {
-  idle: "",
-  fetching: "ページを取得中...",
-  extracting: "本文を抽出中...",
-  completed: "取り込み完了",
-  error: "",
-};
-
 export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
   open,
   onOpenChange,
   onClipped,
 }) => {
+  const { t } = useTranslation();
+  const statusMessages: Record<WebClipperStatus, string> = useMemo(
+    () => ({
+      idle: "",
+      fetching: t("editor.webClipper.statusFetching"),
+      extracting: t("editor.webClipper.statusExtracting"),
+      completed: t("editor.webClipper.statusCompleted"),
+      error: "",
+    }),
+    [t],
+  );
   const { getToken } = useAuth();
   const api = useMemo(() => createApiClient({ getToken }), [getToken]);
   const { status, clippedContent, error, clip, reset, getTiptapContent } = useWebClipper({ api });
@@ -49,7 +52,6 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
     useWebClipperDialogState({ open, clip, reset });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
-  const navigate = useNavigate();
 
   useEffect(() => {
     if (status === "error") {
@@ -79,24 +81,29 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
         } catch (err) {
           if (isAuthRedirectError(err)) {
             toast({
-              title: "ログインが必要です",
-              description: "再度ログインしてください",
+              title: t("editor.webClipper.loginRequired"),
+              description: t("editor.webClipper.loginRequiredDescription"),
               variant: "destructive",
             });
-            navigate("/sign-in", { replace: true });
-            return;
+            commitAttemptedAndFailed = true;
+            // Continue importing content without thumbnail; do not redirect
+          } else {
+            console.error("Failed to commit thumbnail:", err);
+            toast({
+              title: t("editor.webClipper.thumbnailSaveFailed"),
+              description: t("editor.webClipper.thumbnailSaveFailedDescription"),
+              variant: "destructive",
+            });
+            commitAttemptedAndFailed = true;
           }
-          console.error("Failed to commit thumbnail:", err);
-          toast({
-            title: "サムネイルの保存に失敗しました",
-            description: "コンテンツはそのまま取り込みます。",
-            variant: "destructive",
-          });
-          commitAttemptedAndFailed = true;
         }
       }
-      const thumbnailForContent =
-        committedThumbnail ?? (commitAttemptedAndFailed ? "" : clippedContent.thumbnailUrl);
+      let thumbnailForContent = clippedContent.thumbnailUrl;
+      if (committedThumbnail) {
+        thumbnailForContent = committedThumbnail;
+      } else if (commitAttemptedAndFailed) {
+        thumbnailForContent = "";
+      }
       const tiptapContent = getTiptapContent(thumbnailForContent, committedProvider);
       if (tiptapContent) {
         onClipped(
@@ -110,7 +117,7 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
     } finally {
       setIsSubmitting(false);
     }
-  }, [clippedContent, getTiptapContent, navigate, onClipped, onOpenChange, toast]);
+  }, [clippedContent, getTiptapContent, onClipped, onOpenChange, toast, t]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -131,17 +138,15 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Link2 className="h-5 w-5" />
-            URLから取り込み
+            {t("editor.webClipper.title")}
           </DialogTitle>
-          <DialogDescription>
-            Webページの本文を抽出してページとして保存します。 引用元URLは自動的に記録されます。
-          </DialogDescription>
+          <DialogDescription>{t("editor.webClipper.description")}</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 py-4">
           <div className="space-y-2">
             <Input
-              placeholder="https://example.com/article"
+              placeholder={t("editor.webClipper.placeholder")}
               value={url}
               onChange={(e) => {
                 setUrl(e.target.value);
@@ -174,9 +179,7 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
             </Alert>
           )}
 
-          <p className="text-xs text-muted-foreground">
-            💡 対応していないページもあります。著作権にご注意ください。
-          </p>
+          <p className="text-xs text-muted-foreground">{t("editor.webClipper.tip")}</p>
         </div>
 
         <WebClipperDialogFooter

--- a/src/components/editor/WebClipperDialogFooter.tsx
+++ b/src/components/editor/WebClipperDialogFooter.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Loader2, ExternalLink } from "lucide-react";
 import { Button, DialogFooter } from "@zedi/ui";
 
@@ -14,23 +15,26 @@ export const WebClipperDialogFooter: React.FC<WebClipperDialogFooterProps> = ({
   hasContent,
   onCancel,
   onSubmit,
-}) => (
-  <DialogFooter className="gap-2 sm:gap-0">
-    <Button variant="outline" onClick={onCancel} disabled={isBusy}>
-      キャンセル
-    </Button>
-    <Button onClick={onSubmit} disabled={isBusy || !hasContent}>
-      {isBusy ? (
-        <>
-          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          取り込み中...
-        </>
-      ) : (
-        <>
-          <ExternalLink className="mr-2 h-4 w-4" />
-          取り込み
-        </>
-      )}
-    </Button>
-  </DialogFooter>
-);
+}) => {
+  const { t } = useTranslation();
+  return (
+    <DialogFooter className="gap-2 sm:gap-0">
+      <Button variant="outline" onClick={onCancel} disabled={isBusy}>
+        {t("editor.webClipper.cancel")}
+      </Button>
+      <Button onClick={onSubmit} disabled={isBusy || !hasContent}>
+        {isBusy ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            {t("editor.webClipper.importing")}
+          </>
+        ) : (
+          <>
+            <ExternalLink className="mr-2 h-4 w-4" />
+            {t("editor.webClipper.import")}
+          </>
+        )}
+      </Button>
+    </DialogFooter>
+  );
+};

--- a/src/components/editor/WebClipperDialogFooter.tsx
+++ b/src/components/editor/WebClipperDialogFooter.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Loader2, ExternalLink } from "lucide-react";
+import { Button, DialogFooter } from "@zedi/ui";
+
+interface WebClipperDialogFooterProps {
+  isBusy: boolean;
+  hasContent: boolean;
+  onCancel: () => void;
+  onSubmit: () => void;
+}
+
+export const WebClipperDialogFooter: React.FC<WebClipperDialogFooterProps> = ({
+  isBusy,
+  hasContent,
+  onCancel,
+  onSubmit,
+}) => (
+  <DialogFooter className="gap-2 sm:gap-0">
+    <Button variant="outline" onClick={onCancel} disabled={isBusy}>
+      キャンセル
+    </Button>
+    <Button onClick={onSubmit} disabled={isBusy || !hasContent}>
+      {isBusy ? (
+        <>
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          取り込み中...
+        </>
+      ) : (
+        <>
+          <ExternalLink className="mr-2 h-4 w-4" />
+          取り込み
+        </>
+      )}
+    </Button>
+  </DialogFooter>
+);

--- a/src/components/editor/WebClipperDialogPreview.tsx
+++ b/src/components/editor/WebClipperDialogPreview.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Check } from "lucide-react";
+import { Alert, AlertDescription } from "@zedi/ui";
+import type { ClippedContent } from "@/lib/webClipper";
+
+interface WebClipperDialogPreviewProps {
+  clippedContent: ClippedContent;
+}
+
+export const WebClipperDialogPreview: React.FC<WebClipperDialogPreviewProps> = ({
+  clippedContent,
+}) => (
+  <Alert className="border-green-500/50 bg-green-50 dark:bg-green-950/20">
+    <Check className="h-4 w-4 text-green-600" />
+    <AlertDescription className="text-green-800 dark:text-green-200">
+      <div className="space-y-1">
+        <div className="font-medium">{clippedContent.title}</div>
+        {clippedContent.siteName && (
+          <div className="text-xs opacity-70">{clippedContent.siteName}</div>
+        )}
+      </div>
+    </AlertDescription>
+  </Alert>
+);

--- a/src/components/editor/useWebClipperDialogState.ts
+++ b/src/components/editor/useWebClipperDialogState.ts
@@ -4,6 +4,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useDebouncedCallback } from "@/hooks/useDebouncedCallback";
 import { isValidUrl } from "@/lib/webClipper";
+
 interface UseWebClipperDialogStateOptions {
   open: boolean;
   clip: (url: string) => Promise<unknown>;

--- a/src/components/editor/useWebClipperDialogState.ts
+++ b/src/components/editor/useWebClipperDialogState.ts
@@ -38,10 +38,12 @@ export function useWebClipperDialogState({ open, clip, reset }: UseWebClipperDia
 
   useEffect(() => {
     if (!open) {
-      queueMicrotask(() => {
-        setUrl("");
-        setUrlError(null);
-      });
+      // Sync clear to avoid race: if we deferred (queueMicrotask), a fast reopen could
+      // let the deferred clear run after user typed, wiping their input.
+      /* eslint-disable react-hooks/set-state-in-effect -- intentional sync reset on close */
+      setUrl("");
+      setUrlError(null);
+      /* eslint-enable react-hooks/set-state-in-effect */
       lastClippedUrlRef.current = "";
       reset();
     }

--- a/src/components/editor/useWebClipperDialogState.ts
+++ b/src/components/editor/useWebClipperDialogState.ts
@@ -1,0 +1,77 @@
+/**
+ * Web Clipper ダイアログの URL 入力・自動 clip・リセットを管理する hook
+ */
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useDebouncedCallback } from "@/hooks/useDebouncedCallback";
+import { isValidUrl } from "@/lib/webClipper";
+interface UseWebClipperDialogStateOptions {
+  open: boolean;
+  clip: (url: string) => Promise<unknown>;
+  reset: () => void;
+}
+
+export function useWebClipperDialogState({ open, clip, reset }: UseWebClipperDialogStateOptions) {
+  const [url, setUrl] = useState("");
+  const [urlError, setUrlError] = useState<string | null>(null);
+  const lastClippedUrlRef = useRef<string>("");
+
+  const triggerAutoClip = useDebouncedCallback(
+    useCallback(() => {
+      const trimmed = url.trim();
+      if (!trimmed || !isValidUrl(trimmed)) return;
+      if (trimmed === lastClippedUrlRef.current) return;
+      lastClippedUrlRef.current = trimmed;
+      clip(trimmed);
+    }, [url, clip]),
+    500,
+  );
+
+  useEffect(() => {
+    if (!url) {
+      lastClippedUrlRef.current = "";
+      reset();
+    } else if (url !== lastClippedUrlRef.current) {
+      reset();
+    }
+  }, [url, reset]);
+
+  useEffect(() => {
+    if (!open) {
+      queueMicrotask(() => {
+        setUrl("");
+        setUrlError(null);
+      });
+      lastClippedUrlRef.current = "";
+      reset();
+    }
+  }, [open, reset]);
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      const text = e.clipboardData.getData("text").trim();
+      if (text && isValidUrl(text)) {
+        e.preventDefault();
+        setUrl(text);
+        setUrlError(null);
+        if (text !== lastClippedUrlRef.current) {
+          lastClippedUrlRef.current = text;
+          clip(text);
+        }
+      }
+    },
+    [clip],
+  );
+
+  useEffect(() => {
+    triggerAutoClip();
+  }, [url, triggerAutoClip]);
+
+  return {
+    url,
+    setUrl,
+    urlError,
+    setUrlError,
+    lastClippedUrlRef,
+    handlePaste,
+  };
+}

--- a/src/components/editor/useWebClipperDialogState.ts
+++ b/src/components/editor/useWebClipperDialogState.ts
@@ -6,12 +6,11 @@ import { useDebouncedCallback } from "@/hooks/useDebouncedCallback";
 import { isValidUrl } from "@/lib/webClipper";
 
 interface UseWebClipperDialogStateOptions {
-  open: boolean;
   clip: (url: string) => Promise<unknown>;
   reset: () => void;
 }
 
-export function useWebClipperDialogState({ open, clip, reset }: UseWebClipperDialogStateOptions) {
+export function useWebClipperDialogState({ clip, reset }: UseWebClipperDialogStateOptions) {
   const [url, setUrl] = useState("");
   const [urlError, setUrlError] = useState<string | null>(null);
   const lastClippedUrlRef = useRef<string>("");
@@ -36,18 +35,12 @@ export function useWebClipperDialogState({ open, clip, reset }: UseWebClipperDia
     }
   }, [url, reset]);
 
-  useEffect(() => {
-    if (!open) {
-      // Sync clear to avoid race: if we deferred (queueMicrotask), a fast reopen could
-      // let the deferred clear run after user typed, wiping their input.
-      /* eslint-disable react-hooks/set-state-in-effect -- intentional sync reset on close */
-      setUrl("");
-      setUrlError(null);
-      /* eslint-enable react-hooks/set-state-in-effect */
-      lastClippedUrlRef.current = "";
-      reset();
-    }
-  }, [open, reset]);
+  const resetDialogState = useCallback(() => {
+    setUrl("");
+    setUrlError(null);
+    lastClippedUrlRef.current = "";
+    reset();
+  }, [reset]);
 
   const handlePaste = useCallback(
     (e: React.ClipboardEvent) => {
@@ -76,5 +69,6 @@ export function useWebClipperDialogState({ open, clip, reset }: UseWebClipperDia
     setUrlError,
     lastClippedUrlRef,
     handlePaste,
+    resetDialogState,
   };
 }

--- a/src/components/layout/FABMenu.tsx
+++ b/src/components/layout/FABMenu.tsx
@@ -56,16 +56,24 @@ interface FABMenuProps {
   onOpenChange: (open: boolean) => void;
   onSelect: (option: FABMenuOption) => void;
   trigger: React.ReactNode;
+  /** Options to hide from the menu (e.g. auth-gated features for guests) */
+  hiddenOptions?: FABMenuOption[];
 }
 
-export const FABMenu: React.FC<FABMenuProps> = ({ open, onOpenChange, onSelect, trigger }) => {
+export const FABMenu: React.FC<FABMenuProps> = ({
+  open,
+  onOpenChange,
+  onSelect,
+  trigger,
+  hiddenOptions,
+}) => {
   const { t } = useTranslation();
   const handleSelect = (option: FABMenuOption) => {
     onSelect(option);
     onOpenChange(false);
   };
 
-  const menuItems: Array<{
+  const allItems: Array<{
     icon: React.ElementType;
     label: string;
     option: FABMenuOption;
@@ -75,6 +83,10 @@ export const FABMenu: React.FC<FABMenuProps> = ({ open, onOpenChange, onSelect, 
     { icon: Link2, label: t("common.createFromUrl"), option: "url" },
     { icon: FileText, label: t("common.createNew"), option: "blank" },
   ];
+
+  const menuItems = hiddenOptions
+    ? allItems.filter((item) => !hiddenOptions.includes(item.option))
+    : allItems;
 
   return (
     <>

--- a/src/components/layout/FloatingActionButton.tsx
+++ b/src/components/layout/FloatingActionButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Plus, X } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@zedi/ui";
@@ -24,6 +24,12 @@ const FloatingActionButton: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isWebClipperOpen, setIsWebClipperOpen] = useState(false);
   const [isImageDialogOpen, setIsImageDialogOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isSignedIn) {
+      queueMicrotask(() => setIsWebClipperOpen(false));
+    }
+  }, [isSignedIn]);
 
   const handleMenuSelect = async (option: FABMenuOption) => {
     switch (option) {
@@ -80,7 +86,7 @@ const FloatingActionButton: React.FC = () => {
     } catch (error) {
       console.error("Failed to create page from URL:", error);
       toast({
-        title: "ページの作成に失敗しました",
+        title: t("common.createPageFailed"),
         variant: "destructive",
       });
     }
@@ -125,7 +131,7 @@ const FloatingActionButton: React.FC = () => {
     } catch (error) {
       console.error("Failed to create page from image:", error);
       toast({
-        title: "ページの作成に失敗しました",
+        title: t("common.createPageFailed"),
         variant: "destructive",
       });
     }

--- a/src/components/layout/FloatingActionButton.tsx
+++ b/src/components/layout/FloatingActionButton.tsx
@@ -11,6 +11,7 @@ import { WebClipperDialog } from "@/components/editor/WebClipperDialog";
 import { ImageCreateDialog } from "./ImageCreateDialog";
 import { useTranslation } from "react-i18next";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@zedi/ui";
+import { useAuth } from "@/hooks/useAuth";
 
 const FloatingActionButton: React.FC = () => {
   const { t } = useTranslation();
@@ -18,6 +19,7 @@ const FloatingActionButton: React.FC = () => {
   const { createNewPage, isCreating } = useCreateNewPage();
   const createPageMutation = useCreatePage();
   const { toast } = useToast();
+  const { isSignedIn } = useAuth();
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isWebClipperOpen, setIsWebClipperOpen] = useState(false);
@@ -161,14 +163,17 @@ const FloatingActionButton: React.FC = () => {
         onOpenChange={setIsMenuOpen}
         onSelect={handleMenuSelect}
         trigger={fabButton}
+        hiddenOptions={isSignedIn ? undefined : ["url"]}
       />
 
-      {/* URL から作成ダイアログ */}
-      <WebClipperDialog
-        open={isWebClipperOpen}
-        onOpenChange={setIsWebClipperOpen}
-        onClipped={handleWebClipped}
-      />
+      {/* URL から作成ダイアログ（ログイン時のみ） */}
+      {isSignedIn && (
+        <WebClipperDialog
+          open={isWebClipperOpen}
+          onOpenChange={setIsWebClipperOpen}
+          onClipped={handleWebClipped}
+        />
+      )}
 
       {/* 画像から作成ダイアログ */}
       <ImageCreateDialog

--- a/src/hooks/useWebClipper.test.ts
+++ b/src/hooks/useWebClipper.test.ts
@@ -107,6 +107,27 @@ describe("useWebClipper", () => {
       fakeContent.siteName,
       fakeContent.thumbnailUrl,
       fakeContent.title,
+      undefined,
+    );
+  });
+
+  it("getTiptapContent passes thumbnailUrl and storageProviderId when provided", async () => {
+    mockClipWebPage.mockResolvedValue(fakeContent);
+    mockFormatClippedContentAsTiptap.mockReturnValue({ type: "doc", content: [] });
+    const { result } = renderHook(() => useWebClipper());
+
+    await act(async () => {
+      await result.current.clip("https://example.com");
+    });
+
+    result.current.getTiptapContent("https://committed.com/thumb.png", "s3");
+    expect(mockFormatClippedContentAsTiptap).toHaveBeenCalledWith(
+      fakeContent.content,
+      fakeContent.sourceUrl,
+      fakeContent.siteName,
+      "https://committed.com/thumb.png",
+      fakeContent.title,
+      "s3",
     );
   });
 
@@ -126,6 +147,7 @@ describe("useWebClipper", () => {
       fakeContent.siteName,
       "https://committed.com/thumb.png",
       fakeContent.title,
+      undefined,
     );
   });
 });

--- a/src/hooks/useWebClipper.ts
+++ b/src/hooks/useWebClipper.ts
@@ -20,7 +20,10 @@ export interface UseWebClipperReturn {
   error: string | null;
   clip: (url: string) => Promise<ClippedContent | null>;
   reset: () => void;
-  getTiptapContent: (thumbnailUrl?: string | null) => string | null;
+  getTiptapContent: (
+    thumbnailUrl?: string | null,
+    storageProviderId?: string | null,
+  ) => string | null;
 }
 
 export function useWebClipper(options: UseWebClipperOptions = {}): UseWebClipperReturn {
@@ -66,13 +69,14 @@ export function useWebClipper(options: UseWebClipperOptions = {}): UseWebClipper
   );
 
   const reset = useCallback(() => {
+    clipIdRef.current += 1;
     setStatus("idle");
     setClippedContent(null);
     setError(null);
   }, []);
 
   const getTiptapContent = useCallback(
-    (thumbnailUrl?: string | null): string | null => {
+    (thumbnailUrl?: string | null, storageProviderId?: string | null): string | null => {
       if (!clippedContent) return null;
 
       const tiptapDoc = formatClippedContentAsTiptap(
@@ -81,6 +85,7 @@ export function useWebClipper(options: UseWebClipperOptions = {}): UseWebClipper
         clippedContent.siteName,
         thumbnailUrl ?? clippedContent.thumbnailUrl,
         clippedContent.title,
+        storageProviderId,
       );
 
       return JSON.stringify(tiptapDoc);

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -32,5 +32,7 @@
   "discardAndLeave": "Leave without saving",
   "guestSyncPrompt": "Log in to sync to the cloud",
   "useWithoutSignIn": "Use without signing in",
-  "startUsingApp": "Start using the app"
+  "startUsingApp": "Start using the app",
+  "createPageFailed": "Failed to create page",
+  "copyFailed": "Copy failed"
 }

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -90,5 +90,27 @@
     "generating": "Generating image",
     "labelRecommendation": "Recommendations",
     "labelThumbnails": "Thumbnail candidates"
+  },
+  "webClipper": {
+    "title": "Import from URL",
+    "description": "Extract and save web page content. Source URL is recorded automatically.",
+    "placeholder": "https://example.com/article",
+    "statusFetching": "Fetching page...",
+    "statusExtracting": "Extracting content...",
+    "statusCompleted": "Import ready",
+    "loginRequired": "Sign in required",
+    "loginRequiredDescription": "Please sign in again.",
+    "thumbnailSaveFailed": "Failed to save thumbnail",
+    "thumbnailSaveFailedDescription": "Content will be imported without it.",
+    "tip": "💡 Some pages may not be supported. Please respect copyright.",
+    "cancel": "Cancel",
+    "importing": "Importing...",
+    "import": "Import"
+  },
+  "markdownExport": {
+    "sourceAttribution": "📎 Source",
+    "downloaded": "Markdown file downloaded",
+    "copied": "Markdown copied to clipboard",
+    "copyFailed": "Copy failed"
   }
 }

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -32,5 +32,7 @@
   "discardAndLeave": "保存せずに移動",
   "guestSyncPrompt": "ログインしてクラウドに同期",
   "useWithoutSignIn": "ログインせずに使う",
-  "startUsingApp": "アプリを使い始める"
+  "startUsingApp": "アプリを使い始める",
+  "createPageFailed": "ページの作成に失敗しました",
+  "copyFailed": "コピーに失敗しました"
 }

--- a/src/i18n/locales/ja/editor.json
+++ b/src/i18n/locales/ja/editor.json
@@ -90,5 +90,27 @@
     "generating": "画像を生成中",
     "labelRecommendation": "おすすめ",
     "labelThumbnails": "サムネイル候補"
+  },
+  "webClipper": {
+    "title": "URLから取り込み",
+    "description": "Webページの本文を抽出してページとして保存します。引用元URLは自動的に記録されます。",
+    "placeholder": "https://example.com/article",
+    "statusFetching": "ページを取得中...",
+    "statusExtracting": "本文を抽出中...",
+    "statusCompleted": "取り込み完了",
+    "loginRequired": "ログインが必要です",
+    "loginRequiredDescription": "再度ログインしてください",
+    "thumbnailSaveFailed": "サムネイルの保存に失敗しました",
+    "thumbnailSaveFailedDescription": "コンテンツはそのまま取り込みます。",
+    "tip": "💡 対応していないページもあります。著作権にご注意ください。",
+    "cancel": "キャンセル",
+    "importing": "取り込み中...",
+    "import": "取り込み"
+  },
+  "markdownExport": {
+    "sourceAttribution": "📎 引用元",
+    "downloaded": "Markdownファイルをダウンロードしました",
+    "copied": "Markdownをクリップボードにコピーしました",
+    "copyFailed": "コピーに失敗しました"
   }
 }

--- a/src/lib/htmlToTiptap.test.ts
+++ b/src/lib/htmlToTiptap.test.ts
@@ -43,6 +43,27 @@ describe("formatClippedContentAsTiptap", () => {
     expect(second?.type).toBe("paragraph");
   });
 
+  it("includes storageProviderId in image attrs when provided", () => {
+    const result = formatClippedContentAsTiptap(
+      "<p>Body</p>",
+      "https://example.com",
+      null,
+      "https://cdn.example.com/thumb.png",
+      "Title",
+      "s3",
+    );
+    const first = result.content?.[0];
+    expect(first?.type).toBe("image");
+    expect(first).toMatchObject({
+      type: "image",
+      attrs: {
+        src: "https://cdn.example.com/thumb.png",
+        alt: "Title",
+        storageProviderId: "s3",
+      },
+    });
+  });
+
   it("omits image when thumbnailUrl is empty string", () => {
     const result = formatClippedContentAsTiptap(
       "<p>Body</p>",

--- a/src/lib/htmlToTiptap.ts
+++ b/src/lib/htmlToTiptap.ts
@@ -164,6 +164,7 @@ export function formatClippedContentAsTiptap(
   siteName?: string | null,
   thumbnailUrl?: string | null,
   title?: string | null,
+  storageProviderId?: string | null,
 ): JSONContent {
   void sourceUrl;
   void siteName;
@@ -175,7 +176,11 @@ export function formatClippedContentAsTiptap(
   const imageNode: JSONContent | null = trimmedThumbnail
     ? {
         type: "image",
-        attrs: { src: trimmedThumbnail, alt: title || "OGP thumbnail" },
+        attrs: {
+          src: trimmedThumbnail,
+          alt: title || "OGP thumbnail",
+          ...(storageProviderId && { storageProviderId }),
+        },
       }
     : null;
 

--- a/src/lib/markdownExport.ts
+++ b/src/lib/markdownExport.ts
@@ -168,13 +168,24 @@ function applyMarks(text: string, marks: TiptapMark[]): string {
 }
 
 /**
+ * Build source attribution block for Markdown export (optional)
+ */
+function buildSourceAttribution(sourceUrl?: string | null): string {
+  if (!sourceUrl?.trim()) return "";
+  return `> 📎 引用元: [${sourceUrl}](${sourceUrl})\n\n`;
+}
+
+/**
  * Download content as a Markdown file
  */
-export function downloadMarkdown(title: string, content: string): void {
+export function downloadMarkdown(title: string, content: string, sourceUrl?: string | null): void {
   const markdown = tiptapToMarkdown(content);
+  const attribution = buildSourceAttribution(sourceUrl);
 
-  // Add title as H1 if not empty
-  const fullContent = title ? `# ${title}\n\n${markdown}` : markdown;
+  // Add title as H1 if not empty, then attribution, then content
+  const fullContent = title
+    ? `# ${title}\n\n${attribution}${markdown}`
+    : `${attribution}${markdown}`;
 
   const blob = new Blob([fullContent], { type: "text/markdown;charset=utf-8" });
   const url = URL.createObjectURL(blob);
@@ -203,11 +214,18 @@ function sanitizeFilename(name: string): string {
 /**
  * Copy Markdown content to clipboard
  */
-export async function copyMarkdownToClipboard(title: string, content: string): Promise<void> {
+export async function copyMarkdownToClipboard(
+  title: string,
+  content: string,
+  sourceUrl?: string | null,
+): Promise<void> {
   const markdown = tiptapToMarkdown(content);
+  const attribution = buildSourceAttribution(sourceUrl);
 
-  // Add title as H1 if not empty
-  const fullContent = title ? `# ${title}\n\n${markdown}` : markdown;
+  // Add title as H1 if not empty, then attribution, then content
+  const fullContent = title
+    ? `# ${title}\n\n${attribution}${markdown}`
+    : `${attribution}${markdown}`;
 
   await navigator.clipboard.writeText(fullContent);
 }

--- a/src/lib/markdownExport.ts
+++ b/src/lib/markdownExport.ts
@@ -167,20 +167,35 @@ function applyMarks(text: string, marks: TiptapMark[]): string {
   return result;
 }
 
+export interface MarkdownExportOptions {
+  /** Default title when empty (for filename) */
+  defaultTitle?: string;
+  /** Label for source attribution block (e.g. "📎 引用元:") */
+  attributionLabel?: string;
+}
+
 /**
- * Build source attribution block for Markdown export (optional)
+ * Build source attribution block for Markdown export (optional).
+ * Uses angle-bracket autolink for URLs to avoid Markdown parsing issues with parens/brackets.
  */
-function buildSourceAttribution(sourceUrl?: string | null): string {
+function buildSourceAttribution(sourceUrl?: string | null, attributionLabel?: string): string {
   if (!sourceUrl?.trim()) return "";
-  return `> 📎 引用元: [${sourceUrl}](${sourceUrl})\n\n`;
+  const label = attributionLabel?.trim() || "📎 Source:";
+  return `> ${label} <${sourceUrl.trim()}>\n\n`;
 }
 
 /**
  * Download content as a Markdown file
  */
-export function downloadMarkdown(title: string, content: string, sourceUrl?: string | null): void {
+export function downloadMarkdown(
+  title: string,
+  content: string,
+  sourceUrl?: string | null,
+  options?: MarkdownExportOptions,
+): void {
+  const { defaultTitle = "Untitled", attributionLabel } = options ?? {};
   const markdown = tiptapToMarkdown(content);
-  const attribution = buildSourceAttribution(sourceUrl);
+  const attribution = buildSourceAttribution(sourceUrl, attributionLabel);
 
   // Add title as H1 if not empty, then attribution, then content
   const fullContent = title
@@ -192,7 +207,7 @@ export function downloadMarkdown(title: string, content: string, sourceUrl?: str
 
   const link = document.createElement("a");
   link.href = url;
-  link.download = sanitizeFilename(title || "無題のページ") + ".md";
+  link.download = sanitizeFilename(title || defaultTitle) + ".md";
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
@@ -218,9 +233,11 @@ export async function copyMarkdownToClipboard(
   title: string,
   content: string,
   sourceUrl?: string | null,
+  options?: MarkdownExportOptions,
 ): Promise<void> {
+  const { attributionLabel } = options ?? {};
   const markdown = tiptapToMarkdown(content);
-  const attribution = buildSourceAttribution(sourceUrl);
+  const attribution = buildSourceAttribution(sourceUrl, attributionLabel);
 
   // Add title as H1 if not empty, then attribution, then content
   const fullContent = title


### PR DESCRIPTION
## 概要

`docs/reviews/review-develop-vs-main-20260314-1.md` で指摘された Critical 3 件と Warning 5 件に対応しました。Web Clipper の未ログイン時無効化、stale response の race 修正、format 修正、storageProviderId 付与、Markdown export での引用元保持、PR レビューフロー doc 修正、deploy-prod の frozen-lockfile、WebClipperDialog の分割を含みます。

## 変更点

| 領域 | 主な変更 |
| --- | --- |
| `src/components/layout/` | FABMenu に hiddenOptions 追加、FloatingActionButton で未ログイン時に Web Clipper を非表示 |
| `src/components/editor/` | WebClipperDialog を useWebClipperDialogState / WebClipperDialogPreview / WebClipperDialogFooter に分割 |
| `src/hooks/useWebClipper.ts` | reset() で clipIdRef を進めて stale response を防ぐ、getTiptapContent に storageProviderId 引数追加 |
| `src/lib/htmlToTiptap.ts` | formatClippedContentAsTiptap に storageProviderId 引数追加 |
| `src/lib/markdownExport.ts` | downloadMarkdown / copyMarkdownToClipboard に sourceUrl 引数追加、引用元ブロックを出力に含める |
| `src/components/editor/PageEditor/` | useMarkdownExport に sourceUrl を渡す |
| `.github/workflows/deploy-prod.yml` | deploy-admin の bun install に --frozen-lockfile を追加 |
| `AGENTS.md`, `.cursor/skills/handle-pr-review/SKILL.md` | 未返信 vs 未解決の注意、ページネーションの記載を追加 |
| `docs/reviews/` | セルフレビューレポート追加 |

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [x] 📝 ドキュメント (Documentation)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run lint` と `bun run format:check` が通ることを確認
2. `bun run test:run` で単体テストが通ることを確認
3. 未ログイン状態で FAB を開き、「URLから取り込み」が表示されないことを確認
4. ログイン後、Web Clipper で URL を取り込み、サムネイル画像の「保存先」表示が正しいことを確認
5. クリップしたページを Markdown エクスポート/コピーし、引用元ブロックが含まれることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

未ログイン時の FAB メニューで「URLから取り込み」が非表示になる変更あり。必要に応じて追加。

## 関連 Issue

<!-- なし -->

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Web Clipperに多言語対応を追加し、ユーザーインターフェースを改善しました
  * Markdownエクスポート時にソース属性を自動付与できるようになりました
  * Webクリッパーが認証状態を確認するようになり、セキュリティが向上しました

* **改善**
  * Web Clipperダイアログの状態管理とプレビュー表示を最適化しました
  * エラーメッセージが多言語で表示されるようになりました
  * デプロイメントの再現性を向上させました

* **ドキュメント**
  * PR レビュープロセスのドキュメントを更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->