### PR TITLE
fix(api): restrict note is_official to admins (#429)

### DIFF
--- a/server/api/src/__tests__/routes/notes/crud.test.ts
+++ b/server/api/src/__tests__/routes/notes/crud.test.ts
@@ -196,10 +196,9 @@ describe("PUT /api/notes/:noteId", () => {
     expect(res.status).toBe(403);
   });
 
-  it("should not require admin when is_official is unchanged on update", async () => {
+  it("should return 403 when non-admin sends is_official even if equal to current (TOCTOU)", async () => {
     const mockNote = createMockNote({ isOfficial: true });
-    const updatedNote = createMockNote({ isOfficial: true, title: "Renamed" });
-    const { app } = createTestApp([[mockNote], [updatedNote]]);
+    const { app } = createTestApp([[mockNote], [{ role: "user" }]]);
 
     const res = await app.request(`/api/notes/${mockNote.id}`, {
       method: "PUT",
@@ -207,7 +206,39 @@ describe("PUT /api/notes/:noteId", () => {
       body: JSON.stringify({ title: "Renamed", is_official: true }),
     });
 
+    expect(res.status).toBe(403);
+  });
+
+  it("should allow admin to set is_official from false to true on update", async () => {
+    const mockNote = createMockNote({ isOfficial: false });
+    const updatedNote = createMockNote({ isOfficial: true });
+    const { app } = createTestApp([[mockNote], [{ role: "admin" }], [updatedNote]]);
+
+    const res = await app.request(`/api/notes/${mockNote.id}`, {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ is_official: true }),
+    });
+
     expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.is_official).toBe(true);
+  });
+
+  it("should allow admin to set is_official from true to false on update", async () => {
+    const mockNote = createMockNote({ isOfficial: true });
+    const updatedNote = createMockNote({ isOfficial: false });
+    const { app } = createTestApp([[mockNote], [{ role: "admin" }], [updatedNote]]);
+
+    const res = await app.request(`/api/notes/${mockNote.id}`, {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ is_official: false }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.is_official).toBe(false);
   });
 
   it("should return 400 when is_official is not a boolean on update", async () => {

--- a/server/api/src/__tests__/routes/notes/crud.test.ts
+++ b/server/api/src/__tests__/routes/notes/crud.test.ts
@@ -103,6 +103,33 @@ describe("POST /api/notes", () => {
 
     expect(res.status).toBe(401);
   });
+
+  it("should return 403 when non-admin sets is_official true on create", async () => {
+    const { app } = createTestApp([[{ role: "user" }]]);
+
+    const res = await app.request("/api/notes", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ title: "Fake official", is_official: true }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("should allow admin to create note with is_official true", async () => {
+    const mockNote = createMockNote({ isOfficial: true });
+    const { app } = createTestApp([[{ role: "admin" }], [mockNote], []]);
+
+    const res = await app.request("/api/notes", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ title: "Official", is_official: true }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.is_official).toBe(true);
+  });
 });
 
 // ── PUT /api/notes/:noteId ──────────────────────────────────────────────────
@@ -142,6 +169,33 @@ describe("PUT /api/notes/:noteId", () => {
     });
 
     expect(res.status).toBe(403);
+  });
+
+  it("should return 403 when non-admin changes is_official", async () => {
+    const mockNote = createMockNote({ isOfficial: false });
+    const { app } = createTestApp([[mockNote], [{ role: "user" }]]);
+
+    const res = await app.request(`/api/notes/${mockNote.id}`, {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ is_official: true }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("should not require admin when is_official is unchanged on update", async () => {
+    const mockNote = createMockNote({ isOfficial: true });
+    const updatedNote = createMockNote({ isOfficial: true, title: "Renamed" });
+    const { app } = createTestApp([[mockNote], [updatedNote]]);
+
+    const res = await app.request(`/api/notes/${mockNote.id}`, {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ title: "Renamed", is_official: true }),
+    });
+
+    expect(res.status).toBe(200);
   });
 });
 

--- a/server/api/src/__tests__/routes/notes/crud.test.ts
+++ b/server/api/src/__tests__/routes/notes/crud.test.ts
@@ -130,6 +130,18 @@ describe("POST /api/notes", () => {
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.is_official).toBe(true);
   });
