### PR TITLE
fix: ページタイトルを Y.Doc 保存と同期し、オートタイトルを新規ページに限定

### DIFF
--- a/src/components/editor/PageEditor/usePageEditor.ts
+++ b/src/components/editor/PageEditor/usePageEditor.ts
@@ -65,6 +65,7 @@ export function usePageEditor() {
   const handlers = usePageEditorHandlers({
     title: state.title,
     content: state.content,
+    enableAutoTitle: state.isNewPage,
     duplicatePage: state.duplicatePage ?? null,
     setTitle: state.setTitle,
     setContent: state.setContent,

--- a/src/components/editor/PageEditor/usePageEditorHandlers.ts
+++ b/src/components/editor/PageEditor/usePageEditorHandlers.ts
@@ -20,17 +20,9 @@ interface UsePageEditorHandlersOptions {
   location: { pathname: string; search: string; hash?: string };
 }
 
-/**
- *
- */
+/** Page editor event handlers (title, content, wiki, navigation). */
 export function usePageEditorHandlers(options: UsePageEditorHandlersOptions) {
-  /**
-   *
-   */
   const navigate = useNavigate();
-  /**
-   *
-   */
   const {
     title,
     content,
@@ -46,16 +38,10 @@ export function usePageEditorHandlers(options: UsePageEditorHandlersOptions) {
     location,
   } = options;
 
-  /**
-   *
-   */
   const handleContentChange = useCallback(
     (newContent: string) => {
       setContent(newContent);
       if (enableAutoTitle && !title) {
-        /**
-         *
-         */
         const autoTitle = generateAutoTitle(newContent);
         if (autoTitle !== "無題のページ") {
           setTitle(autoTitle);
@@ -63,15 +49,14 @@ export function usePageEditorHandlers(options: UsePageEditorHandlersOptions) {
           saveChanges(autoTitle, newContent);
           return;
         }
+        saveChanges("無題のページ", newContent);
+        return;
       }
       saveChanges(title, newContent);
     },
     [title, enableAutoTitle, saveChanges, validateTitle, setContent, setTitle],
   );
 
-  /**
-   *
-   */
   const handleTitleChange = useCallback(
     (newTitle: string) => {
       setTitle(newTitle);
@@ -81,9 +66,6 @@ export function usePageEditorHandlers(options: UsePageEditorHandlersOptions) {
     [content, saveChanges, validateTitle, setTitle],
   );
 
-  /**
-   *
-   */
   const handleContentError = useCallback(
     (error: ContentError | null) => {
       setContentError(error);
@@ -91,34 +73,19 @@ export function usePageEditorHandlers(options: UsePageEditorHandlersOptions) {
     [setContentError],
   );
 
-  /**
-   *
-   */
   const handleOpenDuplicatePage = useCallback(() => {
     if (duplicatePage) {
       navigate(`/page/${duplicatePage.id}`);
     }
   }, [duplicatePage, navigate]);
 
-  /**
-   *
-   */
   const handleGenerateWiki = useCallback(() => {
     generateWiki(title);
   }, [generateWiki, title]);
 
-  /**
-   *
-   */
   const handleGoToAISettings = useCallback(() => {
     resetWiki();
-    /**
-     *
-     */
     const returnTo = `${location.pathname}${location.search}${location.hash ?? ""}`;
-    /**
-     *
-     */
     const search = new URLSearchParams({ section: "ai", returnTo }).toString();
     navigate(`/settings?${search}`);
   }, [resetWiki, navigate, location.pathname, location.search, location.hash]);

--- a/src/components/editor/PageEditor/usePageEditorHandlers.ts
+++ b/src/components/editor/PageEditor/usePageEditorHandlers.ts
@@ -7,6 +7,8 @@ import type { Page } from "@/types/page";
 interface UsePageEditorHandlersOptions {
   title: string;
   content: string;
+  /** true のときだけオートタイトル（コンテンツ先頭行からの自動生成）を有効にする */
+  enableAutoTitle: boolean;
   duplicatePage: Page | null;
   setTitle: (title: string) => void;
   setContent: (content: string) => void;
@@ -18,11 +20,21 @@ interface UsePageEditorHandlersOptions {
   location: { pathname: string; search: string; hash?: string };
 }
 
+/**
+ *
+ */
 export function usePageEditorHandlers(options: UsePageEditorHandlersOptions) {
+  /**
+   *
+   */
   const navigate = useNavigate();
+  /**
+   *
+   */
   const {
     title,
     content,
+    enableAutoTitle,
     duplicatePage,
     setTitle,
     setContent,
@@ -34,19 +46,32 @@ export function usePageEditorHandlers(options: UsePageEditorHandlersOptions) {
     location,
   } = options;
 
+  /**
+   *
+   */
   const handleContentChange = useCallback(
     (newContent: string) => {
       setContent(newContent);
-      const autoTitle = !title ? generateAutoTitle(newContent) : title;
-      if (!title && autoTitle !== "無題のページ") {
-        setTitle(autoTitle);
-        validateTitle(autoTitle);
+      if (enableAutoTitle && !title) {
+        /**
+         *
+         */
+        const autoTitle = generateAutoTitle(newContent);
+        if (autoTitle !== "無題のページ") {
+          setTitle(autoTitle);
+          validateTitle(autoTitle);
+          saveChanges(autoTitle, newContent);
+          return;
+        }
       }
-      saveChanges(autoTitle || title, newContent);
+      saveChanges(title, newContent);
     },
-    [title, saveChanges, validateTitle, setContent, setTitle],
+    [title, enableAutoTitle, saveChanges, validateTitle, setContent, setTitle],
   );
 
+  /**
+   *
+   */
   const handleTitleChange = useCallback(
     (newTitle: string) => {
       setTitle(newTitle);
@@ -56,6 +81,9 @@ export function usePageEditorHandlers(options: UsePageEditorHandlersOptions) {
     [content, saveChanges, validateTitle, setTitle],
   );
 
+  /**
+   *
+   */
   const handleContentError = useCallback(
     (error: ContentError | null) => {
       setContentError(error);
@@ -63,19 +91,34 @@ export function usePageEditorHandlers(options: UsePageEditorHandlersOptions) {
     [setContentError],
   );
 
+  /**
+   *
+   */
   const handleOpenDuplicatePage = useCallback(() => {
     if (duplicatePage) {
       navigate(`/page/${duplicatePage.id}`);
     }
   }, [duplicatePage, navigate]);
 
+  /**
+   *
+   */
   const handleGenerateWiki = useCallback(() => {
     generateWiki(title);
   }, [generateWiki, title]);
 
+  /**
+   *
+   */
   const handleGoToAISettings = useCallback(() => {
     resetWiki();
+    /**
+     *
+     */
     const returnTo = `${location.pathname}${location.search}${location.hash ?? ""}`;
+    /**
+     *
+     */
     const search = new URLSearchParams({ section: "ai", returnTo }).toString();
     navigate(`/settings?${search}`);
   }, [resetWiki, navigate, location.pathname, location.search, location.hash]);

--- a/src/components/editor/PageEditor/usePageEditorStateAndSync.ts
+++ b/src/components/editor/PageEditor/usePageEditorStateAndSync.ts
@@ -54,11 +54,12 @@ function useSyncCollaborationPageTitle(
   title: string,
   collaboration: ReturnType<typeof useCollaboration>,
 ): void {
+  const { setPageTitle } = collaboration;
   useEffect(() => {
-    if (isLocalDocEnabled && title) {
-      collaboration.setPageTitle(title);
+    if (isLocalDocEnabled) {
+      setPageTitle(title);
     }
-  }, [isLocalDocEnabled, title, collaboration]);
+  }, [isLocalDocEnabled, title, setPageTitle]);
 }
 
 /**

--- a/src/components/editor/PageEditor/usePageEditorStateAndSync.ts
+++ b/src/components/editor/PageEditor/usePageEditorStateAndSync.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { usePage, useUpdatePage } from "@/hooks/usePageQueries";
 import { useTitleValidation } from "@/hooks/useTitleValidation";
@@ -43,6 +43,22 @@ function usePageEditorDeletionAndNav(
   const { handleExportMarkdown, handleCopyMarkdown } = useMarkdownExport(title, content, sourceUrl);
   usePageEditorKeyboard({ onBack: deletion.handleBack });
   return { ...deletion, handleExportMarkdown, handleCopyMarkdown };
+}
+
+/**
+ * Pushes current page title into CollaborationManager so PUT /content includes it.
+ * タイトルを CollaborationManager に渡し、Y.Doc 保存時にサーバーへ同期する。
+ */
+function useSyncCollaborationPageTitle(
+  isLocalDocEnabled: boolean,
+  title: string,
+  collaboration: ReturnType<typeof useCollaboration>,
+): void {
+  useEffect(() => {
+    if (isLocalDocEnabled && title) {
+      collaboration.setPageTitle(title);
+    }
+  }, [isLocalDocEnabled, title, collaboration]);
 }
 
 /**
@@ -135,6 +151,8 @@ export function usePageEditorStateAndSync() {
 
   const { displayLastSaved, pendingInitialContent, setPendingInitialContent } =
     useDisplayLastSavedAndPending(autoSaveLastSaved, lastSaved);
+
+  useSyncCollaborationPageTitle(isLocalDocEnabled, title, collaboration);
 
   usePageEditorAIEffects({
     isNewPage,

--- a/src/hooks/useCollaboration.ts
+++ b/src/hooks/useCollaboration.ts
@@ -148,6 +148,10 @@ export function useCollaboration({
     managerRef.current?.flushSave();
   }, []);
 
+  const setPageTitle = useCallback((title: string) => {
+    managerRef.current?.setPageTitle(title);
+  }, []);
+
   const collaborationUser =
     enabled && effectiveUserId
       ? {
@@ -166,5 +170,6 @@ export function useCollaboration({
     updateSelection,
     reconnect,
     flushSave,
+    setPageTitle,
   };
 }

--- a/src/lib/collaboration/CollaborationManager.test.ts
+++ b/src/lib/collaboration/CollaborationManager.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as Y from "yjs";
 import { CollaborationManager } from "./CollaborationManager";
 
 const mockYDocOn = vi.fn();
 const mockYDocDestroy = vi.fn();
-const mockYDocGetXmlFragment = vi.fn().mockReturnValue({ toJSON: () => "" });
+const mockYDocGetXmlFragment = vi.fn().mockReturnValue({
+  toJSON: () => "",
+  toArray: () => [],
+});
 
 vi.mock("yjs", () => ({
   Doc: function Doc() {
@@ -105,6 +109,47 @@ describe("CollaborationManager", () => {
 
       expect(mockIdbDestroy).toHaveBeenCalled();
       expect(mockYDocDestroy).toHaveBeenCalled();
+    });
+  });
+
+  describe("setPageTitle and saveToApi", () => {
+    it("includes title in PUT /content JSON body when setPageTitle was called", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal("fetch", fetchMock);
+
+      vi.mocked(Y.encodeStateAsUpdate).mockReturnValueOnce(new Uint8Array([1, 2, 3, 4]));
+
+      const manager = new CollaborationManager("page-abc", "user-1", "Test User", mockGetAuthToken);
+      manager.setPageTitle("Synced Title");
+      manager.flushSave();
+
+      await vi.waitFor(() => {
+        const putCall = fetchMock.mock.calls.find(
+          (call) =>
+            typeof call[0] === "string" &&
+            String(call[0]).includes("/content") &&
+            (call[1] as RequestInit | undefined)?.method === "PUT",
+        );
+        expect(putCall).toBeDefined();
+      });
+
+      const putCall = fetchMock.mock.calls.find(
+        (call) =>
+          typeof call[0] === "string" &&
+          String(call[0]).includes("/content") &&
+          (call[1] as RequestInit | undefined)?.method === "PUT",
+      );
+      const body = putCall?.[1]?.body as string;
+      const parsed = JSON.parse(body) as {
+        title?: string;
+        ydoc_state?: string;
+        content_text?: string;
+      };
+      expect(parsed.title).toBe("Synced Title");
+      expect(parsed).toHaveProperty("ydoc_state");
+      expect(parsed).toHaveProperty("content_text");
+
+      vi.unstubAllGlobals();
     });
   });
 });

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -12,6 +12,9 @@ import { Awareness } from "y-protocols/awareness";
 import type { UserPresence, ConnectionStatus, CollaborationState } from "./types";
 import { getUserColor } from "./types";
 
+/**
+ *
+ */
 export type CollaborationManagerMode = "local" | "collaborative";
 
 /** Debounce timer for saving Y.Doc to API in local mode. */
@@ -23,6 +26,9 @@ const DUPLICATION_RATIO_THRESHOLD = 1.5;
 /** ブラウザの keepalive ペイロード制限（64 KiB）より少し小さい安全な上限（バイト） */
 const KEEPALIVE_PAYLOAD_LIMIT = 63 * 1024;
 
+/**
+ *
+ */
 export class CollaborationManager {
   private ydoc: Y.Doc;
   private wsProvider: HocuspocusProvider | null = null;
@@ -39,7 +45,15 @@ export class CollaborationManager {
   private apiSaveTimer: ReturnType<typeof setTimeout> | null = null;
   /** Whether initial API fetch has completed (local mode). */
   private apiFetched = false;
+  /**
+   * ページタイトル。saveToApi 時に PUT リクエストに含めてサーバーに同期する。
+   * Page title included in PUT requests to keep the server in sync.
+   */
+  private pageTitle: string | null = null;
 
+  /**
+   *
+   */
   constructor(
     pageId: string,
     userId: string,
@@ -82,12 +96,27 @@ export class CollaborationManager {
     try {
       if (this.destroyed) return;
 
+      /**
+       *
+       */
       const baseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
+      /**
+       *
+       */
       const origin = baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
+      /**
+       *
+       */
       const url = `${origin}/api/pages/${encodeURIComponent(this.pageId)}/content`;
 
+      /**
+       *
+       */
       const beforeText = this.getPlainText();
 
+      /**
+       *
+       */
       const res = await fetch(url, {
         credentials: "include",
       });
@@ -95,14 +124,26 @@ export class CollaborationManager {
       if (this.destroyed) return;
 
       if (res.ok) {
+        /**
+         *
+         */
         const data = (await res.json()) as {
           ok?: boolean;
           data?: { ydoc_state?: string };
           ydoc_state?: string;
         };
+        /**
+         *
+         */
         const envelope = data?.ok === true && data?.data ? data.data : data;
+        /**
+         *
+         */
         const b64 = envelope?.ydoc_state;
         if (b64 && typeof b64 === "string") {
+          /**
+           *
+           */
           const binary = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
           if (binary.length > 2) {
             Y.applyUpdate(this.ydoc, binary);
@@ -161,34 +202,76 @@ export class CollaborationManager {
   private async saveToApi(): Promise<void> {
     if (this.destroyed) return;
     try {
+      /**
+       *
+       */
       const state = Y.encodeStateAsUpdate(this.ydoc);
       if (state.length <= 2) return; // empty Y.Doc
 
       // Base64 encode
+      /**
+       *
+       */
       let b64 = "";
+      /**
+       *
+       */
       const chunkSize = 8192;
-      for (let i = 0; i < state.length; i += chunkSize) {
+      for (
+        /**
+         *
+         */
+        let i = 0;
+        i < state.length;
+        i += chunkSize
+      ) {
         b64 += String.fromCharCode(...state.subarray(i, i + chunkSize));
       }
       b64 = btoa(b64);
 
+      /**
+       *
+       */
       const fragment = this.ydoc.getXmlFragment("default");
+      /**
+       *
+       */
       const contentText = fragment.toJSON() ? this.extractText(fragment) : "";
 
+      /**
+       *
+       */
       const baseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
+      /**
+       *
+       */
       const origin = baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
+      /**
+       *
+       */
       const url = `${origin}/api/pages/${encodeURIComponent(this.pageId)}/content`;
 
+      /**
+       *
+       */
+      const payload: Record<string, string> = {
+        ydoc_state: b64,
+        content_text: contentText,
+      };
+      if (this.pageTitle !== null) {
+        payload.title = this.pageTitle;
+      }
+
+      /**
+       *
+       */
       const res = await fetch(url, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
         },
         credentials: "include",
-        body: JSON.stringify({
-          ydoc_state: b64,
-          content_text: contentText, // 全文検索用プレーンテキスト
-        }),
+        body: JSON.stringify(payload),
       });
 
       if (this.destroyed) return;
@@ -212,13 +295,22 @@ export class CollaborationManager {
    * マージ前後のテキストを比較し、不自然な増加があれば console.error で報告する。
    */
   private detectContentDuplication(beforeText: string, phase: string): void {
+    /**
+     *
+     */
     const afterText = this.getPlainText();
     if (beforeText.length < 10) return;
     if (afterText.length <= beforeText.length) return;
 
+    /**
+     *
+     */
     const ratio = afterText.length / beforeText.length;
     if (ratio < DUPLICATION_RATIO_THRESHOLD) return;
 
+    /**
+     *
+     */
     const occurrences = afterText.split(beforeText).length - 1;
     if (occurrences < 2) return;
 
@@ -236,12 +328,21 @@ export class CollaborationManager {
    * XmlFragment からプレーンテキストを抽出
    */
   private extractText(fragment: Y.XmlFragment): string {
+    /**
+     *
+     */
     const parts: string[] = [];
+    /**
+     *
+     */
     const walk = (node: Y.XmlFragment | Y.XmlElement | Y.XmlText) => {
       if (node instanceof Y.XmlText) {
         parts.push(node.toJSON());
       } else {
-        for (const child of node.toArray()) {
+        for (/**
+         *
+         */
+        const child of node.toArray()) {
           if (
             child instanceof Y.XmlText ||
             child instanceof Y.XmlElement ||
@@ -257,6 +358,9 @@ export class CollaborationManager {
   }
 
   private async connectWebSocket() {
+    /**
+     *
+     */
     const token = await this.getAuthToken();
     if (!token) {
       console.warn("[Collab] No auth token, staying offline");
@@ -264,7 +368,13 @@ export class CollaborationManager {
       return;
     }
 
+    /**
+     *
+     */
     const wsUrl = import.meta.env.VITE_REALTIME_URL || "ws://localhost:1234";
+    /**
+     *
+     */
     const documentName = `page-${this.pageId}`;
 
     this.wsProvider = new HocuspocusProvider({
@@ -306,6 +416,9 @@ export class CollaborationManager {
   setLocalPresence(presence: Partial<UserPresence>) {
     if (!this.awareness) return;
 
+    /**
+     *
+     */
     const current = this.awareness.getLocalState() || {};
     this.awareness.setLocalState({
       ...current,
@@ -336,7 +449,13 @@ export class CollaborationManager {
   private updatePresence() {
     if (!this.awareness) return;
 
+    /**
+     *
+     */
     const states = this.awareness.getStates();
+    /**
+     *
+     */
     const onlineUsers: UserPresence[] = [];
 
     states.forEach((state, clientId) => {
@@ -361,6 +480,14 @@ export class CollaborationManager {
     // 現在の状態を即座に通知
     listener(this.state);
     return () => this.listeners.delete(listener);
+  }
+
+  /**
+   * ページタイトルを設定する。次回の saveToApi / fireAndForgetSave で PUT に含まれる。
+   * Set the page title so it is included in subsequent PUT requests to the server.
+   */
+  setPageTitle(title: string): void {
+    this.pageTitle = title;
   }
 
   /**
@@ -395,6 +522,9 @@ export class CollaborationManager {
    * 手動再接続
    */
   reconnect() {
+    /**
+     *
+     */
     const websocketProvider = (
       this.wsProvider as HocuspocusProvider & {
         configuration?: { websocketProvider?: { connect?: () => Promise<void>; status?: string } };
@@ -419,8 +549,14 @@ export class CollaborationManager {
 
     // 最終保存: ydoc 破棄前に同期的にステートをエンコードし、非同期で送信
     if (this.mode === "local" && this.apiFetched) {
+      /**
+       *
+       */
       const state = Y.encodeStateAsUpdate(this.ydoc);
       if (state.length > 2) {
+        /**
+         *
+         */
         const contentText = this.extractText(this.ydoc.getXmlFragment("default"));
         this.fireAndForgetSave(state, contentText);
       }
@@ -445,24 +581,65 @@ export class CollaborationManager {
    * ブラウザの keepalive ペイロード制限（約 64 KiB）を超える場合は keepalive なしで送信する。
    */
   private fireAndForgetSave(state: Uint8Array, contentText: string): void {
+    /**
+     *
+     */
     let b64 = "";
+    /**
+     *
+     */
     const chunkSize = 8192;
-    for (let i = 0; i < state.length; i += chunkSize) {
+    for (
+      /**
+       *
+       */
+      let i = 0;
+      i < state.length;
+      i += chunkSize
+    ) {
       b64 += String.fromCharCode(...state.subarray(i, i + chunkSize));
     }
     b64 = btoa(b64);
 
-    const body = JSON.stringify({
+    /**
+     *
+     */
+    const payload: Record<string, string> = {
       ydoc_state: b64,
       content_text: contentText,
-    });
+    };
+    if (this.pageTitle !== null) {
+      payload.title = this.pageTitle;
+    }
+    /**
+     *
+     */
+    const body = JSON.stringify(payload);
+    /**
+     *
+     */
     const bodyByteLength =
       typeof TextEncoder !== "undefined" ? new TextEncoder().encode(body).length : body.length * 2;
+    /**
+     *
+     */
     const useKeepalive = bodyByteLength <= KEEPALIVE_PAYLOAD_LIMIT;
 
+    /**
+     *
+     */
     const rawBaseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
+    /**
+     *
+     */
     const baseUrl = rawBaseUrl.replace(/\/$/, "");
+    /**
+     *
+     */
     const origin = baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
+    /**
+     *
+     */
     const url = `${origin}/api/pages/${encodeURIComponent(this.pageId)}/content`;
 
     fetch(url, {

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -199,6 +199,23 @@ export class CollaborationManager {
     void this.saveToApi();
   }
 
+  /**
+   * PUT /content 用 JSON ボディ。ydoc_state / content_text に加え、setPageTitle 済みなら title を含む。
+   */
+  private buildPutContentBody(ydocStateB64: string, contentText: string): Record<string, string> {
+    /**
+     *
+     */
+    const payload: Record<string, string> = {
+      ydoc_state: ydocStateB64,
+      content_text: contentText,
+    };
+    if (this.pageTitle !== null) {
+      payload.title = this.pageTitle;
+    }
+    return payload;
+  }
+
   private async saveToApi(): Promise<void> {
     if (this.destroyed) return;
     try {
@@ -208,7 +225,6 @@ export class CollaborationManager {
       const state = Y.encodeStateAsUpdate(this.ydoc);
       if (state.length <= 2) return; // empty Y.Doc
 
-      // Base64 encode
       /**
        *
        */
@@ -254,13 +270,7 @@ export class CollaborationManager {
       /**
        *
        */
-      const payload: Record<string, string> = {
-        ydoc_state: b64,
-        content_text: contentText,
-      };
-      if (this.pageTitle !== null) {
-        payload.title = this.pageTitle;
-      }
+      const payload = this.buildPutContentBody(b64, contentText);
 
       /**
        *
@@ -604,13 +614,7 @@ export class CollaborationManager {
     /**
      *
      */
-    const payload: Record<string, string> = {
-      ydoc_state: b64,
-      content_text: contentText,
-    };
-    if (this.pageTitle !== null) {
-      payload.title = this.pageTitle;
-    }
+    const payload = this.buildPutContentBody(b64, contentText);
     /**
      *
      */

--- a/src/lib/collaboration/types.ts
+++ b/src/lib/collaboration/types.ts
@@ -87,6 +87,13 @@ export interface UseCollaborationReturn extends CollaborationState {
   reconnect: () => void;
   /** 保留中の保存をキャンセルし、直ちに API へ保存する（local モード・URL 取り込み後の即時保存用） */
   flushSave: () => void;
+  /**
+   * ページタイトルを CollaborationManager に伝達する。
+   * 次回の Y.Doc 保存時にサーバーへ同期される。
+   * Notify the CollaborationManager of the current page title
+   * so it is included in the next Y.Doc save to the server.
+   */
+  setPageTitle: (title: string) => void;
 }
 
 /**


### PR DESCRIPTION
## 概要

個人ページのタイトルがメタデータ同期（`/api/sync/pages`）まで待たないとサーバーに載らず、別端末では「無題」表示になり、本文ロード時のオートタイトルで誤ったタイトルが保存される問題を修正しました。

- Y.Doc 保存（`PUT /api/pages/:id/content`）に現在のタイトルを同梱し、本文保存のタイミングで `pages.title` も更新されるようにしました。
- コンテンツ先頭からの自動タイトル生成は**新規ページ作成フロー**（`/page/new` 相当）に限定し、既存ページで同期遅延時に本文がタイトルに入り込むのを防ぎました。

## 変更点

### `src/lib/collaboration/`
- `CollaborationManager`: `setPageTitle` と `pageTitle` を保持し、`saveToApi` / `fireAndForgetSave` の JSON に `title` を含める
- `types.ts`: `UseCollaborationReturn` に `setPageTitle` を追加

### `src/hooks/`
- `useCollaboration`: `manager.setPageTitle` を公開

### `src/components/editor/PageEditor/`
- `usePageEditorStateAndSync`: `useSyncCollaborationPageTitle` でタイトルを collaboration に同期
- `usePageEditorHandlers`: `enableAutoTitle` フラグでオートタイトルを新規ページのみに制限
- `usePageEditor`: `enableAutoTitle: state.isNewPage` を渡す

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. 端末 A でログインし、個人ページを作成してタイトルと本文を入力する。
2. 別端末 B で同アカウントにログインし、同期後にページ一覧でタイトルが正しく表示されることを確認する。
3. 端末 B で当該ページを開き、タイトルが本文先頭で上書きされないことを確認する。

## チェックリスト

- [x] テストがすべてパスする（`bun run test:run`）
- [x] Lint エラーがない（変更ファイルに ESLint エラーなし）
- [ ] 必要に応じてドキュメントを更新した（本件はコード・TSDoc で十分）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

UI の見た目の変更はありません（挙動の修正のみ）。

## 関連 Issue

<!-- 該当 Issue があれば記載 -->

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ページエディタの自動タイトル生成機能をより細かく制御できるようになりました。
  * ページタイトルがコラボレーション機能と同期され、共有される際にタイトル情報が正確に反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->