### PR TITLE
feat(ci): main/develop向けPRでClaude Code Reviewを自動実行

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,13 +15,15 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: レビュー対象の PR 番号（手動実行時のみ必須）
-        required: false
+        description: レビュー対象の PR 番号（手動実行時必須）
+        required: true
         type: string
 
 jobs:
   claude-review:
     runs-on: ubuntu-latest
+    # fork からの PR では secrets が渡らず失敗するため、同一リポジトリ PR のみ実行
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write
@@ -43,7 +45,7 @@ jobs:
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           # pull_request トリガー時は github.event.pull_request.number、
-          # 手動実行時は inputs.pr_number を使用
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number || inputs.pr_number }}"
+          # 手動実行時は github.event.inputs.pr_number を使用
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.inputs.pr_number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,3 +1,11 @@
+# Claude Code Review - main/develop 向け PR で自動実行
+#
+# 初回セットアップ時の注意:
+# OIDC 検証のため、ワークフローはデフォルトブランチ(main)に存在し同一内容である必要があります。
+# 初回の PR では Claude Code Review が失敗しますが、マージ後・develop→main リリース後に
+# 以降の PR で正常動作します。continue-on-error により初回失敗時もマージをブロックしません。
+# ref: https://github.com/anthropics/claude-code-action/issues/722
+#
 name: Claude Code Review
 
 on:
@@ -28,6 +36,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        continue-on-error: true # 初回 OIDC 失敗時もマージをブロックしない（issues/722）
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,11 +1,14 @@
 name: Claude Code Review
 
 on:
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       pr_number:
-        description: レビュー対象の PR 番号
-        required: true
+        description: レビュー対象の PR 番号（手動実行時のみ必須）
+        required: false
         type: string
 
 jobs:
@@ -30,6 +33,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ inputs.pr_number }}"
+          # pull_request トリガー時は github.event.pull_request.number、
+          # 手動実行時は inputs.pr_number を使用
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number || inputs.pr_number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## 概要

Claude Code Review ワークフローを main および develop ブランチ向けの PR で自動実行するよう変更しました。これにより、main/develop にマージされる前の PR に対して、CI として Claude Code によるコードレビューが自動的に実施されます。

## 変更点

| 領域 | 主な変更 |
|------|----------|
| `.github/workflows/` | claude-code-review.yml に pull_request トリガーを追加 |

- **pull_request トリガー追加**: `main`, `develop` をターゲットとする PR の opened / synchronize / reopened 時に自動実行
- **手動実行の維持**: workflow_dispatch は引き続き利用可能。手動時は `pr_number` 入力を指定して任意の PR をレビュー可能
- **PR 番号の動的取得**: 自動トリガー時は `github.event.pull_request.number`、手動時は `inputs.pr_number` を使用

## 変更の種類

- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. 本 PR を開いた時点で、Claude Code Review ワークフローが CI チェックとして実行されることを確認
2. `CLAUDE_CODE_OAUTH_TOKEN` がリポジトリシークレットに設定されていることを確認

## チェックリスト

- [x] テストがすべてパスする（対象ファイルは YAML のみ）
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した（本 PR 説明で補足）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

<!-- なし -->

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * コードレビューワークフローを強化しました。フォークされたプルリクエストへの対応を改善し、より安全なプロセス管理を実現します。
  * 手動実行オプションを追加し、柔軟なワークフロー実行が可能になりました。
  * レビュー処理の失敗がマージをブロックしないよう改善し、開発の流れを円滑にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->