### PR TITLE
fix: address PR #450 review comments

### DIFF
--- a/packages/ui/src/components/chart.tsx
+++ b/packages/ui/src/components/chart.tsx
@@ -185,7 +185,7 @@ const ChartTooltipContent = React.forwardRef<
 
             return (
               <div
-                key={item.graphicalItemId}
+                key={item.graphicalItemId ?? index}
                 className={cn(
                   "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
                   indicator === "dot" && "items-center",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,7 +54,8 @@ const App = () => (
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        {/* unstable_useTransitions を無効化: リンク後の表示が遅れる問題を防ぐ（RR v7 は future 廃止） */}
+        {/* unstable_useTransitions を無効化: リンク後の表示が遅れる問題を防ぐ（RR v7 は future 廃止）
+            Disable unstable_useTransitions: prevents display delay after link navigation (RR v7 removed future flags) */}
         <BrowserRouter unstable_useTransitions={false}>
           <AIChatProvider>
             <AIChatConversationsProvider>

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -92,12 +92,12 @@ export class CollaborationManager {
   }
 
   /**
-   * API リクエスト用の origin。`VITE_API_BASE_URL` の末尾スラッシュを除去し、URL 連結時の二重スラッシュを防ぐ。
-   * Resolves API origin from env, stripping a trailing slash to avoid `//api` in URLs.
+   * API リクエスト用の origin。`VITE_API_BASE_URL` の末尾スラッシュ（複数可）を除去し、URL 連結時の二重スラッシュを防ぐ。
+   * Resolves API origin from env, stripping one or more trailing slashes to avoid `//api` in URLs.
    */
   private getApiOrigin(): string {
     const rawBaseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
-    const baseUrl = rawBaseUrl.replace(/\/$/, "");
+    const baseUrl = rawBaseUrl.replace(/\/+$/, "");
     return baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
   }
 

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -13,7 +13,8 @@ import type { UserPresence, ConnectionStatus, CollaborationState } from "./types
 import { getUserColor } from "./types";
 
 /**
- *
+ * コラボレーションの動作モード。
+ * Collaboration operating mode: local (personal pages) or collaborative (shared notes).
  */
 export type CollaborationManagerMode = "local" | "collaborative";
 
@@ -27,7 +28,8 @@ const DUPLICATION_RATIO_THRESHOLD = 1.5;
 const KEEPALIVE_PAYLOAD_LIMIT = 63 * 1024;
 
 /**
- *
+ * Y.js ドキュメントの管理・永続化・リアルタイム同期を担当するマネージャー。
+ * Manages Y.js document lifecycle, IndexedDB persistence, and real-time sync.
  */
 export class CollaborationManager {
   private ydoc: Y.Doc;
@@ -96,27 +98,12 @@ export class CollaborationManager {
     try {
       if (this.destroyed) return;
 
-      /**
-       *
-       */
       const baseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
-      /**
-       *
-       */
       const origin = baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
-      /**
-       *
-       */
       const url = `${origin}/api/pages/${encodeURIComponent(this.pageId)}/content`;
 
-      /**
-       *
-       */
       const beforeText = this.getPlainText();
 
-      /**
-       *
-       */
       const res = await fetch(url, {
         credentials: "include",
       });
@@ -124,26 +111,14 @@ export class CollaborationManager {
       if (this.destroyed) return;
 
       if (res.ok) {
-        /**
-         *
-         */
         const data = (await res.json()) as {
           ok?: boolean;
           data?: { ydoc_state?: string };
           ydoc_state?: string;
         };
-        /**
-         *
-         */
         const envelope = data?.ok === true && data?.data ? data.data : data;
-        /**
-         *
-         */
         const b64 = envelope?.ydoc_state;
         if (b64 && typeof b64 === "string") {
-          /**
-           *
-           */
           const binary = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
           if (binary.length > 2) {
             Y.applyUpdate(this.ydoc, binary);
@@ -203,9 +178,6 @@ export class CollaborationManager {
    * PUT /content 用 JSON ボディ。ydoc_state / content_text に加え、setPageTitle 済みなら title を含む。
    */
   private buildPutContentBody(ydocStateB64: string, contentText: string): Record<string, string> {
-    /**
-     *
-     */
     const payload: Record<string, string> = {
       ydoc_state: ydocStateB64,
       content_text: contentText,
@@ -219,62 +191,25 @@ export class CollaborationManager {
   private async saveToApi(): Promise<void> {
     if (this.destroyed) return;
     try {
-      /**
-       *
-       */
       const state = Y.encodeStateAsUpdate(this.ydoc);
       if (state.length <= 2) return; // empty Y.Doc
 
-      /**
-       *
-       */
       let b64 = "";
-      /**
-       *
-       */
       const chunkSize = 8192;
-      for (
-        /**
-         *
-         */
-        let i = 0;
-        i < state.length;
-        i += chunkSize
-      ) {
+      for (let i = 0; i < state.length; i += chunkSize) {
         b64 += String.fromCharCode(...state.subarray(i, i + chunkSize));
       }
       b64 = btoa(b64);
 
-      /**
-       *
-       */
       const fragment = this.ydoc.getXmlFragment("default");
-      /**
-       *
-       */
-      const contentText = fragment.toJSON() ? this.extractText(fragment) : "";
+      const contentText = this.extractText(fragment);
 
-      /**
-       *
-       */
       const baseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
-      /**
-       *
-       */
       const origin = baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
-      /**
-       *
-       */
       const url = `${origin}/api/pages/${encodeURIComponent(this.pageId)}/content`;
 
-      /**
-       *
-       */
       const payload = this.buildPutContentBody(b64, contentText);
 
-      /**
-       *
-       */
       const res = await fetch(url, {
         method: "PUT",
         headers: {
@@ -305,22 +240,13 @@ export class CollaborationManager {
    * マージ前後のテキストを比較し、不自然な増加があれば console.error で報告する。
    */
   private detectContentDuplication(beforeText: string, phase: string): void {
-    /**
-     *
-     */
     const afterText = this.getPlainText();
     if (beforeText.length < 10) return;
     if (afterText.length <= beforeText.length) return;
 
-    /**
-     *
-     */
     const ratio = afterText.length / beforeText.length;
     if (ratio < DUPLICATION_RATIO_THRESHOLD) return;
 
-    /**
-     *
-     */
     const occurrences = afterText.split(beforeText).length - 1;
     if (occurrences < 2) return;
 
@@ -338,21 +264,12 @@ export class CollaborationManager {
    * XmlFragment からプレーンテキストを抽出
    */
   private extractText(fragment: Y.XmlFragment): string {
-    /**
-     *
-     */
     const parts: string[] = [];
-    /**
-     *
-     */
     const walk = (node: Y.XmlFragment | Y.XmlElement | Y.XmlText) => {
       if (node instanceof Y.XmlText) {
         parts.push(node.toJSON());
       } else {
-        for (/**
-         *
-         */
-        const child of node.toArray()) {
+        for (const child of node.toArray()) {
           if (
             child instanceof Y.XmlText ||
             child instanceof Y.XmlElement ||
@@ -368,9 +285,6 @@ export class CollaborationManager {
   }
 
   private async connectWebSocket() {
-    /**
-     *
-     */
     const token = await this.getAuthToken();
     if (!token) {
       console.warn("[Collab] No auth token, staying offline");
@@ -378,13 +292,7 @@ export class CollaborationManager {
       return;
     }
 
-    /**
-     *
-     */
     const wsUrl = import.meta.env.VITE_REALTIME_URL || "ws://localhost:1234";
-    /**
-     *
-     */
     const documentName = `page-${this.pageId}`;
 
     this.wsProvider = new HocuspocusProvider({
@@ -426,9 +334,6 @@ export class CollaborationManager {
   setLocalPresence(presence: Partial<UserPresence>) {
     if (!this.awareness) return;
 
-    /**
-     *
-     */
     const current = this.awareness.getLocalState() || {};
     this.awareness.setLocalState({
       ...current,
@@ -459,13 +364,7 @@ export class CollaborationManager {
   private updatePresence() {
     if (!this.awareness) return;
 
-    /**
-     *
-     */
     const states = this.awareness.getStates();
-    /**
-     *
-     */
     const onlineUsers: UserPresence[] = [];
 
     states.forEach((state, clientId) => {
@@ -532,9 +431,6 @@ export class CollaborationManager {
    * 手動再接続
    */
   reconnect() {
-    /**
-     *
-     */
     const websocketProvider = (
       this.wsProvider as HocuspocusProvider & {
         configuration?: { websocketProvider?: { connect?: () => Promise<void>; status?: string } };
@@ -559,14 +455,8 @@ export class CollaborationManager {
 
     // 最終保存: ydoc 破棄前に同期的にステートをエンコードし、非同期で送信
     if (this.mode === "local" && this.apiFetched) {
-      /**
-       *
-       */
       const state = Y.encodeStateAsUpdate(this.ydoc);
       if (state.length > 2) {
-        /**
-         *
-         */
         const contentText = this.extractText(this.ydoc.getXmlFragment("default"));
         this.fireAndForgetSave(state, contentText);
       }
@@ -591,59 +481,22 @@ export class CollaborationManager {
    * ブラウザの keepalive ペイロード制限（約 64 KiB）を超える場合は keepalive なしで送信する。
    */
   private fireAndForgetSave(state: Uint8Array, contentText: string): void {
-    /**
-     *
-     */
     let b64 = "";
-    /**
-     *
-     */
     const chunkSize = 8192;
-    for (
-      /**
-       *
-       */
-      let i = 0;
-      i < state.length;
-      i += chunkSize
-    ) {
+    for (let i = 0; i < state.length; i += chunkSize) {
       b64 += String.fromCharCode(...state.subarray(i, i + chunkSize));
     }
     b64 = btoa(b64);
 
-    /**
-     *
-     */
     const payload = this.buildPutContentBody(b64, contentText);
-    /**
-     *
-     */
     const body = JSON.stringify(payload);
-    /**
-     *
-     */
     const bodyByteLength =
       typeof TextEncoder !== "undefined" ? new TextEncoder().encode(body).length : body.length * 2;
-    /**
-     *
-     */
     const useKeepalive = bodyByteLength <= KEEPALIVE_PAYLOAD_LIMIT;
 
-    /**
-     *
-     */
     const rawBaseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
-    /**
-     *
-     */
     const baseUrl = rawBaseUrl.replace(/\/$/, "");
-    /**
-     *
-     */
     const origin = baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
-    /**
-     *
-     */
     const url = `${origin}/api/pages/${encodeURIComponent(this.pageId)}/content`;
 
     fetch(url, {

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -54,7 +54,8 @@ export class CollaborationManager {
   private pageTitle: string | null = null;
 
   /**
-   *
+   * 新しい CollaborationManager を作成する。
+   * Creates a new CollaborationManager for the given page and user.
    */
   constructor(
     pageId: string,
@@ -91,6 +92,29 @@ export class CollaborationManager {
   }
 
   /**
+   * API リクエスト用の origin。`VITE_API_BASE_URL` の末尾スラッシュを除去し、URL 連結時の二重スラッシュを防ぐ。
+   * Resolves API origin from env, stripping a trailing slash to avoid `//api` in URLs.
+   */
+  private getApiOrigin(): string {
+    const rawBaseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
+    const baseUrl = rawBaseUrl.replace(/\/$/, "");
+    return baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
+  }
+
+  /**
+   * Y.js エンコード済みステートを Base64 文字列に変換する（大きなペイロードはチャンク処理）。
+   * Encodes a Y.js state update to Base64 (chunked for large payloads).
+   */
+  private encodeStateUpdateToBase64(state: Uint8Array): string {
+    let b64 = "";
+    const chunkSize = 8192;
+    for (let i = 0; i < state.length; i += chunkSize) {
+      b64 += String.fromCharCode(...state.subarray(i, i + chunkSize));
+    }
+    return btoa(b64);
+  }
+
+  /**
    * REST API から Y.Doc を取得してローカル Y.Doc にマージする（local モード用）。
    * マージ後、Y.Doc の変更監視を開始する。
    */
@@ -98,8 +122,7 @@ export class CollaborationManager {
     try {
       if (this.destroyed) return;
 
-      const baseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
-      const origin = baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
+      const origin = this.getApiOrigin();
       const url = `${origin}/api/pages/${encodeURIComponent(this.pageId)}/content`;
 
       const beforeText = this.getPlainText();
@@ -194,18 +217,10 @@ export class CollaborationManager {
       const state = Y.encodeStateAsUpdate(this.ydoc);
       if (state.length <= 2) return; // empty Y.Doc
 
-      let b64 = "";
-      const chunkSize = 8192;
-      for (let i = 0; i < state.length; i += chunkSize) {
-        b64 += String.fromCharCode(...state.subarray(i, i + chunkSize));
-      }
-      b64 = btoa(b64);
+      const b64 = this.encodeStateUpdateToBase64(state);
+      const contentText = this.getPlainText();
 
-      const fragment = this.ydoc.getXmlFragment("default");
-      const contentText = this.extractText(fragment);
-
-      const baseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
-      const origin = baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
+      const origin = this.getApiOrigin();
       const url = `${origin}/api/pages/${encodeURIComponent(this.pageId)}/content`;
 
       const payload = this.buildPutContentBody(b64, contentText);
@@ -457,7 +472,7 @@ export class CollaborationManager {
     if (this.mode === "local" && this.apiFetched) {
       const state = Y.encodeStateAsUpdate(this.ydoc);
       if (state.length > 2) {
-        const contentText = this.extractText(this.ydoc.getXmlFragment("default"));
+        const contentText = this.getPlainText();
         this.fireAndForgetSave(state, contentText);
       }
     }
@@ -481,12 +496,7 @@ export class CollaborationManager {
    * ブラウザの keepalive ペイロード制限（約 64 KiB）を超える場合は keepalive なしで送信する。
    */
   private fireAndForgetSave(state: Uint8Array, contentText: string): void {
-    let b64 = "";
-    const chunkSize = 8192;
-    for (let i = 0; i < state.length; i += chunkSize) {
-      b64 += String.fromCharCode(...state.subarray(i, i + chunkSize));
-    }
-    b64 = btoa(b64);
+    const b64 = this.encodeStateUpdateToBase64(state);
 
     const payload = this.buildPutContentBody(b64, contentText);
     const body = JSON.stringify(payload);
@@ -494,9 +504,7 @@ export class CollaborationManager {
       typeof TextEncoder !== "undefined" ? new TextEncoder().encode(body).length : body.length * 2;
     const useKeepalive = bodyByteLength <= KEEPALIVE_PAYLOAD_LIMIT;
 
-    const rawBaseUrl = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
-    const baseUrl = rawBaseUrl.replace(/\/$/, "");
-    const origin = baseUrl || (typeof window !== "undefined" ? window.location.origin : "");
+    const origin = this.getApiOrigin();
     const url = `${origin}/api/pages/${encodeURIComponent(this.pageId)}/content`;
 
     fetch(url, {

--- a/src/lib/htmlToTiptap.test.ts
+++ b/src/lib/htmlToTiptap.test.ts
@@ -79,6 +79,30 @@ describe("formatClippedContentAsTiptap", () => {
 });
 
 describe("htmlToTiptapJSON", () => {
+  it("rejects javascript: and data: URI schemes in links", () => {
+    const html =
+      '<p><a href="javascript:alert(1)">bad-js</a> <a href="data:text/html;base64,AAAA">bad-data</a></p>';
+    const result = htmlToTiptapJSON(html);
+    const json = JSON.stringify(result);
+    expect(json).not.toContain("javascript:alert(1)");
+    expect(json).not.toContain("data:text/html");
+  });
+
+  it("allows safe URI schemes (https, mailto, tel) and relative paths", () => {
+    const html = [
+      '<p><a href="https://example.com">https</a>',
+      '<a href="mailto:test@example.com">mail</a>',
+      '<a href="tel:+819012345678">tel</a>',
+      '<a href="/relative/path">relative</a></p>',
+    ].join(" ");
+    const result = htmlToTiptapJSON(html);
+    const json = JSON.stringify(result);
+    expect(json).toContain("https://example.com");
+    expect(json).toContain("mailto:test@example.com");
+    expect(json).toContain("tel:+819012345678");
+    expect(json).toContain("/relative/path");
+  });
+
   it("converts inline <img> tags to image nodes", () => {
     const html = '<p>Before</p><img src="https://example.com/photo.png" alt="photo"><p>After</p>';
     const result = htmlToTiptapJSON(html);


### PR DESCRIPTION
## 概要

PR #450 (Release: develop を main にマージ) のレビューコメントに対応する修正 PR。

## 変更点

### `src/lib/collaboration/CollaborationManager.ts`
- 空の JSDoc ブロック（`/** */`）を約 50 箇所削除。ESLint `jsdoc/no-blank-block-descriptions` 違反を解消
- `fragment.toJSON()` による非効率な存在チェックを `this.extractText(fragment)` の直接呼び出しに置換
- 複数行に分割されていた `for` ループを 1 行に整理
- export された型 (`CollaborationManagerMode`) とクラス (`CollaborationManager`) にバイリンガル JSDoc を追加

### `packages/ui/src/components/chart.tsx`
- Recharts 3 の `item.graphicalItemId` が未定義の場合に React key 警告が出る問題を `?? index` フォールバックで修正

### `src/App.tsx`
- `BrowserRouter` の `unstable_useTransitions` コメントにバイリンガル（英語）説明を追加

### `src/lib/htmlToTiptap.test.ts`
- `htmlToTiptapJSON` の URI 許可/拒否テストを追加（`javascript:` / `data:` の拒否、`https` / `mailto` / `tel` / 相対パスの許可）

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)

## テスト方法

1. `bun run lint` — エラー 0 を確認
2. `bunx vitest run src/lib/htmlToTiptap.test.ts src/lib/collaboration/CollaborationManager.test.ts` — 16/16 passed

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

PR #450 のレビューコメント対応

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * チャートのツールチップでのリスト更新処理を安定化しました。

* **テスト**
  * リンクのhrefサニタイズ検証テストを追加しました（危険なスキームを除外、安全なスキームと相対パスを保持）。

* **リファクタ**
  * コード内部の処理を整理して一貫性と保守性を向上しました。

* **ドキュメント**
  * ルーティングに関するコメントを明確化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->