### PR TITLE
fix: preserve inline images in web clip HTML→Tiptap conversion

### DIFF
--- a/src/lib/htmlToTiptap.test.ts
+++ b/src/lib/htmlToTiptap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatClippedContentAsTiptap } from "./htmlToTiptap";
+import { formatClippedContentAsTiptap, htmlToTiptapJSON } from "./htmlToTiptap";
 
 describe("formatClippedContentAsTiptap", () => {
   it("returns main content without citation block or thumbnail when thumbnailUrl is omitted", () => {
@@ -75,5 +75,49 @@ describe("formatClippedContentAsTiptap", () => {
     const first = result.content?.[0];
     expect(first?.type).toBe("paragraph");
     expect(first?.type).not.toBe("image");
+  });
+});
+
+describe("htmlToTiptapJSON", () => {
+  it("converts inline <img> tags to image nodes", () => {
+    const html = '<p>Before</p><img src="https://example.com/photo.png" alt="photo"><p>After</p>';
+    const result = htmlToTiptapJSON(html);
+
+    expect(result.type).toBe("doc");
+    const imageNodes = result.content?.filter((n) => n.type === "image") ?? [];
+    expect(imageNodes.length).toBe(1);
+    expect(imageNodes[0]).toMatchObject({
+      type: "image",
+      attrs: expect.objectContaining({
+        src: "https://example.com/photo.png",
+        alt: "photo",
+      }),
+    });
+  });
+
+  it("preserves multiple inline images in article body", () => {
+    const html = [
+      "<p>Intro</p>",
+      '<img src="https://example.com/img1.png" alt="first">',
+      "<p>Middle</p>",
+      '<img src="https://example.com/img2.jpg" alt="second">',
+      "<p>End</p>",
+    ].join("");
+    const result = htmlToTiptapJSON(html);
+
+    const imageNodes = result.content?.filter((n) => n.type === "image") ?? [];
+    expect(imageNodes.length).toBe(2);
+    expect(imageNodes[0]?.attrs).toMatchObject({ src: "https://example.com/img1.png" });
+    expect(imageNodes[1]?.attrs).toMatchObject({ src: "https://example.com/img2.jpg" });
+  });
+
+  it("converts <img> wrapped in other elements", () => {
+    const html =
+      '<div><figure><img src="https://example.com/fig.webp" alt="figure"></figure></div>';
+    const result = htmlToTiptapJSON(html);
+
+    const imageNodes = result.content?.filter((n) => n.type === "image") ?? [];
+    expect(imageNodes.length).toBe(1);
+    expect(imageNodes[0]?.attrs).toMatchObject({ src: "https://example.com/fig.webp" });
   });
 });

--- a/src/lib/htmlToTiptap.ts
+++ b/src/lib/htmlToTiptap.ts
@@ -11,17 +11,34 @@ import { common, createLowlight } from "lowlight";
 
 const lowlight = createLowlight(common);
 
-// Tiptap の拡張機能（TiptapEditorと同じ構成にする）
-// generateJSON が認識できるノードタイプを定義。Image がないと <img> がドロップされる。
+/**
+ * Link の `isAllowedUri` はエディタ（`editorConfig.ts`）と同じ方針で、
+ * クリップ結果のリンクがエディタで拒否されないよう揃える。
+ * Keep aligned with `createEditorExtensions` Link XSS rules.
+ */
+function isClipLinkUriAllowed(url: string | undefined): boolean {
+  const value = (url ?? "").trim();
+  if (!value) return false;
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(value)) return true;
+  if (/^https?:\/\//i.test(value)) return true;
+  if (/^(mailto|tel):/i.test(value)) return true;
+  return false;
+}
+
+// Web クリップ用の最小スキーマ（サーバー `clipAndCreate` と同系）。
+// Table / TaskList 等は含めない — 拡張は別 PR で検討する。
+// generateJSON に Image がないと <img> がドロップされる。
 const extensions = [
   StarterKit.configure({
     heading: {
       levels: [1, 2, 3],
     },
     codeBlock: false,
+    link: false,
   }),
   Link.configure({
     openOnClick: false,
+    isAllowedUri: isClipLinkUriAllowed,
   }),
   Image,
   CodeBlockLowlight.configure({
@@ -123,9 +140,11 @@ function cleanupHtml(html: string): string {
 }
 
 /**
- * 空の要素を再帰的に削除
+ * 空の要素を再帰的に削除。
+ * `VOID_LIKE_KEEP_TAGS` は cleanupHtml の `unwantedSelectors` で既に除去される
+ * video / iframe / input 等は含めない（純粋な自己完結タグのみ）。
  */
-const VOID_CONTENT_TAGS = new Set(["IMG", "VIDEO", "IFRAME", "HR", "BR", "INPUT", "SOURCE"]);
+const VOID_LIKE_KEEP_TAGS = new Set(["IMG", "HR", "BR", "SOURCE"]);
 
 function removeEmptyElements(element: Element): void {
   const children = Array.from(element.children);
@@ -133,8 +152,8 @@ function removeEmptyElements(element: Element): void {
   for (const child of children) {
     removeEmptyElements(child);
 
-    // void 要素（img, hr 等）は自身がコンテンツなので削除しない
-    if (VOID_CONTENT_TAGS.has(child.tagName)) continue;
+    // 子を持たないが自己完結コンテンツとなる要素は削除しない（img 等）
+    if (VOID_LIKE_KEEP_TAGS.has(child.tagName)) continue;
 
     const hasContent =
       child.textContent?.trim() || child.querySelector("img, video, iframe, hr, br");

--- a/src/lib/htmlToTiptap.ts
+++ b/src/lib/htmlToTiptap.ts
@@ -5,12 +5,14 @@ import { generateJSON } from "@tiptap/html";
 import type { JSONContent } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import Link from "@tiptap/extension-link";
+import Image from "@tiptap/extension-image";
 import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
 import { common, createLowlight } from "lowlight";
 
 const lowlight = createLowlight(common);
 
 // Tiptap の拡張機能（TiptapEditorと同じ構成にする）
+// generateJSON が認識できるノードタイプを定義。Image がないと <img> がドロップされる。
 const extensions = [
   StarterKit.configure({
     heading: {
@@ -21,6 +23,7 @@ const extensions = [
   Link.configure({
     openOnClick: false,
   }),
+  Image,
   CodeBlockLowlight.configure({
     lowlight,
     defaultLanguage: null,
@@ -122,13 +125,17 @@ function cleanupHtml(html: string): string {
 /**
  * 空の要素を再帰的に削除
  */
+const VOID_CONTENT_TAGS = new Set(["IMG", "VIDEO", "IFRAME", "HR", "BR", "INPUT", "SOURCE"]);
+
 function removeEmptyElements(element: Element): void {
   const children = Array.from(element.children);
 
   for (const child of children) {
     removeEmptyElements(child);
 
-    // テキストコンテンツが空で、子要素もない場合は削除
+    // void 要素（img, hr 等）は自身がコンテンツなので削除しない
+    if (VOID_CONTENT_TAGS.has(child.tagName)) continue;
+
     const hasContent =
       child.textContent?.trim() || child.querySelector("img, video, iframe, hr, br");
     if (!hasContent && child.children.length === 0) {


### PR DESCRIPTION
## 概要

「URLから作成」で Web ページを取り込む際、Readability が抽出した本文内の `<img>` が Tiptap に変換されず落ちていた問題を修正しました。`generateJSON` に `Image` 拡張を追加し、`cleanupHtml` の空要素削除で void 要素（`img` 等）を誤って削除しないようにしました。

## 変更点

- `src/lib/htmlToTiptap.ts`
  - `@tiptap/extension-image` を `extensions` に追加し、HTML 内の `<img>` を `image` ノードとして変換できるようにした。
  - `removeEmptyElements` で `IMG` 等の void 要素を「空」とみなして削除しないようにした。
- `src/lib/htmlToTiptap.test.ts`
  - インライン画像・複数画像・ラップされた `<img>` の変換を検証するテストを追加した。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run vitest run src/lib/htmlToTiptap.test.ts` がパスすることを確認する。
2. アプリで「URLから作成」を開き、本文に画像を含む記事（例: Zenn）の URL を取り込み、エディタに画像ブロックが表示されることを確認する。

## チェックリスト

- [x] テストがすべてパスする（変更ファイルに対する `vitest run src/lib/htmlToTiptap.test.ts`）
- [x] Lint エラーがない（変更ファイルに対する `eslint`）
- [ ] 必要に応じてドキュメントを更新した（不要）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

<!-- ロジック修正のため省略可 -->

## 関連 Issue

<!-- なし -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * HTMLから形式への変換時に画像のサポートが追加されました。

* **バグ修正**
  * リンク処理の検証ロジックを改善し、セキュリティが強化されました。

* **テスト**
  * 画像変換機能の包括的なテストケースが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->