### PR TITLE
fix(api): POST /api/clip/fetch に SSRF 対策を追加 (#428)

### DIFF
--- a/server/api/src/__tests__/routes/clip.test.ts
+++ b/server/api/src/__tests__/routes/clip.test.ts
@@ -90,6 +90,8 @@ describe("POST /api/clip/fetch", () => {
       body: JSON.stringify({ url: "http://127.0.0.1:8080/" }),
     });
     expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toMatch(/URL not allowed|only public http/i);
   });
 
   it("returns 200 with html when fetch succeeds", async () => {
@@ -104,7 +106,7 @@ describe("POST /api/clip/fetch", () => {
     const res = await app.request("/api/clip/fetch", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ url: "https://example.com/article" }),
+      body: JSON.stringify({ url: "http://8.8.8.8/article" }),
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { html?: string; url?: string; content_type?: string };

--- a/server/api/src/__tests__/routes/clip.test.ts
+++ b/server/api/src/__tests__/routes/clip.test.ts
@@ -1,0 +1,114 @@
+/**
+ * /api/clip ルートのテスト（fetch の SSRF 拒否・認証）
+ * Tests for clip routes: fetch SSRF rejection and auth.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+type AuthSession = Awaited<ReturnType<typeof import("../../auth.js").auth.api.getSession>>;
+
+vi.mock("../../db/client.js", () => ({
+  getDb: vi.fn(() => ({})),
+}));
+
+const mockSessionUser = {
+  id: "user-1",
+  email: "u@e.com",
+  name: "",
+  image: null as string | null,
+  emailVerified: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  role: null as string | null,
+};
+
+vi.mock("../../auth.js", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+import { auth } from "../../auth.js";
+import { Hono } from "hono";
+import { errorHandler } from "../../middleware/errorHandler.js";
+import clipRoutes from "../../routes/clip.js";
+import type { AppEnv } from "../../types/index.js";
+
+function createClipApp() {
+  const app = new Hono<AppEnv>();
+  app.onError(errorHandler);
+  app.route("/api/clip", clipRoutes);
+  return app;
+}
+
+describe("POST /api/clip/fetch", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.mocked(auth.api.getSession).mockResolvedValue({ user: mockSessionUser } as AuthSession);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns 401 when session is missing", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue(null);
+    const app = createClipApp();
+    const res = await app.request("/api/clip/fetch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://example.com/" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when url is missing", async () => {
+    const app = createClipApp();
+    const res = await app.request("/api/clip/fetch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for localhost (SSRF protection)", async () => {
+    const app = createClipApp();
+    const res = await app.request("/api/clip/fetch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "http://localhost/page" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toMatch(/URL not allowed|only public http/i);
+  });
+
+  it("returns 400 for 127.0.0.1 (SSRF protection)", async () => {
+    const app = createClipApp();
+    const res = await app.request("/api/clip/fetch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "http://127.0.0.1:8080/" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with html when fetch succeeds", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response("<html>hi</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    ) as unknown as typeof fetch;
+
+    const app = createClipApp();
+    const res = await app.request("/api/clip/fetch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://example.com/article" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { html?: string; url?: string; content_type?: string };
+    expect(body.html).toBe("<html>hi</html>");
+    expect(body.content_type).toBe("text/html");
+  });
+});

--- a/server/api/src/lib/clipAndCreate.ts
+++ b/server/api/src/lib/clipAndCreate.ts
@@ -18,7 +18,6 @@ import { prosemirrorJSONToYDoc } from "@tiptap/y-tiptap";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import { pages, pageContents } from "../schema/index.js";
 import type * as schema from "../schema/index.js";
-import { isClipUrlAllowed, isClipUrlAllowedAfterDns } from "./clipUrlPolicy.js";
 import { ClipFetchBlockedError, fetchClipHtmlWithRedirects } from "./clipServerFetch.js";
 
 const lowlight = createLowlight(common);
@@ -119,13 +118,6 @@ export interface ClipAndCreateInput {
  */
 export async function clipAndCreate(input: ClipAndCreateInput): Promise<ClipAndCreateResult> {
   const { url, userId, db } = input;
-
-  if (!isClipUrlAllowed(url)) {
-    throw new Error("URL not allowed");
-  }
-  if (!(await isClipUrlAllowedAfterDns(url))) {
-    throw new Error("URL not allowed");
-  }
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 15_000);

--- a/server/api/src/lib/clipAndCreate.ts
+++ b/server/api/src/lib/clipAndCreate.ts
@@ -19,6 +19,7 @@ import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import { pages, pageContents } from "../schema/index.js";
 import type * as schema from "../schema/index.js";
 import { isClipUrlAllowed, isClipUrlAllowedAfterDns } from "./clipUrlPolicy.js";
+import { ClipFetchBlockedError, fetchClipHtmlWithRedirects } from "./clipServerFetch.js";
 
 const lowlight = createLowlight(common);
 const YDOC_FRAGMENT = "default";
@@ -54,65 +55,6 @@ function resolveUrl(base: string, relative: string | null): string | null {
   } catch {
     return null;
   }
-}
-
-async function fetchHtmlWithRedirects(
-  url: string,
-  controller: AbortController,
-): Promise<{ html: string; finalUrl: string }> {
-  const MAX_REDIRECTS = 5;
-  let response!: Response;
-  let currentUrl = url;
-
-  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-    response = await fetch(currentUrl, {
-      headers: {
-        "User-Agent": "zedi-clip/1.0 (https://zedi.app)",
-        Accept: "text/html,application/xhtml+xml,*/*;q=0.8",
-      },
-      redirect: "manual",
-      signal: controller.signal,
-    });
-    const isRedirect =
-      response.type === "opaqueredirect" || [301, 302, 303, 307, 308].includes(response.status);
-    if (isRedirect) {
-      const location = response.headers.get("Location");
-      if (!location || hop === MAX_REDIRECTS) {
-        throw new Error("Too many redirects or invalid Location");
-      }
-
-      let nextUrl: string;
-      try {
-        nextUrl = new URL(location, currentUrl).href;
-      } catch {
-        throw new Error("Invalid redirect Location");
-      }
-
-      if (!isClipUrlAllowed(nextUrl)) {
-        throw new Error("Redirect to disallowed URL");
-      }
-      if (!(await isClipUrlAllowedAfterDns(nextUrl))) {
-        throw new Error("Redirect to disallowed URL");
-      }
-      currentUrl = nextUrl;
-      continue;
-    }
-    break;
-  }
-
-  if (response.url !== currentUrl && !isClipUrlAllowed(response.url)) {
-    throw new Error("Redirect to disallowed URL");
-  }
-  if (!(await isClipUrlAllowedAfterDns(response.url))) {
-    throw new Error("Redirect to disallowed URL");
-  }
-
-  if (!response.ok) {
-    throw new Error(`Fetch failed: ${response.status}`);
-  }
-
-  const html = await response.text();
-  return { html, finalUrl: response.url };
 }
 
 function cleanupHtml(html: string, doc: Document): string {
@@ -191,7 +133,14 @@ export async function clipAndCreate(input: ClipAndCreateInput): Promise<ClipAndC
   let finalUrl: string;
 
   try {
-    ({ html, finalUrl } = await fetchHtmlWithRedirects(url, controller));
+    try {
+      ({ html, finalUrl } = await fetchClipHtmlWithRedirects(url, controller));
+    } catch (err) {
+      if (err instanceof ClipFetchBlockedError) {
+        throw new Error("URL not allowed");
+      }
+      throw err;
+    }
   } finally {
     clearTimeout(timeout);
   }

--- a/server/api/src/lib/clipServerFetch.test.ts
+++ b/server/api/src/lib/clipServerFetch.test.ts
@@ -2,8 +2,13 @@
  * clipServerFetch（SSRF 安全な fetch）の単体テスト
  * Unit tests for clipServerFetch (SSRF-safe fetch).
  */
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { lookup } from "node:dns/promises";
 import { ClipFetchBlockedError, fetchClipHtmlWithRedirects } from "./clipServerFetch.js";
+
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn(),
+}));
 
 const originalFetch = globalThis.fetch;
 
