### PR TITLE
fix: remove clearLastClippedUrl on error to avoid unintended debounce retry

### DIFF
--- a/src/components/editor/WebClipperDialog.tsx
+++ b/src/components/editor/WebClipperDialog.tsx
@@ -60,12 +60,6 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
 
   const hasFreshContent = Boolean(clippedContent) && isCurrentUrlClipped();
 
-  // エラー時に clearLastClippedUrl を呼ばない。呼ぶと debounce の残りタイマーが
-  // lastClippedUrlRef のクリアを検知し、500ms 後に unintended retry を行うため。
-  // Error時は ref をそのままにし、ユーザーは URL を編集するかダイアログを閉じて再試行できる。
-  // Do not call clearLastClippedUrl on error; otherwise the debounce callback
-  // would retry 500ms later (unintended). User can retry by editing URL or reopening dialog.
-
   const handleDialogOpenChange = useCallback(
     (nextOpen: boolean) => {
       if (!nextOpen) {

--- a/src/components/editor/WebClipperDialog.tsx
+++ b/src/components/editor/WebClipperDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import React, { useState, useMemo, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Link2, Loader2, AlertCircle } from "lucide-react";
 import { Input } from "@zedi/ui";
@@ -52,7 +52,7 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
   const { getToken } = useAuth();
   const api = useMemo(() => createApiClient({ getToken }), [getToken]);
   const { status, clippedContent, error, clip, reset, getTiptapContent } = useWebClipper({ api });
-  const { url, setUrl, handlePaste, resetDialogState, clearLastClippedUrl, isCurrentUrlClipped } =
+  const { url, setUrl, handlePaste, resetDialogState, isCurrentUrlClipped } =
     useWebClipperDialogState({ clip, reset });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isSubmittingRef = useRef(false);
@@ -60,11 +60,11 @@ export const WebClipperDialog: React.FC<WebClipperDialogProps> = ({
 
   const hasFreshContent = Boolean(clippedContent) && isCurrentUrlClipped();
 
-  useEffect(() => {
-    if (status === "error") {
-      clearLastClippedUrl();
-    }
-  }, [status, clearLastClippedUrl]);
+  // エラー時に clearLastClippedUrl を呼ばない。呼ぶと debounce の残りタイマーが
+  // lastClippedUrlRef のクリアを検知し、500ms 後に unintended retry を行うため。
+  // Error時は ref をそのままにし、ユーザーは URL を編集するかダイアログを閉じて再試行できる。
+  // Do not call clearLastClippedUrl on error; otherwise the debounce callback
+  // would retry 500ms later (unintended). User can retry by editing URL or reopening dialog.
 
   const handleDialogOpenChange = useCallback(
     (nextOpen: boolean) => {

--- a/src/components/editor/useWebClipperDialogState.ts
+++ b/src/components/editor/useWebClipperDialogState.ts
@@ -34,7 +34,7 @@ interface UseWebClipperDialogStateOptions {
  * ```tsx
  * const {
  *   url, setUrl,
- *   handlePaste, resetDialogState, clearLastClippedUrl
+ *   handlePaste, resetDialogState, isCurrentUrlClipped
  * } = useWebClipperDialogState({ clip: doClip, reset: clearContent });
  * ```
  */
@@ -62,14 +62,6 @@ export function useWebClipperDialogState({ clip, reset }: UseWebClipperDialogSta
       reset();
     }
   }, [url, reset]);
-
-  /**
-   * エラー時に lastClippedUrl をリセットし、再クリップを許可する。
-   * Clears the last clipped URL so a retry is allowed (e.g. after clip failure).
-   */
-  const clearLastClippedUrl = useCallback(() => {
-    lastClippedUrlRef.current = "";
-  }, []);
 
   const resetDialogState = useCallback(() => {
     setUrl("");
@@ -110,7 +102,6 @@ export function useWebClipperDialogState({ clip, reset }: UseWebClipperDialogSta
     setUrl,
     handlePaste,
     resetDialogState,
-    clearLastClippedUrl,
     isCurrentUrlClipped,
   };
 }

--- a/src/components/editor/useWebClipperDialogState.ts
+++ b/src/components/editor/useWebClipperDialogState.ts
@@ -40,6 +40,10 @@ interface UseWebClipperDialogStateOptions {
  */
 export function useWebClipperDialogState({ clip, reset }: UseWebClipperDialogStateOptions) {
   const [url, setUrl] = useState("");
+  // エラー時に lastClippedUrlRef をクリアしてはいけない。クリアすると debounce の残りタイマーが
+  // 500ms 後に unintended retry を行う。ユーザーは URL を編集するかダイアログを閉じて再試行する。
+  // Do not clear lastClippedUrlRef on clip error; otherwise the debounce callback would retry 500ms later.
+  // User retries by editing URL or reopening the dialog.
   const lastClippedUrlRef = useRef<string>("");
 
   const triggerAutoClip = useDebouncedCallback(


### PR DESCRIPTION
## 概要

PR #353 の Devin レビュー指摘に対応する。

エラー時に `clearLastClippedUrl()` を呼ぶと、debounce の残りタイマーが発火した際に `lastClippedUrlRef` が空であるため unintended retry が発生していた。エラー時は ref をクリアせず、ユーザーは URL を編集するかダイアログを閉じて再試行できる。

## 変更内容

- `WebClipperDialog.tsx`: `status === "error"` 時の `useEffect` で `clearLastClippedUrl()` を呼んでいた処理を削除
- 未使用の `useEffect` import と `clearLastClippedUrl` の destructuring を削除
- 意図を説明するコメントを追加（日英両対応）

## 関連

- PR #353
- Devin AI review comment (Error effect clearing lastClippedUrlRef causes unintended auto-retry after paste failure)


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ウェブクリッパーで、現在のURLが既にクリップ済みかを判定する機能を追加しました。

* **リファクタリング**
  * 一部の自動リセット処理（エラー時に直前のクリップ情報を消去する動作）を削除しました。エラー発生時は手動での再試行が必要となる場合があります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->