### PR TITLE
docs(skills): PR base is integration branch, not main

### DIFF
--- a/.cursor/skills/create-pull-request/SKILL.md
+++ b/.cursor/skills/create-pull-request/SKILL.md
@@ -6,12 +6,20 @@ description: >
   project PR template. Use when the user asks to "create a PR", "make a pull
   request", "open a PR", or "PRを作成して". Branch name or issue number
   (e.g. "feature/add-login" or "123" → feature/123) should be obtained from
-  the user message or requested if missing.
+  the user message or requested if missing. PR base (--base) must target the
+  current integration branch (e.g. develop or the branch you branched from),
+  never main unless the user explicitly requests a release PR.
 ---
 
 # Create Pull Request
 
-This skill uses `develop` as the default base branch. If the current branch already contains the intended commits, reuse that branch and create or update the PR from it. When creating a new branch (from `develop`), obtain the branch name from the user (e.g. `feature/add-login`) or derive it from an issue number (e.g. `123` → `feature/123`). If neither is provided, ask the user.
+This skill uses **`develop` as the default `--base` branch** for Zedi. **Do not use `main` as `--base`** unless the user explicitly asks for a release or mainline merge PR.
+
+**Skills / `.cursor/skills/` (and similar workflow-only changes):** Open the PR so it **merges into the branch you were on when you created the topic branch** (the current integration line)—typically `develop` after `git checkout -b` from `develop`, or a parent feature branch if you branched from there. **Never open Skills-only PRs with `--base main`** by default.
+
+If the current branch already contains the intended commits, reuse that branch and create or update the PR from it. When creating a new branch, obtain the branch name from the user (e.g. `feature/add-login`) or derive it from an issue number (e.g. `123` → `feature/123`). If neither is provided, ask the user.
+
+**Recording `BASE_BRANCH`:** Right before `git checkout -b <topic>`, note the branch name you are leaving (e.g. `PARENT=$(git branch --show-current)`); use that as `BASE_BRANCH` for `gh pr create --base`. If you did not create a new branch, use `develop` when it is the integration branch, or the branch the user specifies.
 
 ## Preflight
 
@@ -27,6 +35,7 @@ gh auth status                      # GitHub CLI authenticated
    - If the working tree is dirty, ask the user to commit or stash first, or create the new branch from the current state explicitly.
    - Run `git pull --ff-only origin develop`.
    - Determine the new branch name: from user (e.g. `feature/add-login`) or issue number (e.g. `123` → `feature/123`). If missing, ask: "ブランチ名（例: feature/add-login）またはイシュー番号（例: 123）を教えてください."
+   - Before creating the topic branch, set the PR merge target: `BASE_BRANCH=$(git branch --show-current)` (on `develop`, this is `develop`—use this for `gh pr create --base`, not `main`).
    - Create the branch: `git checkout -b <ブランチ名>`.
    - If the new branch is dirty after creation, commit with an appropriate message (Conventional Commits recommended).
 
@@ -42,9 +51,11 @@ Run **Phase 1** commands in parallel (they are independent), then **Phase 2**.
 ### Phase 1: Gather context (run in parallel)
 
 ```bash
-BASE_BRANCH="develop"
+# BASE_BRANCH: branch to merge into (never default to main for Skills / routine work).
+# Prefer PARENT captured before `git checkout -b`, else develop for Zedi.
+BASE_BRANCH="${BASE_BRANCH:-develop}"
 CURRENT=$(git branch --show-current)
-echo "Branch: $CURRENT -> $BASE_BRANCH"
+echo "Branch: $CURRENT -> $BASE_BRANCH (merge target)"
 
 # 1b. Commit list (chronological)
 git log ${BASE_BRANCH}..HEAD --format="%h %s" --reverse
@@ -195,16 +206,16 @@ Derive the PR title from commit messages:
 
 ## Decision points
 
-| Situation                    | Action                                                                 |
-| ---------------------------- | ---------------------------------------------------------------------- |
-| Not on develop (has commits) | Reuse current branch; create or update PR from it                      |
-| On develop                   | Pull, create new branch (get name from user), then create or update PR |
-| Branch name / issue missing  | Ask user for branch name or issue number                               |
-| Working tree dirty on branch | Commit on the new branch before investigation                          |
-| Existing PR found            | Update that PR's body instead of creating a new PR                     |
-| Base branch not specified    | Default to `develop`                                                   |
-| PR is very large (>50 files) | Suggest splitting, but proceed if user confirms                        |
-| Lint/format/test fail        | Fix, commit, then re-run Step 3 before pushing                         |
+| Situation                    | Action                                                                                                                                    |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Not on develop (has commits) | Reuse current branch; create or update PR from it                                                                                         |
+| On develop                   | Pull, create new branch (get name from user), then create or update PR                                                                    |
+| Branch name / issue missing  | Ask user for branch name or issue number                                                                                                  |
+| Working tree dirty on branch | Commit on the new branch before investigation                                                                                             |
+| Existing PR found            | Update that PR's body instead of creating a new PR                                                                                        |
+| Base branch not specified    | Default to `develop`; never `main` unless user asks for release PR. For stacked work, use parent branch captured before `git checkout -b` |
+| PR is very large (>50 files) | Suggest splitting, but proceed if user confirms                                                                                           |
+| Lint/format/test fail        | Fix, commit, then re-run Step 3 before pushing                                                                                            |
 
 ## Response format
 


### PR DESCRIPTION
## 概要

`create-pull-request` Skill を更新し、PR の `--base` を **現在の統合ライン（`develop` や分岐元の作業ブランチ）** に向け、**既定で `main` にしない**ことを明文化しました。Skills / `.cursor/skills/` だけの変更でも `main` を base にしない運用を明示します。

## 変更点

- `.cursor/skills/create-pull-request/SKILL.md`
  - フロントマターの description に PR base の方針を追記
  - `main` を `--base` にしない（リリース PR 等でユーザーが明示した場合のみ）を本文に記載
  - Skills 変更時は「トピックブランチを切る直前のブランチ」へマージする PR にする手順（`BASE_BRANCH` の記録）を追加
  - Phase 1 の `BASE_BRANCH` 説明と Decision table を更新

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [x] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. 該当 Skill の Markdown を目視で確認する。
2. `bun run test:run` を実行し、既存テストがパスすることを確認した。

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない（変更は Markdown のみ）
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

該当なし

## 関連 Issue

なし

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
