### PR TITLE
fix(security): restrict GET /api/users/:id to self-only access (#430)

### DIFF
--- a/server/api/src/__tests__/routes/users.test.ts
+++ b/server/api/src/__tests__/routes/users.test.ts
@@ -1,0 +1,149 @@
+/**
+ * ユーザールートのテスト（GET /me, GET /:id）
+ * Tests for user routes (GET /me, GET /:id)
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Context, Next } from "hono";
+import { Hono } from "hono";
+import type { AppEnv } from "../../types/index.js";
+import { createMockDb } from "./notes/setup.js";
+
+vi.mock("../../middleware/auth.js", () => ({
+  authRequired: async (c: Context<AppEnv>, next: Next) => {
+    const userId = c.req.header("x-test-user-id");
+    if (!userId) return c.json({ message: "Unauthorized" }, 401);
+    c.set("userId", userId);
+    await next();
+  },
+  authOptional: async (c: Context<AppEnv>, next: Next) => {
+    const userId = c.req.header("x-test-user-id");
+    if (userId) c.set("userId", userId);
+    await next();
+  },
+}));
+
+import userRoutes from "../../routes/users.js";
+
+const TEST_USER_ID = "user-test-123";
+const OTHER_USER_ID = "user-other-456";
+
+function createTestApp(dbResults: unknown[]) {
+  const { db, chains } = createMockDb(dbResults);
+  const app = new Hono<AppEnv>();
+
+  app.use("*", async (c, next) => {
+    c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+    await next();
+  });
+
+  app.route("/api/users", userRoutes);
+  return { app, chains };
+}
+
+function authHeaders(userId = TEST_USER_ID) {
+  return {
+    "x-test-user-id": userId,
+    "Content-Type": "application/json",
+  };
+}
+
+function createMockUser(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TEST_USER_ID,
+    name: "Test User",
+    email: "test@example.com",
+    emailVerified: true,
+    image: "https://example.com/avatar.png",
+    role: "user" as const,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+// ── GET /api/users/me ───────────────────────────────────────────────────────
+
+describe("GET /api/users/me", () => {
+  it("returns the current user's full profile", async () => {
+    const mockUser = createMockUser();
+    const { app } = createTestApp([[mockUser]]);
+
+    const res = await app.request("/api/users/me", { headers: authHeaders() });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: Record<string, unknown> };
+    expect(body.user).toMatchObject({
+      id: TEST_USER_ID,
+      name: "Test User",
+    });
+  });
+
+  it("returns 404 when user does not exist in DB", async () => {
+    const { app } = createTestApp([[]]);
+
+    const res = await app.request("/api/users/me", { headers: authHeaders() });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 without auth", async () => {
+    const { app } = createTestApp([]);
+
+    const res = await app.request("/api/users/me", {
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── GET /api/users/:id ──────────────────────────────────────────────────────
+
+describe("GET /api/users/:id", () => {
+  it("returns own profile (limited fields) when id matches authenticated user", async () => {
+    const mockUser = createMockUser();
+    const { app } = createTestApp([[mockUser]]);
+
+    const res = await app.request(`/api/users/${TEST_USER_ID}`, {
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: Record<string, unknown> };
+    expect(body.user).toMatchObject({
+      id: TEST_USER_ID,
+      name: "Test User",
+      image: "https://example.com/avatar.png",
+    });
+  });
+
+  it("returns 403 when requesting another user's profile", async () => {
+    const { app } = createTestApp([]);
+
+    const res = await app.request(`/api/users/${OTHER_USER_ID}`, {
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when own user not found in DB", async () => {
+    const { app } = createTestApp([[]]);
+
+    const res = await app.request(`/api/users/${TEST_USER_ID}`, {
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 without auth", async () => {
+    const { app } = createTestApp([]);
+
+    const res = await app.request(`/api/users/${TEST_USER_ID}`, {
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/api/src/__tests__/routes/users.test.ts
+++ b/server/api/src/__tests__/routes/users.test.ts
@@ -6,18 +6,13 @@ import { describe, it, expect, vi } from "vitest";
 import type { Context, Next } from "hono";
 import { Hono } from "hono";
 import type { AppEnv } from "../../types/index.js";
-import { createMockDb } from "./notes/setup.js";
+import { createMockDb } from "../createMockDb.js";
 
 vi.mock("../../middleware/auth.js", () => ({
   authRequired: async (c: Context<AppEnv>, next: Next) => {
     const userId = c.req.header("x-test-user-id");
     if (!userId) return c.json({ message: "Unauthorized" }, 401);
     c.set("userId", userId);
-    await next();
-  },
-  authOptional: async (c: Context<AppEnv>, next: Next) => {
-    const userId = c.req.header("x-test-user-id");
-    if (userId) c.set("userId", userId);
     await next();
   },
 }));
@@ -101,8 +96,13 @@ describe("GET /api/users/me", () => {
 
 describe("GET /api/users/:id", () => {
   it("returns own profile (limited fields) when id matches authenticated user", async () => {
-    const mockUser = createMockUser();
-    const { app } = createTestApp([[mockUser]]);
+    /** Drizzle の部分 select と同じ形（モックが余分な列を返すとレスポンス契約のテストにならない） */
+    const mockPublicProfile = {
+      id: TEST_USER_ID,
+      name: "Test User",
+      image: "https://example.com/avatar.png",
+    };
+    const { app } = createTestApp([[mockPublicProfile]]);
 
     const res = await app.request(`/api/users/${TEST_USER_ID}`, {
       headers: authHeaders(),
@@ -110,11 +110,14 @@ describe("GET /api/users/:id", () => {
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as { user: Record<string, unknown> };
+    expect(Object.keys(body.user).sort()).toEqual(["id", "image", "name"]);
     expect(body.user).toMatchObject({
       id: TEST_USER_ID,
       name: "Test User",
       image: "https://example.com/avatar.png",
     });
+    expect(body.user).not.toHaveProperty("email");
+    expect(body.user).not.toHaveProperty("role");
   });
 
   it("returns 403 when requesting another user's profile", async () => {

--- a/server/api/src/__tests__/routes/users.test.ts
+++ b/server/api/src/__tests__/routes/users.test.ts
@@ -22,7 +22,22 @@ import userRoutes from "../../routes/users.js";
 const TEST_USER_ID = "user-test-123";
 const OTHER_USER_ID = "user-other-456";
 
-function createTestApp(dbResults: unknown[]) {
+/** GET /me のモック行（users テーブル全列に相当） / Mock row shape for GET /me (full user row). */
+type MockFullUserRow = {
+  id: string;
+  name: string;
+  email: string;
+  emailVerified: boolean;
+  image: string;
+  role: "user";
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function createTestApp(dbResults: unknown[]): {
+  app: Hono<AppEnv>;
+  chains: ReturnType<typeof createMockDb>["chains"];
+} {
   const { db, chains } = createMockDb(dbResults);
   const app = new Hono<AppEnv>();
 
@@ -35,14 +50,14 @@ function createTestApp(dbResults: unknown[]) {
   return { app, chains };
 }
 
-function authHeaders(userId = TEST_USER_ID) {
+function authHeaders(userId: string = TEST_USER_ID): Record<string, string> {
   return {
     "x-test-user-id": userId,
     "Content-Type": "application/json",
   };
 }
 
-function createMockUser(overrides: Record<string, unknown> = {}) {
+function createMockUser(overrides: Partial<MockFullUserRow> = {}): MockFullUserRow {
   return {
     id: TEST_USER_ID,
     name: "Test User",
@@ -70,7 +85,13 @@ describe("GET /api/users/me", () => {
     expect(body.user).toMatchObject({
       id: TEST_USER_ID,
       name: "Test User",
+      email: "test@example.com",
+      emailVerified: true,
+      image: "https://example.com/avatar.png",
+      role: "user",
     });
+    expect(body.user.createdAt).toEqual(expect.any(String));
+    expect(body.user.updatedAt).toEqual(expect.any(String));
   });
 
   it("returns 404 when user does not exist in DB", async () => {
@@ -96,7 +117,10 @@ describe("GET /api/users/me", () => {
 
 describe("GET /api/users/:id", () => {
   it("returns own profile (limited fields) when id matches authenticated user", async () => {
-    /** Drizzle の部分 select と同じ形（モックが余分な列を返すとレスポンス契約のテストにならない） */
+    /**
+     * Drizzle の部分 select と同じ形。モックが余分な列を返すとレスポンス契約のテストにならない。
+     * Same shape as Drizzle partial select; extra columns in the mock would invalidate the response contract test.
+     */
     const mockPublicProfile = {
       id: TEST_USER_ID,
       name: "Test User",

--- a/server/api/src/routes/users.ts
+++ b/server/api/src/routes/users.ts
@@ -19,9 +19,21 @@ app.get("/me", authRequired, async (c) => {
   return c.json({ user: result[0] });
 });
 
+/**
+ * 自分自身のプロフィール（限定フィールド）を取得する。
+ * 他ユーザーの ID を指定した場合は 403 を返す（列挙リスク防止）。
+ *
+ * Returns own profile (limited fields). Returns 403 for other users'
+ * IDs to prevent user enumeration. See: #430
+ */
 app.get("/:id", authRequired, async (c) => {
   const id = c.req.param("id");
+  const userId = c.get("userId");
   const db = c.get("db");
+
+  if (id !== userId) {
+    throw new HTTPException(403, { message: "Forbidden" });
+  }
 
   const result = await db
     .select({


### PR DESCRIPTION
## 概要

`GET /api/users/:id` で任意のユーザー ID を指定して他ユーザーのプロフィール情報を取得できるセキュリティ上の問題を修正。認証済みユーザーが自分自身の ID 以外を指定した場合に 403 Forbidden を返すようにした。

## 変更点

- `GET /api/users/:id` に `id === userId` チェックを追加し、他ユーザーへのアクセスを遮断
- ユーザールート (`GET /me`, `GET /:id`) の単体テストを新規作成（7テスト）

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `bun run test:run` で全テスト (962件) がパスすることを確認
2. `bun run lint` で Lint エラーがないことを確認
3. 新規テスト `server/api/src/__tests__/routes/users.test.ts` で以下を検証:
   - `GET /me` — 認証済みユーザーの自身のプロフィールが返る
   - `GET /:id` — 自分の ID → 200、他人の ID → 403、認証なし → 401

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #430

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ユーザープロフィール取得時のプライバシー保護を強化しました。認証済みユーザーは自身のプロフィール情報のみにアクセス可能となり、他ユーザーのプロフィールへのアクセスは制限されます。
* **テスト**
  * ユーザーAPIのエンドポイントに対する自動テストを追加。認証動作、ステータス応答（200/401/403/404）、および公開表示フィールドの検証を網羅しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->