### PR TITLE
feat(e2e): ai chat regression tests for panel and page cards (#396)

### DIFF
--- a/e2e/ai-chat-panel.spec.ts
+++ b/e2e/ai-chat-panel.spec.ts
@@ -1,15 +1,9 @@
 /**
  * AI チャット: 設定済みのときヘッダーの AI からグローバルドックのチャットを開ける。
  * E2E: Open AI chat from header on Home (PageEditor uses useLocalPanel — header AI is hidden there).
+ * Page grid: context menu「AIチャットに追加」で参照チップが付く（#396）。
  */
 import { test, expect } from "./auth-mock";
-
-const COMPLETED_ONBOARDING_STATE = {
-  hasCompletedSetupWizard: true,
-  hasCompletedTour: false,
-  completedSteps: [] as string[],
-  dismissedHints: [] as string[],
-};
 
 const MINIMAL_AI_SETTINGS = JSON.stringify({
   provider: "openai",
@@ -25,11 +19,10 @@ test.describe("AI Chat panel", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(
-      ({ onboarding, ai }: { onboarding: typeof COMPLETED_ONBOARDING_STATE; ai: string }) => {
-        localStorage.setItem("zedi-onboarding", JSON.stringify(onboarding));
+      ({ ai }: { ai: string }) => {
         localStorage.setItem("zedi-ai-settings", ai);
       },
-      { onboarding: COMPLETED_ONBOARDING_STATE, ai: MINIMAL_AI_SETTINGS },
+      { ai: MINIMAL_AI_SETTINGS },
     );
   });
 
@@ -40,5 +33,79 @@ test.describe("AI Chat panel", () => {
 
     const composer = page.locator("aside").getByRole("textbox");
     await expect(composer).toBeVisible({ timeout: 20000 });
+  });
+
+  test("adds page reference from home PageCard context menu", async ({ page, helpers }) => {
+    const pageId = await helpers.createNewPage(page);
+    await helpers.waitForEditor(page);
+
+    const title = "E2E Ref Page";
+    await page.getByPlaceholder("タイトル").fill(title);
+    await page.waitForTimeout(1500);
+
+    await helpers.goToHome(page);
+
+    const card = page.locator(".page-card").filter({ hasText: title });
+    await expect(card).toBeVisible({ timeout: 20000 });
+    await card.click({ button: "right" });
+
+    await page.getByRole("menuitem", { name: "AIチャットに追加" }).click();
+
+    const aside = page.locator("aside");
+    await expect(aside).toBeVisible({ timeout: 20000 });
+    await expect(aside.getByRole("textbox")).toBeVisible();
+    await expect(aside.locator(`[data-page-id="${pageId}"]`)).toBeVisible();
+  });
+
+  test.describe("seeded home conversation", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.addInitScript(() => {
+        const now = Date.now();
+        const conversations = [
+          {
+            id: "conv-e2e-seed-home",
+            title: "E2E seeded action",
+            messages: [
+              {
+                id: "msg-e2e-assistant-1",
+                role: "assistant",
+                content: "提案があります。",
+                actions: [
+                  {
+                    type: "create-page",
+                    title: "Seeded Title",
+                    content: "# Hello",
+                    suggestedLinks: [],
+                    reason: "E2E seed",
+                  },
+                ],
+                timestamp: now,
+              },
+            ],
+            createdAt: now,
+            updatedAt: now,
+          },
+        ];
+        localStorage.setItem("zedi-ai-conversations", JSON.stringify(conversations));
+      });
+    });
+
+    test("shows create-page action card when selecting seeded conversation", async ({
+      page,
+      helpers,
+    }) => {
+      await helpers.goToHome(page);
+
+      await page.getByRole("button", { name: "AI", exact: true }).click();
+
+      const aside = page.locator("aside");
+      await expect(aside.getByRole("textbox")).toBeVisible({ timeout: 20000 });
+
+      await aside.getByTitle("会話一覧").click();
+
+      await aside.getByText("E2E seeded action", { exact: false }).click();
+
+      await expect(aside.getByRole("button", { name: "作成する" })).toBeVisible({ timeout: 15000 });
+    });
   });
 });

