### PR TITLE
fix(security): syncPages の links / ghost_links 挿入時に owner_id チェックを追加 (#426)

### DIFF
--- a/server/api/src/__tests__/routes/syncPages.test.ts
+++ b/server/api/src/__tests__/routes/syncPages.test.ts
@@ -1,0 +1,158 @@
+/**
+ * POST /api/sync/pages — IDOR protection tests.
+ * Verifies that links / ghost_links with non-owned source pages are skipped.
+ *
+ * links / ghost_links の source が自分のページでない場合に挿入がスキップされることを検証する。
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Context, Next } from "hono";
+import type { AppEnv } from "../../types/index.js";
+
+vi.mock("../../middleware/auth.js", () => ({
+  authRequired: async (c: Context<AppEnv>, next: Next) => {
+    const userId = c.req.header("x-test-user-id");
+    if (!userId) return c.json({ message: "Unauthorized" }, 401);
+    c.set("userId", userId);
+    await next();
+  },
+}));
+
+import { Hono } from "hono";
+import syncPagesRoute from "../../routes/syncPages.js";
+import { createMockDb } from "../createMockDb.js";
+
+const TEST_USER_ID = "user-owner";
+const OWNED_PAGE = "page-owned-001";
+const OTHER_PAGE = "page-other-999";
+
+function authHeaders() {
+  return {
+    "x-test-user-id": TEST_USER_ID,
+    "Content-Type": "application/json",
+  };
+}
+
+function createSyncApp(dbResults: unknown[]) {
+  const mock = createMockDb(dbResults);
+  const app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("db", mock.db as unknown as AppEnv["Variables"]["db"]);
+    await next();
+  });
+  app.route("/api/sync/pages", syncPagesRoute);
+  return { app, chains: mock.chains };
+}
+
+describe("POST /api/sync/pages — IDOR protection", () => {
+  it("skips link insertion when source_id is not owned by the user", async () => {
+    const oldDate = new Date("2024-01-01T00:00:00Z");
+    const { app, chains } = createSyncApp([
+      // 1: page existence check
+      [{ id: OWNED_PAGE, updatedAt: oldDate, ownerId: TEST_USER_ID }],
+      // 2: page update
+      undefined,
+      // 3: owned pages query for links
+      [{ id: OWNED_PAGE }],
+      // 4: delete existing links for OWNED_PAGE
+      undefined,
+      // 5: insert link (only the owned one)
+      undefined,
+    ]);
+
+    const res = await app.request("/api/sync/pages", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        pages: [{ id: OWNED_PAGE, title: "My Page", updated_at: "2025-06-01T00:00:00Z" }],
+        links: [
+          { source_id: OWNED_PAGE, target_id: "target-a" },
+          { source_id: OTHER_PAGE, target_id: "target-b" },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+
+    const insertChains = chains.filter((c) => c.startMethod === "insert");
+    // 1 page insert/update + 1 owned link insert = only 1 insert
+    // The non-owned link must NOT produce an insert call.
+    expect(insertChains.length).toBe(1);
+  });
+
+  it("skips ghost_link insertion when source_page_id is not owned by the user", async () => {
+    const oldDate = new Date("2024-01-01T00:00:00Z");
+    const { app, chains } = createSyncApp([
+      // 1: page existence check
+      [{ id: OWNED_PAGE, updatedAt: oldDate, ownerId: TEST_USER_ID }],
+      // 2: page update
+      undefined,
+      // 3: owned pages query for ghost_links
+      [{ id: OWNED_PAGE }],
+      // 4: delete existing ghost_links for OWNED_PAGE
+      undefined,
+      // 5: insert ghost_link (only the owned one)
+      undefined,
+    ]);
+
+    const res = await app.request("/api/sync/pages", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        pages: [{ id: OWNED_PAGE, title: "My Page", updated_at: "2025-06-01T00:00:00Z" }],
+        ghost_links: [
+          { link_text: "valid", source_page_id: OWNED_PAGE },
+          { link_text: "malicious", source_page_id: OTHER_PAGE },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+
+    const insertChains = chains.filter((c) => c.startMethod === "insert");
+    expect(insertChains.length).toBe(1);
+  });
+
+  it("skips both links and ghost_links for non-owned pages in combined request", async () => {
+    const oldDate = new Date("2024-01-01T00:00:00Z");
+    const { app, chains } = createSyncApp([
+      // 1: page existence check
+      [{ id: OWNED_PAGE, updatedAt: oldDate, ownerId: TEST_USER_ID }],
+      // 2: page update
+      undefined,
+      // 3: owned pages query for links
+      [{ id: OWNED_PAGE }],
+      // 4: delete existing links for OWNED_PAGE
+      undefined,
+      // 5: insert owned link
+      undefined,
+      // 6: owned pages query for ghost_links
+      [{ id: OWNED_PAGE }],
+      // 7: delete existing ghost_links for OWNED_PAGE
+      undefined,
+      // 8: insert owned ghost_link
+      undefined,
+    ]);
+
+    const res = await app.request("/api/sync/pages", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        pages: [{ id: OWNED_PAGE, title: "My Page", updated_at: "2025-06-01T00:00:00Z" }],
+        links: [
+          { source_id: OWNED_PAGE, target_id: "target-a" },
+          { source_id: OTHER_PAGE, target_id: "target-b" },
+        ],
+        ghost_links: [
+          { link_text: "valid", source_page_id: OWNED_PAGE },
+          { link_text: "malicious", source_page_id: OTHER_PAGE },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+
+    const insertChains = chains.filter((c) => c.startMethod === "insert");
+    // 1 owned link insert + 1 owned ghost_link insert = 2 inserts total
+    expect(insertChains.length).toBe(2);
+  });
+});

--- a/server/api/src/routes/syncPages.ts
+++ b/server/api/src/routes/syncPages.ts
@@ -173,6 +173,7 @@ app.post("/", authRequired, async (c) => {
     }
     for (const link of body.links) {
       if (link.source_id === link.target_id) continue; // self-ref skip
+      if (!ownedIds.has(link.source_id)) continue; // IDOR protection
       await db
         .insert(links)
         .values({
@@ -196,6 +197,7 @@ app.post("/", authRequired, async (c) => {
       await db.delete(ghostLinks).where(eq(ghostLinks.sourcePageId, sourceId));
     }
     for (const gl of body.ghost_links) {
+      if (!ownedGhostIds.has(gl.source_page_id)) continue; // IDOR protection
       await db
         .insert(ghostLinks)
         .values({


### PR DESCRIPTION
## 概要

`POST /api/sync/pages` の links / ghost_links 挿入ループで、`source_id` / `source_page_id` がリクエストユーザーの所有するページかどうかを検証していなかった IDOR 脆弱性を修正。

## 変更点

- `server/api/src/routes/syncPages.ts`: links 挿入ループに `ownedIds.has(link.source_id)` チェックを追加
- `server/api/src/routes/syncPages.ts`: ghost_links 挿入ループに `ownedGhostIds.has(gl.source_page_id)` チェックを追加
- `server/api/src/__tests__/routes/syncPages.test.ts`: IDOR 保護の単体テストを新規追加（3 ケース）

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `bun run test:run` で全テスト（962 件）がパスすることを確認
2. 新規テスト `syncPages.test.ts` が以下を検証:
   - 所有していないページの `source_id` を持つ link が挿入されないこと
   - 所有していないページの `source_page_id` を持つ ghost_link が挿入されないこと
   - links と ghost_links の両方を含むリクエストで、非所有ページの行がどちらもスキップされること

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #426

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
