### PR TITLE
test: AI チャット hooks の単体テスト拡張 (#394)

### DIFF
--- a/src/components/editor/PageEditor/usePendingChatPageGeneration.test.tsx
+++ b/src/components/editor/PageEditor/usePendingChatPageGeneration.test.tsx
@@ -158,4 +158,223 @@ describe("usePendingChatPageGeneration", () => {
       expect(generateWikiContentFromChatOutlineStream).toHaveBeenCalledTimes(1);
     });
   });
+
+  it("on completion calls saveChanges, setContent, and success toast", async () => {
+    const setContent = vi.fn();
+    const setWikiContentForCollab = vi.fn();
+    const saveChanges = vi.fn();
+    const toast = vi.fn();
+
+    renderHook(
+      () =>
+        usePendingChatPageGeneration(
+          buildHookOptions({
+            setContent,
+            setWikiContentForCollab,
+            saveChanges,
+            toast,
+          }),
+        ),
+      {
+        wrapper: ({ children }) => (
+          <MemoryRouter
+            initialEntries={[
+              {
+                pathname: "/page/page-1",
+                state: { pendingChatPageGeneration: defaultPending },
+              },
+            ]}
+          >
+            {children}
+          </MemoryRouter>
+        ),
+      },
+    );
+
+    await waitFor(() => {
+      expect(saveChanges).toHaveBeenCalledWith("Page title", expect.any(String));
+      expect(setContent).toHaveBeenCalled();
+      expect(setWikiContentForCollab).toHaveBeenCalled();
+      expect(toast).toHaveBeenCalledWith({ title: "aiChat.notifications.pageBodyGenerated" });
+    });
+  });
+
+  it("shows pageBodyGenerateFailed toast when stream reports a non-abort error", async () => {
+    generateWikiContentFromChatOutlineStream.mockImplementation(
+      async (
+        _title: string,
+        _outline: string,
+        _conversationText: string,
+        handlers: {
+          onChunk: (chunk: string) => void;
+          onComplete: (result: { content: string }) => void;
+          onError: (err: Error) => void;
+        },
+      ) => {
+        await Promise.resolve();
+        handlers.onError(new Error("stream failed"));
+      },
+    );
+
+    const toast = vi.fn();
+
+    renderHook(() => usePendingChatPageGeneration(buildHookOptions({ toast })), {
+      wrapper: ({ children }) => (
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: "/page/page-1",
+              state: { pendingChatPageGeneration: defaultPending },
+            },
+          ]}
+        >
+          {children}
+        </MemoryRouter>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith({
+        title: "aiChat.notifications.pageBodyGenerateFailed",
+        variant: "destructive",
+      });
+    });
+  });
+
+  it("does not show a destructive toast when error message is ABORTED", async () => {
+    generateWikiContentFromChatOutlineStream.mockImplementation(
+      async (
+        _title: string,
+        _outline: string,
+        _conversationText: string,
+        handlers: {
+          onChunk: (chunk: string) => void;
+          onComplete: (result: { content: string }) => void;
+          onError: (err: Error) => void;
+        },
+      ) => {
+        await Promise.resolve();
+        handlers.onError(new Error("ABORTED"));
+      },
+    );
+
+    const toast = vi.fn();
+
+    renderHook(() => usePendingChatPageGeneration(buildHookOptions({ toast })), {
+      wrapper: ({ children }) => (
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: "/page/page-1",
+              state: { pendingChatPageGeneration: defaultPending },
+            },
+          ]}
+        >
+          {children}
+        </MemoryRouter>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(generateWikiContentFromChatOutlineStream).toHaveBeenCalled();
+    });
+
+    expect(toast).not.toHaveBeenCalledWith(expect.objectContaining({ variant: "destructive" }));
+  });
+
+  it("does not start generation until the editor is initialized", async () => {
+    const { rerender } = renderHook(
+      ({ initialized }: { initialized: boolean }) =>
+        usePendingChatPageGeneration(buildHookOptions({ isInitialized: initialized })),
+      {
+        initialProps: { initialized: false },
+        wrapper: ({ children }) => (
+          <MemoryRouter
+            initialEntries={[
+              {
+                pathname: "/page/page-1",
+                state: { pendingChatPageGeneration: defaultPending },
+              },
+            ]}
+          >
+            {children}
+          </MemoryRouter>
+        ),
+      },
+    );
+
+    await waitFor(() => {
+      expect(generateWikiContentFromChatOutlineStream).not.toHaveBeenCalled();
+    });
+
+    rerender({ initialized: true });
+
+    await waitFor(() => {
+      expect(generateWikiContentFromChatOutlineStream).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not start generation when title is blank", async () => {
+    renderHook(() => usePendingChatPageGeneration(buildHookOptions({ title: "   " })), {
+      wrapper: ({ children }) => (
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: "/page/page-1",
+              state: { pendingChatPageGeneration: defaultPending },
+            },
+          ]}
+        >
+          {children}
+        </MemoryRouter>
+      ),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(generateWikiContentFromChatOutlineStream).not.toHaveBeenCalled();
+  });
+
+  it("invokes setContent when the stream emits chunks (throttled path) before completion", async () => {
+    const setContent = vi.fn();
+    generateWikiContentFromChatOutlineStream.mockImplementation(
+      async (
+        _title: string,
+        _outline: string,
+        _conversationText: string,
+        handlers: {
+          onChunk: (chunk: string) => void;
+          onComplete: (result: { content: string }) => void;
+          onError: (err: Error) => void;
+        },
+      ) => {
+        await Promise.resolve();
+        handlers.onChunk("## ");
+        handlers.onChunk("Hi");
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        handlers.onComplete({ content: "## Hi" });
+      },
+    );
+
+    renderHook(() => usePendingChatPageGeneration(buildHookOptions({ setContent })), {
+      wrapper: ({ children }) => (
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: "/page/page-1",
+              state: { pendingChatPageGeneration: defaultPending },
+            },
+          ]}
+        >
+          {children}
+        </MemoryRouter>
+      ),
+    });
+
+    await waitFor(
+      () => {
+        expect(setContent).toHaveBeenCalled();
+      },
+      { timeout: 4000 },
+    );
+  });
 });