+
+  it("should return 400 when is_official is not a boolean on create", async () => {
+    const { app } = createTestApp([]);
+
+    const res = await app.request("/api/notes", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ title: "Bad", is_official: "true" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
 });
 
 // ── PUT /api/notes/:noteId ──────────────────────────────────────────────────
@@ -196,6 +208,19 @@ describe("PUT /api/notes/:noteId", () => {
     });
 
     expect(res.status).toBe(200);
+  });
+
+  it("should return 400 when is_official is not a boolean on update", async () => {
+    const mockNote = createMockNote();
+    const { app } = createTestApp([[mockNote]]);
+
+    const res = await app.request(`/api/notes/${mockNote.id}`, {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ is_official: 1 }),
+    });
+
+    expect(res.status).toBe(400);
   });
 });
 

--- a/server/api/src/routes/notes/crud.ts
+++ b/server/api/src/routes/notes/crud.ts
@@ -57,6 +57,30 @@ function validateEditPermission(value: string | undefined): NoteEditPermission {
   return value as NoteEditPermission;
 }
 
+/**
+ * Parses `is_official` from JSON for note create (defaults to false).
+ * JSON の `is_official` をノート作成用に解釈する（省略時は false）。
+ *
+ * @throws HTTPException 400 when present but not a boolean
+ */
+function parseIsOfficialForCreate(value: unknown): boolean {
+  if (value === undefined) return false;
+  if (typeof value === "boolean") return value;
+  throw new HTTPException(400, { message: "Invalid is_official" });
+}
+
+/**
+ * Parses optional `is_official` for note update.
+ * ノート更新用の任意 `is_official` を解釈する。
+ *
+ * @throws HTTPException 400 when present but not a boolean
+ */
+function parseIsOfficialForUpdate(value: unknown): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "boolean") return value;
+  throw new HTTPException(400, { message: "Invalid is_official" });
+}
+
 const app = new Hono<AppEnv>();
 
 // ── POST / ──────────────────────────────────────────────────────────────────
