### PR TITLE
fix(ci): sync main→develop で auto-merge 失敗時もジョブを失敗にしない

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -56,10 +56,11 @@ jobs:
           fi
 
           # Enable auto-merge with merge commit. If required checks are not green yet,
-          # GitHub will merge automatically once all required checks pass.
+          # GitHub returns "unstable status" and rejects. We don't fail the job so the
+          # sync PR is still created; maintainers can enable auto-merge manually or it
+          # can be retried later.
           if gh pr merge "$PR_NUMBER" --auto --merge; then
             echo "Enabled auto-merge for PR #$PR_NUMBER"
           else
-            echo "::error::Failed to enable auto-merge for PR #$PR_NUMBER. Check repo auto-merge setting and branch protection."
-            exit 1
+            echo "::warning::Could not enable auto-merge for PR #$PR_NUMBER (e.g. PR in unstable status until checks run). Enable manually or check repo 'Allow auto-merge' and branch protection."
           fi


### PR DESCRIPTION
## 概要

main から develop への同期 PR 作成後に `gh pr merge --auto` を実行すると、PR が「unstable status」のため GitHub が auto-merge を拒否し、ワークフローが exit code 1 で失敗していました。auto-merge の有効化に失敗した場合は `::error::` + `exit 1` ではなく `::warning::` のみにし、同期 PR は作成されたままにします（手動で auto-merge を有効化可能）。

## 変更点

- `.github/workflows/sync-main-to-develop.yml`
  - `gh pr merge --auto --merge` が失敗した場合に `exit 1` をやめ、警告ログのみ出力するように変更

## 変更の種類

- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. main に push して「Sync main to develop」ワークフローを実行
2. 同期 PR が作成され、auto-merge の有効化が失敗してもジョブが成功（緑）になることを確認
3. 必要なら PR 画面で手動で「Merge when ready」を有効にできることを確認

## チェックリスト

- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

なし

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
