### PR TITLE
chore(deps): bump lucide-react to ^1.7.0 across workspaces

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@zedi/ui": "workspace:*",
-    "lucide-react": "^0.576.0",
+    "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^6.30.1"

--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,7 @@
         "input-otp": "^1.4.2",
         "katex": "^0.16.28",
         "lowlight": "^3.3.0",
-        "lucide-react": "^0.577.0",
+        "lucide-react": "^1.7.0",
         "mermaid": "^11.12.2",
         "next-themes": "^0.4.6",
         "openai": "^6.15.0",
@@ -170,7 +170,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@zedi/ui": "workspace:*",
-        "lucide-react": "^0.576.0",
+        "lucide-react": "^1.7.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^6.30.1",
@@ -228,7 +228,7 @@
         "cmdk": "^1.1.1",
         "embla-carousel-react": "^8.6.0",
         "input-otp": "^1.4.2",
-        "lucide-react": "^0.576.0",
+        "lucide-react": "^1.7.0",
         "next-themes": "^0.4.6",
         "react-day-picker": "^9.14.0",
         "react-hook-form": "^7.61.1",
@@ -2148,7 +2148,7 @@
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
-    "lucide-react": ["lucide-react@0.577.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A=="],
+    "lucide-react": ["lucide-react@1.7.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
@@ -3136,8 +3136,6 @@
 
     "@xyflow/react/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
-    "@zedi/ui/lucide-react": ["lucide-react@0.576.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug=="],
-
     "@zedi/ui/recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -3311,8 +3309,6 @@
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "zedi-admin/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
-
-    "zedi-admin/lucide-react": ["lucide-react@0.576.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug=="],
 
     "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "input-otp": "^1.4.2",
     "katex": "^0.16.28",
     "lowlight": "^3.3.0",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.7.0",
     "mermaid": "^11.12.2",
     "next-themes": "^0.4.6",
     "openai": "^6.15.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,7 @@
     "cmdk": "^1.1.1",
     "embla-carousel-react": "^8.6.0",
     "input-otp": "^1.4.2",
-    "lucide-react": "^0.576.0",
+    "lucide-react": "^1.7.0",
     "next-themes": "^0.4.6",
     "react-day-picker": "^9.14.0",
     "react-hook-form": "^7.61.1",


### PR DESCRIPTION
## 概要

Phase 2 として **lucide-react** を **0.x から 1.7.x** に揃えました（ルート、`packages/ui`、`admin`）。`bun.lock` を更新し CI の `bun install --frozen-lockfile` と整合させています。利用しているアイコンはそのまま解決でき、**ソースコードの変更は不要**でした。

Dependabot PR #423 の置き換えです。

## 変更点

- **`package.json`（ルート）**: `lucide-react` → `^1.7.0`
- **`packages/ui/package.json`**: 同上
- **`admin/package.json`**: 同上
- **`bun.lock`**: 再生成

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun install --frozen-lockfile`
2. `bunx tsc --noEmit` / `bun run build`（ルート）
3. `admin` で `bun run build`
4. `bun run test:run`

## チェックリスト

- [x] テストがすべてパスする（`bun run test:run`）
- [x] Lint/型チェック（変更は JSON ロックのみ）
- [ ] 必要に応じてドキュメントを更新した（該当なし）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

意図的な UI 変更はありません。

## 関連 Issue

Related to #423（マージ後に Dependabot PR をクローズ可能）

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
