### PR TITLE
test(api): expand apiClient HTTP, errors, and retry coverage (#393)

### DIFF
--- a/src/lib/api/apiClient.test.ts
+++ b/src/lib/api/apiClient.test.ts
@@ -5,6 +5,23 @@ vi.stubEnv("VITE_API_BASE_URL", "https://api.test.example.com");
 
 import { createApiClient, ApiError } from "./apiClient";
 
+/** Builds a minimal `Response`-like object for stubbing `fetch`. */
+function mockResponse(init: {
+  ok: boolean;
+  status: number;
+  statusText?: string;
+  body: string;
+  headers?: Headers;
+}): Pick<Response, "ok" | "status" | "statusText" | "text" | "headers"> {
+  return {
+    ok: init.ok,
+    status: init.status,
+    statusText: init.statusText ?? "",
+    headers: init.headers ?? new Headers(),
+    text: () => Promise.resolve(init.body),
+  };
+}
+
 describe("apiClient", () => {
   const mockToken = "test-jwt-token";
   const getToken = vi.fn().mockResolvedValue(mockToken);
@@ -178,6 +195,144 @@ describe("apiClient", () => {
         expect((err as ApiError).code).toBe("INVALID_JSON");
       }
     });
+
+    it("throws INVALID_JSON with truncated snippet when body is long (security: no huge error strings)", async () => {
+      const longInvalid = "x".repeat(250);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(longInvalid),
+          headers: new Headers(),
+        }),
+      );
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+
+      await expect(client.getSyncPages()).rejects.toMatchObject({
+        code: "INVALID_JSON",
+        message: expect.stringMatching(/^Invalid JSON response \(HTTP 200\): x{200}…$/),
+      });
+    });
+
+    it("maps 5xx (non-503) to ApiError immediately without retry (resilience: no retry storm)", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: false,
+          status: 502,
+          statusText: "Bad Gateway",
+          body: JSON.stringify({ error: { message: "upstream", code: "BAD_GATEWAY" } }),
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+
+      await expect(client.getSyncPages()).rejects.toMatchObject({
+        status: 502,
+        code: "BAD_GATEWAY",
+        message: "upstream",
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("prefers envelope error.message and error.code on 4xx", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockResponse({
+            ok: false,
+            status: 403,
+            body: JSON.stringify({
+              ok: false,
+              error: { message: "Forbidden action", code: "FORBIDDEN" },
+            }),
+          }),
+        ),
+      );
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+
+      await expect(client.getNotes()).rejects.toMatchObject({
+        status: 403,
+        code: "FORBIDDEN",
+        message: "Forbidden action",
+      });
+    });
+
+    it("falls back to legacy { message, code } when envelope error is absent", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockResponse({
+            ok: false,
+            status: 422,
+            body: JSON.stringify({ message: "Invalid", code: "VALIDATION" }),
+          }),
+        ),
+      );
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+
+      await expect(client.postSyncPages({ pages: [] })).rejects.toMatchObject({
+        status: 422,
+        code: "VALIDATION",
+        message: "Invalid",
+      });
+    });
+
+    it("uses HTTP statusText when error body has no message (boundary)", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockResponse({
+            ok: false,
+            status: 418,
+            statusText: "I'm a teapot",
+            body: JSON.stringify({}),
+          }),
+        ),
+      );
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+
+      await expect(client.getPageContent("x")).rejects.toMatchObject({
+        status: 418,
+        message: "I'm a teapot",
+      });
+    });
+
+    it("throws INVALID_JSON for HTML 500 body before ApiError mapping (malicious/proxy error pages)", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockResponse({
+            ok: false,
+            status: 500,
+            body: "<html>error</html>",
+          }),
+        ),
+      );
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+
+      await expect(client.getSyncPages()).rejects.toMatchObject({
+        code: "INVALID_JSON",
+      });
+    });
+
+    it("throws NETWORK_ERROR with generic message when fetch rejects a non-Error (resilience)", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue("offline"));
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+
+      await expect(client.getSyncPages()).rejects.toMatchObject({
+        status: 0,
+        code: "NETWORK_ERROR",
+        message: "Network error: Failed to fetch",
+      });
+    });
   });
 
   // ── 503 Auto-retry ─────────────────────────────────────────────────
