### PR TITLE
chore(deps): react-router-dom 7.x and BrowserRouter v7 props

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -15,7 +15,7 @@
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^6.30.1"
+    "react-router-dom": "^7.13.2"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -6,7 +6,8 @@ import AiModels from "./pages/ai-models";
 import Users from "./pages/users";
 
 /**
- *
+ * Root component for the admin SPA: sets up routing and the admin auth guard.
+ * 管理画面 SPA のルート。ルーティングと管理者向け認証ガードを構成する。
  */
 function App() {
   return (

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -5,9 +5,14 @@ import Login from "./pages/Login";
 import AiModels from "./pages/ai-models";
 import Users from "./pages/users";
 
+/**
+ *
+ */
 function App() {
   return (
-    <BrowserRouter>
+    // Match main app: disable startTransition wrapping so navigation updates apply immediately (RR v7 API).
+    // メインアプリと同様: startTransition ラップを無効化し遷移を即時反映（RR v7 は unstable_useTransitions）。
+    <BrowserRouter unstable_useTransitions={false}>
       <Routes>
         <Route path="/login" element={<Login />} />
         <Route

--- a/bun.lock
+++ b/bun.lock
@@ -96,7 +96,7 @@
         "react-joyride": "^3.0.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^4.7.0",
-        "react-router-dom": "^6.30.1",
+        "react-router-dom": "^7.13.2",
         "recharts": "^3.8.0",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
@@ -173,7 +173,7 @@
         "lucide-react": "^1.7.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router-dom": "^6.30.1",
+        "react-router-dom": "^7.13.2",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.2",
@@ -899,8 +899,6 @@
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
     "@remirror/core-constants": ["@remirror/core-constants@3.0.0", "", {}, "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg=="],
-
-    "@remix-run/router": ["@remix-run/router@1.23.0", "", {}, "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.9", "", { "os": "android", "cpu": "arm64" }, "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg=="],
 
@@ -2526,9 +2524,9 @@
 
     "react-resizable-panels": ["react-resizable-panels@4.7.0", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-QJTeh8KJR6lKzDwVez+WGPPUPuarIjR3ptg23thJ0G5dAMYJH4iSN1AnNY0DuSP+PgH8s9eYfwrR7AlmX6TvYA=="],
 
-    "react-router": ["react-router@6.30.1", "", { "dependencies": { "@remix-run/router": "1.23.0" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ=="],
+    "react-router": ["react-router@7.13.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA=="],
 
-    "react-router-dom": ["react-router-dom@6.30.1", "", { "dependencies": { "@remix-run/router": "1.23.0", "react-router": "6.30.1" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw=="],
+    "react-router-dom": ["react-router-dom@7.13.2", "", { "dependencies": { "react-router": "7.13.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "react-joyride": "^3.0.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.7.0",
-    "react-router-dom": "^6.30.1",
+    "react-router-dom": "^7.13.2",
     "recharts": "^3.8.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,8 +54,8 @@ const App = () => (
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        {/* v7_startTransition を無効化: リンククリック後のページ切り替えで表示が即時更新されない問題を防ぐ */}
-        <BrowserRouter future={{ v7_startTransition: false, v7_relativeSplatPath: true }}>
+        {/* unstable_useTransitions を無効化: リンク後の表示が遅れる問題を防ぐ（RR v7 は future 廃止） */}
+        <BrowserRouter unstable_useTransitions={false}>
           <AIChatProvider>
             <AIChatConversationsProvider>
               <GlobalShortcutsProvider>


### PR DESCRIPTION
## 概要

Phase 3 として **react-router-dom** を **6.x から 7.13.x** に上げ、`bun.lock` を更新しました。宣言型ルート（`BrowserRouter` / `Routes` / `Route`）はそのまま利用でき、追加のルート書き換えは不要でした。

React Router v7 では `BrowserRouter` の **`future`（v6 系フラグ）が廃止**され、遷移の `startTransition` 挙動は **`unstable_useTransitions`** で制御します。従来どおり「リンク直後に画面が即時更新される」ように、メインアプリ・管理画面の両方で **`unstable_useTransitions={false}`** を指定しています（旧 `future.v7_startTransition: false` と同趣旨）。

Dependabot PR #422 の置き換えです。

## 変更点

- **`package.json` / `admin/package.json`**: `react-router-dom` → `^7.13.2`
- **`bun.lock`**: 再生成
- **`src/App.tsx`**: `BrowserRouter` を v7 API に合わせる
- **`admin/src/App.tsx`**: 同上（メインと挙動を揃える）

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun install --frozen-lockfile`
2. `bunx tsc --noEmit` / `bun run build`（ルート）
3. `admin` で `bun run build`
4. `bun run test:run`
5. 主要画面でリンク遷移が従来どおり即時に反映されるか目視（任意）

## チェックリスト

- [x] テストがすべてパスする（`bun run test:run`）
- [x] Lint（変更ファイルは ESLint 通過）
- [ ] 必要に応じてドキュメントを更新した（該当なし）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

意図的な見た目の変更はありません。

## 関連 Issue

Related to #422（マージ後に Dependabot PR をクローズ可能）

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の変更**
  * ナビゲーション動作を更新し、ページ遷移がより迅速に適用されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->