### PR TITLE
fix(editor): disable browser spellcheck on Tiptap root

### DIFF
--- a/src/components/editor/CodeBlockWithCopyNodeView.tsx
+++ b/src/components/editor/CodeBlockWithCopyNodeView.tsx
@@ -59,9 +59,13 @@ const CodeBlockWithCopyNodeView: React.FC<NodeViewProps> = ({ node }) => {
   const language = (node.attrs.language as string) ?? "";
 
   return (
-    <NodeViewWrapper as="div" className="group/code relative">
-      <pre ref={preRef} className="overflow-x-auto">
-        <NodeViewContent as="code" className={language ? `language-${language}` : ""} />
+    <NodeViewWrapper as="div" className="group/code relative" spellCheck={false}>
+      <pre ref={preRef} className="overflow-x-auto" spellCheck={false}>
+        <NodeViewContent
+          as="code"
+          className={language ? `language-${language}` : ""}
+          spellCheck={false}
+        />
       </pre>
       <button
         type="button"

--- a/src/components/editor/TiptapEditor/editorConfig.ts
+++ b/src/components/editor/TiptapEditor/editorConfig.ts
@@ -32,7 +32,10 @@ import type * as Y from "yjs";
 import type { Awareness } from "y-protocols/awareness";
 
 // Create shared lowlight instance with common languages
-export const lowlight = createLowlight(common);
+export /**
+ *
+ */
+const lowlight = createLowlight(common);
 
 /**
  * Language display name mapping for code block language selector.
@@ -225,10 +228,13 @@ export function createEditorExtensions(options: EditorExtensionsOptions): Extens
 }
 
 /**
- * Default editor props for Tiptap
+ * Default editor props for Tiptap.
+ * spellcheck を無効にし、コードブロック等でブラウザの赤い波線（誤スペル扱い）が出ないようにする。
+ * Disables native spellcheck so code blocks are not underlined as misspellings.
  */
 export const defaultEditorProps = {
   attributes: {
     class: "tiptap-editor focus:outline-none",
+    spellcheck: "false",
   },
 };

--- a/src/components/editor/TiptapEditor/editorConfig.ts
+++ b/src/components/editor/TiptapEditor/editorConfig.ts
@@ -31,11 +31,11 @@ import type { Extension } from "@tiptap/core";
 import type * as Y from "yjs";
 import type { Awareness } from "y-protocols/awareness";
 
-// Create shared lowlight instance with common languages
-export /**
- *
+/**
+ * Shared lowlight instance for code block syntax highlighting (built-in common languages).
+ * コードブロックのシンタックスハイライト用の lowlight 共有インスタンス（common 言語セット）。
  */
-const lowlight = createLowlight(common);
+export const lowlight = createLowlight(common);
 
 /**
  * Language display name mapping for code block language selector.
@@ -228,13 +228,12 @@ export function createEditorExtensions(options: EditorExtensionsOptions): Extens
 }
 
 /**
- * Default editor props for Tiptap.
- * spellcheck を無効にし、コードブロック等でブラウザの赤い波線（誤スペル扱い）が出ないようにする。
- * Disables native spellcheck so code blocks are not underlined as misspellings.
+ * Default editor props for Tiptap (ProseMirror root `editorProps.attributes`).
+ * エディタルートに付与する属性。コードブロックのスペルチェックは NodeView 側で制御する。
+ * Root attributes; code-block spellcheck is handled in `CodeBlockWithCopyNodeView`.
  */
 export const defaultEditorProps = {
   attributes: {
     class: "tiptap-editor focus:outline-none",
-    spellcheck: "false",
   },
 };


### PR DESCRIPTION
## 概要

Tiptap ページエディタのルート要素に `spellcheck="false"` を付与し、コードブロック内の識別子などがブラウザのスペルチェックで赤い波線にならないようにしました。

## 変更点

- `src/components/editor/TiptapEditor/editorConfig.ts`
  - `defaultEditorProps.attributes` に `spellcheck: "false"` を追加
  - 意図を説明する TSDoc を追記

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. ノートを開き、コードブロックに英語の識別子（例: `toISOString`, `ProgressPatch`）を入力する。
2. ブラウザのネイティブスペルチェックの赤い波線が表示されないことを確認する。
3. 通常の本文編集が問題なく行えることを確認する。

## チェックリスト

- [x] テストがすべてパスする（`bun run test:run`）
- [x] Lint エラーがない（変更ファイルに対する ESLint）
- [ ] 必要に応じてドキュメントを更新した（不要）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

<!-- コードブロックの赤い波線が消える挙動の確認用に任意 -->

## 関連 Issue

<!-- なし -->

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * コードブロック内のスペルチェック機能を無効化し、コード入力時の不要な波線表示を削減しました。

* **ドキュメンテーション**
  * エディター設定に関する説明文を更新し、コード構文強調表示とスペルチェック動作の説明を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->