@@ -210,6 +365,36 @@ describe("apiClient", () => {
       expect(result.results).toEqual([]);
     });
 
+    it("retries on 503 with default delay when Retry-After is missing or invalid", async () => {
+      vi.useFakeTimers();
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          statusText: "Service Unavailable",
+          text: () =>
+            Promise.resolve(JSON.stringify({ error: { message: "temp", code: "UNAVAILABLE" } })),
+          headers: new Headers(),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({ results: [] })),
+          headers: new Headers(),
+        });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+      const resultPromise = client.searchSharedNotes("test");
+      await vi.advanceTimersByTimeAsync(2000);
+      const result = await resultPromise;
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result.results).toEqual([]);
+      vi.useRealTimers();
+    });
+
     it("gives up after MAX_RETRIES (3) attempts", async () => {
       vi.useFakeTimers();
       const fetchMock = vi.fn().mockResolvedValue({
@@ -239,6 +424,96 @@ describe("apiClient", () => {
       expect((err as ApiError).status).toBe(503);
       expect(fetchMock).toHaveBeenCalledTimes(4);
       vi.useRealTimers();
+    });
+  });
+
+  // ── requestOptionalAuth (public notes; same fetch, no 503 retry) ───
+
+  describe("requestOptionalAuth", () => {
+    it("throws NETWORK_ERROR when fetch fails (guest / optional-auth path)", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+
+      await expect(client.getNote("note-1")).rejects.toMatchObject({
+        code: "NETWORK_ERROR",
+        status: 0,
+      });
+    });
+
+    it("does not retry on 503 (only authenticated request() retries; boundary)", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: false,
+          status: 503,
+          body: JSON.stringify({ error: { message: "overloaded", code: "UNAVAILABLE" } }),
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+
+      await expect(client.getPublicNotes()).rejects.toMatchObject({ status: 503 });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── URL and query construction ───────────────────────────────────────
+
+  describe("URL and query", () => {
+    it("strips trailing slash from baseUrl when building request URL", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: JSON.stringify({ pages: [], links: [], ghost_links: [], server_time: "t" }),
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com/" });
+      await client.getSyncPages();
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.test.example.com/api/sync/pages");
+    });
+
+    it("passes since as query param for incremental sync", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: JSON.stringify({ pages: [], links: [], ghost_links: [], server_time: "t" }),
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+      await client.getSyncPages("2025-01-01T00:00:00Z");
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain("since=2025-01-01T00%3A00%3A00Z");
+    });
+
+    it("sends default discover query params (sort, limit, offset)", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: JSON.stringify({ official: [], notes: [] }),
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+      await client.getPublicNotes();
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const parsed = new URL(url);
+      expect(parsed.pathname).toBe("/api/notes/discover");
+      expect(parsed.searchParams.get("sort")).toBe("updated");
+      expect(parsed.searchParams.get("limit")).toBe("20");
+      expect(parsed.searchParams.get("offset")).toBe("0");
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`apiClient` の fetch ラッパー・ステータス・ボディ解析・503 リトライ・`requestOptionalAuth` の境界をモックで網羅し、ミューテーション耐性と回復性まわりの意図をテスト名で明示しました。

## 変更点

- 5xx（503 以外）はリトライせず即 `ApiError` になること
- エンベロープ `error` とレガシー `{ message, code }`、および `statusText` フォールバック
- 長い不正 JSON のスニペット、`500` かつ HTML ボディでの `INVALID_JSON`
- `fetch` が `Error` でない場合の `NETWORK_ERROR`
- `Retry-After` なしの 503 でデフォルト待機後にリトライ
- `getNote` / `getPublicNotes` は 503 をリトライしないこと
- `baseUrl` の末尾スラッシュ除去、`since` と discover のクエリ

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run test:run src/lib/api/apiClient.test.ts`
2. `bun run lint` / `bun run format:check`

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した（N/A）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #393
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bcb0252-389c-453c-b8e6-5358d8f2606d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bcb0252-389c-453c-b8e6-5358d8f2606d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
