### PR TITLE
feat(tauri): add claude code sidecar bridge and desktop commands (#456)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ test-results/
 # Tauri
 src-tauri/target/
 src-tauri/gen/
+# Sidecar executable for externalBin (build with `bun run sidecar:build` or `tauri:dev` ensure step)
+src-tauri/binaries/claude-sidecar*
 
 # Local-only notes (not tracked). See AGENTS.md / SPECIFICATION_POLICY.md.
 /docs/

--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ bun run tauri:dev
 bun run tauri:build
 ```
 
+- **Claude Code sidecar** ([Issue #456](https://github.com/otomatty/zedi/issues/456)): Tauri bundles a compiled helper under `src-tauri/binaries/` (`externalBin`). On first `bun run tauri:dev`, a missing binary is built automatically; run `bun run sidecar:build` manually if needed. / `externalBin` 用の sidecar は `src-tauri/binaries/` に配置する。初回 `tauri:dev` で自動ビルド、手動は `bun run sidecar:build`。
+
 > **Windows + Git Bash の場合**: MSVC のビルドツールが PATH に含まれていない場合、
 > Developer Command Prompt for VS 2022 から実行するか、
 > `.bashrc` に `LIB`, `INCLUDE`, `PATH` を設定してください。
@@ -315,7 +317,7 @@ src/                     # フロントエンド（React）
 │   ├── layout/          # レイアウト
 │   └── ui/              # shadcn/ui コンポーネント
 ├── hooks/               # カスタムフック
-├── lib/                 # ユーティリティ
+├── lib/                 # ユーティリティ（`claudeCode/` = Tauri↔Claude Code ブリッジ）
 ├── pages/               # ページコンポーネント
 ├── stores/              # Zustand ストア
 └── types/               # TypeScript 型定義
@@ -323,7 +325,9 @@ src/                     # フロントエンド（React）
 src-tauri/               # Tauri デスクトップバックエンド（Rust）
 ├── src/
 │   ├── main.rs          # デスクトップ エントリポイント
-│   └── lib.rs           # Tauri アプリ本体・Commands 定義
+│   ├── lib.rs           # Tauri アプリ本体・Commands 定義
+│   └── claude_sidecar.rs # Claude Code sidecar プロセス管理（Issue #456）
+├── binaries/            # externalBin（`bun run sidecar:build`、gitignore）
 ├── capabilities/        # セキュリティ権限定義
 ├── icons/               # アプリアイコン（各 OS 用）
 ├── Cargo.toml           # Rust 依存管理

--- a/bun.lock
+++ b/bun.lock
@@ -196,6 +196,17 @@
         "vitest": "^4.0.16",
       },
     },
+    "packages/claude-sidecar": {
+      "name": "@zedi/claude-sidecar",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.90",
+      },
+      "devDependencies": {
+        "typescript": "^6.0.2",
+        "vitest": "^4.0.16",
+      },
+    },
     "packages/ui": {
       "name": "@zedi/ui",
       "version": "0.1.0",
@@ -255,6 +266,8 @@
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.90", "", { "dependencies": { "@anthropic-ai/sdk": "^0.74.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-up5bK0pUbthKIZtNE18WDrIYi0KNpZUhdgjGbkfH/mFQJxI6W/uE3mTiLrCX3UF0SqNl0fMtojBTZPJr2b3O4g=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.80.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g=="],
 
@@ -536,6 +549,8 @@
 
     "@hocuspocus/provider": ["@hocuspocus/provider@3.4.4", "", { "dependencies": { "@hocuspocus/common": "^3.4.4", "@lifeomic/attempt": "^3.0.2", "lib0": "^0.2.87", "ws": "^8.17.1" }, "peerDependencies": { "y-protocols": "^1.0.6", "yjs": "^13.6.8" } }, "sha512-KbsMAfdYcIJD8eMU/5QnpXcSOvIWAcCNI33FSRSaKCIpYBFtAwkYIwWnZJmPZ8a1BMAtqQc+uvy9+UQf7GHnGQ=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
+
     "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
@@ -679,6 +694,8 @@
     "@microsoft/tsdoc": ["@microsoft/tsdoc@0.16.0", "", {}, "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA=="],
 
     "@microsoft/tsdoc-config": ["@microsoft/tsdoc-config@0.18.1", "", { "dependencies": { "@microsoft/tsdoc": "0.16.0", "ajv": "~8.18.0", "jju": "~1.4.0", "resolve": "~1.22.2" } }, "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
 
@@ -1368,7 +1385,11 @@
 
     "@xyflow/system": ["@xyflow/system@0.0.75", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-interpolate": "^3.0.4", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-interpolate": "^3.0.1", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-iXs+AGFLi8w/VlAoc/iSxk+CxfT6o64Uw/k0CKASOPqjqz6E0rb5jFZgJtXGZCpfQI6OQpu5EnumP5fGxQheaQ=="],
 
+    "@zedi/claude-sidecar": ["@zedi/claude-sidecar@workspace:packages/claude-sidecar"],
+
     "@zedi/ui": ["@zedi/ui@workspace:packages/ui"],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -1377,6 +1398,8 @@
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "angular-html-parser": ["angular-html-parser@10.4.0", "", {}, "sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww=="],
 
@@ -1442,6 +1465,8 @@
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -1453,6 +1478,8 @@
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
@@ -1516,6 +1543,10 @@
 
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "conventional-changelog-angular": ["conventional-changelog-angular@8.1.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w=="],
 
     "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@9.1.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA=="],
@@ -1525,6 +1556,10 @@
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
 
@@ -1656,6 +1691,8 @@
 
     "delaunator": ["delaunator@5.0.1", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "des.js": ["des.js@1.1.0", "", { "dependencies": { "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg=="],
@@ -1690,6 +1727,8 @@
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.192", "", {}, "sha512-rP8Ez0w7UNw/9j5eSXCe10o1g/8B1P5SM90PCCMVkIRQn2R0LEHWz4Eh9RnxkniuDe1W0cTSOB3MLlkTGDcuCg=="],
 
     "embla-carousel": ["embla-carousel@8.6.0", "", {}, "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA=="],
@@ -1699,6 +1738,8 @@
     "embla-carousel-reactive-utils": ["embla-carousel-reactive-utils@8.6.0", "", { "peerDependencies": { "embla-carousel": "8.6.0" } }, "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
@@ -1736,6 +1777,8 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
@@ -1770,11 +1813,21 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -1810,6 +1863,8 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
@@ -1823,6 +1878,10 @@
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -1910,6 +1969,8 @@
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
+    "hono": ["hono@4.12.9", "", {}, "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA=="],
+
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
     "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
@@ -1919,6 +1980,8 @@
     "html-parse-stringify": ["html-parse-stringify@3.0.1", "", { "dependencies": { "void-elements": "3.1.0" } }, "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
@@ -1957,6 +2020,10 @@
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -2011,6 +2078,8 @@
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
@@ -2081,6 +2150,8 @@
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
@@ -2232,7 +2303,11 @@
 
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
     "meow": ["meow@12.1.1", "", {}, "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -2296,6 +2371,10 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "miniflare": ["miniflare@4.20260301.1", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.18.2", "workerd": "1.20260301.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-fqkHx0QMKswRH9uqQQQOU/RoaS3Wjckxy3CUX3YGJr0ZIMu7ObvI+NovdYi6RIsSPthNtq+3TPmRNxjeRiasog=="],
@@ -2329,6 +2408,8 @@
     "nanostores": ["nanostores@1.1.1", "", {}, "sha512-EYJqS25r2iBeTtGQCHidXl1VfZ1jXM7Q04zXJOrMlxVVmD0ptxJaNux92n1mJ7c5lN3zTq12MhH/8x59nP+qmg=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
@@ -2364,6 +2445,10 @@
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
     "openai": ["openai@6.15.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-F1Lvs5BoVvmZtzkUEVyh8mDQPPFolq4F+xdsx/DO8Hee8YF3IGAlZqUIsF+DVGhqf4aU0a3bTghsxB6OIsRy1g=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -2397,6 +2482,8 @@
     "parse-statements": ["parse-statements@1.0.11", "", {}, "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA=="],
 
     "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
 
@@ -2435,6 +2522,8 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.6", "", {}, "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
@@ -2524,6 +2613,8 @@
 
     "prosemirror-view": ["prosemirror-view@1.41.4", "", { "dependencies": { "prosemirror-model": "^1.20.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-WkKgnyjNncri03Gjaz3IFWvCAE94XoiEgvtr0/r2Xw7R8/IjK3sKLSiDoCHWcsXSAinVaKlGRZDvMCsF1kbzjA=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
@@ -2531,6 +2622,10 @@
     "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
@@ -2620,6 +2715,8 @@
 
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
@@ -2646,6 +2743,10 @@
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
@@ -2653,6 +2754,8 @@
     "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
@@ -2695,6 +2798,8 @@
     "sql.js": ["sql.js@1.13.0", "", {}, "sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
@@ -2770,6 +2875,8 @@
 
     "to-valid-identifier": ["to-valid-identifier@1.0.0", "", { "dependencies": { "@sindresorhus/base62": "^1.0.0", "reserved-identifiers": "^1.0.0" } }, "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
@@ -2797,6 +2904,8 @@
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
@@ -2846,6 +2955,8 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
@@ -2859,6 +2970,8 @@
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
@@ -2928,6 +3041,8 @@
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
@@ -2966,11 +3081,15 @@
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
     "zustand": ["zustand@5.0.9", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["immer"] }, "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@anthropic-ai/claude-agent-sdk/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.74.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw=="],
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
@@ -3176,6 +3295,10 @@
 
     "ast-v8-to-istanbul/js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
+    "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "browserslist/caniuse-lite": ["caniuse-lite@1.0.30001727", "", {}, "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q=="],
 
     "bun-types/@types/node": ["@types/node@22.16.5", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ=="],
@@ -3226,7 +3349,13 @@
 
     "estree-walker/@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
+    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "express/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "finalhandler/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
@@ -3284,6 +3413,8 @@
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "react-i18next/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "react-remove-scroll/tslib": ["tslib@2.8.0", "", {}, "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="],
@@ -3297,6 +3428,12 @@
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.115.0", "", {}, "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.9", "", {}, "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw=="],
+
+    "router/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "send/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "sharp/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 

--- a/knip.json
+++ b/knip.json
@@ -8,7 +8,7 @@
   "ignoreBinaries": ["docker-compose"],
   "workspaces": {
     ".": {
-      "entry": ["scripts/**/*.ts", "e2e/**/*.ts"],
+      "entry": ["scripts/**/*.ts", "e2e/**/*.ts", "src/lib/claudeCode/index.ts"],
       "project": ["src/**/*.{ts,tsx}", "scripts/**/*.ts", "e2e/**/*.{ts,tsx}"]
     },
     "admin": {
@@ -16,6 +16,9 @@
     },
     "packages/ui": {
       "project": ["src/**/*.{ts,tsx}"]
+    },
+    "packages/claude-sidecar": {
+      "project": ["src/**/*.ts"]
     },
     "server/api": {
       "entry": ["scripts/**/*.ts"],
@@ -83,7 +86,6 @@
     "@types/uuid",
     "@vitejs/plugin-react",
     "wrangler",
-    "@tauri-apps/api",
     "@tauri-apps/plugin-shell",
     "@tauri-apps/plugin-store"
   ],

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "format:check": "prettier --check .",
     "preview": "vite preview",
     "test": "vitest",
-    "test:run": "vitest run && vitest run --config server/hocuspocus/vitest.config.ts",
+    "test:run": "vitest run && vitest run --config packages/claude-sidecar/vitest.config.ts && vitest run --config server/hocuspocus/vitest.config.ts",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",
@@ -58,9 +58,10 @@
     "prepare:extension:prod": "node scripts/prepare-extension.js prod",
     "build:extension": "npm run prepare:extension:prod",
     "build:extension:dev": "npm run prepare:extension:dev",
+    "sidecar:build": "node scripts/build-claude-sidecar.mjs",
     "tauri": "tauri",
-    "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build",
+    "tauri:dev": "node scripts/ensure-claude-sidecar-bin.mjs && tauri dev",
+    "tauri:build": "bun run sidecar:build && tauri build",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/packages/claude-sidecar/package.json
+++ b/packages/claude-sidecar/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@zedi/claude-sidecar",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "JSONL stdin/stdout bridge between Zedi Tauri and @anthropic-ai/claude-agent-sdk. / Tauri と Claude Agent SDK をつなぐ JSONL ブリッジ。",
+  "main": "src/index.ts",
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.90"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.2",
+    "vitest": "^4.0.16"
+  }
+}

--- a/packages/claude-sidecar/src/handlers/installation.ts
+++ b/packages/claude-sidecar/src/handlers/installation.ts
@@ -11,13 +11,21 @@ export interface InstallationCheckResult {
 
 const CLAUDE = process.platform === "win32" ? "claude.exe" : "claude";
 
+/** argv for `claude --version` (Windows uses `cmd /c` for npm-style shims). / Windows は npm 系シム解決のため cmd 経由 */
+function claudeVersionArgv(): string[] {
+  if (process.platform === "win32") {
+    return ["cmd.exe", "/c", "claude", "--version"];
+  }
+  return [CLAUDE, "--version"];
+}
+
 /**
  * Runs `claude --version` (or `claude.exe` on Windows).
  * `claude --version` を実行する（Windows は `claude.exe`）。
  */
 export async function checkClaudeInstallation(): Promise<InstallationCheckResult> {
   try {
-    const proc = Bun.spawn([CLAUDE, "--version"], {
+    const proc = Bun.spawn(claudeVersionArgv(), {
       stdout: "pipe",
       stderr: "pipe",
       stdin: "ignore",

--- a/packages/claude-sidecar/src/handlers/installation.ts
+++ b/packages/claude-sidecar/src/handlers/installation.ts
@@ -1,0 +1,36 @@
+/**
+ * Detects whether the `claude` CLI is on PATH and returns `--version` output when possible.
+ * `claude` CLI が PATH にあり `--version` を取得できるか検査する。
+ */
+
+/** Outcome of a Claude CLI presence check. / Claude CLI 存在確認の結果 */
+export interface InstallationCheckResult {
+  installed: boolean;
+  version?: string;
+}
+
+const CLAUDE = process.platform === "win32" ? "claude.exe" : "claude";
+
+/**
+ * Runs `claude --version` (or `claude.exe` on Windows).
+ * `claude --version` を実行する（Windows は `claude.exe`）。
+ */
+export async function checkClaudeInstallation(): Promise<InstallationCheckResult> {
+  try {
+    const proc = Bun.spawn([CLAUDE, "--version"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const stdoutText = await new Response(proc.stdout).text();
+    const stderrText = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    if (exitCode === 0) {
+      const version = stdoutText.trim() || stderrText.trim() || undefined;
+      return { installed: true, version };
+    }
+  } catch {
+    /* not on PATH or spawn failed */
+  }
+  return { installed: false };
+}

--- a/packages/claude-sidecar/src/handlers/query.ts
+++ b/packages/claude-sidecar/src/handlers/query.ts
@@ -1,0 +1,169 @@
+/**
+ * Runs one Claude Agent SDK `query()` and maps SDK stream events to sidecar stdout lines.
+ * Claude Agent SDK の `query()` を 1 回実行し、ストリームを sidecar の stdout 行に写す。
+ */
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  SDKAssistantMessage,
+  SDKMessage,
+  SDKPartialAssistantMessage,
+  SDKResultMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import type { SidecarResponse } from "../protocol";
+import { formatResponseLine } from "../protocol";
+import type { QueryActivityTracker } from "./status";
+
+/** Writes one newline-terminated JSON line to the host. / ホストへ改行付き JSON 1 行を書く */
+export type WriteLine = (line: string) => void;
+
+const DEFAULT_TOOLS = ["Read", "Write", "Bash", "WebSearch"] as const;
+
+function extractTextDelta(msg: SDKPartialAssistantMessage): string | null {
+  const ev = msg.event as unknown as Record<string, unknown> | undefined;
+  if (!ev || typeof ev !== "object") return null;
+  if (ev.type !== "content_block_delta") return null;
+  const delta = ev.delta as Record<string, unknown> | undefined;
+  if (!delta || delta.type !== "text_delta") return null;
+  const text = delta.text;
+  return typeof text === "string" ? text : null;
+}
+
+function extractAssistantText(msg: SDKAssistantMessage): string {
+  const message = msg.message as { content?: unknown };
+  const content = message.content;
+  if (!Array.isArray(content)) return "";
+  let out = "";
+  for (const block of content) {
+    if (
+      block &&
+      typeof block === "object" &&
+      "type" in block &&
+      (block as { type: string }).type === "text" &&
+      "text" in block
+    ) {
+      out += String((block as { text: string }).text);
+    }
+  }
+  return out;
+}
+
+function isResultMessage(msg: SDKMessage): msg is SDKResultMessage {
+  return typeof msg === "object" && msg !== null && "type" in msg && msg.type === "result";
+}
+
+/**
+ * Emits stream-complete on success or error line on failure.
+ * 成功時は stream-complete、失敗時は error 行を出す。
+ */
+function emitResultOrError(
+  id: string,
+  msg: SDKResultMessage,
+  aggregated: string,
+  emit: (r: SidecarResponse) => void,
+): void {
+  if (msg.subtype === "success") {
+    const finalText = msg.result ?? aggregated;
+    emit({
+      type: "stream-complete",
+      id,
+      result: { content: finalText },
+    });
+    return;
+  }
+  const errors = "errors" in msg && Array.isArray(msg.errors) ? msg.errors.join("; ") : "";
+  emit({
+    type: "error",
+    id,
+    error: errors || `Claude Code finished with subtype ${msg.subtype}`,
+    code: msg.subtype,
+  });
+}
+
+/**
+ * Executes a query; writes {@link SidecarResponse} lines via `writeLine`.
+ * `writeLine` 経由で {@link SidecarResponse} 行を書き出す。
+ */
+export async function runQuery(params: {
+  id: string;
+  prompt: string;
+  cwd?: string;
+  maxTurns?: number;
+  allowedTools?: string[];
+  resume?: string;
+  writeLine: WriteLine;
+  abortController: AbortController;
+  tracker: QueryActivityTracker;
+}): Promise<void> {
+  const { id, prompt, cwd, maxTurns, allowedTools, resume, writeLine, abortController, tracker } =
+    params;
+
+  const emit = (response: SidecarResponse): void => {
+    writeLine(formatResponseLine(response));
+  };
+
+  tracker.start(id);
+  let aggregated = "";
+
+  try {
+    const q = query({
+      prompt,
+      options: {
+        cwd: cwd ?? process.cwd(),
+        maxTurns: maxTurns ?? 10,
+        allowedTools: allowedTools?.length ? allowedTools : [...DEFAULT_TOOLS],
+        abortController,
+        includePartialMessages: true,
+        resume,
+        permissionMode: "acceptEdits",
+        settingSources: ["user", "project", "local"],
+      },
+    });
+
+    for await (const msg of q) {
+      if (abortController.signal.aborted) {
+        break;
+      }
+
+      if (msg.type === "stream_event") {
+        const delta = extractTextDelta(msg);
+        if (delta) {
+          aggregated += delta;
+          emit({ type: "stream-chunk", id, content: delta });
+        }
+        continue;
+      }
+
+      if (msg.type === "assistant") {
+        const text = extractAssistantText(msg);
+        const delta = text.length > 0 ? text.slice(aggregated.length) : "";
+        if (delta.length > 0) {
+          aggregated += delta;
+          emit({ type: "stream-chunk", id, content: delta });
+        }
+        continue;
+      }
+
+      if (isResultMessage(msg)) {
+        emitResultOrError(id, msg, aggregated, emit);
+        return;
+      }
+    }
+
+    emit({
+      type: "stream-complete",
+      id,
+      result: { content: aggregated },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    emit({
+      type: "error",
+      id,
+      error: message,
+      code: "query_exception",
+    });
+  } finally {
+    tracker.end(id);
+  }
+}

--- a/packages/claude-sidecar/src/handlers/query.ts
+++ b/packages/claude-sidecar/src/handlers/query.ts
@@ -110,11 +110,13 @@ export async function runQuery(params: {
       prompt,
       options: {
         cwd: cwd ?? process.cwd(),
-        maxTurns: maxTurns ?? 10,
+        maxTurns: maxTurns ?? 25,
         allowedTools: allowedTools?.length ? allowedTools : [...DEFAULT_TOOLS],
         abortController,
         includePartialMessages: true,
         resume,
+        // Desktop app may later expose this; matches Claude Code CLI-style defaults.
+        // デスクトップでは後段で UI から指定可能にする想定。CLI 相当の既定。
         permissionMode: "acceptEdits",
         settingSources: ["user", "project", "local"],
       },
@@ -148,6 +150,16 @@ export async function runQuery(params: {
         emitResultOrError(id, msg, aggregated, emit);
         return;
       }
+    }
+
+    if (abortController.signal.aborted) {
+      emit({
+        type: "error",
+        id,
+        error: "Query aborted",
+        code: "aborted",
+      });
+      return;
     }
 
     emit({

--- a/packages/claude-sidecar/src/handlers/status.ts
+++ b/packages/claude-sidecar/src/handlers/status.ts
@@ -17,8 +17,8 @@ export class QueryActivityTracker {
     this.active.delete(id);
   }
 
-  /** Clears all active ids (e.g. shutdown). / 全アクティブ ID を消す */
-  abortAll(): void {
+  /** Clears all tracked ids without aborting controllers (e.g. shutdown). / コントローラは中断せず追跡 ID のみクリア */
+  clearAll(): void {
     this.active.clear();
   }
 

--- a/packages/claude-sidecar/src/handlers/status.ts
+++ b/packages/claude-sidecar/src/handlers/status.ts
@@ -1,0 +1,33 @@
+/**
+ * Tracks active query ids for status reporting.
+ * ステータス報告用にアクティブなクエリ ID を追跡する。
+ */
+
+/** Tracks in-flight query ids for `status` RPC. / `status` RPC 用の実行中クエリ ID */
+export class QueryActivityTracker {
+  private readonly active = new Set<string>();
+
+  /** Marks a query as running. / クエリ開始 */
+  start(id: string): void {
+    this.active.add(id);
+  }
+
+  /** Marks a query as finished. / クエリ終了 */
+  end(id: string): void {
+    this.active.delete(id);
+  }
+
+  /** Clears all active ids (e.g. shutdown). / 全アクティブ ID を消す */
+  abortAll(): void {
+    this.active.clear();
+  }
+
+  /** Current activity for sidecar status responses. / ステータス応答用スナップショット */
+  snapshot(): { status: "idle" | "processing"; activeQueryIds: string[] } {
+    const ids = [...this.active];
+    return {
+      status: ids.length > 0 ? "processing" : "idle",
+      activeQueryIds: ids,
+    };
+  }
+}

--- a/packages/claude-sidecar/src/index.ts
+++ b/packages/claude-sidecar/src/index.ts
@@ -1,0 +1,105 @@
+/**
+ * Claude Code sidecar entry: JSONL on stdin/stdout for the Tauri host process.
+ * Tauri ホスト向け stdin/stdout JSONL の Claude Code sidecar エントリ。
+ *
+ * @packageDocumentation
+ */
+
+import * as readline from "node:readline";
+import { formatResponseLine, parseRequestLine } from "./protocol";
+import { checkClaudeInstallation } from "./handlers/installation";
+import { runQuery } from "./handlers/query";
+import { QueryActivityTracker } from "./handlers/status";
+
+const tracker = new QueryActivityTracker();
+const abortById = new Map<string, AbortController>();
+
+function writeLine(line: string): void {
+  process.stdout.write(line);
+}
+
+function emitError(id: string, error: string, code?: string): void {
+  writeLine(formatResponseLine({ type: "error", id, error, code }));
+}
+
+async function handleRequest(raw: string): Promise<void> {
+  let req;
+  try {
+    req = parseRequestLine(raw);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    emitError("protocol", message, "parse_error");
+    return;
+  }
+
+  switch (req.type) {
+    case "shutdown": {
+      tracker.abortAll();
+      writeLine(formatResponseLine({ type: "shutdown-ack" }));
+      process.exit(0);
+      return;
+    }
+    case "status": {
+      const snap = tracker.snapshot();
+      writeLine(
+        formatResponseLine({
+          type: "status-response",
+          correlationId: req.correlationId,
+          status: snap.status,
+          activeQueryIds: snap.activeQueryIds,
+        }),
+      );
+      return;
+    }
+    case "check_installation": {
+      const inst = await checkClaudeInstallation();
+      writeLine(
+        formatResponseLine({
+          type: "installation-status",
+          correlationId: req.correlationId,
+          installed: inst.installed,
+          version: inst.version,
+        }),
+      );
+      return;
+    }
+    case "abort": {
+      abortById.get(req.id)?.abort();
+      return;
+    }
+    case "query": {
+      const ac = new AbortController();
+      abortById.set(req.id, ac);
+      void runQuery({
+        id: req.id,
+        prompt: req.prompt,
+        cwd: req.cwd,
+        maxTurns: req.maxTurns,
+        allowedTools: req.allowedTools,
+        resume: req.resume,
+        writeLine,
+        abortController: ac,
+        tracker,
+      }).finally(() => {
+        abortById.delete(req.id);
+      });
+      return;
+    }
+    default: {
+      emitError("protocol", "unknown request type", "unknown_type");
+    }
+  }
+}
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity,
+});
+
+rl.on("line", (line) => {
+  void handleRequest(line);
+});
+
+rl.on("close", () => {
+  process.exit(0);
+});

--- a/packages/claude-sidecar/src/index.ts
+++ b/packages/claude-sidecar/src/index.ts
@@ -34,7 +34,7 @@ async function handleRequest(raw: string): Promise<void> {
 
   switch (req.type) {
     case "shutdown": {
-      tracker.abortAll();
+      tracker.clearAll();
       writeLine(formatResponseLine({ type: "shutdown-ack" }));
       process.exit(0);
       return;
@@ -68,6 +68,10 @@ async function handleRequest(raw: string): Promise<void> {
       return;
     }
     case "query": {
+      if (abortById.has(req.id)) {
+        emitError(req.id, "duplicate query id", "duplicate_id");
+        return;
+      }
       const ac = new AbortController();
       abortById.set(req.id, ac);
       void runQuery({

--- a/packages/claude-sidecar/src/protocol.test.ts
+++ b/packages/claude-sidecar/src/protocol.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { formatResponseLine, parseRequestLine } from "./protocol";
+
+describe("parseRequestLine", () => {
+  it("parses query request", () => {
+    const r = parseRequestLine(
+      JSON.stringify({
+        type: "query",
+        id: "a",
+        prompt: "hi",
+        cwd: "/tmp",
+        maxTurns: 3,
+      }),
+    );
+    expect(r).toEqual({
+      type: "query",
+      id: "a",
+      prompt: "hi",
+      cwd: "/tmp",
+      maxTurns: 3,
+    });
+  });
+
+  it("throws on empty", () => {
+    expect(() => parseRequestLine("   ")).toThrow(/empty/);
+  });
+});
+
+describe("formatResponseLine", () => {
+  it("ends with newline and round-trips JSON", () => {
+    const line = formatResponseLine({
+      type: "stream-chunk",
+      id: "x",
+      content: "hello",
+    });
+    expect(line.endsWith("\n")).toBe(true);
+    expect(JSON.parse(line.trim())).toEqual({
+      type: "stream-chunk",
+      id: "x",
+      content: "hello",
+    });
+  });
+});

--- a/packages/claude-sidecar/src/protocol.ts
+++ b/packages/claude-sidecar/src/protocol.ts
@@ -1,0 +1,68 @@
+/**
+ * JSONL protocol between the Tauri host and this sidecar process.
+ * Tauri ホストとこの sidecar プロセス間の JSONL プロトコル。
+ *
+ * Each line on stdin is one JSON request; each line on stdout is one JSON response.
+ * stdin の 1 行が 1 リクエスト、stdout の 1 行が 1 レスポンス。
+ */
+
+/** Inbound message from the host (one JSON object per line on stdin). */
+export type SidecarRequest =
+  | {
+      type: "query";
+      id: string;
+      prompt: string;
+      cwd?: string;
+      maxTurns?: number;
+      allowedTools?: string[];
+      /** Optional Claude session to resume (SDK `resume`). */
+      resume?: string;
+      correlationId?: string;
+    }
+  | { type: "abort"; id: string }
+  | { type: "status"; correlationId: string }
+  | { type: "check_installation"; correlationId: string }
+  | { type: "shutdown" };
+
+/** Outbound message to the host (one JSON object per line on stdout). */
+export type SidecarResponse =
+  | { type: "stream-chunk"; id: string; content: string }
+  | { type: "stream-complete"; id: string; result: { content: string } }
+  | { type: "error"; id: string; error: string; code?: string }
+  | {
+      type: "status-response";
+      correlationId: string;
+      status: "idle" | "processing";
+      activeQueryIds: string[];
+    }
+  | {
+      type: "installation-status";
+      correlationId: string;
+      installed: boolean;
+      version?: string;
+    }
+  | { type: "shutdown-ack" };
+
+/**
+ * Parses a single JSON line into {@link SidecarRequest}.
+ * 1 行を {@link SidecarRequest} としてパースする。
+ */
+export function parseRequestLine(line: string): SidecarRequest {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    throw new Error("empty line");
+  }
+  const value: unknown = JSON.parse(trimmed);
+  if (!value || typeof value !== "object" || !("type" in value)) {
+    throw new Error("invalid request: missing type");
+  }
+  return value as SidecarRequest;
+}
+
+/**
+ * Serializes a response as one JSON line (with trailing newline for writing).
+ * レスポンスを JSON 1 行（書き込み用に末尾改行付き）にする。
+ */
+export function formatResponseLine(response: SidecarResponse): string {
+  return `${JSON.stringify(response)}\n`;
+}

--- a/packages/claude-sidecar/tsconfig.json
+++ b/packages/claude-sidecar/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/claude-sidecar/vitest.config.ts
+++ b/packages/claude-sidecar/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  root: import.meta.dirname,
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/scripts/build-claude-sidecar.mjs
+++ b/scripts/build-claude-sidecar.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Compiles `packages/claude-sidecar` with `bun build --compile` and renames the
+ * binary to `claude-sidecar-<rustc-host-tuple>[.exe]` under `src-tauri/binaries/`
+ * for Tauri `bundle.externalBin`.
+ *
+ * `bun build --compile` でコンパイルし、Tauri `externalBin` 用に
+ * `src-tauri/binaries/claude-sidecar-<triple>` にリネームする。
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, renameSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const outDir = join(root, "src-tauri", "binaries");
+
+function run(cmd, args, options = {}) {
+  const r = spawnSync(cmd, args, { cwd: root, stdio: "inherit", ...options });
+  if (r.status !== 0) {
+    process.exit(r.status ?? 1);
+  }
+}
+
+const triple = spawnSync("rustc", ["--print", "host-tuple"], {
+  encoding: "utf8",
+  cwd: root,
+});
+if (triple.error || triple.status !== 0) {
+  console.error("Failed to run rustc --print host-tuple");
+  process.exit(1);
+}
+
+const hostTuple = triple.stdout.trim();
+const ext = process.platform === "win32" ? ".exe" : "";
+const finalName = `claude-sidecar-${hostTuple}${ext}`;
+const tempName = `claude-sidecar-build-temp${ext}`;
+const tempPath = join(outDir, tempName);
+const finalPath = join(outDir, finalName);
+
+mkdirSync(outDir, { recursive: true });
+
+run("bun", ["build", "packages/claude-sidecar/src/index.ts", "--compile", `--outfile=${tempPath}`]);
+
+if (existsSync(finalPath)) {
+  unlinkSync(finalPath);
+}
+renameSync(tempPath, finalPath);
+console.log(`Sidecar binary: ${finalPath}`);

--- a/scripts/build-claude-sidecar.mjs
+++ b/scripts/build-claude-sidecar.mjs
@@ -17,7 +17,12 @@ const root = join(fileURLToPath(new URL(".", import.meta.url)), "..");
 const outDir = join(root, "src-tauri", "binaries");
 
 function run(cmd, args, options = {}) {
-  const r = spawnSync(cmd, args, { cwd: root, stdio: "inherit", ...options });
+  const r = spawnSync(cmd, args, {
+    cwd: root,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+    ...options,
+  });
   if (r.status !== 0) {
     process.exit(r.status ?? 1);
   }

--- a/scripts/ensure-claude-sidecar-bin.mjs
+++ b/scripts/ensure-claude-sidecar-bin.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Ensures `src-tauri/binaries/claude-sidecar-<host-triple>` exists; runs
+ * `sidecar:build` if missing (so `tauri dev` / `cargo` can validate externalBin).
+ *
+ * バイナリが無ければ `sidecar:build` を実行する（`externalBin` 検証用）。
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const triple = spawnSync("rustc", ["--print", "host-tuple"], {
+  encoding: "utf8",
+  cwd: root,
+});
+if (triple.error || triple.status !== 0) {
+  console.error("ensure-claude-sidecar-bin: rustc --print host-tuple failed");
+  process.exit(1);
+}
+const hostTuple = triple.stdout.trim();
+const ext = process.platform === "win32" ? ".exe" : "";
+const finalPath = join(root, "src-tauri", "binaries", `claude-sidecar-${hostTuple}${ext}`);
+
+if (existsSync(finalPath)) {
+  process.exit(0);
+}
+
+console.log("Claude sidecar binary missing; running sidecar:build…");
+const r = spawnSync("bun", ["run", "sidecar:build"], {
+  cwd: root,
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+process.exit(r.status ?? 1);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5051,6 +5051,8 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-shell",
  "tauri-plugin-store",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-store = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["sync", "time", "macros", "rt"] }
+tokio = { version = "1", features = ["sync", "time", "macros", "rt-multi-thread"] }
 uuid = { version = "1", features = ["v4"] }
 
 [profile.dev]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-store = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["sync", "time", "macros"] }
+tokio = { version = "1", features = ["sync", "time", "macros", "rt"] }
 uuid = { version = "1", features = ["v4"] }
 
 [profile.dev]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,8 @@ tauri-plugin-shell = "2"
 tauri-plugin-store = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["sync", "time", "macros"] }
+uuid = { version = "1", features = ["v4"] }
 
 [profile.dev]
 incremental = true

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,17 @@
   "identifier": "default",
   "description": "Default capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": [
+    "core:default",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        {
+          "name": "binaries/claude-sidecar",
+          "sidecar": true,
+          "args": true
+        }
+      ]
+    }
+  ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,7 +11,7 @@
         {
           "name": "binaries/claude-sidecar",
           "sidecar": true,
-          "args": true
+          "args": false
         }
       ]
     }

--- a/src-tauri/src/claude_sidecar.rs
+++ b/src-tauri/src/claude_sidecar.rs
@@ -1,0 +1,297 @@
+//! Claude Code sidecar: spawns the JSONL bridge process and exposes Tauri commands + events.
+//! Claude Code sidecar — JSONL ブリッジプロセスを起動し Tauri コマンド・イベントを提供する。
+//!
+//! Events: `claude-stream-chunk`, `claude-stream-complete`, `claude-error`
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::Value;
+use tauri::{AppHandle, Emitter, State};
+use tauri_plugin_shell::process::{CommandChild, CommandEvent};
+use tauri_plugin_shell::ShellExt;
+use tokio::sync::{oneshot, Mutex as TokioMutex};
+
+/// Shared state for the sidecar child stdin and RPC correlation.
+/// sidecar の子プロセス stdin と相関 ID 用の共有状態。
+#[derive(Debug)]
+pub struct ClaudeSidecarState {
+    repo_root: PathBuf,
+    child: Arc<TokioMutex<Option<CommandChild>>>,
+    pending: Arc<TokioMutex<HashMap<String, oneshot::Sender<Value>>>>,
+}
+
+impl ClaudeSidecarState {
+    /// Builds state using the workspace root (parent of `src-tauri`).
+    /// ワークスペースルート（`src-tauri` の親）で状態を構築する。
+    pub fn new() -> Self {
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("."));
+        Self {
+            repo_root,
+            child: Arc::new(TokioMutex::new(None)),
+            pending: Arc::new(TokioMutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl Default for ClaudeSidecarState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn map_shell_err(e: tauri_plugin_shell::Error) -> String {
+    e.to_string()
+}
+
+async fn process_sidecar_line(
+    app: &AppHandle,
+    pending: &Arc<TokioMutex<HashMap<String, oneshot::Sender<Value>>>>,
+    line: &str,
+) {
+    let value: Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("claude-sidecar: stdout JSON parse error: {e}: {line}");
+            return;
+        }
+    };
+
+    let Some(typ) = value.get("type").and_then(|t| t.as_str()) else {
+        return;
+    };
+
+    match typ {
+        "stream-chunk" => {
+            let _ = app.emit("claude-stream-chunk", &value);
+        }
+        "stream-complete" => {
+            let _ = app.emit("claude-stream-complete", &value);
+        }
+        "error" => {
+            let _ = app.emit("claude-error", &value);
+        }
+        "status-response" | "installation-status" => {
+            if let Some(cid) = value.get("correlationId").and_then(|c| c.as_str()) {
+                let mut guard = pending.lock().await;
+                if let Some(tx) = guard.remove(cid) {
+                    let _ = tx.send(value);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+async fn ensure_sidecar(app: &AppHandle, state: &ClaudeSidecarState) -> Result<(), String> {
+    let mut slot = state.child.lock().await;
+    if slot.is_some() {
+        return Ok(());
+    }
+
+    let (mut rx, child) = if cfg!(debug_assertions) {
+        app.shell()
+            .command("bun")
+            .args(["packages/claude-sidecar/src/index.ts"])
+            .current_dir(&state.repo_root)
+            .spawn()
+            .map_err(map_shell_err)?
+    } else {
+        app.shell()
+            .sidecar("binaries/claude-sidecar")
+            .map_err(map_shell_err)?
+            .spawn()
+            .map_err(map_shell_err)?
+    };
+
+    let app_handle = app.clone();
+    let pending = state.pending.clone();
+    let child_slot = state.child.clone();
+
+    tauri::async_runtime::spawn(async move {
+        let mut line_buf = String::new();
+        while let Some(event) = rx.recv().await {
+            match event {
+                CommandEvent::Stdout(bytes) => {
+                    line_buf.push_str(&String::from_utf8_lossy(&bytes));
+                    while let Some(pos) = line_buf.find('\n') {
+                        let line = line_buf[..pos].trim().to_string();
+                        line_buf.drain(..=pos);
+                        if !line.is_empty() {
+                            process_sidecar_line(&app_handle, &pending, &line).await;
+                        }
+                    }
+                }
+                CommandEvent::Stderr(bytes) => {
+                    eprintln!("claude-sidecar stderr: {}", String::from_utf8_lossy(&bytes));
+                }
+                CommandEvent::Error(e) => {
+                    eprintln!("claude-sidecar command error: {e}");
+                    let _ = app_handle.emit(
+                        "claude-error",
+                        serde_json::json!({
+                            "id": "sidecar",
+                            "error": e,
+                            "code": "sidecar_io_error"
+                        }),
+                    );
+                }
+                CommandEvent::Terminated(payload) => {
+                    eprintln!("claude-sidecar terminated: {payload:?}");
+                    *child_slot.lock().await = None;
+                    let _ = app_handle.emit(
+                        "claude-error",
+                        serde_json::json!({
+                            "id": "sidecar",
+                            "error": "Claude sidecar process terminated",
+                            "code": "sidecar_terminated",
+                            "exitCode": payload.code,
+                            "signal": payload.signal,
+                        }),
+                    );
+                    break;
+                }
+                _ => {}
+            }
+        }
+    });
+
+    *slot = Some(child);
+    Ok(())
+}
+
+async fn write_line(state: &ClaudeSidecarState, line: &str) -> Result<(), String> {
+    let mut guard = state.child.lock().await;
+    let child = guard
+        .as_mut()
+        .ok_or_else(|| "Claude sidecar is not running".to_string())?;
+    let bytes = format!("{}\n", line.trim_end());
+    child
+        .write(bytes.as_bytes())
+        .map_err(|e| format!("failed to write sidecar stdin: {e}"))?;
+    Ok(())
+}
+
+async fn rpc_json(
+    _app: &AppHandle,
+    state: &ClaudeSidecarState,
+    request: Value,
+    correlation_id: &str,
+) -> Result<Value, String> {
+    let (tx, rx) = oneshot::channel();
+    {
+        let mut p = state.pending.lock().await;
+        p.insert(correlation_id.to_string(), tx);
+    }
+
+    let line = serde_json::to_string(&request).map_err(|e| e.to_string())?;
+    if let Err(e) = write_line(state, &line).await {
+        state.pending.lock().await.remove(correlation_id);
+        return Err(e);
+    }
+
+    let out = tokio::time::timeout(Duration::from_secs(30), rx).await;
+    if out.is_err() {
+        state.pending.lock().await.remove(correlation_id);
+        return Err("sidecar RPC timed out".to_string());
+    }
+
+    out.unwrap()
+        .map_err(|_| "sidecar RPC channel closed".to_string())
+}
+
+/// Sends a prompt to Claude Code via the sidecar; returns the request id for event correlation.
+/// sidecar 経由でプロンプトを送り、イベント相関用のリクエスト ID を返す。
+#[tauri::command]
+pub async fn claude_query(
+    app: AppHandle,
+    state: State<'_, ClaudeSidecarState>,
+    prompt: String,
+    cwd: Option<String>,
+    max_turns: Option<u32>,
+    allowed_tools: Option<Vec<String>>,
+    resume: Option<String>,
+) -> Result<String, String> {
+    ensure_sidecar(&app, &state).await?;
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let mut req = serde_json::json!({
+        "type": "query",
+        "id": id,
+        "prompt": prompt,
+    });
+    if let Some(c) = cwd {
+        req["cwd"] = Value::String(c);
+    }
+    if let Some(m) = max_turns {
+        req["maxTurns"] = Value::Number(m.into());
+    }
+    if let Some(tools) = allowed_tools {
+        req["allowedTools"] = serde_json::to_value(tools).map_err(|e| e.to_string())?;
+    }
+    if let Some(r) = resume {
+        req["resume"] = Value::String(r);
+    }
+
+    let line = serde_json::to_string(&req).map_err(|e| e.to_string())?;
+    write_line(&state, &line).await?;
+    Ok(id)
+}
+
+/// Aborts a running query by id.
+/// 実行中のクエリを ID で中断する。
+#[tauri::command]
+pub async fn claude_abort(
+    app: AppHandle,
+    state: State<'_, ClaudeSidecarState>,
+    request_id: String,
+) -> Result<(), String> {
+    ensure_sidecar(&app, &state).await?;
+    let req = serde_json::json!({
+        "type": "abort",
+        "id": request_id,
+    });
+    let line = serde_json::to_string(&req).map_err(|e| e.to_string())?;
+    write_line(&state, &line).await
+}
+
+/// Returns sidecar processing status (idle / active query ids).
+/// sidecar の処理状態（アイドル / アクティブなクエリ ID）を返す。
+#[tauri::command]
+pub async fn claude_status(
+    app: AppHandle,
+    state: State<'_, ClaudeSidecarState>,
+) -> Result<Value, String> {
+    ensure_sidecar(&app, &state).await?;
+
+    let correlation_id = uuid::Uuid::new_v4().to_string();
+    let req = serde_json::json!({
+        "type": "status",
+        "correlationId": correlation_id,
+    });
+
+    rpc_json(&app, &state, req, &correlation_id).await
+}
+
+/// Checks whether the Claude Code CLI is installed (`claude --version`).
+/// Claude Code CLI がインストールされているか（`claude --version`）を確認する。
+#[tauri::command]
+pub async fn check_claude_installation(
+    app: AppHandle,
+    state: State<'_, ClaudeSidecarState>,
+) -> Result<Value, String> {
+    ensure_sidecar(&app, &state).await?;
+
+    let correlation_id = uuid::Uuid::new_v4().to_string();
+    let req = serde_json::json!({
+        "type": "check_installation",
+        "correlationId": correlation_id,
+    });
+
+    rpc_json(&app, &state, req, &correlation_id).await
+}

--- a/src-tauri/src/claude_sidecar.rs
+++ b/src-tauri/src/claude_sidecar.rs
@@ -18,19 +18,27 @@ use tokio::sync::{oneshot, Mutex as TokioMutex};
 /// sidecar の子プロセス stdin と相関 ID 用の共有状態。
 #[derive(Debug)]
 pub struct ClaudeSidecarState {
-    repo_root: PathBuf,
+    /// Dev-only: repo root for `bun packages/claude-sidecar/...`. Omitted in release builds.
+    /// 開発時のみ: `bun` で sidecar を起動する際のリポジトリルート。release では未使用。
+    repo_root: Option<PathBuf>,
     child: Arc<TokioMutex<Option<CommandChild>>>,
     pending: Arc<TokioMutex<HashMap<String, oneshot::Sender<Value>>>>,
 }
 
 impl ClaudeSidecarState {
-    /// Builds state using the workspace root (parent of `src-tauri`).
-    /// ワークスペースルート（`src-tauri` の親）で状態を構築する。
+    /// Builds state. `repo_root` is only set in debug builds (no embedded path in release).
+    /// `repo_root` はデバッグビルドでのみ設定（release にビルドマシン絶対パスを埋め込まない）。
     pub fn new() -> Self {
-        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from("."));
+        let repo_root = if cfg!(debug_assertions) {
+            Some(
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .parent()
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| PathBuf::from(".")),
+            )
+        } else {
+            None
+        };
         Self {
             repo_root,
             child: Arc::new(TokioMutex::new(None)),
@@ -47,6 +55,24 @@ impl Default for ClaudeSidecarState {
 
 fn map_shell_err(e: tauri_plugin_shell::Error) -> String {
     e.to_string()
+}
+
+/// Completes all pending RPC waiters after sidecar failure (timeout avoided).
+/// sidecar 失敗後に保留中 RPC を完了させる（タイムアウト待ちを避ける）。
+async fn fail_pending_rpc(
+    pending: &Arc<TokioMutex<HashMap<String, oneshot::Sender<Value>>>>,
+    message: &str,
+    code: &str,
+) {
+    let mut guard = pending.lock().await;
+    for (cid, tx) in guard.drain() {
+        let _ = tx.send(serde_json::json!({
+            "type": "error",
+            "correlationId": cid,
+            "error": message,
+            "code": code,
+        }));
+    }
 }
 
 async fn process_sidecar_line(
@@ -95,10 +121,14 @@ async fn ensure_sidecar(app: &AppHandle, state: &ClaudeSidecarState) -> Result<(
     }
 
     let (mut rx, child) = if cfg!(debug_assertions) {
+        let root = state
+            .repo_root
+            .as_ref()
+            .ok_or_else(|| "internal error: missing repo root for dev sidecar".to_string())?;
         app.shell()
             .command("bun")
             .args(["packages/claude-sidecar/src/index.ts"])
-            .current_dir(&state.repo_root)
+            .current_dir(root)
             .spawn()
             .map_err(map_shell_err)?
     } else {
@@ -114,14 +144,16 @@ async fn ensure_sidecar(app: &AppHandle, state: &ClaudeSidecarState) -> Result<(
     let child_slot = state.child.clone();
 
     tauri::async_runtime::spawn(async move {
-        let mut line_buf = String::new();
+        let mut line_buf: Vec<u8> = Vec::new();
         while let Some(event) = rx.recv().await {
             match event {
                 CommandEvent::Stdout(bytes) => {
-                    line_buf.push_str(&String::from_utf8_lossy(&bytes));
-                    while let Some(pos) = line_buf.find('\n') {
-                        let line = line_buf[..pos].trim().to_string();
-                        line_buf.drain(..=pos);
+                    line_buf.extend_from_slice(&bytes);
+                    while let Some(pos) = line_buf.iter().position(|&b| b == b'\n') {
+                        let line_bytes: Vec<u8> = line_buf.drain(..=pos).collect();
+                        let without_nl = line_bytes.strip_suffix(b"\n").unwrap_or(&line_bytes);
+                        let without_cr = without_nl.strip_suffix(b"\r").unwrap_or(without_nl);
+                        let line = String::from_utf8_lossy(without_cr).trim().to_string();
                         if !line.is_empty() {
                             process_sidecar_line(&app_handle, &pending, &line).await;
                         }
@@ -132,17 +164,25 @@ async fn ensure_sidecar(app: &AppHandle, state: &ClaudeSidecarState) -> Result<(
                 }
                 CommandEvent::Error(e) => {
                     eprintln!("claude-sidecar command error: {e}");
+                    fail_pending_rpc(&pending, "sidecar command error", "sidecar_io_error").await;
                     let _ = app_handle.emit(
                         "claude-error",
                         serde_json::json!({
                             "id": "sidecar",
-                            "error": e,
-                            "code": "sidecar_io_error"
+                            "error": e.to_string(),
+                            "code": "sidecar_io_error",
+                            "type": "error",
                         }),
                     );
                 }
                 CommandEvent::Terminated(payload) => {
                     eprintln!("claude-sidecar terminated: {payload:?}");
+                    fail_pending_rpc(
+                        &pending,
+                        "Claude sidecar process terminated",
+                        "sidecar_terminated",
+                    )
+                    .await;
                     *child_slot.lock().await = None;
                     let _ = app_handle.emit(
                         "claude-error",
@@ -150,6 +190,7 @@ async fn ensure_sidecar(app: &AppHandle, state: &ClaudeSidecarState) -> Result<(
                             "id": "sidecar",
                             "error": "Claude sidecar process terminated",
                             "code": "sidecar_terminated",
+                            "type": "error",
                             "exitCode": payload.code,
                             "signal": payload.signal,
                         }),
@@ -171,9 +212,12 @@ async fn write_line(state: &ClaudeSidecarState, line: &str) -> Result<(), String
         .as_mut()
         .ok_or_else(|| "Claude sidecar is not running".to_string())?;
     let bytes = format!("{}\n", line.trim_end());
-    child
-        .write(bytes.as_bytes())
-        .map_err(|e| format!("failed to write sidecar stdin: {e}"))?;
+    let bytes_buf = bytes.into_bytes();
+    tokio::task::block_in_place(|| {
+        child
+            .write(&bytes_buf)
+            .map_err(|e| format!("failed to write sidecar stdin: {e}"))
+    })?;
     Ok(())
 }
 
@@ -201,8 +245,19 @@ async fn rpc_json(
         return Err("sidecar RPC timed out".to_string());
     }
 
-    out.unwrap()
-        .map_err(|_| "sidecar RPC channel closed".to_string())
+    let value = out
+        .unwrap()
+        .map_err(|_| "sidecar RPC channel closed".to_string())?;
+
+    if value.get("type").and_then(|t| t.as_str()) == Some("error") {
+        let msg = value
+            .get("error")
+            .and_then(|e| e.as_str())
+            .unwrap_or("sidecar RPC error");
+        return Err(msg.to_string());
+    }
+
+    Ok(value)
 }
 
 /// Sends a prompt to Claude Code via the sidecar; returns the request id for event correlation.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+mod claude_sidecar;
+
 /// Tauri アプリケーション共通エントリポイント。
 /// デスクトップ (main.rs) とモバイル (mobile entry point) の両方から呼ばれる。
 ///
@@ -8,6 +10,13 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_store::Builder::default().build())
+        .manage(claude_sidecar::ClaudeSidecarState::new())
+        .invoke_handler(tauri::generate_handler![
+            claude_sidecar::claude_query,
+            claude_sidecar::claude_abort,
+            claude_sidecar::claude_status,
+            claude_sidecar::check_claude_installation,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,6 +25,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "externalBin": ["binaries/claude-sidecar"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/lib/claudeCode/bridge.test.ts
+++ b/src/lib/claudeCode/bridge.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import {
+  checkClaudeInstallation,
+  claudeAbort,
+  claudeQuery,
+  claudeStatus,
+  onClaudeError,
+  onClaudeStreamChunk,
+  onClaudeStreamComplete,
+} from "./bridge";
+
+describe("claudeCode bridge", () => {
+  const originals = { window: globalThis.window };
+
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+    vi.mocked(listen).mockReset();
+    vi.mocked(listen).mockResolvedValue(() => {});
+    Object.defineProperty(globalThis, "window", {
+      value: { __TAURI_INTERNALS__: {} },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      value: originals.window,
+      configurable: true,
+    });
+  });
+
+  it("claudeQuery invokes claude_query with camelCase args", async () => {
+    vi.mocked(invoke).mockResolvedValue("req-1");
+    const id = await claudeQuery("hello", { cwd: "/tmp", maxTurns: 5 });
+    expect(id).toBe("req-1");
+    expect(invoke).toHaveBeenCalledWith("claude_query", {
+      prompt: "hello",
+      cwd: "/tmp",
+      maxTurns: 5,
+      allowedTools: null,
+      resume: null,
+    });
+  });
+
+  it("claudeAbort invokes claude_abort", async () => {
+    vi.mocked(invoke).mockResolvedValue(undefined);
+    await claudeAbort("req-1");
+    expect(invoke).toHaveBeenCalledWith("claude_abort", { requestId: "req-1" });
+  });
+
+  it("claudeStatus invokes claude_status", async () => {
+    const status = {
+      type: "status-response" as const,
+      correlationId: "c",
+      status: "idle" as const,
+      activeQueryIds: [],
+    };
+    vi.mocked(invoke).mockResolvedValue(status);
+    await expect(claudeStatus()).resolves.toEqual(status);
+  });
+
+  it("checkClaudeInstallation invokes check_claude_installation", async () => {
+    const inst = {
+      type: "installation-status" as const,
+      correlationId: "c",
+      installed: false,
+    };
+    vi.mocked(invoke).mockResolvedValue(inst);
+    await expect(checkClaudeInstallation()).resolves.toEqual(inst);
+  });
+
+  it("onClaudeStreamChunk registers listen with event name", async () => {
+    await onClaudeStreamChunk(() => {});
+    expect(listen).toHaveBeenCalledWith("claude-stream-chunk", expect.any(Function));
+  });
+
+  it("onClaudeStreamComplete registers listen with event name", async () => {
+    await onClaudeStreamComplete(() => {});
+    expect(listen).toHaveBeenCalledWith("claude-stream-complete", expect.any(Function));
+  });
+
+  it("onClaudeError registers listen with event name", async () => {
+    await onClaudeError(() => {});
+    expect(listen).toHaveBeenCalledWith("claude-error", expect.any(Function));
+  });
+
+  it("throws when not in Tauri", async () => {
+    Object.defineProperty(globalThis, "window", {
+      value: {},
+      configurable: true,
+    });
+    await expect(claudeQuery("x")).rejects.toThrow(/desktop app/i);
+  });
+});

--- a/src/lib/claudeCode/bridge.ts
+++ b/src/lib/claudeCode/bridge.ts
@@ -1,0 +1,119 @@
+/**
+ * Tauri invoke/listen wrappers for the Claude Code sidecar (Issue #456).
+ * Claude Code sidecar 向け `invoke` / `listen` ラッパー（Issue #456）。
+ *
+ * Requires the Zedi desktop shell (`__TAURI_INTERNALS__`).
+ * Zedi デスクトップ（`__TAURI_INTERNALS__`）が必要。
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import {
+  CLAUDE_ERROR_EVENT,
+  CLAUDE_STREAM_CHUNK_EVENT,
+  CLAUDE_STREAM_COMPLETE_EVENT,
+  type ClaudeErrorPayload,
+  type ClaudeInstallationResult,
+  type ClaudeStreamChunkPayload,
+  type ClaudeStreamCompletePayload,
+  type ClaudeStatusResult,
+} from "./types";
+
+/** Throws if not running inside a Tauri WebView. / Tauri WebView 外なら例外 */
+function assertTauriWebview(): void {
+  if (typeof window === "undefined" || !("__TAURI_INTERNALS__" in window)) {
+    throw new Error(
+      "Claude Code sidecar is only available in the Zedi desktop app. / Claude Code sidecar は Zedi デスクトップアプリでのみ利用できます。",
+    );
+  }
+}
+
+/** Optional arguments for {@link claudeQuery}. / {@link claudeQuery} の任意引数 */
+export interface ClaudeQueryOptions {
+  cwd?: string;
+  maxTurns?: number;
+  allowedTools?: string[];
+  /** SDK session resume id. / SDK のセッション再開 ID */
+  resume?: string;
+}
+
+/**
+ * Sends a prompt; returns the request id to correlate stream events.
+ * プロンプトを送り、ストリームイベントと突き合わせるリクエスト ID を返す。
+ */
+export async function claudeQuery(prompt: string, options?: ClaudeQueryOptions): Promise<string> {
+  assertTauriWebview();
+  return invoke<string>("claude_query", {
+    prompt,
+    cwd: options?.cwd ?? null,
+    maxTurns: options?.maxTurns ?? null,
+    allowedTools: options?.allowedTools ?? null,
+    resume: options?.resume ?? null,
+  });
+}
+
+/**
+ * Aborts a running query by the id returned from {@link claudeQuery}.
+ * {@link claudeQuery} で返った ID で実行中クエリを中断する。
+ */
+export async function claudeAbort(requestId: string): Promise<void> {
+  assertTauriWebview();
+  await invoke("claude_abort", { requestId });
+}
+
+/**
+ * Sidecar idle/processing snapshot (RPC via sidecar).
+ * sidecar 経由の RPC でアイドル／処理中のスナップショットを取得する。
+ */
+export async function claudeStatus(): Promise<ClaudeStatusResult> {
+  assertTauriWebview();
+  return invoke<ClaudeStatusResult>("claude_status");
+}
+
+/**
+ * Whether `claude` CLI is on PATH (`claude --version`).
+ * `claude` CLI が PATH にあるか（`claude --version`）。
+ */
+export async function checkClaudeInstallation(): Promise<ClaudeInstallationResult> {
+  assertTauriWebview();
+  return invoke<ClaudeInstallationResult>("check_claude_installation");
+}
+
+/**
+ * Subscribe to streaming chunks for all queries; filter by `payload.id` if needed.
+ * 全クエリのストリームチャンクを購読する。必要なら `payload.id` でフィルタする。
+ */
+export function onClaudeStreamChunk(
+  callback: (payload: ClaudeStreamChunkPayload) => void,
+): Promise<UnlistenFn> {
+  assertTauriWebview();
+  return listen<ClaudeStreamChunkPayload>(CLAUDE_STREAM_CHUNK_EVENT, (event) => {
+    callback(event.payload);
+  });
+}
+
+/**
+ * Subscribe to query completion events.
+ * クエリ完了イベントを購読する。
+ */
+export function onClaudeStreamComplete(
+  callback: (payload: ClaudeStreamCompletePayload) => void,
+): Promise<UnlistenFn> {
+  assertTauriWebview();
+  return listen<ClaudeStreamCompletePayload>(CLAUDE_STREAM_COMPLETE_EVENT, (event) => {
+    callback(event.payload);
+  });
+}
+
+/**
+ * Subscribe to sidecar / SDK errors.
+ * sidecar / SDK エラーを購読する。
+ */
+export function onClaudeError(
+  callback: (payload: ClaudeErrorPayload) => void,
+): Promise<UnlistenFn> {
+  assertTauriWebview();
+  return listen<ClaudeErrorPayload>(CLAUDE_ERROR_EVENT, (event) => {
+    callback(event.payload);
+  });
+}

--- a/src/lib/claudeCode/index.ts
+++ b/src/lib/claudeCode/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Claude Code desktop integration (Tauri sidecar bridge).
+ * Claude Code デスクトップ連携（Tauri sidecar ブリッジ）。
+ */
+
+export * from "./types";
+export * from "./bridge";

--- a/src/lib/claudeCode/types.ts
+++ b/src/lib/claudeCode/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Payload shapes for Tauri events emitted by the Claude Code sidecar bridge.
+ * Claude Code sidecar ブリッジが発行する Tauri イベントのペイロード形。
+ */
+
+/** Emitted as {@link CLAUDE_STREAM_CHUNK_EVENT}. */
+export interface ClaudeStreamChunkPayload {
+  type: "stream-chunk";
+  id: string;
+  content: string;
+}
+
+/** Emitted as {@link CLAUDE_STREAM_COMPLETE_EVENT}. */
+export interface ClaudeStreamCompletePayload {
+  type: "stream-complete";
+  id: string;
+  result: { content: string };
+}
+
+/** Emitted as {@link CLAUDE_ERROR_EVENT}. */
+export interface ClaudeErrorPayload {
+  type?: string;
+  id: string;
+  error: string;
+  code?: string;
+  exitCode?: number | null;
+  signal?: number | null;
+}
+
+/** Result of {@link claudeStatus} (sidecar `status-response`). */
+export interface ClaudeStatusResult {
+  type: "status-response";
+  correlationId: string;
+  status: "idle" | "processing";
+  activeQueryIds: string[];
+}
+
+/** Result of {@link checkClaudeInstallation} (sidecar `installation-status`). */
+export interface ClaudeInstallationResult {
+  type: "installation-status";
+  correlationId: string;
+  installed: boolean;
+  version?: string;
+}
+
+/** Tauri event name for streaming assistant text chunks. */
+export const CLAUDE_STREAM_CHUNK_EVENT = "claude-stream-chunk" as const;
+
+/** Tauri event name when a query finishes successfully. */
+export const CLAUDE_STREAM_COMPLETE_EVENT = "claude-stream-complete" as const;
+
+/** Tauri event name for errors (sidecar, SDK, or process). */
+export const CLAUDE_ERROR_EVENT = "claude-error" as const;

--- a/src/lib/claudeCode/types.ts
+++ b/src/lib/claudeCode/types.ts
@@ -3,21 +3,21 @@
  * Claude Code sidecar ブリッジが発行する Tauri イベントのペイロード形。
  */
 
-/** Emitted as {@link CLAUDE_STREAM_CHUNK_EVENT}. */
+/** Emitted as {@link CLAUDE_STREAM_CHUNK_EVENT}. / {@link CLAUDE_STREAM_CHUNK_EVENT} として発行される。 */
 export interface ClaudeStreamChunkPayload {
   type: "stream-chunk";
   id: string;
   content: string;
 }
 
-/** Emitted as {@link CLAUDE_STREAM_COMPLETE_EVENT}. */
+/** Emitted as {@link CLAUDE_STREAM_COMPLETE_EVENT}. / {@link CLAUDE_STREAM_COMPLETE_EVENT} として発行される。 */
 export interface ClaudeStreamCompletePayload {
   type: "stream-complete";
   id: string;
   result: { content: string };
 }
 
-/** Emitted as {@link CLAUDE_ERROR_EVENT}. */
+/** Emitted as {@link CLAUDE_ERROR_EVENT}. / {@link CLAUDE_ERROR_EVENT} として発行される。 */
 export interface ClaudeErrorPayload {
   type?: string;
   id: string;
@@ -27,7 +27,7 @@ export interface ClaudeErrorPayload {
   signal?: number | null;
 }
 
-/** Result of {@link claudeStatus} (sidecar `status-response`). */
+/** Result of {@link claudeStatus} (sidecar `status-response`). / {@link claudeStatus} の結果（sidecar `status-response`）。 */
 export interface ClaudeStatusResult {
   type: "status-response";
   correlationId: string;
@@ -35,7 +35,7 @@ export interface ClaudeStatusResult {
   activeQueryIds: string[];
 }
 
-/** Result of {@link checkClaudeInstallation} (sidecar `installation-status`). */
+/** Result of {@link checkClaudeInstallation} (sidecar `installation-status`). / {@link checkClaudeInstallation} の結果（sidecar `installation-status`）。 */
 export interface ClaudeInstallationResult {
   type: "installation-status";
   correlationId: string;
@@ -43,11 +43,11 @@ export interface ClaudeInstallationResult {
   version?: string;
 }
 
-/** Tauri event name for streaming assistant text chunks. */
+/** Tauri event name for streaming assistant text chunks. / ストリーミングアシスタントテキストチャンク用の Tauri イベント名。 */
 export const CLAUDE_STREAM_CHUNK_EVENT = "claude-stream-chunk" as const;
 
-/** Tauri event name when a query finishes successfully. */
+/** Tauri event name when a query finishes successfully. / クエリ正常完了時の Tauri イベント名。 */
 export const CLAUDE_STREAM_COMPLETE_EVENT = "claude-stream-complete" as const;
 
-/** Tauri event name for errors (sidecar, SDK, or process). */
+/** Tauri event name for errors (sidecar, SDK, or process). / エラー（sidecar, SDK, プロセス）用の Tauri イベント名。 */
 export const CLAUDE_ERROR_EVENT = "claude-error" as const;


### PR DESCRIPTION
## 概要

Tauri の Sidecar と `@anthropic-ai/claude-agent-sdk` を使い、デスクトップから Claude Code を呼び出す基盤を追加します（[Issue #456](https://github.com/otomatty/zedi/issues/456)）。WebView からは Tauri Commands / Events でストリーミング応答を受け取れます。

## 変更点

### `packages/claude-sidecar/`
- JSONL（stdin/stdout）で Rust ホストと通信する sidecar
- `query()` / `abort` / `status` / `check_installation`（`claude --version`）
- Vitest（`protocol.test.ts`）

### `src-tauri/`
- `claude_sidecar.rs`: 子プロセス起動（dev: `bun`、release: `externalBin`）、stdout を行パースして `emit`
- Commands: `claude_query`, `claude_abort`, `claude_status`, `check_claude_installation`
- Events: `claude-stream-chunk`, `claude-stream-complete`, `claude-error`
- `tauri.conf.json` の `externalBin`、`capabilities` の `shell:allow-execute`（sidecar）

### `src/lib/claudeCode/`
- `invoke` / `listen` ラッパー、型、`bridge.test.ts`（モック）

### ルート
- `sidecar:build`、`ensure-claude-sidecar-bin.mjs`（`tauri:dev` / `tauri:build` と連携）
- README、`.gitignore`（`src-tauri/binaries/claude-sidecar*`）、`knip.json`、`bun.lock`

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [x] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun install`（リポジトリルート）
2. 初回のみ: `bun run sidecar:build`（または `bun run tauri:dev` の ensure がバイナリを生成）
3. `bunx vitest run --config packages/claude-sidecar/vitest.config.ts`
4. `bunx vitest run src/lib/claudeCode/bridge.test.ts`
5. `cd src-tauri && cargo check`

## チェックリスト

- [x] 本 PR 追加範囲の Vitest を実行済み
- [x] 本 PR 対象の TS パスで ESLint / Prettier を確認済み
- [x] README を更新済み（sidecar の前提・手順）
- [x] コミットメッセージは Conventional Commits に従っている

**Note:** リポジトリ全体の `bun run format:check` は既存ファイルの差分で失敗する場合があります（本変更ファイルは Prettier 済み）。

## スクリーンショット（UI 変更がある場合）

なし（UI 統合は別タスク）。

## 関連 Issue

Closes #456

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Claude Codeサイドカー統合を追加し、デスクトップからAIへのクエリ実行・中断・ステータス確認が可能に。
  * インストール確認コマンドとストリーミング応答イベント（チャンク/完了/エラー）を公開。

* **テスト**
  * サイドカー向けプロトコルとブリッジのユニットテストを追加。

* **ドキュメント**
  * デスクトップセットアップ説明とプロジェクト構成図を更新。

* **その他**
  * サイドカーの自動ビルド/確保スクリプトとバンドル設定、ビルド関連設定を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->