--- a/src/components/editor/PageEditor/usePendingChatPageGeneration.test.tsx
+++ b/src/components/editor/PageEditor/usePendingChatPageGeneration.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, renderHook, waitFor, screen } from "@testing-library/react";
+import { act, render, renderHook, waitFor, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React, { useEffect } from "react";
 import type { Location } from "react-router-dom";
@@ -315,7 +315,8 @@ describe("usePendingChatPageGeneration", () => {
   });
 
   it("does not start generation when title is blank", async () => {
-    renderHook(() => usePendingChatPageGeneration(buildHookOptions({ title: "   " })), {
+    const blankTitleOptions = buildHookOptions({ title: "   " });
+    renderHook(() => usePendingChatPageGeneration(blankTitleOptions), {
       wrapper: ({ children }) => (
         <MemoryRouter
           initialEntries={[
@@ -330,51 +331,61 @@ describe("usePendingChatPageGeneration", () => {
       ),
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
     expect(generateWikiContentFromChatOutlineStream).not.toHaveBeenCalled();
   });
 
   it("invokes setContent when the stream emits chunks (throttled path) before completion", async () => {
-    const setContent = vi.fn();
-    generateWikiContentFromChatOutlineStream.mockImplementation(
-      async (
-        _title: string,
-        _outline: string,
-        _conversationText: string,
-        handlers: {
-          onChunk: (chunk: string) => void;
-          onComplete: (result: { content: string }) => void;
-          onError: (err: Error) => void;
+    vi.useFakeTimers();
+    try {
+      const setContent = vi.fn();
+      generateWikiContentFromChatOutlineStream.mockImplementation(
+        async (
+          _title: string,
+          _outline: string,
+          _conversationText: string,
+          handlers: {
+            onChunk: (chunk: string) => void;
+            onComplete: (result: { content: string }) => void;
+            onError: (err: Error) => void;
+          },
+        ) => {
+          await Promise.resolve();
+          handlers.onChunk("## ");
+          handlers.onChunk("Hi");
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 200);
+          });
+          handlers.onComplete({ content: "## Hi" });
         },
-      ) => {
+      );
+
+      renderHook(() => usePendingChatPageGeneration(buildHookOptions({ setContent })), {
+        wrapper: ({ children }) => (
+          <MemoryRouter
+            initialEntries={[
+              {
+                pathname: "/page/page-1",
+                state: { pendingChatPageGeneration: defaultPending },
+              },
+            ]}
+          >
+            {children}
+          </MemoryRouter>
+        ),
+      });
+
+      await act(async () => {
         await Promise.resolve();
-        handlers.onChunk("## ");
-        handlers.onChunk("Hi");
-        await new Promise((resolve) => setTimeout(resolve, 200));
-        handlers.onComplete({ content: "## Hi" });
-      },
-    );
+        await vi.advanceTimersByTimeAsync(150);
+      });
 
-    renderHook(() => usePendingChatPageGeneration(buildHookOptions({ setContent })), {
-      wrapper: ({ children }) => (
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: "/page/page-1",
-              state: { pendingChatPageGeneration: defaultPending },
-            },
-          ]}
-        >
-          {children}
-        </MemoryRouter>
-      ),
-    });
-
-    await waitFor(
-      () => {
-        expect(setContent).toHaveBeenCalled();
-      },
-      { timeout: 4000 },
-    );
+      expect(setContent).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/hooks/runAIChatAction.test.ts
+++ b/src/hooks/runAIChatAction.test.ts
@@ -8,6 +8,25 @@ const t = ((key: string, opts?: Record<string, unknown>) => {
   return key;
 }) as RunAIChatActionDeps["t"];
 
+/** Minimal Tiptap JSON that already contains a wiki link to Alpha (for suggest-wiki-links guards). */
+const TIPTAP_WITH_ALPHA_WIKI_LINK = JSON.stringify({
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "x",
+          marks: [
+            { type: "wikiLink", attrs: { title: "Alpha", exists: false, referenced: false } },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
 function baseDeps(overrides: Partial<RunAIChatActionDeps> = {}): RunAIChatActionDeps {
   return {
     pageContext: null,
@@ -177,9 +196,9 @@ describe("runAIChatAction — append and errors", () => {
     });
   });
 
-  it("append-to-page: requires matching page context", async () => {
+  it("append-to-page: appends and shows appendSuccess when titles match", async () => {
     const toast = vi.fn();
-    const appendContentToCurrentPage = vi.fn();
+    const appendContentToCurrentPage = vi.fn().mockResolvedValue(true);
     const deps = baseDeps({
       pageContext: {
         type: "editor",
@@ -199,6 +218,221 @@ describe("runAIChatAction — append and errors", () => {
     });
 
     expect(appendContentToCurrentPage).toHaveBeenCalledWith("## More");
-    expect(toast).toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith({
+      title: "aiChat.notifications.appendSuccess:Current",
+    });
+  });
+});
+
+describe("runAIChatAction — append guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("append-to-page: shows pageContextRequired when pageId is missing", async () => {
+    const toast = vi.fn();
+    const appendContentToCurrentPage = vi.fn();
+    const deps = baseDeps({
+      pageContext: {
+        type: "editor",
+        pageId: "",
+        pageTitle: "Current",
+        pageFullContent: "",
+      },
+      appendContentToCurrentPage,
+      toast,
+    });
+
+    await runAIChatAction(deps, {
+      type: "append-to-page",
+      pageTitle: "Current",
+      content: "## More",
+      reason: "r",
+    });
+
+    expect(appendContentToCurrentPage).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith({
+      title: "aiChat.notifications.pageContextRequired",
+      variant: "destructive",
+    });
+  });
+
+  it("append-to-page: shows appendUnavailable when target title does not match current", async () => {
+    const toast = vi.fn();
+    const appendContentToCurrentPage = vi.fn();
+    const deps = baseDeps({
+      pageContext: {
+        type: "editor",
+        pageId: "x",
+        pageTitle: "Current",
+        pageFullContent: "",
+      },
+      appendContentToCurrentPage,
+      toast,
+    });
+
+    await runAIChatAction(deps, {
+      type: "append-to-page",
+      pageTitle: "Other Page",
+      content: "## More",
+      reason: "r",
+    });
+
+    expect(appendContentToCurrentPage).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith({
+      title: "aiChat.notifications.appendUnavailable",
+      variant: "destructive",
+    });
+  });
+});
+
+describe("runAIChatAction — suggest-wiki-links", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows pageContextRequired when pageId is missing", async () => {
+    const toast = vi.fn();
+    const appendContentToCurrentPage = vi.fn();
+    const deps = baseDeps({
+      pageContext: {
+        type: "editor",
+        pageId: "",
+        pageTitle: "T",
+        pageFullContent: "",
+      },
+      appendContentToCurrentPage,
+      getLatestPageFullContent: () => "",
+      toast,
+    });
+
+    await runAIChatAction(deps, {
+      type: "suggest-wiki-links",
+      links: [{ keyword: "A", existingPageTitle: "A" }],
+      reason: "r",
+    });
+
+    expect(appendContentToCurrentPage).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith({
+      title: "aiChat.notifications.pageContextRequired",
+      variant: "destructive",
+    });
+  });
+
+  it("shows noNewWikiLinks when suggested titles are already linked in content", async () => {
+    const toast = vi.fn();
+    const appendContentToCurrentPage = vi.fn();
+    const deps = baseDeps({
+      pageContext: {
+        type: "editor",
+        pageId: "p1",
+        pageTitle: "T",
+        pageFullContent: TIPTAP_WITH_ALPHA_WIKI_LINK,
+      },
+      appendContentToCurrentPage,
+      getLatestPageFullContent: () => TIPTAP_WITH_ALPHA_WIKI_LINK,
+      toast,
+    });
+
+    await runAIChatAction(deps, {
+      type: "suggest-wiki-links",
+      links: [{ keyword: "Alpha", existingPageTitle: "Alpha" }],
+      reason: "r",
+    });
+
+    expect(appendContentToCurrentPage).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith({ title: "aiChat.notifications.noNewWikiLinks" });
+  });
+
+  it("shows appendFailed when append returns false", async () => {
+    const toast = vi.fn();
+    const appendContentToCurrentPage = vi.fn().mockResolvedValue(false);
+    const deps = baseDeps({
+      pageContext: {
+        type: "editor",
+        pageId: "p1",
+        pageTitle: "My Page",
+        pageFullContent: "",
+      },
+      appendContentToCurrentPage,
+      getLatestPageFullContent: () => "",
+      toast,
+    });
+
+    await runAIChatAction(deps, {
+      type: "suggest-wiki-links",
+      links: [{ keyword: "Beta", existingPageTitle: "Beta" }],
+      reason: "r",
+    });
+
+    expect(appendContentToCurrentPage).toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith({
+      title: "aiChat.notifications.appendFailed:My Page",
+      variant: "destructive",
+    });
+  });
+
+  it("shows wikiLinksAdded on success", async () => {
+    const toast = vi.fn();
+    const appendContentToCurrentPage = vi.fn().mockResolvedValue(true);
+    const deps = baseDeps({
+      pageContext: {
+        type: "editor",
+        pageId: "p1",
+        pageTitle: "T",
+        pageFullContent: "",
+      },
+      appendContentToCurrentPage,
+      getLatestPageFullContent: () => "",
+      toast,
+    });
+
+    await runAIChatAction(deps, {
+      type: "suggest-wiki-links",
+      links: [{ keyword: "Gamma", existingPageTitle: "Gamma" }],
+      reason: "r",
+    });
+
+    expect(appendContentToCurrentPage).toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith({
+      title: "aiChat.notifications.wikiLinksAdded:1",
+    });
+  });
+});
+
+describe("runAIChatAction — create navigation guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("create-page: does not navigate when create returns no id", async () => {
+    const createPageMutateAsync = vi.fn().mockResolvedValue({ id: undefined });
+    const navigate = vi.fn();
+    const deps = baseDeps({ createPageMutateAsync, navigate, messages: [] });
+
+    await runAIChatAction(deps, {
+      type: "create-page",
+      title: "T",
+      outline: "",
+      suggestedLinks: [],
+      reason: "r",
+    });
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("create-multiple-pages: does not navigate when no page gets an id", async () => {
+    const createPageMutateAsync = vi.fn().mockResolvedValue({});
+    const navigate = vi.fn();
+    const deps = baseDeps({ createPageMutateAsync, navigate, messages: [] });
+
+    await runAIChatAction(deps, {
+      type: "create-multiple-pages",
+      pages: [{ title: "A", content: "", suggestedLinks: [] }],
+      linkStructure: [],
+      reason: "r",
+    });
+
+    expect(navigate).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useAIChatActions.test.ts
+++ b/src/hooks/useAIChatActions.test.ts
@@ -223,4 +223,151 @@ describe("useAIChatActions", () => {
       title: "aiChat.notifications.wikiLinksAdded",
     });
   });
+
+  it("create-multiple-pages creates each page and does not navigate", async () => {
+    const { result } = renderHook(() => useAIChatActions({ pageContext: null }), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.handleExecuteAction({
+        type: "create-multiple-pages",
+        pages: [
+          { title: "A", content: "body-a", suggestedLinks: [] },
+          { title: "B", content: "body-b", suggestedLinks: [] },
+        ],
+        linkStructure: [],
+        reason: "test",
+      });
+    });
+
+    expect(mockCreatePageMutateAsync).toHaveBeenCalledTimes(2);
+    expect(mockCreatePageMutateAsync).toHaveBeenNthCalledWith(1, {
+      title: "A",
+      content: "body-a",
+    });
+    expect(mockCreatePageMutateAsync).toHaveBeenNthCalledWith(2, {
+      title: "B",
+      content: "body-b",
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("append-to-page shows appendUnavailable when page title does not match", async () => {
+    const pageContext = {
+      type: "editor" as const,
+      pageId: "page-1",
+      pageTitle: "Current Page",
+      pageFullContent: "",
+    };
+    const { result } = renderHook(() => useAIChatActions({ pageContext }), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.handleExecuteAction({
+        type: "append-to-page",
+        pageTitle: "Other",
+        content: "x",
+        reason: "test",
+      });
+    });
+
+    expect(mockUpdatePageMutateAsync).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "aiChat.notifications.appendUnavailable",
+      variant: "destructive",
+    });
+  });
+
+  it("suggest-wiki-links shows noNewWikiLinks when all suggested titles are already present", async () => {
+    const pageContext = {
+      type: "editor" as const,
+      pageId: "page-1",
+      pageTitle: "Current Page",
+      pageFullContent: JSON.stringify({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "x",
+                marks: [
+                  {
+                    type: "wikiLink",
+                    attrs: { title: "Already", exists: false, referenced: false },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    };
+    const { result } = renderHook(() => useAIChatActions({ pageContext }), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.handleExecuteAction({
+        type: "suggest-wiki-links",
+        links: [{ keyword: "Already", existingPageTitle: "Already" }],
+        reason: "test",
+      });
+    });
+
+    expect(mockUpdatePageMutateAsync).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith({ title: "aiChat.notifications.noNewWikiLinks" });
+  });
+
+  it("append-to-page shows actionFailed and rolls back when syncLinks throws", async () => {
+    const pageContext = {
+      type: "editor" as const,
+      pageId: "page-1",
+      pageTitle: "Current Page",
+      pageFullContent: "",
+    };
+    mockSyncLinks.mockRejectedValue(new Error("sync failed"));
+
+    const { result } = renderHook(() => useAIChatActions({ pageContext }), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.handleExecuteAction({
+        type: "append-to-page",
+        pageTitle: "Current Page",
+        content: "Append body",
+        reason: "test",
+      });
+    });
+
+    expect(mockUpdatePageMutateAsync).toHaveBeenCalledTimes(2);
+    expect(mockSyncLinks).toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "aiChat.notifications.actionFailed",
+      variant: "destructive",
+    });
+  });
+
+  it("create-page does not navigate when mutate returns no id", async () => {
+    mockCreatePageMutateAsync.mockResolvedValueOnce({ id: undefined });
+    const { result } = renderHook(() => useAIChatActions({ pageContext: null }), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.handleExecuteAction({
+        type: "create-page",
+        title: "Solo",
+        content: "c",
+        suggestedLinks: [],
+        reason: "test",
+      });
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Issue #394 に対し、`runAIChatAction` / `useAIChatActions` / `usePendingChatPageGeneration` の主要パス（成功・失敗・ガード・キャンセル相当）を単体テストで固定し、Stryker Survivors 削減に寄与するテストを追加しました。

## 変更点

- `runAIChatAction.test.ts`: ページコンテキスト不足・タイトル不一致、suggest-wiki-links の no-op / 失敗 / 成功、作成時 ID なしでナビゲートしないケースなど
- `useAIChatActions.test.ts`: 複数ページ作成、タイトル不一致、`syncLinks` 失敗時のロールバックと `actionFailed`、既存リンクのみの noNewWikiLinks、作成結果に id がない場合のナビゲート抑止
- `usePendingChatPageGeneration.test.tsx`: 完了時の `saveChanges` / トースト、ストリームエラー vs `ABORTED`、初期化・タイトル未準備ガード、チャンク経由の `setContent`

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run test:run`
2. `bun run format:check`

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない（変更ファイルに新規エラーなし）
- [ ] 必要に応じてドキュメントを更新した（不要）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

なし（テストのみ）

## 関連 Issue

Closes #394
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55886eff-ce5b-43b0-8f65-ae8fb198803f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55886eff-ce5b-43b0-8f65-ae8fb198803f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * AI チャット機能に関する複数のテストケースを追加し、ページ生成完了時の通知処理、エラーハンドリング、初期化フロー、ページ追記時の検証、ウィキリンク提案時の既存リンク判定、作成失敗時のロールバック動作などを網羅的にカバーしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->