### PR TITLE
fix(hocuspocus): HOCUSPOCUS_DEV_MODE でのみ API 未設定時の認証バイパスを許可 (#431)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ VITE_API_BASE_URL=http://localhost:3000
 # Production: wss://realtime.zedi-note.app
 VITE_REALTIME_URL=ws://localhost:1234
 
+# Hocuspocus server (server/hocuspocus): internal URL of the API for session verification (Better Auth cookie).
+# 未設定のままでは本番・ステージングで接続拒否。ローカルだけで API なしで試す場合のみ HOCUSPOCUS_DEV_MODE=true（非本番のみ）。
+# API_INTERNAL_URL=http://localhost:3000
+# HOCUSPOCUS_DEV_MODE=true
+
 # Polar (Pro plan billing)
 VITE_POLAR_PRO_MONTHLY_PRODUCT_ID=YOUR_POLAR_MONTHLY_PRODUCT_ID
 VITE_POLAR_PRO_YEARLY_PRODUCT_ID=YOUR_POLAR_YEARLY_PRODUCT_ID

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "format:check": "prettier --check .",
     "preview": "vite preview",
     "test": "vitest",
-    "test:run": "vitest run",
+    "test:run": "vitest run && vitest run --config server/hocuspocus/vitest.config.ts",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",

--- a/server/hocuspocus/package.json
+++ b/server/hocuspocus/package.json
@@ -22,6 +22,7 @@
     "@types/pg": "^8.16.0",
     "@types/ws": "^8.18.1",
     "tsx": "^4.19.0",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "vitest": "^4.0.16"
   }
 }

--- a/server/hocuspocus/package.json
+++ b/server/hocuspocus/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
     "@hocuspocus/extension-redis": "^3.4.4",

--- a/server/hocuspocus/src/dev-auth-bypass.test.ts
+++ b/server/hocuspocus/src/dev-auth-bypass.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { decideAuthWhenApiInternalUrlMissing, isTruthyEnvFlag } from "./dev-auth-bypass.js";
+
+describe("isTruthyEnvFlag", () => {
+  it("treats 1, true, yes as true (case-insensitive)", () => {
+    expect(isTruthyEnvFlag("true")).toBe(true);
+    expect(isTruthyEnvFlag("TRUE")).toBe(true);
+    expect(isTruthyEnvFlag("1")).toBe(true);
+    expect(isTruthyEnvFlag("yes")).toBe(true);
+    expect(isTruthyEnvFlag("  true  ")).toBe(true);
+  });
+
+  it("rejects other strings and empty", () => {
+    expect(isTruthyEnvFlag(undefined)).toBe(false);
+    expect(isTruthyEnvFlag("")).toBe(false);
+    expect(isTruthyEnvFlag("false")).toBe(false);
+    expect(isTruthyEnvFlag("0")).toBe(false);
+    expect(isTruthyEnvFlag("on")).toBe(false);
+  });
+});
+
+describe("decideAuthWhenApiInternalUrlMissing", () => {
+  it("always throws in production", () => {
+    expect(decideAuthWhenApiInternalUrlMissing("production", undefined)).toEqual({
+      action: "throw",
+      message: "API_INTERNAL_URL must be set in production",
+    });
+    expect(decideAuthWhenApiInternalUrlMissing("production", "true")).toEqual({
+      action: "throw",
+      message: "API_INTERNAL_URL must be set in production",
+    });
+  });
+
+  it("throws in non-production when dev flag is unset", () => {
+    const d = decideAuthWhenApiInternalUrlMissing("development", undefined);
+    expect(d.action).toBe("throw");
+    if (d.action === "throw") {
+      expect(d.message).toContain("API_INTERNAL_URL");
+    }
+  });
+
+  it("allows dev bypass in non-production when HOCUSPOCUS_DEV_MODE is true", () => {
+    expect(decideAuthWhenApiInternalUrlMissing("development", "true")).toEqual({
+      action: "dev_bypass",
+    });
+    expect(decideAuthWhenApiInternalUrlMissing(undefined, "1")).toEqual({
+      action: "dev_bypass",
+    });
+  });
+});