@@ -13,6 +18,13 @@ afterEach(() => {
 });
 
 describe("fetchClipHtmlWithRedirects", () => {
+  beforeEach(() => {
+    vi.mocked(lookup).mockReset();
+    vi.mocked(lookup).mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+    ] as unknown as Awaited<ReturnType<typeof lookup>>);
+  });
+
   it("throws ClipFetchBlockedError when redirect targets private IP", async () => {
     const fetchMock = vi.fn();
     globalThis.fetch = fetchMock as unknown as typeof fetch;

--- a/server/api/src/lib/clipServerFetch.test.ts
+++ b/server/api/src/lib/clipServerFetch.test.ts
@@ -1,0 +1,60 @@
+/**
+ * clipServerFetch（SSRF 安全な fetch）の単体テスト
+ * Unit tests for clipServerFetch (SSRF-safe fetch).
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ClipFetchBlockedError, fetchClipHtmlWithRedirects } from "./clipServerFetch.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("fetchClipHtmlWithRedirects", () => {
+  it("throws ClipFetchBlockedError when redirect targets private IP", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { Location: "http://127.0.0.1/secret" },
+      }),
+    );
+
+    const controller = new AbortController();
+    await expect(
+      fetchClipHtmlWithRedirects("https://example.com/page", controller),
+    ).rejects.toThrow(ClipFetchBlockedError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns html and finalUrl when response is 200", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    fetchMock.mockResolvedValueOnce(
+      new Response("<html>ok</html>", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+
+    const controller = new AbortController();
+    const result = await fetchClipHtmlWithRedirects("https://example.com/", controller);
+    expect(result.html).toBe("<html>ok</html>");
+    expect(result.contentType).toBe("text/html; charset=utf-8");
+    expect(result.finalUrl).toBeDefined();
+  });
+
+  it("throws when response is not ok", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 500 }));
+
+    const controller = new AbortController();
+    await expect(fetchClipHtmlWithRedirects("https://example.com/", controller)).rejects.toThrow(
+      /Fetch failed: 500/,
+    );
+  });
+});

--- a/server/api/src/lib/clipServerFetch.ts
+++ b/server/api/src/lib/clipServerFetch.ts
@@ -1,0 +1,101 @@
+/**
+ * サーバー側クリップ用 URL 取得（SSRF 対策付きリダイレクト追従）
+ * Server-side clip fetch with SSRF-safe manual redirect handling.
+ */
+import { isClipUrlAllowed, isClipUrlAllowedAfterDns } from "./clipUrlPolicy.js";
+
+const MAX_REDIRECTS = 5;
+
+/**
+ * URL がポリシーに違反した場合に投げる（clip/fetch は 400 にマップする）。
+ * Thrown when URL policy blocks a request; clip/fetch maps this to HTTP 400.
+ */
+export class ClipFetchBlockedError extends Error {
+  /**
+   * ブロック理由付きのエラー。Error with a stable name for policy violations.
+   *
+   * @param message - 人間可読メッセージ（API の error にそのまま載せる）。Human-readable message for API error body.
+   */
+  constructor(message = "URL not allowed") {
+    super(message);
+    this.name = "ClipFetchBlockedError";
+  }
+}
+
+/**
+ * http(s) で HTML を取得する。リダイレクトは手動で追従し、各ホップで SSRF チェックを行う。
+ * Fetches HTML over http(s) with manual redirects and SSRF checks on each hop.
+ *
+ * @param url - 事前に isClipUrlAllowed / isClipUrlAllowedAfterDns を通した URL。Pre-validated URL.
+ * @param controller - AbortSignal 用。Abort controller for cancellation.
+ * @returns 本文・最終 URL・Content-Type。Body, final URL, and Content-Type.
+ */
+export async function fetchClipHtmlWithRedirects(
+  url: string,
+  controller: AbortController,
+): Promise<{ html: string; finalUrl: string; contentType: string }> {
+  let response!: Response;
+  let currentUrl = url;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    response = await fetch(currentUrl, {
+      headers: {
+        "User-Agent": "zedi-clip/1.0 (https://zedi.app)",
+        Accept: "text/html,application/xhtml+xml,*/*;q=0.8",
+      },
+      redirect: "manual",
+      signal: controller.signal,
+    });
+    const isRedirect =
+      response.type === "opaqueredirect" || [301, 302, 303, 307, 308].includes(response.status);
+    if (isRedirect) {
+      const location = response.headers.get("Location");
+      if (!location || hop === MAX_REDIRECTS) {
+        throw new ClipFetchBlockedError("Redirect chain not allowed");
+      }
+
+      let nextUrl: string;
+      try {
+        nextUrl = new URL(location, currentUrl).href;
+      } catch {
+        throw new ClipFetchBlockedError("Invalid redirect Location");
+      }
+
+      if (!isClipUrlAllowed(nextUrl)) {
+        throw new ClipFetchBlockedError(
+          "URL not allowed: only public http/https URLs are supported (no localhost, private IP, or internal hosts)",
+        );
+      }
+      if (!(await isClipUrlAllowedAfterDns(nextUrl))) {
+        throw new ClipFetchBlockedError(
+          "URL not allowed: only public http/https URLs are supported (no localhost, private IP, or internal hosts)",
+        );
+      }
+      currentUrl = nextUrl;
+      continue;
+    }
+    break;
+  }
+
+  // `new Response()` 等では url が空のことがある。実リクエストでは response.url が最終 URL。
+  // `new Response()` may leave url empty; real fetch sets the final URL on response.url.
+  const finalUrlForPolicy = response.url || currentUrl;
+  if (!isClipUrlAllowed(finalUrlForPolicy)) {
+    throw new ClipFetchBlockedError(
+      "URL not allowed: only public http/https URLs are supported (no localhost, private IP, or internal hosts)",
+    );
+  }
+  if (!(await isClipUrlAllowedAfterDns(finalUrlForPolicy))) {
+    throw new ClipFetchBlockedError(
+      "URL not allowed: only public http/https URLs are supported (no localhost, private IP, or internal hosts)",
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(`Fetch failed: ${response.status}`);
+  }
+
+  const html = await response.text();
+  const contentType = response.headers.get("content-type") || "";
+  return { html, finalUrl: response.url || currentUrl, contentType };
+}

--- a/server/api/src/lib/clipServerFetch.ts
+++ b/server/api/src/lib/clipServerFetch.ts
@@ -2,9 +2,16 @@
  * サーバー側クリップ用 URL 取得（SSRF 対策付きリダイレクト追従）
  * Server-side clip fetch with SSRF-safe manual redirect handling.
  */
-import { isClipUrlAllowed, isClipUrlAllowedAfterDns } from "./clipUrlPolicy.js";
+import { isClipUrlAllowedAfterDns } from "./clipUrlPolicy.js";
 
 const MAX_REDIRECTS = 5;
+
+/**
+ * clip fetch で拒否するときの API エラー文言（routes と共有）。
+ * Shared API error message when a clip fetch URL is rejected.
+ */
+export const DISALLOWED_CLIP_URL_MESSAGE =
+  "URL not allowed: only public http/https URLs are supported (no localhost, private IP, or internal hosts)";
 
 /**
  * URL がポリシーに違反した場合に投げる（clip/fetch は 400 にマップする）。
@@ -23,10 +30,21 @@ export class ClipFetchBlockedError extends Error {
 }
 
 /**
+ * DNS 解決込みで URL が許可されることを検証し、不可なら {@link ClipFetchBlockedError} を投げる。
+ * Validates URL with DNS resolution; throws {@link ClipFetchBlockedError} if not allowed.
+ */
+export async function assertClipFetchUrlAllowed(url: string): Promise<void> {
+  if (!(await isClipUrlAllowedAfterDns(url))) {
+    throw new ClipFetchBlockedError(DISALLOWED_CLIP_URL_MESSAGE);
+  }
+}
+
+/**
  * http(s) で HTML を取得する。リダイレクトは手動で追従し、各ホップで SSRF チェックを行う。
  * Fetches HTML over http(s) with manual redirects and SSRF checks on each hop.
  *
- * @param url - 事前に isClipUrlAllowed / isClipUrlAllowedAfterDns を通した URL。Pre-validated URL.
+ * @param url - http(s)。初回 fetch の前に {@link assertClipFetchUrlAllowed} で再検証する。
+ *   http(s) URL; re-validated with {@link assertClipFetchUrlAllowed} before the first fetch.
  * @param controller - AbortSignal 用。Abort controller for cancellation.
  * @returns 本文・最終 URL・Content-Type。Body, final URL, and Content-Type.
  */
@@ -34,6 +52,8 @@ export async function fetchClipHtmlWithRedirects(
   url: string,
   controller: AbortController,
 ): Promise<{ html: string; finalUrl: string; contentType: string }> {
+  await assertClipFetchUrlAllowed(url);
+
   let response!: Response;
   let currentUrl = url;
 
@@ -61,16 +81,7 @@ export async function fetchClipHtmlWithRedirects(
         throw new ClipFetchBlockedError("Invalid redirect Location");
       }
 
-      if (!isClipUrlAllowed(nextUrl)) {
-        throw new ClipFetchBlockedError(
-          "URL not allowed: only public http/https URLs are supported (no localhost, private IP, or internal hosts)",
-        );
-      }
-      if (!(await isClipUrlAllowedAfterDns(nextUrl))) {
-        throw new ClipFetchBlockedError(
-          "URL not allowed: only public http/https URLs are supported (no localhost, private IP, or internal hosts)",
-        );
-      }
+      await assertClipFetchUrlAllowed(nextUrl);
       currentUrl = nextUrl;
       continue;
     }
@@ -80,16 +91,7 @@ export async function fetchClipHtmlWithRedirects(
   // `new Response()` 等では url が空のことがある。実リクエストでは response.url が最終 URL。
   // `new Response()` may leave url empty; real fetch sets the final URL on response.url.
   const finalUrlForPolicy = response.url || currentUrl;
-  if (!isClipUrlAllowed(finalUrlForPolicy)) {
-    throw new ClipFetchBlockedError(
-      "URL not allowed: only public http/https URLs are supported (no localhost, private IP, or internal hosts)",
-    );
-  }
-  if (!(await isClipUrlAllowedAfterDns(finalUrlForPolicy))) {
-    throw new ClipFetchBlockedError(
-      "URL not allowed: only public http/https URLs are supported (no localhost, private IP, or internal hosts)",
-    );
-  }
+  await assertClipFetchUrlAllowed(finalUrlForPolicy);
 
   if (!response.ok) {
     throw new Error(`Fetch failed: ${response.status}`);

--- a/server/api/src/lib/clipServerFetch.ts
+++ b/server/api/src/lib/clipServerFetch.ts
@@ -32,9 +32,11 @@ export class ClipFetchBlockedError extends Error {
 /**
  * DNS 解決込みで URL が許可されることを検証し、不可なら {@link ClipFetchBlockedError} を投げる。
  * Validates URL with DNS resolution; throws {@link ClipFetchBlockedError} if not allowed.
+ *
+ * @param signal - 渡すと DNS lookup がリクエストの abort/timeout と同期する。Optional; ties DNS lookup to request abort/timeout.
  */
-export async function assertClipFetchUrlAllowed(url: string): Promise<void> {
-  if (!(await isClipUrlAllowedAfterDns(url))) {
+export async function assertClipFetchUrlAllowed(url: string, signal?: AbortSignal): Promise<void> {
+  if (!(await isClipUrlAllowedAfterDns(url, { signal }))) {
     throw new ClipFetchBlockedError(DISALLOWED_CLIP_URL_MESSAGE);
   }
 }
@@ -45,14 +47,17 @@ export async function assertClipFetchUrlAllowed(url: string): Promise<void> {
  *
  * @param url - http(s)。初回 fetch の前に {@link assertClipFetchUrlAllowed} で再検証する。
  *   http(s) URL; re-validated with {@link assertClipFetchUrlAllowed} before the first fetch.
- * @param controller - AbortSignal 用。Abort controller for cancellation.
+ * @param controller - AbortSignal 用。DNS 検証と fetch の両方に渡す。Abort controller for DNS validation and fetch.
  * @returns 本文・最終 URL・Content-Type。Body, final URL, and Content-Type.
+ *
+ * **制限 / Limitation**: 実 TCP/TLS はホスト名で再接続するため、DNS リバインド完全対策（検証 IP への接続固定）は未実装。`ext` の clip-and-create と同様の TOCTOU 残存。Issue #428 参照。
+ * **Limitation**: TCP/TLS reconnects by hostname; full DNS-rebind mitigation (bind to validated IP) is not implemented; same TOCTOU caveat as ext clip-and-create (see issue #428).
  */
 export async function fetchClipHtmlWithRedirects(
   url: string,
   controller: AbortController,
 ): Promise<{ html: string; finalUrl: string; contentType: string }> {
-  await assertClipFetchUrlAllowed(url);
+  await assertClipFetchUrlAllowed(url, controller.signal);
 
   let response!: Response;
   let currentUrl = url;
@@ -81,7 +86,7 @@ export async function fetchClipHtmlWithRedirects(
         throw new ClipFetchBlockedError("Invalid redirect Location");
       }
 
-      await assertClipFetchUrlAllowed(nextUrl);
+      await assertClipFetchUrlAllowed(nextUrl, controller.signal);
       currentUrl = nextUrl;
       continue;
     }
@@ -91,7 +96,7 @@ export async function fetchClipHtmlWithRedirects(
   // `new Response()` 等では url が空のことがある。実リクエストでは response.url が最終 URL。
   // `new Response()` may leave url empty; real fetch sets the final URL on response.url.
   const finalUrlForPolicy = response.url || currentUrl;
-  await assertClipFetchUrlAllowed(finalUrlForPolicy);
+  await assertClipFetchUrlAllowed(finalUrlForPolicy, controller.signal);
 
   if (!response.ok) {
     throw new Error(`Fetch failed: ${response.status}`);

--- a/server/api/src/lib/clipUrlPolicy.ts
+++ b/server/api/src/lib/clipUrlPolicy.ts
@@ -5,8 +5,12 @@
  * 除外: localhost, loopback, プライベート IP, link-local, .local, chrome/about/file.
  * Policy for clip-and-create and clipUrl. Allows http/https only; rejects localhost, loopback, private IP, link-local, .local.
  */
+import type { LookupAllOptions } from "node:dns";
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
+
+/** Node の `dns.lookup` は runtime で `signal` を受け取るが、TypeScript の `LookupOptions` に未反映のため拡張する。Runtime accepts `signal`; types omit it so we extend locally. */
+type LookupAllOptionsWithSignal = LookupAllOptions & { signal?: AbortSignal };
 
 /**
  * 文字列の IP がプライベート・ループバック・link-local かどうかを判定する。
@@ -77,8 +81,13 @@ export function isClipUrlAllowed(url: string): boolean {
  * DNS 解決後の IP がすべて公開アドレスであることを確認する（SSRF 対策）。
  * ホスト名がドメインの場合は resolve し、いずれかが private/loopback/link-local なら false。
  * Verifies that all resolved IPs for the URL hostname are public (no private/loopback/link-local).
+ *
+ * @param options - 省略可。`signal` を渡すと `dns.lookup` を中断可能（fetch の AbortController と共有）。Optional; pass `signal` to abort in-flight DNS lookup.
  */
-export async function isClipUrlAllowedAfterDns(url: string): Promise<boolean> {
+export async function isClipUrlAllowedAfterDns(
+  url: string,
+  options?: { signal?: AbortSignal },
+): Promise<boolean> {
   if (!isClipUrlAllowed(url)) return false;
   try {
     const parsed = new URL(url.trim());
@@ -88,12 +97,14 @@ export async function isClipUrlAllowedAfterDns(url: string): Promise<boolean> {
     }
     // ホスト名がすでに IP の場合は、private/ULA でなければ許可する（ULA 短縮形 fc::1 等もここで判定）。
     if (isIP(hostname) !== 0) return !isPrivateOrLoopbackOrLinkLocalIp(hostname);
-    const result = await lookup(hostname, { all: true });
+    const lookupOpts: LookupAllOptionsWithSignal = { all: true, signal: options?.signal };
+    const result = await lookup(hostname, lookupOpts);
     const addresses = result.map((r) => r.address);
     if (addresses.length === 0) return false;
     const allPublic = addresses.every((addr) => !isPrivateOrLoopbackOrLinkLocalIp(addr));
     return allPublic;
-  } catch {
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
     return false;
   }
 }

--- a/server/api/src/routes/clip.ts
+++ b/server/api/src/routes/clip.ts
@@ -6,12 +6,7 @@
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { authRequired } from "../middleware/auth.js";
-import {
-  ClipFetchBlockedError,
-  DISALLOWED_CLIP_URL_MESSAGE,
-  fetchClipHtmlWithRedirects,
-} from "../lib/clipServerFetch.js";
-import { isClipUrlAllowedAfterDns } from "../lib/clipUrlPolicy.js";
+import { ClipFetchBlockedError, fetchClipHtmlWithRedirects } from "../lib/clipServerFetch.js";
 import type { AppEnv } from "../types/index.js";
 
 const app = new Hono<AppEnv>();
@@ -24,10 +19,6 @@ app.post("/fetch", authRequired, async (c) => {
   }
 
   const url = body.url.trim();
-
-  if (!(await isClipUrlAllowedAfterDns(url))) {
-    throw new HTTPException(400, { message: DISALLOWED_CLIP_URL_MESSAGE });
-  }
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10_000);

--- a/server/api/src/routes/clip.ts
+++ b/server/api/src/routes/clip.ts
@@ -6,12 +6,13 @@
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { authRequired } from "../middleware/auth.js";
-import { ClipFetchBlockedError, fetchClipHtmlWithRedirects } from "../lib/clipServerFetch.js";
-import { isClipUrlAllowed, isClipUrlAllowedAfterDns } from "../lib/clipUrlPolicy.js";
+import {
+  ClipFetchBlockedError,
+  DISALLOWED_CLIP_URL_MESSAGE,
+  fetchClipHtmlWithRedirects,
+} from "../lib/clipServerFetch.js";
+import { isClipUrlAllowedAfterDns } from "../lib/clipUrlPolicy.js";
 import type { AppEnv } from "../types/index.js";
-
-const DISALLOWED_URL_MESSAGE =
-  "URL not allowed: only public http/https URLs are supported (no localhost, private IP, or internal hosts)";
 
 const app = new Hono<AppEnv>();
 
@@ -24,11 +25,8 @@ app.post("/fetch", authRequired, async (c) => {
 
   const url = body.url.trim();
 
-  if (!isClipUrlAllowed(url)) {
-    throw new HTTPException(400, { message: DISALLOWED_URL_MESSAGE });
-  }
   if (!(await isClipUrlAllowedAfterDns(url))) {
-    throw new HTTPException(400, { message: DISALLOWED_URL_MESSAGE });
+    throw new HTTPException(400, { message: DISALLOWED_CLIP_URL_MESSAGE });
   }
 
   const controller = new AbortController();

--- a/server/api/src/routes/clip.ts
+++ b/server/api/src/routes/clip.ts
@@ -1,12 +1,17 @@
 /**
  * /api/clip — Web クリッピング
  *
- * POST /api/clip/fetch — URL から HTML をサーバーサイドで取得
+ * POST /api/clip/fetch — URL から HTML をサーバーサイドで取得（SSRF 対策あり）
  */
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { authRequired } from "../middleware/auth.js";
+import { ClipFetchBlockedError, fetchClipHtmlWithRedirects } from "../lib/clipServerFetch.js";
+import { isClipUrlAllowed, isClipUrlAllowedAfterDns } from "../lib/clipUrlPolicy.js";
 import type { AppEnv } from "../types/index.js";
+
+const DISALLOWED_URL_MESSAGE =
+  "URL not allowed: only public http/https URLs are supported (no localhost, private IP, or internal hosts)";
 
 const app = new Hono<AppEnv>();
 
@@ -19,48 +24,39 @@ app.post("/fetch", authRequired, async (c) => {
 
   const url = body.url.trim();
 
-  // URL バリデーション
-  try {
-    const parsed = new URL(url);
-    if (!["http:", "https:"].includes(parsed.protocol)) {
-      throw new HTTPException(400, { message: "Only http/https URLs are supported" });
-    }
-  } catch {
-    throw new HTTPException(400, { message: "Invalid URL" });
+  if (!isClipUrlAllowed(url)) {
+    throw new HTTPException(400, { message: DISALLOWED_URL_MESSAGE });
+  }
+  if (!(await isClipUrlAllowedAfterDns(url))) {
+    throw new HTTPException(400, { message: DISALLOWED_URL_MESSAGE });
   }
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10_000);
 
   try {
-    const response = await fetch(url, {
-      headers: {
-        "User-Agent": "zedi-clip/1.0 (https://zedi.app)",
-        Accept: "text/html,application/xhtml+xml,*/*;q=0.8",
-      },
-      redirect: "follow",
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      throw new HTTPException(502, {
-        message: `Fetch failed: ${response.status}`,
+    try {
+      const { html, finalUrl, contentType } = await fetchClipHtmlWithRedirects(url, controller);
+      return c.json({
+        html,
+        url: finalUrl,
+        content_type: contentType,
       });
+    } catch (err) {
+      if (err instanceof ClipFetchBlockedError) {
+        throw new HTTPException(400, { message: err.message });
+      }
+      throw err;
     }
-
-    const contentType = response.headers.get("content-type") || "";
-    const html = await response.text();
-
-    return c.json({
-      html,
-      url: response.url, // final URL after redirects
-      content_type: contentType,
-    });
   } catch (err) {
     if (err instanceof HTTPException) throw err;
-    const message =
-      err instanceof Error && err.name === "AbortError" ? "Request timed out" : "Fetch failed";
-    throw new HTTPException(502, { message });
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new HTTPException(502, { message: "Request timed out" });
+    }
+    if (err instanceof Error && err.message.startsWith("Fetch failed:")) {
+      throw new HTTPException(502, { message: err.message });
+    }
+    throw new HTTPException(502, { message: "Fetch failed" });
   } finally {
     clearTimeout(timeout);
   }


### PR DESCRIPTION
## 概要

認証済みユーザー向け `POST /api/clip/fetch` が任意 URL を `redirect: follow` で取得しており、プライベート IP やリダイレクト経由の内部アクセスに悪用されるおそれがありました。`clipUrlPolicy` と `ext` の `clip-and-create` と同様の SSRF 対策（文字列検証・DNS 後検証・手動リダイレクトで各ホップ検証）を適用し、取得処理は `clipAndCreate` から共通化しました。

## 変更点

- `server/api/src/lib/clipServerFetch.ts`（新規）: `fetchClipHtmlWithRedirects`、`ClipFetchBlockedError`
- `server/api/src/routes/clip.ts`: `isClipUrlAllowed` / `isClipUrlAllowedAfterDns` と上記 fetch を利用
- `server/api/src/lib/clipAndCreate.ts`: 重複していた fetch ロジックを `clipServerFetch` に移行
- `server/api/src/lib/clipServerFetch.test.ts`, `server/api/src/__tests__/routes/clip.test.ts`: 単体・ルートテスト

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `cd server/api && bun run test:run`（全 190 テスト通過）
2. 任意: ローカルでセッション付き `POST /api/clip/fetch` に `http://127.0.0.1/` を送り 400 になることを確認

## チェックリスト

- [x] テストがすべてパスする（`server/api` の `bun run test:run`）
- [x] Lint エラーがない（変更ファイルは pre-commit で eslint / prettier 済み）
- [ ] 必要に応じてドキュメントを更新した（API のエラー文言のみ変更のため省略）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

なし（API のみ）

## 関連 Issue

Closes #428

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * クリップ取得の安全性とリダイレクト処理を強化し、公開URL以外へのアクセスをより確実に防止します。
  * フェッチ失敗やタイムアウト時の返却メッセージを明確化しました。
* **バグ修正**
  * 中間・最終リダイレクト先の検証を改善し、不正なURL処理での誤動作を修正しました。
* **テスト**
  * クリップ取得とSSRF対策のカバレッジを追加し、複数シナリオで動作を検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->