### PR TITLE
fix(api): Railway Docker ビルド向けに bun-types を devDependency 追加

### DIFF
--- a/server/api/bun.lock
+++ b/server/api/bun.lock
@@ -32,6 +32,7 @@
         "@types/jsdom": "^28.0.0",
         "@types/node": "^25.3.3",
         "@types/pg": "^8.18.0",
+        "bun-types": "^1.3.11",
         "drizzle-kit": "^0.31.9",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
@@ -547,6 +548,8 @@
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "c12": ["c12@3.1.0", "", { "dependencies": { "chokidar": "^4.0.3", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^16.6.1", "exsolve": "^1.0.7", "giget": "^2.0.0", "jiti": "^2.4.2", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^1.0.0", "pkg-types": "^2.2.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "^0.3.5" }, "optionalPeers": ["magicast"] }, "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw=="],
 

--- a/server/api/package.json
+++ b/server/api/package.json
@@ -44,6 +44,7 @@
     "@types/jsdom": "^28.0.0",
     "@types/node": "^25.3.3",
     "@types/pg": "^8.18.0",
+    "bun-types": "^1.3.11",
     "drizzle-kit": "^0.31.9",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",


### PR DESCRIPTION
## 概要

Railway の **api-dev** デプロイで Docker ビルドが `tsc` により失敗していました（`TS2688: Cannot find type definition file for 'bun-types'`）。`server/api/tsconfig.json` の `types` に `bun-types` が含まれる一方、`package.json` にパッケージが無くイメージ内の `bun install` で型定義が入らないことが原因です。`bun-types` を devDependency に追加して解消します。

## 変更点

- `server/api/package.json`: `bun-types` を devDependencies に追加
- `server/api/bun.lock`: ロックファイル更新

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `cd server/api && bun run build && bun run test:run` が通ることを確認（実施済み）。
2. マージ後、`develop` への push で Railway api-dev が再デプロイされ、ビルドが成功することを Railway ダッシュボードで確認。

## チェックリスト

- [x] テストがすべてパスする（`server/api` の Vitest）
- [x] Lint エラーがない（変更は JSON のみ）
- [ ] 必要に応じてドキュメントを更新した（不要）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

なし

## 関連 Issue

なし（Railway ビルド失敗の調査に基づく修正）


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