--- a/server/hocuspocus/src/dev-auth-bypass.ts
+++ b/server/hocuspocus/src/dev-auth-bypass.ts
@@ -1,0 +1,68 @@
+/**
+ * Hocuspocus auth when `API_INTERNAL_URL` is unset.
+ * `API_INTERNAL_URL` 未設定時の認証方針（開発用バイパス可否）。
+ */
+
+const TRUTHY_FLAGS = new Set(["1", "true", "yes"]);
+
+/**
+ * Whether an environment variable is considered enabled (trimmed, ASCII case-insensitive).
+ * `1` / `true` / `yes` のみを真とする（誤って `on` などを真にしない）。
+ *
+ * @param value - Raw env value / 環境変数の生値
+ */
+export function isTruthyEnvFlag(value: string | undefined): boolean {
+  if (value == null) return false;
+  const v = value.trim().toLowerCase();
+  return TRUTHY_FLAGS.has(v);
+}
+
+/**
+ * Result when internal API URL is missing / 内部 API URL 欠落時の分岐結果。
+ */
+export type MissingApiInternalUrlAuthDecision =
+  | { readonly action: "dev_bypass" }
+  | { readonly action: "throw"; readonly message: string };
+
+/**
+ * Decide auth when `API_INTERNAL_URL` is not set.
+ * 本番では常に拒否。それ以外では `HOCUSPOCUS_DEV_MODE` が真のときのみ開発バイパスを許可する。
+ *
+ * @param nodeEnv - `process.env.NODE_ENV`
+ * @param hocuspocusDevMode - `process.env.HOCUSPOCUS_DEV_MODE`
+ */
+export function decideAuthWhenApiInternalUrlMissing(
+  nodeEnv: string | undefined,
+  hocuspocusDevMode: string | undefined,
+): MissingApiInternalUrlAuthDecision {
+  if (nodeEnv === "production") {
+    return {
+      action: "throw",
+      message: "API_INTERNAL_URL must be set in production",
+    };
+  }
+  if (isTruthyEnvFlag(hocuspocusDevMode)) {
+    return { action: "dev_bypass" };
+  }
+  return {
+    action: "throw",
+    message:
+      "API_INTERNAL_URL must be set, or set HOCUSPOCUS_DEV_MODE=true only for trusted local development",
+  };
+}
+
+let loggedDevAuthBypass = false;
+
+/**
+ * Emit a single high-visibility warning when dev auth bypass is used.
+ * 開発バイパス利用時に、プロセスあたり一度だけ警告を出す。
+ */
+export function warnDevAuthBypassOnce(): void {
+  if (loggedDevAuthBypass) return;
+  loggedDevAuthBypass = true;
+  console.warn(
+    "[Auth] SECURITY: Hocuspocus auth bypass is active (HOCUSPOCUS_DEV_MODE). " +
+      "Any client can read/write documents. Do not expose this server. / " +
+      "認証がバイパスされています。信頼できないネットワークに公開しないでください。",
+  );
+}

--- a/server/hocuspocus/src/index.ts
+++ b/server/hocuspocus/src/index.ts
@@ -4,6 +4,11 @@ import { WebSocketServer } from "ws";
 import { Redis } from "@hocuspocus/extension-redis";
 import { Pool, PoolClient } from "pg";
 import * as Y from "yjs";
+import {
+  decideAuthWhenApiInternalUrlMissing,
+  isTruthyEnvFlag,
+  warnDevAuthBypassOnce,
+} from "./dev-auth-bypass.js";
 
 const PORT = parseInt(process.env.PORT || "1234", 10);
 const REDIS_URL = process.env.REDIS_URL;
