### PR TITLE
fix(api): stream GET /api/media/:id to avoid storage CORS (#441)

### DIFF
--- a/server/api/src/__tests__/routes/media.test.ts
+++ b/server/api/src/__tests__/routes/media.test.ts
@@ -241,9 +241,11 @@ describe("GET /api/media/:id — proxy stream (no redirect to storage)", () => {
   };
 
   it("returns 200 and streams object bytes with Content-Type from DB row", async () => {
+    const payload = Buffer.from("fake-bytes");
     mockS3Send.mockResolvedValueOnce({
-      Body: Readable.from([Buffer.from("fake-bytes")]),
+      Body: Readable.from([payload]),
       ContentType: "image/jpeg",
+      ContentLength: payload.length,
     });
     const app = createMediaApp([[mediaRow]]);
 
@@ -254,9 +256,49 @@ describe("GET /api/media/:id — proxy stream (no redirect to storage)", () => {
 
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toBe("image/png");
+    expect(res.headers.get("Content-Length")).toBe(String(payload.length));
     expect(res.headers.get("Cache-Control")).toBe("private, max-age=3600");
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Content-Disposition")).toBeNull();
     expect(await res.text()).toBe("fake-bytes");
+  });
+
+  it("uses S3 Content-Type when DB row has no content type and MIME is safe", async () => {
+    mockS3Send.mockResolvedValueOnce({
+      Body: Readable.from([Buffer.from("w")]),
+      ContentType: "image/webp",
+      ContentLength: 1,
+    });
+    const app = createMediaApp([[{ ...mediaRow, contentType: null }]]);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "GET",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/webp");
+    expect(res.headers.get("Content-Disposition")).toBeNull();
+  });
+
+  it("forces application/octet-stream and attachment for disallowed types such as SVG", async () => {
+    mockS3Send.mockResolvedValueOnce({
+      Body: Readable.from([Buffer.from("<svg")]),
+      ContentType: "image/svg+xml",
+      ContentLength: 4,
+    });
+    const app = createMediaApp([
+      [{ ...mediaRow, contentType: "image/svg+xml", fileName: "x.svg" }],
+    ]);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "GET",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
+    expect(res.headers.get("Content-Disposition")).toBe('attachment; filename="x.svg"');
   });
 
   it("returns 403 when media belongs to another user", async () => {

--- a/server/api/src/__tests__/routes/media.test.ts
+++ b/server/api/src/__tests__/routes/media.test.ts
@@ -257,7 +257,8 @@ describe("GET /api/media/:id — proxy stream (no redirect to storage)", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toBe("image/png");
     expect(res.headers.get("Content-Length")).toBe(String(payload.length));
-    expect(res.headers.get("Cache-Control")).toBe("private, max-age=3600");
+    expect(res.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(res.headers.get("Vary")).toBe("Cookie");
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(res.headers.get("Content-Disposition")).toBeNull();
     expect(await res.text()).toBe("fake-bytes");
@@ -278,6 +279,24 @@ describe("GET /api/media/:id — proxy stream (no redirect to storage)", () => {
 
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toBe("image/webp");
+    expect(res.headers.get("Content-Disposition")).toBeNull();
+  });
+
+  it("returns inline image/avif when declared on the row", async () => {
+    mockS3Send.mockResolvedValueOnce({
+      Body: Readable.from([Buffer.from("x")]),
+      ContentType: "application/octet-stream",
+      ContentLength: 1,
+    });
+    const app = createMediaApp([[{ ...mediaRow, contentType: "image/avif", fileName: "x.avif" }]]);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "GET",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/avif");
     expect(res.headers.get("Content-Disposition")).toBeNull();
   });
 

--- a/server/api/src/__tests__/routes/media.test.ts
+++ b/server/api/src/__tests__/routes/media.test.ts
@@ -1,10 +1,16 @@
 /**
  * POST /api/media/confirm の S3 キー所有者検証テスト。
- * Tests for S3 key ownership validation on POST /api/media/confirm.
+ * GET /api/media/:id のプロキシ配信テスト。
+ * Tests for S3 key ownership on confirm and streaming GET for media.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Readable } from "node:stream";
 import type { Context, Next } from "hono";
 import type { AppEnv } from "../../types/index.js";
+
+const { mockS3Send } = vi.hoisted(() => ({
+  mockS3Send: vi.fn(),
+}));
 
 vi.mock("../../middleware/auth.js", () => ({
   authRequired: async (c: Context<AppEnv>, next: Next) => {
@@ -28,8 +34,8 @@ vi.mock("../../lib/env.js", () => ({
 }));
 
 vi.mock("@aws-sdk/client-s3", () => {
-  function MockS3Client() {
-    /* stub */
+  class MockS3Client {
+    send = (...args: unknown[]) => mockS3Send(...args);
   }
   function MockPutObjectCommand() {
     /* stub */
@@ -77,6 +83,10 @@ function createMediaApp(dbResults: unknown[]) {
   app.route("/api/media", mediaRoutes);
   return app;
 }
+
+beforeEach(() => {
+  mockS3Send.mockReset();
+});
 
 describe("POST /api/media/confirm — S3 key ownership validation", () => {
   it("accepts s3_key matching the authenticated user's prefix", async () => {
@@ -214,5 +224,102 @@ describe("POST /api/media/confirm — S3 key ownership validation", () => {
     });
 
     expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/media/:id — proxy stream (no redirect to storage)", () => {
+  const s3Key = `users/${TEST_USER_ID}/media/${MEDIA_ID}/photo.png`;
+  const mediaRow = {
+    id: MEDIA_ID,
+    ownerId: TEST_USER_ID,
+    s3Key,
+    fileName: "photo.png",
+    contentType: "image/png",
+    fileSize: null as number | null,
+    pageId: null as string | null,
+    createdAt: new Date(),
+  };
+
+  it("returns 200 and streams object bytes with Content-Type from DB row", async () => {
+    mockS3Send.mockResolvedValueOnce({
+      Body: Readable.from([Buffer.from("fake-bytes")]),
+      ContentType: "image/jpeg",
+    });
+    const app = createMediaApp([[mediaRow]]);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "GET",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+    expect(res.headers.get("Cache-Control")).toBe("private, max-age=3600");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(await res.text()).toBe("fake-bytes");
+  });
+
+  it("returns 403 when media belongs to another user", async () => {
+    const app = createMediaApp([[{ ...mediaRow, ownerId: ATTACKER_ID }]]);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "GET",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(403);
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when media row is missing", async () => {
+    const app = createMediaApp([[]]);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "GET",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(404);
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 without auth header", async () => {
+    const app = createMediaApp([[mediaRow]]);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, { method: "GET" });
+
+    expect(res.status).toBe(401);
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when S3 reports NoSuchKey", async () => {
+    mockS3Send.mockRejectedValueOnce({
+      name: "NoSuchKey",
+      $metadata: { httpStatusCode: 404 },
+    });
+    const app = createMediaApp([[mediaRow]]);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "GET",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("Object not found");
+  });
+
+  it("returns 502 on unexpected S3 GetObject failure", async () => {
+    mockS3Send.mockRejectedValueOnce(new Error("network down"));
+    const app = createMediaApp([[mediaRow]]);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "GET",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("Failed to retrieve object");
   });
 });

--- a/server/api/src/routes/media.ts
+++ b/server/api/src/routes/media.ts
@@ -26,6 +26,53 @@ const s3 = new S3Client({
 
 const BUCKET = getEnv("STORAGE_BUCKET_NAME");
 
+/**
+ * api オリジンでバイトを返すため、ユーザー提供の Content-Type をそのまま使わない。
+ * インライン表示してよい画像のみ許可（SVG は XSS リスクのため除外 — サムネイル配信と同様）。
+ *
+ * Do not reflect user-supplied Content-Type verbatim when serving from the API origin.
+ * Only allow safe inline image types (exclude SVG — same rationale as thumbnail/serve).
+ */
+const SAFE_INLINE_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
+
+/**
+ * MIME 文字列からセミコロンより前の部分だけを小文字で返す。
+ *
+ * Returns the part before `;`, lowercased (e.g. `image/png; charset=binary` → `image/png`).
+ *
+ * @param raw - MIME string, possibly with parameters
+ */
+function normalizeMimeBase(raw: string | undefined | null): string | null {
+  if (!raw) return null;
+  const base = raw.split(";")[0]?.trim().toLowerCase();
+  return base || null;
+}
+
+/**
+ * プロキシ応答用の Content-Type と、必要なら Content-Disposition（attachment）。
+ *
+ * Resolves safe `Content-Type` and optional `Content-Disposition` for proxied bytes.
+ */
+function resolveProxyContentHeaders(
+  rowContentType: string | null | undefined,
+  s3ContentType: string | undefined,
+  fileName: string | null | undefined,
+): { contentType: string; contentDisposition?: string } {
+  const declared = normalizeMimeBase(rowContentType) ?? normalizeMimeBase(s3ContentType);
+  if (declared && SAFE_INLINE_IMAGE_TYPES.has(declared)) {
+    return { contentType: declared };
+  }
+  const safeFile =
+    fileName
+      ?.trim()
+      .replace(/[^\w.-]+/g, "_")
+      .slice(0, 200) || "download";
+  return {
+    contentType: "application/octet-stream",
+    contentDisposition: `attachment; filename="${safeFile}"`,
+  };
+}
+
 const app = new Hono<AppEnv>();
 
 app.post("/upload", authRequired, async (c) => {
@@ -139,16 +186,30 @@ app.get("/:id", authRequired, async (c) => {
   const body = response.Body;
   if (!body) return c.json({ error: "Object not found" }, 404);
 
-  const contentType = row.contentType ?? response.ContentType ?? "application/octet-stream";
+  const { contentType, contentDisposition } = resolveProxyContentHeaders(
+    row.contentType,
+    response.ContentType,
+    row.fileName,
+  );
 
   const webStream = body instanceof Readable ? Readable.toWeb(body) : (body as ReadableStream);
+
+  const headers: Record<string, string> = {
+    "Content-Type": contentType,
+    "Cache-Control": "private, max-age=3600",
+    "X-Content-Type-Options": "nosniff",
+  };
+  if (contentDisposition) {
+    headers["Content-Disposition"] = contentDisposition;
+  }
+  const len = response.ContentLength;
+  if (typeof len === "number" && len >= 0) {
+    headers["Content-Length"] = String(len);
+  }
+
   return new Response(webStream as BodyInit, {
     status: 200,
-    headers: {
-      "Content-Type": contentType,
-      "Cache-Control": "private, max-age=3600",
-      "X-Content-Type-Options": "nosniff",
-    },
+    headers,
   });
 });
 

--- a/server/api/src/routes/media.ts
+++ b/server/api/src/routes/media.ts
@@ -1,3 +1,4 @@
+import { Readable } from "node:stream";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { eq } from "drizzle-orm";
@@ -99,6 +100,14 @@ app.post("/confirm", authRequired, async (c) => {
   return c.json({ media: result[0] });
 });
 
+/**
+ * GET /api/media/:id — メディアをプロキシ配信
+ * 302 で presigned URL へ飛ばすと、ブラウザの credentials 付き fetch がストレージ側で CORS に阻まれることがあるため、
+ * API 上で GetObject してストリーム返却する（サムネイル配信と同じ理由）。
+ *
+ * GET /api/media/:id — proxy media bytes through the API.
+ * A 302 to a presigned URL can make credentialed browser fetches fail on storage CORS; stream from S3 here instead (same as thumbnails).
+ */
 app.get("/:id", authRequired, async (c) => {
   const mediaId = c.req.param("id");
   const userId = c.get("userId");
@@ -112,13 +121,35 @@ app.get("/:id", authRequired, async (c) => {
     throw new HTTPException(403, { message: "You can only access your own media" });
   }
 
-  const signedUrl = await getSignedUrl(
-    s3,
-    new GetObjectCommand({ Bucket: BUCKET, Key: row.s3Key }),
-    { expiresIn: 3600 },
-  );
+  let response;
+  try {
+    response = await s3.send(new GetObjectCommand({ Bucket: BUCKET, Key: row.s3Key }));
+  } catch (err) {
+    const meta = (err as { name?: string; $metadata?: { httpStatusCode?: number } } | undefined)
+      ?.$metadata;
+    const code = meta?.httpStatusCode;
+    const name = (err as { name?: string }).name;
+    if (name === "NoSuchKey" || code === 404) {
+      return c.json({ error: "Object not found" }, 404);
+    }
+    console.error("[media] S3 GetObject failed:", err);
+    return c.json({ error: "Failed to retrieve object" }, 502);
+  }
 
-  return c.redirect(signedUrl, 302);
+  const body = response.Body;
+  if (!body) return c.json({ error: "Object not found" }, 404);
+
+  const contentType = row.contentType ?? response.ContentType ?? "application/octet-stream";
+
+  const webStream = body instanceof Readable ? Readable.toWeb(body) : (body as ReadableStream);
+  return new Response(webStream as BodyInit, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "private, max-age=3600",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
 });
 
 app.delete("/:id", authRequired, async (c) => {

--- a/server/api/src/routes/media.ts
+++ b/server/api/src/routes/media.ts
@@ -28,12 +28,23 @@ const BUCKET = getEnv("STORAGE_BUCKET_NAME");
 
 /**
  * api オリジンでバイトを返すため、ユーザー提供の Content-Type をそのまま使わない。
- * インライン表示してよい画像のみ許可（SVG は XSS リスクのため除外 — サムネイル配信と同様）。
+ * ブラウザが img で表示しやすいラスタ系のみインライン許可（SVG は XSS のため除外 — サムネイル配信と同様）。
+ * AVIF/APNG などはアップロードで保存され得るため GET でも同じ扱いにする（/upload は file.type 依存のためここで広げる）。
  *
- * Do not reflect user-supplied Content-Type verbatim when serving from the API origin.
- * Only allow safe inline image types (exclude SVG — same rationale as thumbnail/serve).
+ * Do not reflect user-supplied Content-Type verbatim from the API origin.
+ * Allow common safe raster types for inline display; exclude SVG (XSS — same as thumbnail/serve).
+ * Include AVIF/APNG so GET matches types clients may store via `/upload`.
  */
-const SAFE_INLINE_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
+const SAFE_INLINE_IMAGE_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+  "image/apng",
+  "image/bmp",
+  "image/x-ms-bmp",
+]);
 
 /**
  * MIME 文字列からセミコロンより前の部分だけを小文字で返す。
@@ -194,9 +205,12 @@ app.get("/:id", authRequired, async (c) => {
 
   const webStream = body instanceof Readable ? Readable.toWeb(body) : (body as ReadableStream);
 
+  // Cookie セッション認可: ログアウト後の別アカウントで古いバイトが再利用されないよう no-store + Vary: Cookie
+  // Cookie-auth: avoid serving stale cached bytes after logout or account switch
   const headers: Record<string, string> = {
     "Content-Type": contentType,
-    "Cache-Control": "private, max-age=3600",
+    "Cache-Control": "private, no-store",
+    Vary: "Cookie",
     "X-Content-Type-Options": "nosniff",
   };
   if (contentDisposition) {


### PR DESCRIPTION
## 概要

エディタの `getAuthenticatedImageUrl` が `credentials: include` で `GET /api/media/:id` を叩いたとき、302 で R2/S3 の presigned URL に追従し、ストレージ側の CORS で `fetch` が失敗していた問題を修正する。`GET` は API 上で `GetObject` してストリーム返却する（`thumbnail/serve` と同じ方針）。

## 変更点

- `server/api/src/routes/media.ts`: `GET /:id` を presigned リダイレクトからプロキシ配信に変更。S3 エラーは 404/502 を JSON で返却。
- `server/api/src/__tests__/routes/media.test.ts`: `mockS3Send` と GET の成功・403・404・401・NoSuchKey・502 のテストを追加。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run lint` と `bun run test:run` が通ることを確認。
2. デプロイ後、エディタで画像を貼り付け、`/api/media/:id` が 200 で画像バイトを返しブラウザで表示されることを確認。

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した（今回は不要）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

UI 変更なし（API のみ）。

## 関連 Issue

Closes #441

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メディア取得でS3から直接ストリーム配信するプロキシを導入し、ダウンロードレスポンスを直接返すようにしました。
  * レスポンスにContent-LengthやContent-Dispositionを条件付きで付与します。

* **バグ修正**
  * S3取得失敗時の応答を改善し、存在しないオブジェクトで404、その他で502を返すようにしました。

* **セキュリティ向上**
  * MIME検証を強化し、許可外はapplication/octet-streamで添付提供、セキュリティヘッダーを追加しました。

* **テスト**
  * GET/POSTの動作やストリーミング・エラーケースを網羅するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->