--- a/e2e/ai-chat-panel.spec.ts
+++ b/e2e/ai-chat-panel.spec.ts
@@ -41,7 +41,7 @@ test.describe("AI Chat panel", () => {
 
     const title = "E2E Ref Page";
     await page.getByPlaceholder("タイトル").fill(title);
-    await page.waitForTimeout(1500);
+    await expect(page.getByText(/に保存/)).toBeVisible({ timeout: 20000 });
 
     await helpers.goToHome(page);
 

--- a/e2e/auth-mock.ts
+++ b/e2e/auth-mock.ts
@@ -78,17 +78,16 @@ const helpers = {
  * Seeds onboarding so Home renders (FAB, grid) for mock signed-in users.
  */
 export const test = base.extend<{ helpers: typeof helpers }>({
-  page: async ({ page }, use) => {
+  page: async ({ page }, continueFixture) => {
     await page.addInitScript((onboarding: typeof E2E_DEFAULT_ONBOARDING) => {
       localStorage.setItem("zedi-onboarding", JSON.stringify(onboarding));
     }, E2E_DEFAULT_ONBOARDING);
-    // eslint-disable-next-line react-hooks/rules-of-hooks -- Playwright fixture continuation (not React)
-    await use(page);
+    await continueFixture(page);
   },
-  // eslint-disable-next-line no-empty-pattern
-  helpers: async ({}, use) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    await use(helpers);
+  /** Depends on `page` only to satisfy Playwright's destructuring requirement (no empty `{}`). */
+  helpers: async ({ page: _page }, continueFixture) => {
+    void _page;
+    await continueFixture(helpers);
   },
 });
 

--- a/e2e/auth-mock.ts
+++ b/e2e/auth-mock.ts
@@ -6,6 +6,14 @@
  */
 import { test as base, expect, Page } from "@playwright/test";
 
+/** Default onboarding so signed-in E2E users stay on /home (not redirected to /onboarding). */
+const E2E_DEFAULT_ONBOARDING = {
+  hasCompletedSetupWizard: true,
+  hasCompletedTour: false,
+  completedSteps: [] as string[],
+  dismissedHints: [] as string[],
+};
+
 /**
  * Helper functions for E2E tests.
  */
@@ -20,15 +28,17 @@ const helpers = {
 
   /**
    * Create a new page and return its ID.
+   * Uses the home FAB (「新規作成」): `/page/new` is no longer a creation entry (editor redirects to /home).
    */
   async createNewPage(page: Page): Promise<string> {
-    // Navigate to new page
-    await page.goto("/page/new");
+    await page.goto("/home");
+    await page.waitForLoadState("networkidle");
 
-    // Wait for redirect to actual page with UUID
+    await page.locator('[data-tour-id="tour-fab"]').click();
+    await page.getByRole("button", { name: "新規作成" }).click();
+
     await page.waitForURL(/\/page\/(?!new).+/, { timeout: 15000 });
 
-    // Extract page ID from URL
     const url = page.url();
     const match = url.match(/\/page\/([^/]+)/);
     if (!match) {
@@ -65,8 +75,16 @@ const helpers = {
 
 /**
  * Custom test fixture with helpers.
+ * Seeds onboarding so Home renders (FAB, grid) for mock signed-in users.
  */
 export const test = base.extend<{ helpers: typeof helpers }>({
+  page: async ({ page }, use) => {
+    await page.addInitScript((onboarding: typeof E2E_DEFAULT_ONBOARDING) => {
+      localStorage.setItem("zedi-onboarding", JSON.stringify(onboarding));
+    }, E2E_DEFAULT_ONBOARDING);
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- Playwright fixture continuation (not React)
+    await use(page);
+  },
   // eslint-disable-next-line no-empty-pattern
   helpers: async ({}, use) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/e2e/linked-pages.spec.ts
+++ b/e2e/linked-pages.spec.ts
@@ -13,7 +13,7 @@ test.describe("Linked Pages Cards", () => {
     await helpers.createNewPage(page);
 
     // Should see the title input
-    await expect(page.getByPlaceholder("タイトルを入力")).toBeVisible();
+    await expect(page.getByPlaceholder("タイトル")).toBeVisible();
 
     // Should see the editor
     await expect(page.locator(".tiptap")).toBeVisible();
@@ -24,7 +24,7 @@ test.describe("Linked Pages Cards", () => {
     await helpers.createNewPage(page);
 
     // Enter title
-    const titleInput = page.getByPlaceholder("タイトルを入力");
+    const titleInput = page.getByPlaceholder("タイトル");
     await titleInput.fill("Test Page Title");
 
     // Wait for auto-save (debounced 500ms + some buffer)
@@ -42,7 +42,7 @@ test.describe("Linked Pages Cards", () => {
     await helpers.createNewPage(page);
 
     // Enter title first to avoid warning
-    await page.getByPlaceholder("タイトルを入力").fill("Editor Test");
+    await page.getByPlaceholder("タイトル").fill("Editor Test");
     await page.waitForTimeout(500);
 
     // Click on editor and type
@@ -59,7 +59,7 @@ test.describe("Linked Pages Cards", () => {
     await helpers.createNewPage(page);
 
     // Enter title first
-    await page.getByPlaceholder("タイトルを入力").fill("WikiLink Test");
+    await page.getByPlaceholder("タイトル").fill("WikiLink Test");
     await page.waitForTimeout(500);
 
     // Click on editor and type [[
@@ -80,7 +80,7 @@ test.describe("Linked Pages Cards", () => {
     helpers,
   }) => {
     await helpers.createNewPage(page);
-    await page.getByPlaceholder("タイトルを入力").fill("Closed Link Test");
+    await page.getByPlaceholder("タイトル").fill("Closed Link Test");
     // Wait for editor to be ready (no "save complete" UI; debounced save + editor init)
     await page.waitForTimeout(500);
 
@@ -108,7 +108,7 @@ test.describe("Linked Pages Cards", () => {
     // Step 1: Create "Target Page"
     await helpers.createNewPage(page);
 
-    await page.getByPlaceholder("タイトルを入力").fill("Target Page");
+    await page.getByPlaceholder("タイトル").fill("Target Page");
 
     const editor1 = page.locator(".tiptap");
     await editor1.click();
@@ -121,7 +121,7 @@ test.describe("Linked Pages Cards", () => {
     await helpers.createNewPage(page);
     const sourcePageUrl = page.url();
 
-    await page.getByPlaceholder("タイトルを入力").fill("Source Page");
+    await page.getByPlaceholder("タイトル").fill("Source Page");
 
     const editor2 = page.locator(".tiptap");
     await editor2.click();
@@ -171,7 +171,7 @@ test.describe("Linked Pages Cards", () => {
     await helpers.createNewPage(page);
     const pageUrl = page.url();
 
-    await page.getByPlaceholder("タイトルを入力").fill("Ghost Link Test");
+    await page.getByPlaceholder("タイトル").fill("Ghost Link Test");
 
     const editor = page.locator(".tiptap");
     await editor.click();

--- a/e2e/page-editor.spec.ts
+++ b/e2e/page-editor.spec.ts
@@ -13,15 +13,14 @@ test.describe("Page Editor", () => {
 
       // Verify editor is visible
       await expect(page.locator(".tiptap")).toBeVisible({ timeout: 10000 });
-      await expect(page.getByPlaceholder("タイトルを入力")).toBeVisible();
+      await expect(page.getByPlaceholder("タイトル")).toBeVisible();
     });
 
-    test("should show loading state during page creation", async ({ page }) => {
+    test("redirects /page/new to home (direct /page/new is not a creation entry)", async ({
+      page,
+    }) => {
       await page.goto("/page/new");
-
-      // Loading spinner should be visible briefly
-      // Note: This may be too fast to catch in some cases
-      await page.waitForURL(/\/page\/(?!new).+/, { timeout: 15000 });
+      await expect(page).toHaveURL(/\/home/, { timeout: 10000 });
     });
   });
 
@@ -29,7 +28,7 @@ test.describe("Page Editor", () => {
     test("should save title changes with auto-save", async ({ page, helpers }) => {
       await helpers.createNewPage(page);
 
-      const titleInput = page.getByPlaceholder("タイトルを入力");
+      const titleInput = page.getByPlaceholder("タイトル");
       await titleInput.fill("Test Title");
 
       // Wait for debounced save (500ms + buffer)
@@ -46,19 +45,23 @@ test.describe("Page Editor", () => {
       // Create first page with title
       await helpers.createNewPage(page);
 
-      await page.getByPlaceholder("タイトルを入力").fill("Unique Title");
+      await page.getByPlaceholder("タイトル").fill("Unique Title");
       await page.waitForTimeout(1500);
 
       // Create second page with same title
       await helpers.createNewPage(page);
 
-      await page.getByPlaceholder("タイトルを入力").fill("Unique Title");
-      await page.waitForTimeout(1500);
+      await page.getByPlaceholder("タイトル").fill("Unique Title");
+      // Debounced duplicate check (useTitleValidation) + save
+      await page.waitForTimeout(2500);
 
-      // Should show duplicate warning
-      await expect(page.getByText(/同じタイトルのページ/)).toBeVisible({
-        timeout: 5000,
-      });
+      // Duplicate message: toast + inline title (two role=alert with same copy)
+      await expect(
+        page
+          .getByRole("alert")
+          .filter({ hasText: /既に存在します/ })
+          .first(),
+      ).toBeVisible({ timeout: 15000 });
     });
   });
 
@@ -74,7 +77,7 @@ test.describe("Page Editor", () => {
       await page.waitForTimeout(1500);
 
       // Title should be auto-generated from content
-      const titleInput = page.getByPlaceholder("タイトルを入力");
+      const titleInput = page.getByPlaceholder("タイトル");
       await expect(titleInput).toHaveValue("Auto generated title from first line");
     });
 
@@ -83,7 +86,7 @@ test.describe("Page Editor", () => {
       const currentUrl = page.url();
 
       // Enter title
-      await page.getByPlaceholder("タイトルを入力").fill("Content Test");
+      await page.getByPlaceholder("タイトル").fill("Content Test");
       await page.waitForTimeout(500);
 
       // Enter content
@@ -134,7 +137,7 @@ test.describe("Page Editor", () => {
       await helpers.createNewPage(page);
 
       // Enter title
-      await page.getByPlaceholder("タイトルを入力").fill("Test Topic");
+      await page.getByPlaceholder("タイトル").fill("Test Topic");
       await page.waitForTimeout(500);
 
       // Wiki生成 button should be visible
@@ -145,7 +148,7 @@ test.describe("Page Editor", () => {
       await helpers.createNewPage(page);
 
       // Enter title
-      await page.getByPlaceholder("タイトルを入力").fill("Test Topic");
+      await page.getByPlaceholder("タイトル").fill("Test Topic");
       await page.waitForTimeout(500);
 
       // Enter content
@@ -164,7 +167,7 @@ test.describe("Page Editor", () => {
       await helpers.createNewPage(page);
 
       // Enter title to avoid delete warning
-      await page.getByPlaceholder("タイトルを入力").fill("Navigation Test");
+      await page.getByPlaceholder("タイトル").fill("Navigation Test");
       await page.waitForTimeout(1500);
 
       // Click back button
@@ -201,7 +204,7 @@ test.describe("Page Editor", () => {
       await helpers.createNewPage(page);
 
       // Enter title
-      await page.getByPlaceholder("タイトルを入力").fill("Actions Test");
+      await page.getByPlaceholder("タイトル").fill("Actions Test");
       await page.waitForTimeout(500);
 
       // Click more options button
@@ -219,7 +222,7 @@ test.describe("Page Editor", () => {
       const pageUrl = page.url();
 
       // Enter title
-      await page.getByPlaceholder("タイトルを入力").fill("Delete Test");
+      await page.getByPlaceholder("タイトル").fill("Delete Test");
       await page.waitForTimeout(1500);
 
       // Click more options and delete
@@ -241,7 +244,7 @@ test.describe("Page Editor", () => {
       await helpers.createNewPage(page);
 
       // Enter title to avoid delete warning
-      await page.getByPlaceholder("タイトルを入力").fill("Shortcut Test");
+      await page.getByPlaceholder("タイトル").fill("Shortcut Test");
       await page.waitForTimeout(1500);
 
       // Press Cmd+H (or Ctrl+H on Windows/Linux)
@@ -256,7 +259,7 @@ test.describe("Page Editor", () => {
     test("should show linked pages section when page has WikiLinks", async ({ page, helpers }) => {
       // Create target page first
       await helpers.createNewPage(page);
-      await page.getByPlaceholder("タイトルを入力").fill("Target Page for Links");
+      await page.getByPlaceholder("タイトル").fill("Target Page for Links");
       await page.locator(".tiptap").click();
       await page.keyboard.type("Content of target page");
       await page.waitForTimeout(2000);
@@ -265,7 +268,7 @@ test.describe("Page Editor", () => {
       await helpers.createNewPage(page);
       const sourceUrl = page.url();
 
-      await page.getByPlaceholder("タイトルを入力").fill("Source Page with Links");
+      await page.getByPlaceholder("タイトル").fill("Source Page with Links");
       await page.locator(".tiptap").click();
 
       // Type WikiLink
@@ -302,7 +305,7 @@ test.describe("Page Editor", () => {
         },
         { timeout: 10000 },
       );
-      await page.getByPlaceholder("タイトルを入力").fill("Context Menu Delete Test");
+      await page.getByPlaceholder("タイトル").fill("Context Menu Delete Test");
       await syncPromise;
 
       await page.goto("/home");

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -83,7 +83,7 @@ test.describe("Global Search - Data Tests", () => {
   test("should show recent pages section", async ({ page, helpers }) => {
     // Create a page first
     await helpers.createNewPage(page);
-    await page.getByPlaceholder("タイトルを入力").fill("Recent Page Test");
+    await page.getByPlaceholder("タイトル").fill("Recent Page Test");
     await page.waitForTimeout(2000);
 
     // Open search on the same page

--- a/src/components/auth/MockAuthProvider.tsx
+++ b/src/components/auth/MockAuthProvider.tsx
@@ -6,7 +6,8 @@
  */
 import { createContext, useContext, ReactNode } from "react";
 
-const MOCK_USER_ID = "e2e_test_user_123";
+/** Same ID as local-first guest storage so E2E creates pages offline (no API). / API 不要で IndexedDB のみ作成するため local-user と一致させる。 */
+const MOCK_USER_ID = "local-user";
 const MOCK_USER_EMAIL = "e2e-test@example.com";
 
 interface MockAuthContextValue {
@@ -27,7 +28,13 @@ interface MockAuthProviderProps {
   children: ReactNode;
 }
 
+/**
+ *
+ */
 export function MockAuthProvider({ children }: MockAuthProviderProps) {
+  /**
+   *
+   */
   const mockAuthValue: MockAuthContextValue = {
     isLoaded: true,
     isSignedIn: true,
@@ -43,7 +50,13 @@ export function MockAuthProvider({ children }: MockAuthProviderProps) {
   return <MockAuthContext.Provider value={mockAuthValue}>{children}</MockAuthContext.Provider>;
 }
 
+/**
+ *
+ */
 export function useMockAuth(): MockAuthContextValue {
+  /**
+   *
+   */
   const context = useContext(MockAuthContext);
   if (!context) {
     throw new Error("useMockAuth must be used within a MockAuthProvider");
@@ -51,10 +64,16 @@ export function useMockAuth(): MockAuthContextValue {
   return context;
 }
 
+/**
+ *
+ */
 export function MockSignedIn({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }
 
+/**
+ *
+ */
 export function MockSignedOut({ children }: { children: ReactNode }) {
   void children;
   return null;

--- a/src/components/auth/MockAuthProvider.tsx
+++ b/src/components/auth/MockAuthProvider.tsx
@@ -29,12 +29,10 @@ interface MockAuthProviderProps {
 }
 
 /**
- *
+ * E2E 用の認証プロバイダー。子ツリーにモックの認証コンテキストを供給する。
+ * Mock auth provider for E2E. Supplies mock auth context to the subtree.
  */
 export function MockAuthProvider({ children }: MockAuthProviderProps) {
-  /**
-   *
-   */
   const mockAuthValue: MockAuthContextValue = {
     isLoaded: true,
     isSignedIn: true,
@@ -51,12 +49,10 @@ export function MockAuthProvider({ children }: MockAuthProviderProps) {
 }
 
 /**
- *
+ * MockAuthContext からモック認証状態を取得する。MockAuthProvider 内でのみ使用する。
+ * Returns mock auth from MockAuthContext. Must be used within MockAuthProvider.
  */
 export function useMockAuth(): MockAuthContextValue {
-  /**
-   *
-   */
   const context = useContext(MockAuthContext);
   if (!context) {
     throw new Error("useMockAuth must be used within a MockAuthProvider");
@@ -65,14 +61,16 @@ export function useMockAuth(): MockAuthContextValue {
 }
 
 /**
- *
+ * E2E 用の SignedIn 代替。子を常に描画する。
+ * Mock SignedIn for E2E. Always renders children.
  */
 export function MockSignedIn({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }
 
 /**
- *
+ * E2E 用の SignedOut 代替。子は描画しない（null を返す）。
+ * Mock SignedOut for E2E. Renders nothing (returns null).
  */
 export function MockSignedOut({ children }: { children: ReactNode }) {
   void children;


### PR DESCRIPTION
## 概要

Issue #396 に対応し、AI チャットドックとホームの PageCard 連携、およびシード会話でのアクションカード表示を Playwright で検証する。E2E では API 不要でページ作成できるようモックユーザーを \`local-user\` に揃え、FAB 経由の新規ページ作成・オンボーディングシード・タイトル placeholder を現行 UI に合わせて修正した。

## 変更点

### \`e2e/\`
- **\`ai-chat-panel.spec.ts\`**: 既存の「ヘッダー AI でチャット開く」に加え、(1) PageCard 右クリック「AIチャットに追加」で \`[data-page-id]\` チップ、(2) \`zedi-ai-conversations\` シードで会話一覧→「作成する」ボタンを追加。
- **\`auth-mock.ts\`**: \`/page/new\` 廃止に合わせ FAB「新規作成」で新規ページ作成。全テストで \`zedi-onboarding\` をシード。Playwright の \`use\` に eslint 除外コメント。

### \`src/components/auth/\`
- **\`MockAuthProvider.tsx\`**: E2E 時の \`userId\` を \`local-user\` にし、IndexedDB のみでのページ作成（オフライン E2E）を可能に。

### その他 E2E
- **\`linked-pages.spec.ts\`**, **\`search.spec.ts\`**: タイトル入力の placeholder を \`タイトル\` に統一（\`PageTitleBlock\` と一致）。
- **\`page-editor.spec.ts\`**: \`/page/new\` は \`/home\` へリダイレクトする挙動へテスト更新。重複タイトル警告は \`useTitleValidation\` の文言・複数 \`role=alert\` に合わせて修正。

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. \`bun install\`（未実施なら）
2. \`bun run test:e2e -- e2e/ai-chat-panel.spec.ts\`（変更の中心）
3. 任意: \`CI=1 bun run test:e2e\`（全 E2E。環境により一部既存シナリオが失敗する場合あり）

## チェックリスト

- [x] 該当 E2E（\`ai-chat-panel.spec.ts\`）をローカルで実行
- [ ] リポジトリ全体の Lint が 0 error（既存 warning 多数のため、変更ファイルは pre-commit で通過）
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

なし（テスト・モック認証のみ）

## 関連 Issue

Closes #396

（ロードマップ #397 は子 Issue 完了まで開いたまま）

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * ホームからページを開く際の AI チャット機能の E2E テストを追加
  * 複数の E2E テストでテストデータの整合性を改善

* **Chores**
  * テスト環境のセットアップを改善（オンボーディング状態の管理）
  * モック認証の設定を更新
  * テスト用プレースホルダーテキストを統一

<!-- end of auto-generated comment: release notes by coderabbit.ai -->