@@ -240,9 +245,14 @@ const hocuspocus = new Hocuspocus({
     console.log(`[Auth] Document: ${documentName}, Token: ${token ? "provided" : "none"}`);
 
     if (!API_INTERNAL_URL) {
-      if (process.env.NODE_ENV === "production") {
-        throw new Error("API_INTERNAL_URL must be set in production");
+      const decision = decideAuthWhenApiInternalUrlMissing(
+        process.env.NODE_ENV,
+        process.env.HOCUSPOCUS_DEV_MODE,
+      );
+      if (decision.action === "throw") {
+        throw new Error(decision.message);
       }
+      warnDevAuthBypassOnce();
       return { user: { id: "dev-user", name: "Developer" } };
     }
 
@@ -363,6 +373,19 @@ httpServer.listen(PORT, () => {
   console.log(`  WebSocket:    ws://localhost:${PORT}`);
   console.log(`  Redis:        ${REDIS_URL ? "Enabled" : "Disabled"}`);
   console.log(`  Environment:  ${process.env.NODE_ENV || "development"}`);
+  if (!API_INTERNAL_URL && process.env.NODE_ENV !== "production") {
+    if (isTruthyEnvFlag(process.env.HOCUSPOCUS_DEV_MODE)) {
+      console.warn(
+        "[Auth] API_INTERNAL_URL is unset; HOCUSPOCUS_DEV_MODE allows unauthenticated collaboration. / " +
+          "内部 API URL 未設定のため開発バイパスが有効です。",
+      );
+    } else {
+      console.warn(
+        "[Auth] API_INTERNAL_URL is unset; WebSocket auth will fail until it is set or HOCUSPOCUS_DEV_MODE=true (local dev only). / " +
+          "内部 API URL 未設定のため接続は拒否されます（ローカル検証のみ HOCUSPOCUS_DEV_MODE=true）。",
+      );
+    }
+  }
   console.log("========================================");
 });
 

--- a/server/hocuspocus/src/index.ts
+++ b/server/hocuspocus/src/index.ts
@@ -14,6 +14,9 @@ const PORT = parseInt(process.env.PORT || "1234", 10);
 const REDIS_URL = process.env.REDIS_URL;
 const DATABASE_URL = process.env.DATABASE_URL;
 const API_INTERNAL_URL = process.env.API_INTERNAL_URL;
+/** Cached env reads for auth paths (avoid repeated `process.env` lookups). / 認証経路用に env を一度だけ読む */
+const NODE_ENV = process.env.NODE_ENV;
+const HOCUSPOCUS_DEV_MODE = process.env.HOCUSPOCUS_DEV_MODE;
 
 type AuthenticatedUser = {
   id: string;
@@ -245,10 +248,7 @@ const hocuspocus = new Hocuspocus({
     console.log(`[Auth] Document: ${documentName}, Token: ${token ? "provided" : "none"}`);
 
     if (!API_INTERNAL_URL) {
-      const decision = decideAuthWhenApiInternalUrlMissing(
-        process.env.NODE_ENV,
-        process.env.HOCUSPOCUS_DEV_MODE,
-      );
+      const decision = decideAuthWhenApiInternalUrlMissing(NODE_ENV, HOCUSPOCUS_DEV_MODE);
       if (decision.action === "throw") {
         throw new Error(decision.message);
       }
@@ -363,6 +363,14 @@ wss.on("connection", (socket, request) => {
   hocuspocus.handleConnection(socket, request);
 });
 
+if (NODE_ENV === "production" && !API_INTERNAL_URL) {
+  console.error(
+    "[Auth] CRITICAL: API_INTERNAL_URL is unset in production. Refusing to start. / " +
+      "本番で内部 API URL が未設定です。起動を中止します。",
+  );
+  process.exit(1);
+}
+
 // サーバー起動
 httpServer.listen(PORT, () => {
   console.log("========================================");
@@ -372,9 +380,9 @@ httpServer.listen(PORT, () => {
   console.log(`  Health:       http://localhost:${PORT}/health`);
   console.log(`  WebSocket:    ws://localhost:${PORT}`);
   console.log(`  Redis:        ${REDIS_URL ? "Enabled" : "Disabled"}`);
-  console.log(`  Environment:  ${process.env.NODE_ENV || "development"}`);
-  if (!API_INTERNAL_URL && process.env.NODE_ENV !== "production") {
-    if (isTruthyEnvFlag(process.env.HOCUSPOCUS_DEV_MODE)) {
+  console.log(`  Environment:  ${NODE_ENV || "development"}`);
+  if (!API_INTERNAL_URL && NODE_ENV !== "production") {
+    if (isTruthyEnvFlag(HOCUSPOCUS_DEV_MODE)) {
       console.warn(
         "[Auth] API_INTERNAL_URL is unset; HOCUSPOCUS_DEV_MODE allows unauthenticated collaboration. / " +
           "内部 API URL 未設定のため開発バイパスが有効です。",

--- a/server/hocuspocus/tsconfig.json
+++ b/server/hocuspocus/tsconfig.json
@@ -17,5 +17,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/server/hocuspocus/vitest.config.ts
+++ b/server/hocuspocus/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  root,
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## 概要

[Hocuspocus #431](https://github.com/otomatty/zedi/issues/431) 対応。`API_INTERNAL_URL` 未設定時に `NODE_ENV !== "production"` だけで認証・認可がスキップされていた挙動をやめ、**明示的な `HOCUSPOCUS_DEV_MODE`**（`true` / `1` / `yes`）がある場合のみ開発用 `dev-user` バイパスを許可する。

## 変更点

- `decideAuthWhenApiInternalUrlMissing` に判定を集約（`server/hocuspocus/src/dev-auth-bypass.ts`）
- 起動時と初回バイパス時に警告ログ
- Vitest で単体テスト追加、ルート `bun run test:run` に Hocuspocus 設定を連結
- `.env.example` に `API_INTERNAL_URL` / `HOCUSPOCUS_DEV_MODE` のコメント追記

## 変更の種類

- [x] バグ修正 (Bug fix)
- [ ] 新機能 (New feature)
- [x] 破壊的変更 (Breaking change)
- [ ] ドキュメント (Documentation)
- [ ] スタイル/リファクタリング (Style/Refactor)
- [x] テスト (Tests)
- [ ] ビルド/CI (Build/CI)

**破壊的変更（ローカル開発）**: これまで `API_INTERNAL_URL` なしで Hocuspocus を動かしていた場合は、`HOCUSPOCUS_DEV_MODE=true` を付けるか `API_INTERNAL_URL` を設定してください。Docker Compose 利用時は既に `API_INTERNAL_URL` が設定されているため影響なし。

## テスト方法

1. `bun run test:run`（ルート Vitest + Hocuspocus）
2. `cd server/hocuspocus && bun run build`

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない（変更ファイルに対する ESLint / Prettier 確認済み）
- [x] 必要に応じてドキュメントを更新した（`.env.example`）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #431

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * Hocuspocusサーバーの専用テストスイートを追加しました。

* **チョア**
  * 本番環境でのAPI認証検証の設定プレースホルダーを追加しました。
  * 開発環境での設定フローを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->