@@ -69,13 +93,14 @@ app.post("/", authRequired, async (c) => {
     title?: string;
     visibility?: string;
     edit_permission?: string;
-    is_official?: boolean;
+    is_official?: unknown;
   }>();
 
   const visibility = validateVisibility(body.visibility);
   const editPermission = validateEditPermission(body.edit_permission);
+  const isOfficial = parseIsOfficialForCreate(body.is_official);
 
-  if (body.is_official === true) {
+  if (isOfficial === true) {
     await requireAdminUser(db, userId);
   }
 
@@ -86,7 +111,7 @@ app.post("/", authRequired, async (c) => {
       title: body.title ?? null,
       visibility,
       editPermission,
-      isOfficial: body.is_official ?? false,
+      isOfficial,
     })
     .returning();
 
@@ -127,10 +152,11 @@ app.put("/:noteId", authRequired, async (c) => {
     title?: string;
     visibility?: string;
     edit_permission?: string;
-    is_official?: boolean;
+    is_official?: unknown;
   }>();
 
-  if (body.is_official !== undefined && body.is_official !== note.isOfficial) {
+  const isOfficial = parseIsOfficialForUpdate(body.is_official);
+  if (isOfficial !== undefined && isOfficial !== note.isOfficial) {
     await requireAdminUser(db, userId);
   }
 
@@ -145,7 +171,7 @@ app.put("/:noteId", authRequired, async (c) => {
       title: body.title !== undefined ? body.title : undefined,
       visibility,
       editPermission,
-      isOfficial: body.is_official !== undefined ? body.is_official : undefined,
+      isOfficial: isOfficial !== undefined ? isOfficial : undefined,
       updatedAt: new Date(),
     })
     .where(eq(notes.id, noteId))

--- a/server/api/src/routes/notes/crud.ts
+++ b/server/api/src/routes/notes/crud.ts
@@ -146,7 +146,7 @@ app.put("/:noteId", authRequired, async (c) => {
   const userId = c.get("userId");
   const db = c.get("db");
 
-  const note = await requireNoteOwner(db, noteId, userId);
+  await requireNoteOwner(db, noteId, userId);
 
   const body = await c.req.json<{
     title?: string;
@@ -156,7 +156,12 @@ app.put("/:noteId", authRequired, async (c) => {
   }>();
 
   const isOfficial = parseIsOfficialForUpdate(body.is_official);
-  if (isOfficial !== undefined && isOfficial !== note.isOfficial) {
+  // Require admin whenever the client sends `is_official`, not only when it differs from
+  // the row we read. Otherwise a non-admin could race with an admin toggle and overwrite
+  // the flag using a payload that matched the stale snapshot (TOCTOU).
+  // 読み取り時点と同じ値でもボディに含めたら admin 必須。並行更新との競合で非管理者が
+  // フラグを上書きするのを防ぐ。
+  if (isOfficial !== undefined) {
     await requireAdminUser(db, userId);
   }
 

--- a/server/api/src/routes/notes/crud.ts
+++ b/server/api/src/routes/notes/crud.ts
@@ -28,6 +28,7 @@ import type {
 import {
   noteRowToApi,
   requireNoteOwner,
+  requireAdminUser,
   getNoteRole,
   getActivePageCounts,
   getActiveMemberCounts,
@@ -74,6 +75,10 @@ app.post("/", authRequired, async (c) => {
   const visibility = validateVisibility(body.visibility);
   const editPermission = validateEditPermission(body.edit_permission);
 
+  if (body.is_official === true) {
+    await requireAdminUser(db, userId);
+  }
+
   const result = await db
     .insert(notes)
     .values({
@@ -116,7 +121,7 @@ app.put("/:noteId", authRequired, async (c) => {
   const userId = c.get("userId");
   const db = c.get("db");
 
-  await requireNoteOwner(db, noteId, userId);
+  const note = await requireNoteOwner(db, noteId, userId);
 
   const body = await c.req.json<{
     title?: string;
@@ -124,6 +129,10 @@ app.put("/:noteId", authRequired, async (c) => {
     edit_permission?: string;
     is_official?: boolean;
   }>();
+
+  if (body.is_official !== undefined && body.is_official !== note.isOfficial) {
+    await requireAdminUser(db, userId);
+  }
 
   const visibility =
     body.visibility !== undefined ? validateVisibility(body.visibility) : undefined;

--- a/server/api/src/routes/notes/helpers.ts
+++ b/server/api/src/routes/notes/helpers.ts
@@ -12,7 +12,8 @@ import type { NoteApiFields, NoteRole, NoteMemberRole } from "./types.js";
 // ── Mappers ─────────────────────────────────────────────────────────────────
 
 /**
- *
+ * Maps a DB note row to API snake_case fields.
+ * DB のノート行を API 用の snake_case フィールドへ変換する。
  */
 export function noteRowToApi(note: Note): NoteApiFields {
   return {
@@ -32,12 +33,10 @@ export function noteRowToApi(note: Note): NoteApiFields {
 // ── DB Helpers ──────────────────────────────────────────────────────────────
 
 /**
- *
+ * Returns a non-deleted note by id, or null.
+ * 削除されていないノートを id で取得する。なければ null。
  */
 export async function findActiveNoteById(db: Database, noteId: string): Promise<Note | null> {
-  /**
-   *
-   */
   const result = await db
     .select()
     .from(notes)
@@ -47,7 +46,10 @@ export async function findActiveNoteById(db: Database, noteId: string): Promise<
 }
 
 /**
+ * Ensures the user owns the note; returns the note row.
+ * ユーザーがノートの所有者であることを検証し、行を返す。
  *
+ * @throws HTTPException 404 if missing, 403 if not owner
  */
 export async function requireNoteOwner(
   db: Database,
@@ -55,9 +57,6 @@ export async function requireNoteOwner(
   userId: string,
   forbiddenMessage = "Forbidden",
 ): Promise<Note> {
-  /**
-   *
-   */
   const note = await findActiveNoteById(db, noteId);
   if (!note) throw new HTTPException(404, { message: "Note not found" });
   if (note.ownerId !== userId) {
@@ -87,16 +86,14 @@ export async function requireAdminUser(db: Database, userId: string): Promise<vo
 }
 
 /**
- *
+ * Active (non-deleted) page counts per note id.
+ * ノート ID ごとのアクティブ（未削除）ページ数を返す。
  */
 export async function getActivePageCounts(
   db: Database,
   noteIds: string[],
 ): Promise<Map<string, number>> {
   if (noteIds.length === 0) return new Map();
-  /**
-   *
-   */
   const counts = await db
     .select({
       noteId: notePages.noteId,
@@ -116,16 +113,14 @@ export async function getActivePageCounts(
 }
 
 /**
- *
+ * Active member counts per note id (non-deleted memberships).
+ * ノート ID ごとのアクティブメンバー数（未削除のメンバーシップ）を返す。
  */
 export async function getActiveMemberCounts(
   db: Database,
   noteIds: string[],
 ): Promise<Map<string, number>> {
   if (noteIds.length === 0) return new Map();
-  /**
-   *
-   */
   const counts = await db
     .select({
       noteId: noteMembers.noteId,
@@ -140,7 +135,8 @@ export async function getActiveMemberCounts(
 // ── Role & Permission ───────────────────────────────────────────────────────
 
 /**
- *
+ * Resolves the caller's role for a note (owner, member, guest, or none).
+ * 呼び出し元のノートに対するロール（owner / メンバー / guest / なし）を解決する。
  */
 export async function getNoteRole(
   noteId: string,
@@ -148,18 +144,12 @@ export async function getNoteRole(
   userEmail: string | undefined,
   db: Database,
 ): Promise<{ role: NoteRole; note: Note | null }> {
-  /**
-   *
-   */
   const note = await findActiveNoteById(db, noteId);
   if (!note) return { role: null, note: null };
 
   if (userId && note.ownerId === userId) return { role: "owner", note };
 
   if (userEmail) {
-    /**
-     *
-     */
     const member = await db
       .select({ role: noteMembers.role })
       .from(noteMembers)
@@ -172,9 +162,6 @@ export async function getNoteRole(
       )
       .limit(1);
 
-    /**
-     *
-     */
     const firstMember = member[0];
     if (firstMember) {
       return { role: firstMember.role as NoteMemberRole, note };
@@ -189,7 +176,8 @@ export async function getNoteRole(
 }
 
 /**
- *
+ * Whether the role may edit the note given visibility and edit_permission.
+ * visibility / edit_permission に基づき、そのロールがノートを編集できるか。
  */
 export function canEdit(role: NoteRole, note: Note): boolean {
   if (role === "owner") return true;

--- a/server/api/src/routes/notes/helpers.ts
+++ b/server/api/src/routes/notes/helpers.ts
@@ -4,13 +4,16 @@
  */
 import { HTTPException } from "hono/http-exception";
 import { eq, and, sql, inArray } from "drizzle-orm";
-import { notes, notePages, noteMembers, pages } from "../../schema/index.js";
+import { notes, notePages, noteMembers, pages, users } from "../../schema/index.js";
 import type { Note } from "../../schema/index.js";
 import type { Database } from "../../types/index.js";
 import type { NoteApiFields, NoteRole, NoteMemberRole } from "./types.js";
 
 // ── Mappers ─────────────────────────────────────────────────────────────────
 
+/**
+ *
+ */
 export function noteRowToApi(note: Note): NoteApiFields {
   return {
     id: note.id,
@@ -28,7 +31,13 @@ export function noteRowToApi(note: Note): NoteApiFields {
 
 // ── DB Helpers ──────────────────────────────────────────────────────────────
 
+/**
+ *
+ */
 export async function findActiveNoteById(db: Database, noteId: string): Promise<Note | null> {
+  /**
+   *
+   */
   const result = await db
     .select()
     .from(notes)
@@ -37,12 +46,18 @@ export async function findActiveNoteById(db: Database, noteId: string): Promise<
   return result[0] ?? null;
 }
 
+/**
+ *
+ */
 export async function requireNoteOwner(
   db: Database,
   noteId: string,
   userId: string,
   forbiddenMessage = "Forbidden",
 ): Promise<Note> {
+  /**
+   *
+   */
   const note = await findActiveNoteById(db, noteId);
   if (!note) throw new HTTPException(404, { message: "Note not found" });
   if (note.ownerId !== userId) {
@@ -51,11 +66,37 @@ export async function requireNoteOwner(
   return note;
 }
 
+/**
+ * Requires `userId` to have admin role (`users.role === 'admin'`).
+ * Used when creating a note with `is_official: true` or changing `is_official` on update.
+ *
+ * `userId` が admin（`users.role === 'admin'`）であることを検証する。
+ * ノート作成で `is_official: true` とする場合、または更新で `is_official` を変更する場合に使う。
+ *
+ * @throws HTTPException 403 when the user is not an admin
+ */
+export async function requireAdminUser(db: Database, userId: string): Promise<void> {
+  const row = await db
+    .select({ role: users.role })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  if (row[0]?.role !== "admin") {
+    throw new HTTPException(403, { message: "Only admins can set is_official" });
+  }
+}
+
+/**
+ *
+ */
 export async function getActivePageCounts(
   db: Database,
   noteIds: string[],
 ): Promise<Map<string, number>> {
   if (noteIds.length === 0) return new Map();
+  /**
+   *
+   */
   const counts = await db
     .select({
       noteId: notePages.noteId,
@@ -74,11 +115,17 @@ export async function getActivePageCounts(
   return new Map(counts.map((c) => [c.noteId, c.count]));
 }
 
+/**
+ *
+ */
 export async function getActiveMemberCounts(
   db: Database,
   noteIds: string[],
 ): Promise<Map<string, number>> {
   if (noteIds.length === 0) return new Map();
+  /**
+   *
+   */
   const counts = await db
     .select({
       noteId: noteMembers.noteId,
@@ -92,18 +139,27 @@ export async function getActiveMemberCounts(
 
 // ── Role & Permission ───────────────────────────────────────────────────────
 
+/**
+ *
+ */
 export async function getNoteRole(
   noteId: string,
   userId: string | undefined,
   userEmail: string | undefined,
   db: Database,
 ): Promise<{ role: NoteRole; note: Note | null }> {
+  /**
+   *
+   */
   const note = await findActiveNoteById(db, noteId);
   if (!note) return { role: null, note: null };
 
   if (userId && note.ownerId === userId) return { role: "owner", note };
 
   if (userEmail) {
+    /**
+     *
+     */
     const member = await db
       .select({ role: noteMembers.role })
       .from(noteMembers)
@@ -116,6 +172,9 @@ export async function getNoteRole(
       )
       .limit(1);
 
+    /**
+     *
+     */
     const firstMember = member[0];
     if (firstMember) {
       return { role: firstMember.role as NoteMemberRole, note };
@@ -129,6 +188,9 @@ export async function getNoteRole(
   return { role: null, note };
 }
 
+/**
+ *
+ */
 export function canEdit(role: NoteRole, note: Note): boolean {
   if (role === "owner") return true;
   if (role === "editor" && note.editPermission !== "owner_only") return true;


### PR DESCRIPTION
## 概要

`POST /api/notes` と `PUT /api/notes/:noteId` で、一般ユーザーが `is_official` を操作できていた問題を修正した。`users.role === 'admin'` のユーザーのみ、公式フラグの付与・変更ができる。

## 変更点

### `server/api/`

- `helpers.ts`: `requireAdminUser` を追加（DB の `user.role` で admin を検証）
- `crud.ts`: 作成時 `is_official: true`、更新時に `is_official` の値が既存から変わる場合のみ admin を要求
- `crud.test.ts`: 403 / 成功パスのテストを追加

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `cd server/api && bun run test:run`（194 tests パス）
2. 任意: 認証ユーザーで `POST /api/notes` に `{"is_official":true}` を送り 403 になること、admin ユーザーでは 201 になることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない（変更ファイルは lint-staged 済み）
- [ ] 必要に応じてドキュメントを更新した（API の挙動変更のみで TSDoc を追加済み）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

なし（API のみ）

## 関連 Issue

Closes #429

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ノートの公式フラグ（is_official）の設定・変更は管理者権限が必要になりました。
  * 作成時は未指定でfalseが既定となり、更新時は指定がある場合のみ反映されます。
  * 不正な型（例："true"、1など）は受け付けず400エラーを返します。

* **テスト**
  * POST/PUT の権限チェックと is_official 入力バリデーションを網羅するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->