### PR TITLE
feat(editor): agent slash commands via claude code sidecar (#460)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -8,7 +8,12 @@
   "ignoreBinaries": ["docker-compose"],
   "workspaces": {
     ".": {
-      "entry": ["scripts/**/*.ts", "e2e/**/*.ts", "src/lib/claudeCode/index.ts"],
+      "entry": [
+        "scripts/**/*.ts",
+        "e2e/**/*.ts",
+        "src/lib/claudeCode/index.ts",
+        "src/lib/agentSlashCommands/index.ts"
+      ],
       "project": ["src/**/*.{ts,tsx}", "scripts/**/*.ts", "e2e/**/*.{ts,tsx}"]
     },
     "admin": {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod claude_sidecar;
+mod workspace_paths;
 
 /// Tauri アプリケーション共通エントリポイント。
 /// デスクトップ (main.rs) とモバイル (mobile entry point) の両方から呼ばれる。
@@ -17,6 +18,7 @@ pub fn run() {
             claude_sidecar::claude_status,
             claude_sidecar::check_claude_installation,
             claude_sidecar::claude_list_models,
+            workspace_paths::list_workspace_directory_entries,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/workspace_paths.rs
+++ b/src-tauri/src/workspace_paths.rs
@@ -1,0 +1,58 @@
+//! Workspace-relative directory listing for slash-command path completion.
+//! スラッシュコマンドのパス補完用、ワークスペース相対ディレクトリ一覧。
+
+use std::path::PathBuf;
+
+/// Lists file and subdirectory names under `relative_dir` (relative to process cwd).
+/// `relative_dir` が空なら cwd 直下を列挙する。
+/// Directories are suffixed with `/`. Hidden names (leading `.`) are skipped.
+///
+/// 列挙先が cwd 外に出る場合はエラーにする（パストラバーサル対策）。
+#[tauri::command]
+pub fn list_workspace_directory_entries(relative_dir: String) -> Result<Vec<String>, String> {
+    let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+    let target = resolve_under_cwd(&cwd, &relative_dir)?;
+    if !target.is_dir() {
+        return Ok(vec![]);
+    }
+    let mut out: Vec<String> = Vec::new();
+    for entry in std::fs::read_dir(&target).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue;
+        }
+        let is_dir = entry.file_type().map_err(|e| e.to_string())?.is_dir();
+        out.push(if is_dir {
+            format!("{name}/")
+        } else {
+            name
+        });
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn resolve_under_cwd(cwd: &PathBuf, relative_dir: &str) -> Result<PathBuf, String> {
+    let trimmed = relative_dir.trim();
+    if trimmed.is_empty() {
+        return Ok(cwd.clone());
+    }
+    let mut acc = cwd.clone();
+    for comp in std::path::Path::new(trimmed).components() {
+        match comp {
+            std::path::Component::Normal(c) => acc.push(c),
+            std::path::Component::ParentDir => {
+                acc.pop();
+            }
+            std::path::Component::CurDir => {}
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => {
+                return Err("invalid path".into());
+            }
+        }
+    }
+    if !acc.starts_with(cwd) {
+        return Err("path outside workspace".into());
+    }
+    Ok(acc)
+}

--- a/src-tauri/src/workspace_paths.rs
+++ b/src-tauri/src/workspace_paths.rs
@@ -8,10 +8,12 @@ use std::path::PathBuf;
 /// Directories are suffixed with `/`. Hidden names (leading `.`) are skipped.
 ///
 /// 列挙先が cwd 外に出る場合はエラーにする（パストラバーサル対策）。
+/// 存在するパスは `canonicalize` してシンボリックリンク越しのエスケープを検出する。
 #[tauri::command]
 pub fn list_workspace_directory_entries(relative_dir: String) -> Result<Vec<String>, String> {
     let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
-    let target = resolve_under_cwd(&cwd, &relative_dir)?;
+    let cwd_canon = cwd.canonicalize().map_err(|e| e.to_string())?;
+    let target = resolve_under_cwd(&cwd_canon, &relative_dir)?;
     if !target.is_dir() {
         return Ok(vec![]);
     }
@@ -33,17 +35,29 @@ pub fn list_workspace_directory_entries(relative_dir: String) -> Result<Vec<Stri
     Ok(out)
 }
 
-fn resolve_under_cwd(cwd: &PathBuf, relative_dir: &str) -> Result<PathBuf, String> {
+fn resolve_under_cwd(cwd_canon: &PathBuf, relative_dir: &str) -> Result<PathBuf, String> {
     let trimmed = relative_dir.trim();
     if trimmed.is_empty() {
-        return Ok(cwd.clone());
+        return Ok(cwd_canon.clone());
     }
-    let mut acc = cwd.clone();
+    let mut acc = cwd_canon.clone();
     for comp in std::path::Path::new(trimmed).components() {
         match comp {
-            std::path::Component::Normal(c) => acc.push(c),
+            std::path::Component::Normal(c) => {
+                acc.push(c);
+                if acc.exists() {
+                    let canon = acc.canonicalize().map_err(|e| e.to_string())?;
+                    if !canon.starts_with(cwd_canon) {
+                        return Err("path outside workspace".into());
+                    }
+                    acc = canon;
+                }
+            }
             std::path::Component::ParentDir => {
                 acc.pop();
+                if !acc.starts_with(cwd_canon) {
+                    return Err("path outside workspace".into());
+                }
             }
             std::path::Component::CurDir => {}
             std::path::Component::RootDir | std::path::Component::Prefix(_) => {
@@ -51,7 +65,14 @@ fn resolve_under_cwd(cwd: &PathBuf, relative_dir: &str) -> Result<PathBuf, Strin
             }
         }
     }
-    if !acc.starts_with(cwd) {
+    if acc.exists() {
+        let canon = acc.canonicalize().map_err(|e| e.to_string())?;
+        if !canon.starts_with(cwd_canon) {
+            return Err("path outside workspace".into());
+        }
+        return Ok(canon);
+    }
+    if !acc.starts_with(cwd_canon) {
         return Err("path outside workspace".into());
     }
     Ok(acc)

--- a/src/components/editor/TiptapEditor.tsx
+++ b/src/components/editor/TiptapEditor.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { EditorContent } from "@tiptap/react";
 import { cn } from "@zedi/ui";
 import { MermaidGeneratorDialog } from "./MermaidGeneratorDialog";
@@ -12,6 +13,7 @@ import { EditorBubbleMenu } from "./TiptapEditor/EditorBubbleMenu";
 import { TableBubbleMenu } from "./TiptapEditor/TableBubbleMenu";
 import { EditorRecommendationBar } from "@/components/editor/TiptapEditor/EditorRecommendationBar";
 import { useTiptapEditorController } from "./TiptapEditor/useTiptapEditorController";
+import { SlashAgentLoadingOverlay } from "./TiptapEditor/SlashAgentLoadingOverlay";
 
 // Re-export types for consumers
 export type { ContentError } from "./TiptapEditor/useContentSanitizer";
@@ -41,6 +43,7 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
   wikiContentForCollab,
   onWikiContentApplied,
 }) => {
+  const { t } = useTranslation();
   const {
     editor,
     editorFontSizePx,
@@ -72,6 +75,9 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
     storageSetupDialogOpen,
     setStorageSetupDialogOpen,
     handleGoToStorageSettings,
+    slashAgentBusy,
+    claudeAgentSlashAvailable,
+    onSlashAgentBusyChange,
   } = useTiptapEditorController({
     content,
     onChange,
@@ -131,8 +137,11 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
           position={slashPos}
           suggestionRef={slashRef}
           onClose={handleSlashClose}
+          claudeAgentSlashAvailable={claudeAgentSlashAvailable}
+          onAgentBusyChange={onSlashAgentBusyChange}
         />
       )}
+      {slashAgentBusy ? <SlashAgentLoadingOverlay label={t("editor.slashAgentRunning")} /> : null}
       <MermaidGeneratorDialog
         open={mermaidDialogOpen}
         onOpenChange={setMermaidDialogOpen}

--- a/src/components/editor/TiptapEditor/SlashAgentLoadingOverlay.tsx
+++ b/src/components/editor/TiptapEditor/SlashAgentLoadingOverlay.tsx
@@ -18,7 +18,7 @@ interface SlashAgentLoadingOverlayProps {
 export function SlashAgentLoadingOverlay({ label }: SlashAgentLoadingOverlayProps) {
   return (
     <div
-      className="bg-background/80 pointer-events-none absolute inset-0 z-40 flex items-center justify-center"
+      className="bg-background/80 absolute inset-0 z-40 flex items-center justify-center"
       aria-busy="true"
       aria-live="polite"
     >

--- a/src/components/editor/TiptapEditor/SlashAgentLoadingOverlay.tsx
+++ b/src/components/editor/TiptapEditor/SlashAgentLoadingOverlay.tsx
@@ -1,0 +1,31 @@
+/**
+ * Full-bleed overlay while a Claude Code slash command runs.
+ * Claude Code スラッシュ実行中のオーバーレイ。
+ */
+
+import React from "react";
+import { Loader2 } from "lucide-react";
+
+interface SlashAgentLoadingOverlayProps {
+  /** i18n label (e.g. editor.slashAgentRunning). / 表示ラベル */
+  label: string;
+}
+
+/**
+ * Blocks interaction with the editor shell while the agent runs.
+ * エージェント実行中はエディタ操作をブロックする表示。
+ */
+export function SlashAgentLoadingOverlay({ label }: SlashAgentLoadingOverlayProps) {
+  return (
+    <div
+      className="bg-background/80 pointer-events-none absolute inset-0 z-40 flex items-center justify-center"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <div className="border-border bg-popover text-foreground flex items-center gap-2 rounded-lg border px-4 py-3 shadow-md">
+        <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+        <span className="text-sm">{label}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/TiptapEditor/SlashAgentLoadingOverlay.tsx
+++ b/src/components/editor/TiptapEditor/SlashAgentLoadingOverlay.tsx
@@ -3,7 +3,7 @@
  * Claude Code スラッシュ実行中のオーバーレイ。
  */
 
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { Loader2 } from "lucide-react";
 
 interface SlashAgentLoadingOverlayProps {
@@ -16,11 +16,24 @@ interface SlashAgentLoadingOverlayProps {
  * エージェント実行中はエディタ操作をブロックする表示。
  */
 export function SlashAgentLoadingOverlay({ label }: SlashAgentLoadingOverlayProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    rootRef.current?.focus({ preventScroll: true });
+  }, []);
+
   return (
     <div
-      className="bg-background/80 absolute inset-0 z-40 flex items-center justify-center"
+      ref={rootRef}
+      tabIndex={-1}
+      className="bg-background/80 absolute inset-0 z-40 flex items-center justify-center outline-none"
       aria-busy="true"
       aria-live="polite"
+      role="presentation"
+      onKeyDown={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
     >
       <div className="border-border bg-popover text-foreground flex items-center gap-2 rounded-lg border px-4 py-3 shadow-md">
         <Loader2 className="h-5 w-5 animate-spin" aria-hidden />

--- a/src/components/editor/TiptapEditor/SlashMenuRows.tsx
+++ b/src/components/editor/TiptapEditor/SlashMenuRows.tsx
@@ -1,0 +1,74 @@
+/**
+ * Renders block + agent slash menu rows.
+ * ブロック＋エージェントのスラッシュ行を描画する。
+ */
+
+import React from "react";
+import { cn } from "@zedi/ui";
+import { Bot } from "lucide-react";
+import { slashMenuIconMap, agentSlashIconName } from "./slashSuggestionIcons";
+import type { UnifiedSlashMenuItem } from "./slashAgentMenuHelpers";
+interface SlashMenuRowsProps {
+  items: UnifiedSlashMenuItem[];
+  selectedIndex: number;
+  onSelectIndex: (index: number) => void;
+  t: (key: string) => string;
+}
+
+/**
+ * Listbox rows for slash commands.
+ * スラッシュコマンドの listbox 行。
+ */
+export function SlashMenuRows({ items, selectedIndex, onSelectIndex, t }: SlashMenuRowsProps) {
+  return (
+    <>
+      {items.map((entry, index) => {
+        if (entry.kind === "block") {
+          const item = entry.item;
+          const Icon = slashMenuIconMap[item.icon];
+          return (
+            <button
+              key={item.id}
+              role="option"
+              aria-selected={index === selectedIndex}
+              onClick={() => onSelectIndex(index)}
+              className={cn(
+                "flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors",
+                index === selectedIndex ? "bg-accent text-accent-foreground" : "hover:bg-muted",
+              )}
+            >
+              {Icon && <Icon className="text-muted-foreground h-4 w-4 shrink-0" />}
+              <div className="flex min-w-0 flex-col">
+                <span className="truncate font-medium">{t(`editor.slash.${item.id}.title`)}</span>
+                <span className="text-muted-foreground truncate text-xs">
+                  {t(`editor.slash.${item.id}.description`)}
+                </span>
+              </div>
+            </button>
+          );
+        }
+        const Icon = slashMenuIconMap[agentSlashIconName[entry.id]] ?? Bot;
+        return (
+          <button
+            key={entry.id}
+            role="option"
+            aria-selected={index === selectedIndex}
+            onClick={() => onSelectIndex(index)}
+            className={cn(
+              "flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors",
+              index === selectedIndex ? "bg-accent text-accent-foreground" : "hover:bg-muted",
+            )}
+          >
+            <Icon className="text-muted-foreground h-4 w-4 shrink-0" />
+            <div className="flex min-w-0 flex-col">
+              <span className="truncate font-medium">{t(`editor.slash.${entry.id}.title`)}</span>
+              <span className="text-muted-foreground truncate text-xs">
+                {t(`editor.slash.${entry.id}.description`)}
+              </span>
+            </div>
+          </button>
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/editor/TiptapEditor/SlashPathCompletionSection.tsx
+++ b/src/components/editor/TiptapEditor/SlashPathCompletionSection.tsx
@@ -3,26 +3,29 @@
  * メインスラッシュメニュー下のワークスペースパス補完一覧。
  */
 
-import React from "react";
+import React, { forwardRef } from "react";
+import { cn } from "@zedi/ui";
 
 interface SlashPathCompletionSectionProps {
   suggestions: string[];
   onPick: (name: string) => void;
   t: (key: string) => string;
+  /** Highlighted row when navigating with keyboard (-1 = none). / キーボード選択行（-1 でなし） */
+  selectedIndex: number;
 }
 
 /**
  * Secondary list of path name suggestions (Tauri workspace).
  * パス名候補のセカンダリ一覧（Tauri ワークスペース）。
  */
-export function SlashPathCompletionSection({
-  suggestions,
-  onPick,
-  t,
-}: SlashPathCompletionSectionProps) {
+export const SlashPathCompletionSection = forwardRef<
+  HTMLDivElement,
+  SlashPathCompletionSectionProps
+>(function SlashPathCompletionSection({ suggestions, onPick, t, selectedIndex }, ref) {
   if (suggestions.length === 0) return null;
   return (
     <div
+      ref={ref}
       className="border-border max-h-[160px] overflow-y-auto border-t p-1"
       role="group"
       aria-label={t("editor.slashPathCompletionAriaLabel")}
@@ -30,16 +33,21 @@ export function SlashPathCompletionSection({
       <div className="text-muted-foreground px-2 py-1 text-xs">
         {t("editor.slashPathCompletionHint")}
       </div>
-      {suggestions.map((p) => (
+      {suggestions.map((p, i) => (
         <button
           key={p}
           type="button"
           onClick={() => onPick(p)}
-          className="hover:bg-muted block w-full truncate rounded px-2 py-1.5 text-left text-sm"
+          className={cn(
+            "hover:bg-muted block w-full truncate rounded px-2 py-1.5 text-left text-sm",
+            selectedIndex === i && "bg-muted",
+          )}
         >
           {p}
         </button>
       ))}
     </div>
   );
-}
+});
+
+SlashPathCompletionSection.displayName = "SlashPathCompletionSection";

--- a/src/components/editor/TiptapEditor/SlashPathCompletionSection.tsx
+++ b/src/components/editor/TiptapEditor/SlashPathCompletionSection.tsx
@@ -24,7 +24,7 @@ export function SlashPathCompletionSection({
   return (
     <div
       className="border-border max-h-[160px] overflow-y-auto border-t p-1"
-      role="listbox"
+      role="group"
       aria-label={t("editor.slashPathCompletionAriaLabel")}
     >
       <div className="text-muted-foreground px-2 py-1 text-xs">

--- a/src/components/editor/TiptapEditor/SlashPathCompletionSection.tsx
+++ b/src/components/editor/TiptapEditor/SlashPathCompletionSection.tsx
@@ -1,0 +1,45 @@
+/**
+ * Workspace path completion list below the main slash menu.
+ * メインスラッシュメニュー下のワークスペースパス補完一覧。
+ */
+
+import React from "react";
+
+interface SlashPathCompletionSectionProps {
+  suggestions: string[];
+  onPick: (name: string) => void;
+  t: (key: string) => string;
+}
+
+/**
+ * Secondary list of path name suggestions (Tauri workspace).
+ * パス名候補のセカンダリ一覧（Tauri ワークスペース）。
+ */
+export function SlashPathCompletionSection({
+  suggestions,
+  onPick,
+  t,
+}: SlashPathCompletionSectionProps) {
+  if (suggestions.length === 0) return null;
+  return (
+    <div
+      className="border-border max-h-[160px] overflow-y-auto border-t p-1"
+      role="listbox"
+      aria-label={t("editor.slashPathCompletionAriaLabel")}
+    >
+      <div className="text-muted-foreground px-2 py-1 text-xs">
+        {t("editor.slashPathCompletionHint")}
+      </div>
+      {suggestions.map((p) => (
+        <button
+          key={p}
+          type="button"
+          onClick={() => onPick(p)}
+          className="hover:bg-muted block w-full truncate rounded px-2 py-1.5 text-left text-sm"
+        >
+          {p}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/editor/TiptapEditor/SlashSuggestionLayer.tsx
+++ b/src/components/editor/TiptapEditor/SlashSuggestionLayer.tsx
@@ -1,197 +1,40 @@
-import React, {
-  useState,
-  useEffect,
-  useCallback,
-  useImperativeHandle,
-  forwardRef,
-  useRef,
-} from "react";
+/**
+ * Floating slash menu wrapper (positioning only).
+ * スラッシュメニューのフローティングラッパー（位置のみ）。
+ */
+
+import React from "react";
 import type { Editor } from "@tiptap/core";
 import type { SlashSuggestionState } from "../extensions/slashSuggestionPlugin";
-import { slashCommandItems, filterSlashCommandItems } from "./slashCommandItems";
-import { cn } from "@zedi/ui";
-import { useTranslation } from "react-i18next";
-import {
-  Pilcrow,
-  Heading1,
-  Heading2,
-  Heading3,
-  List,
-  ListOrdered,
-  CheckSquare,
-  Quote,
-  Code2,
-  Minus,
-  Table,
-  ImagePlus,
-  GitBranch,
-  Sigma,
-  Radical,
-} from "lucide-react";
+import { SlashSuggestionMenu } from "./SlashSuggestionMenu";
+import type { SlashSuggestionHandle } from "./slashSuggestionHandle";
 
-/** Map icon name string → Lucide component */
-const iconMap: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
-  Pilcrow,
-  Heading1,
-  Heading2,
-  Heading3,
-  List,
-  ListOrdered,
-  CheckSquare,
-  Quote,
-  Code2,
-  Minus,
-  Table,
-  ImagePlus,
-  GitBranch,
-  Sigma,
-  Radical,
-};
-
-/**
- *
- */
-export interface SlashSuggestionHandle {
-  onKeyDown: (event: KeyboardEvent) => boolean;
-}
+export type { SlashSuggestionHandle } from "./slashSuggestionHandle";
 
 interface SlashSuggestionLayerProps {
   editor: Editor | null;
   suggestionState: SlashSuggestionState | null;
   position: { top: number; left: number } | null;
-  suggestionRef: React.RefObject<SlashSuggestionHandle>;
+  suggestionRef: React.RefObject<SlashSuggestionHandle | null>;
   onClose: () => void;
+  /** When false, agent rows are omitted (web or Claude CLI missing). / false ならエージェント行を出さない */
+  claudeAgentSlashAvailable: boolean;
+  /** Fires while Claude Code runs for an agent command. / エージェント実行中 */
+  onAgentBusyChange?: (busy: boolean) => void;
 }
 
-const SlashSuggestionMenu = forwardRef<
-  SlashSuggestionHandle,
-  {
-    editor: Editor;
-    query: string;
-    range: { from: number; to: number };
-    onClose: () => void;
-  }
->(({ editor, query, range, onClose }, ref) => {
-  const { t } = useTranslation();
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const listRef = useRef<HTMLDivElement>(null);
-
-  const items = filterSlashCommandItems(slashCommandItems, query, editor, t);
-
-  // Reset selection when query changes
-  useEffect(() => {
-    queueMicrotask(() => setSelectedIndex(0));
-  }, [query]);
-
-  const selectItem = useCallback(
-    (index: number) => {
-      const item = items[index];
-      if (item) {
-        item.action(editor, range);
-        onClose();
-      }
-    },
-    [items, editor, range, onClose],
-  );
-
-  // Scroll selected item into view
-  useEffect(() => {
-    if (!listRef.current) return;
-    const buttons = listRef.current.querySelectorAll("button");
-    const target = buttons[selectedIndex];
-    if (target) {
-      target.scrollIntoView({ block: "nearest" });
-    }
-  }, [selectedIndex]);
-
-  useImperativeHandle(ref, () => ({
-    onKeyDown: (event: KeyboardEvent) => {
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        setSelectedIndex((prev) => (prev <= 0 ? items.length - 1 : prev - 1));
-        return true;
-      }
-
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        setSelectedIndex((prev) => (prev >= items.length - 1 ? 0 : prev + 1));
-        return true;
-      }
-
-      if (event.key === "Enter") {
-        event.preventDefault();
-        selectItem(selectedIndex);
-        return true;
-      }
-
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-        return true;
-      }
-
-      return false;
-    },
-  }));
-
-  if (items.length === 0) {
-    return (
-      <div className="shadow-elevated animate-fade-in border-border bg-popover min-w-[240px] overflow-hidden rounded-lg border">
-        <div className="text-muted-foreground px-3 py-2 text-sm">{t("editor.slashNoResults")}</div>
-      </div>
-    );
-  }
-
-  return (
-    <div
-      ref={listRef}
-      className="shadow-elevated animate-fade-in border-border bg-popover max-h-[320px] max-w-[320px] min-w-[240px] overflow-hidden overflow-y-auto rounded-lg border"
-      role="listbox"
-      aria-label={t("editor.slashMenuAriaLabel")}
-    >
-      <div className="p-1">
-        {items.map((item, index) => {
-          const Icon = iconMap[item.icon];
-          return (
-            <button
-              key={item.id}
-              role="option"
-              aria-selected={index === selectedIndex}
-              onClick={() => selectItem(index)}
-              className={cn(
-                "flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors",
-                index === selectedIndex ? "bg-accent text-accent-foreground" : "hover:bg-muted",
-              )}
-            >
-              {Icon && <Icon className="text-muted-foreground h-4 w-4 shrink-0" />}
-              <div className="flex min-w-0 flex-col">
-                <span className="truncate font-medium">{t(`editor.slash.${item.id}.title`)}</span>
-                <span className="text-muted-foreground truncate text-xs">
-                  {t(`editor.slash.${item.id}.description`)}
-                </span>
-              </div>
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-});
-
-SlashSuggestionMenu.displayName = "SlashSuggestionMenu";
-
 /**
- *
+ * Positions the slash menu under the `/` trigger.
+ * `/` トリガー下にスラッシュメニューを配置する。
  */
-export /**
- *
- */
-const SlashSuggestionLayer: React.FC<SlashSuggestionLayerProps> = ({
+export const SlashSuggestionLayer: React.FC<SlashSuggestionLayerProps> = ({
   editor,
   suggestionState,
   position,
   suggestionRef,
   onClose,
+  claudeAgentSlashAvailable,
+  onAgentBusyChange,
 }) => {
   if (!suggestionState?.active || !suggestionState.range || !position || !editor) return null;
 
@@ -209,6 +52,8 @@ const SlashSuggestionLayer: React.FC<SlashSuggestionLayerProps> = ({
         query={suggestionState.query}
         range={suggestionState.range}
         onClose={onClose}
+        claudeAgentSlashAvailable={claudeAgentSlashAvailable}
+        onAgentBusyChange={onAgentBusyChange}
       />
     </div>
   );

--- a/src/components/editor/TiptapEditor/SlashSuggestionMenu.tsx
+++ b/src/components/editor/TiptapEditor/SlashSuggestionMenu.tsx
@@ -3,174 +3,34 @@
  * スラッシュコマンドメニュー本体（ref でキーボード）。ブロック＋任意の Claude エージェント行。
  */
 
-import React, {
-  useState,
-  useEffect,
-  useCallback,
-  useImperativeHandle,
-  forwardRef,
-  useRef,
-  useMemo,
-} from "react";
-import type { Editor } from "@tiptap/core";
-import { useToast } from "@zedi/ui";
-import { useTranslation } from "react-i18next";
-import type { AgentSlashCommandId } from "@/lib/agentSlashCommands/types";
-import { executeAgentSlashCommand } from "@/lib/agentSlashCommands/executeAgentSlashCommand";
-import {
-  matchAgentSlashByQuery,
-  shouldOfferPathCompletion,
-} from "@/lib/agentSlashCommands/parseAgentSlashQuery";
-import { useWorkspacePathCompletions } from "./useWorkspacePathCompletions";
-import { mergeSlashItems, buildNewArgsFromPick } from "./slashAgentMenuHelpers";
+import React, { forwardRef } from "react";
 import { SlashMenuRows } from "./SlashMenuRows";
 import { SlashPathCompletionSection } from "./SlashPathCompletionSection";
 import type { SlashSuggestionHandle } from "./slashSuggestionHandle";
+import { useSlashSuggestionMenu } from "./useSlashSuggestionMenu";
+import type { SlashSuggestionMenuProps } from "./slashSuggestionMenuProps";
 
-/** Props for {@link SlashSuggestionMenu}. / {@link SlashSuggestionMenu} の props */
-export interface SlashSuggestionMenuProps {
-  editor: Editor;
-  query: string;
-  range: { from: number; to: number };
-  onClose: () => void;
-  claudeAgentSlashAvailable: boolean;
-  onAgentBusyChange?: (busy: boolean) => void;
-}
+export type { SlashSuggestionMenuProps };
 
 /**
  * Slash menu with imperative keyboard handler for the editor keydown bridge.
  * エディタの keydown ブリッジ用の命令型キーボードハンドラ付きスラッシュメニュー。
  */
 export const SlashSuggestionMenu = forwardRef<SlashSuggestionHandle, SlashSuggestionMenuProps>(
-  ({ editor, query, range, onClose, claudeAgentSlashAvailable, onAgentBusyChange }, ref) => {
-    const { t } = useTranslation();
-    const { toast } = useToast();
-    const [selectedIndex, setSelectedIndex] = useState(0);
-    const listRef = useRef<HTMLDivElement>(null);
-
-    const items = useMemo(
-      () => mergeSlashItems(query, editor, t, claudeAgentSlashAvailable),
-      [query, editor, t, claudeAgentSlashAvailable],
-    );
-
-    const pathMatch = matchAgentSlashByQuery(query);
-    const pathCompletionEnabled =
-      claudeAgentSlashAvailable && shouldOfferPathCompletion(query) && pathMatch !== null;
-    const pathArgs = pathMatch?.args ?? "";
-    const pathSuggestions = useWorkspacePathCompletions(pathArgs, pathCompletionEnabled);
-
-    useEffect(() => {
-      queueMicrotask(() => setSelectedIndex(0));
-    }, [query]);
-
-    useEffect(() => {
-      setSelectedIndex((i) => {
-        if (items.length === 0) return 0;
-        return Math.min(i, items.length - 1);
-      });
-    }, [items.length]);
-
-    const runAgentCommand = useCallback(
-      async (id: AgentSlashCommandId) => {
-        onClose();
-        onAgentBusyChange?.(true);
-        try {
-          const err = await executeAgentSlashCommand({
-            commandId: id,
-            query,
-            editor,
-            range,
-          });
-          if (err) {
-            toast({
-              title: t("editor.slashAgent.errorTitle"),
-              description: err,
-              variant: "destructive",
-            });
-          }
-        } finally {
-          onAgentBusyChange?.(false);
-        }
-      },
-      [onClose, onAgentBusyChange, query, editor, range, toast, t],
-    );
-
-    const selectItem = useCallback(
-      async (index: number) => {
-        const entry = items[index];
-        if (!entry) return;
-        if (entry.kind === "block") {
-          entry.item.action(editor, range);
-          onClose();
-          return;
-        }
-        await runAgentCommand(entry.id);
-      },
-      [items, editor, range, onClose, runAgentCommand],
-    );
-
-    const applyPathPick = useCallback(
-      (picked: string) => {
-        const m = matchAgentSlashByQuery(query);
-        if (!m) return;
-        const newArgs = buildNewArgsFromPick(pathArgs, picked);
-        const newQuery = `${m.prefix} ${newArgs}`.trim();
-        editor.chain().focus().deleteRange(range).insertContent(`/${newQuery} `).run();
-      },
-      [editor, query, range, pathArgs],
-    );
-
-    useEffect(() => {
-      if (!listRef.current) return;
-      const buttons = listRef.current.querySelectorAll("button");
-      const target = buttons[selectedIndex];
-      if (target) {
-        target.scrollIntoView({ block: "nearest" });
-      }
-    }, [selectedIndex]);
-
-    useImperativeHandle(
-      ref,
-      () => ({
-        onKeyDown: (event: KeyboardEvent) => {
-          if (items.length === 0) {
-            if (event.key === "Escape") {
-              event.preventDefault();
-              onClose();
-              return true;
-            }
-            return false;
-          }
-
-          if (event.key === "ArrowUp") {
-            event.preventDefault();
-            setSelectedIndex((prev) => (prev <= 0 ? items.length - 1 : prev - 1));
-            return true;
-          }
-
-          if (event.key === "ArrowDown") {
-            event.preventDefault();
-            setSelectedIndex((prev) => (prev >= items.length - 1 ? 0 : prev + 1));
-            return true;
-          }
-
-          if (event.key === "Enter") {
-            event.preventDefault();
-            void selectItem(selectedIndex);
-            return true;
-          }
-
-          if (event.key === "Escape") {
-            event.preventDefault();
-            onClose();
-            return true;
-          }
-
-          return false;
-        },
-      }),
-      [items, onClose, selectItem, selectedIndex],
-    );
+  (props, ref) => {
+    const {
+      t,
+      items,
+      listRef,
+      pathSectionRef,
+      selectedIndex,
+      pathCompletionEnabled,
+      pathSuggestions,
+      pathSectionActive,
+      pathSelectedIndex,
+      selectItem,
+      applyPathPick,
+    } = useSlashSuggestionMenu(props, ref);
 
     if (items.length === 0) {
       return (
@@ -198,7 +58,13 @@ export const SlashSuggestionMenu = forwardRef<SlashSuggestionHandle, SlashSugges
           />
         </div>
         {pathCompletionEnabled && pathSuggestions.length > 0 ? (
-          <SlashPathCompletionSection suggestions={pathSuggestions} onPick={applyPathPick} t={t} />
+          <SlashPathCompletionSection
+            ref={pathSectionRef}
+            suggestions={pathSuggestions}
+            onPick={applyPathPick}
+            t={t}
+            selectedIndex={pathSectionActive ? pathSelectedIndex : -1}
+          />
         ) : null}
       </div>
     );

--- a/src/components/editor/TiptapEditor/SlashSuggestionMenu.tsx
+++ b/src/components/editor/TiptapEditor/SlashSuggestionMenu.tsx
@@ -1,0 +1,188 @@
+/**
+ * Slash command menu content (keyboard via ref). Blocks + optional Claude agent rows.
+ * スラッシュコマンドメニュー本体（ref でキーボード）。ブロック＋任意の Claude エージェント行。
+ */
+
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useImperativeHandle,
+  forwardRef,
+  useRef,
+  useMemo,
+} from "react";
+import type { Editor } from "@tiptap/core";
+import { useToast } from "@zedi/ui";
+import { useTranslation } from "react-i18next";
+import type { AgentSlashCommandId } from "@/lib/agentSlashCommands/types";
+import { executeAgentSlashCommand } from "@/lib/agentSlashCommands/executeAgentSlashCommand";
+import {
+  matchAgentSlashByQuery,
+  shouldOfferPathCompletion,
+} from "@/lib/agentSlashCommands/parseAgentSlashQuery";
+import { useWorkspacePathCompletions } from "./useWorkspacePathCompletions";
+import { mergeSlashItems, buildNewArgsFromPick } from "./slashAgentMenuHelpers";
+import { SlashMenuRows } from "./SlashMenuRows";
+import { SlashPathCompletionSection } from "./SlashPathCompletionSection";
+import type { SlashSuggestionHandle } from "./slashSuggestionHandle";
+
+/** Props for {@link SlashSuggestionMenu}. / {@link SlashSuggestionMenu} の props */
+export interface SlashSuggestionMenuProps {
+  editor: Editor;
+  query: string;
+  range: { from: number; to: number };
+  onClose: () => void;
+  claudeAgentSlashAvailable: boolean;
+  onAgentBusyChange?: (busy: boolean) => void;
+}
+
+/**
+ * Slash menu with imperative keyboard handler for the editor keydown bridge.
+ * エディタの keydown ブリッジ用の命令型キーボードハンドラ付きスラッシュメニュー。
+ */
+export const SlashSuggestionMenu = forwardRef<SlashSuggestionHandle, SlashSuggestionMenuProps>(
+  ({ editor, query, range, onClose, claudeAgentSlashAvailable, onAgentBusyChange }, ref) => {
+    const { t } = useTranslation();
+    const { toast } = useToast();
+    const [selectedIndex, setSelectedIndex] = useState(0);
+    const listRef = useRef<HTMLDivElement>(null);
+
+    const items = useMemo(
+      () => mergeSlashItems(query, editor, t, claudeAgentSlashAvailable),
+      [query, editor, t, claudeAgentSlashAvailable],
+    );
+
+    const pathMatch = matchAgentSlashByQuery(query);
+    const pathCompletionEnabled =
+      claudeAgentSlashAvailable && shouldOfferPathCompletion(query) && pathMatch !== null;
+    const pathArgs = pathMatch?.args ?? "";
+    const pathSuggestions = useWorkspacePathCompletions(pathArgs, pathCompletionEnabled);
+
+    useEffect(() => {
+      queueMicrotask(() => setSelectedIndex(0));
+    }, [query]);
+
+    const runAgentCommand = useCallback(
+      async (id: AgentSlashCommandId) => {
+        onClose();
+        onAgentBusyChange?.(true);
+        try {
+          const err = await executeAgentSlashCommand({
+            commandId: id,
+            query,
+            editor,
+            range,
+          });
+          if (err) {
+            toast({
+              title: t("editor.slashAgent.errorTitle"),
+              description: err,
+              variant: "destructive",
+            });
+          }
+        } finally {
+          onAgentBusyChange?.(false);
+        }
+      },
+      [onClose, onAgentBusyChange, query, editor, range, toast, t],
+    );
+
+    const selectItem = useCallback(
+      async (index: number) => {
+        const entry = items[index];
+        if (!entry) return;
+        if (entry.kind === "block") {
+          entry.item.action(editor, range);
+          onClose();
+          return;
+        }
+        await runAgentCommand(entry.id);
+      },
+      [items, editor, range, onClose, runAgentCommand],
+    );
+
+    const applyPathPick = useCallback(
+      (picked: string) => {
+        const m = matchAgentSlashByQuery(query);
+        if (!m) return;
+        const newArgs = buildNewArgsFromPick(pathArgs, picked);
+        const newQuery = `${m.prefix} ${newArgs}`.trim();
+        editor.chain().focus().deleteRange(range).insertContent(`/${newQuery} `).run();
+      },
+      [editor, query, range, pathArgs],
+    );
+
+    useEffect(() => {
+      if (!listRef.current) return;
+      const buttons = listRef.current.querySelectorAll("button");
+      const target = buttons[selectedIndex];
+      if (target) {
+        target.scrollIntoView({ block: "nearest" });
+      }
+    }, [selectedIndex]);
+
+    useImperativeHandle(ref, () => ({
+      onKeyDown: (event: KeyboardEvent) => {
+        if (event.key === "ArrowUp") {
+          event.preventDefault();
+          setSelectedIndex((prev) => (prev <= 0 ? items.length - 1 : prev - 1));
+          return true;
+        }
+
+        if (event.key === "ArrowDown") {
+          event.preventDefault();
+          setSelectedIndex((prev) => (prev >= items.length - 1 ? 0 : prev + 1));
+          return true;
+        }
+
+        if (event.key === "Enter") {
+          event.preventDefault();
+          void selectItem(selectedIndex);
+          return true;
+        }
+
+        if (event.key === "Escape") {
+          event.preventDefault();
+          onClose();
+          return true;
+        }
+
+        return false;
+      },
+    }));
+
+    if (items.length === 0) {
+      return (
+        <div className="shadow-elevated animate-fade-in border-border bg-popover min-w-[240px] overflow-hidden rounded-lg border">
+          <div className="text-muted-foreground px-3 py-2 text-sm">
+            {t("editor.slashNoResults")}
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="shadow-elevated animate-fade-in border-border bg-popover max-w-[min(420px,90vw)] min-w-[240px] overflow-hidden rounded-lg border">
+        <div
+          ref={listRef}
+          className="max-h-[320px] overflow-y-auto p-1"
+          role="listbox"
+          aria-label={t("editor.slashMenuAriaLabel")}
+        >
+          <SlashMenuRows
+            items={items}
+            selectedIndex={selectedIndex}
+            onSelectIndex={(i) => void selectItem(i)}
+            t={t}
+          />
+        </div>
+        {pathCompletionEnabled && pathSuggestions.length > 0 ? (
+          <SlashPathCompletionSection suggestions={pathSuggestions} onPick={applyPathPick} t={t} />
+        ) : null}
+      </div>
+    );
+  },
+);
+
+SlashSuggestionMenu.displayName = "SlashSuggestionMenu";

--- a/src/components/editor/TiptapEditor/SlashSuggestionMenu.tsx
+++ b/src/components/editor/TiptapEditor/SlashSuggestionMenu.tsx
@@ -63,6 +63,13 @@ export const SlashSuggestionMenu = forwardRef<SlashSuggestionHandle, SlashSugges
       queueMicrotask(() => setSelectedIndex(0));
     }, [query]);
 
+    useEffect(() => {
+      setSelectedIndex((i) => {
+        if (items.length === 0) return 0;
+        return Math.min(i, items.length - 1);
+      });
+    }, [items.length]);
+
     const runAgentCommand = useCallback(
       async (id: AgentSlashCommandId) => {
         onClose();
@@ -122,35 +129,48 @@ export const SlashSuggestionMenu = forwardRef<SlashSuggestionHandle, SlashSugges
       }
     }, [selectedIndex]);
 
-    useImperativeHandle(ref, () => ({
-      onKeyDown: (event: KeyboardEvent) => {
-        if (event.key === "ArrowUp") {
-          event.preventDefault();
-          setSelectedIndex((prev) => (prev <= 0 ? items.length - 1 : prev - 1));
-          return true;
-        }
+    useImperativeHandle(
+      ref,
+      () => ({
+        onKeyDown: (event: KeyboardEvent) => {
+          if (items.length === 0) {
+            if (event.key === "Escape") {
+              event.preventDefault();
+              onClose();
+              return true;
+            }
+            return false;
+          }
 
-        if (event.key === "ArrowDown") {
-          event.preventDefault();
-          setSelectedIndex((prev) => (prev >= items.length - 1 ? 0 : prev + 1));
-          return true;
-        }
+          if (event.key === "ArrowUp") {
+            event.preventDefault();
+            setSelectedIndex((prev) => (prev <= 0 ? items.length - 1 : prev - 1));
+            return true;
+          }
 
-        if (event.key === "Enter") {
-          event.preventDefault();
-          void selectItem(selectedIndex);
-          return true;
-        }
+          if (event.key === "ArrowDown") {
+            event.preventDefault();
+            setSelectedIndex((prev) => (prev >= items.length - 1 ? 0 : prev + 1));
+            return true;
+          }
 
-        if (event.key === "Escape") {
-          event.preventDefault();
-          onClose();
-          return true;
-        }
+          if (event.key === "Enter") {
+            event.preventDefault();
+            void selectItem(selectedIndex);
+            return true;
+          }
 
-        return false;
-      },
-    }));
+          if (event.key === "Escape") {
+            event.preventDefault();
+            onClose();
+            return true;
+          }
+
+          return false;
+        },
+      }),
+      [items, onClose, selectItem, selectedIndex],
+    );
 
     if (items.length === 0) {
       return (

--- a/src/components/editor/TiptapEditor/slashAgentMenuHelpers.ts
+++ b/src/components/editor/TiptapEditor/slashAgentMenuHelpers.ts
@@ -37,8 +37,17 @@ export function filterAgentSlashItems(query: string, t: TFunction): AgentSlashCo
     const aliasesStr = t(`editor.slash.${def.id}.aliases`);
     const aliases = aliasesStr ? aliasesStr.split(",").map((s) => s.trim().toLowerCase()) : [];
     let ok = false;
-    if (title.includes(q)) ok = true;
-    else if (aliases.some((a) => a.includes(q) || q.includes(a))) ok = true;
+    if (firstToken && title.includes(firstToken)) ok = true;
+    else if (
+      firstToken &&
+      aliases.some(
+        (a) =>
+          (firstToken.length >= 2 && a.includes(firstToken)) ||
+          firstToken.startsWith(a) ||
+          a.startsWith(firstToken),
+      )
+    )
+      ok = true;
     else if (def.prefix.startsWith(firstToken) || firstToken.startsWith(def.prefix)) ok = true;
     else if (def.aliases?.some((a) => a.startsWith(firstToken) || firstToken.startsWith(a)))
       ok = true;

--- a/src/components/editor/TiptapEditor/slashAgentMenuHelpers.ts
+++ b/src/components/editor/TiptapEditor/slashAgentMenuHelpers.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure helpers for merging block + agent slash menu items.
+ * ブロック＋エージェントのスラッシュ項目をマージする純粋ヘルパー。
+ */
+
+import type { Editor } from "@tiptap/core";
+import type { AgentSlashCommandId } from "@/lib/agentSlashCommands/types";
+import { AGENT_SLASH_PREFIXES } from "@/lib/agentSlashCommands/parseAgentSlashQuery";
+import {
+  slashCommandItems,
+  filterSlashCommandItems,
+  type SlashCommandItem,
+} from "./slashCommandItems";
+import { parsePathCompletionArgs } from "./useWorkspacePathCompletions";
+
+/** One row in the unified slash menu. / 統合スラッシュメニューの 1 行 */
+export type UnifiedSlashMenuItem =
+  | { kind: "block"; item: SlashCommandItem }
+  | { kind: "agent"; id: AgentSlashCommandId };
+
+type TFunction = (key: string) => string;
+
+/**
+ * Filters agent command ids by query (title / aliases / prefix).
+ * クエリでエージェントコマンド ID を絞り込む。
+ */
+export function filterAgentSlashItems(query: string, t: TFunction): AgentSlashCommandId[] {
+  const q = query.toLowerCase().trim();
+  const firstToken = q.split(/\s+/)[0] ?? "";
+  const out: AgentSlashCommandId[] = [];
+  for (const def of AGENT_SLASH_PREFIXES) {
+    if (!q) {
+      out.push(def.id);
+      continue;
+    }
+    const title = t(`editor.slash.${def.id}.title`).toLowerCase();
+    const aliasesStr = t(`editor.slash.${def.id}.aliases`);
+    const aliases = aliasesStr ? aliasesStr.split(",").map((s) => s.trim().toLowerCase()) : [];
+    let ok = false;
+    if (title.includes(q)) ok = true;
+    else if (aliases.some((a) => a.includes(q) || q.includes(a))) ok = true;
+    else if (def.prefix.startsWith(firstToken) || firstToken.startsWith(def.prefix)) ok = true;
+    else if (def.aliases?.some((a) => a.startsWith(firstToken) || firstToken.startsWith(a)))
+      ok = true;
+    if (ok) out.push(def.id);
+  }
+  return out;
+}
+
+/**
+ * Merges filtered block items and (optionally) agent items.
+ * ブロック項目と（任意で）エージェント項目をマージする。
+ */
+export function mergeSlashItems(
+  query: string,
+  editor: Editor,
+  t: TFunction,
+  claudeAgentAvailable: boolean,
+): UnifiedSlashMenuItem[] {
+  const blocks = filterSlashCommandItems([...slashCommandItems], query, editor, t).map((item) => ({
+    kind: "block" as const,
+    item,
+  }));
+  if (!claudeAgentAvailable) return blocks;
+  const agents = filterAgentSlashItems(query, t).map((id) => ({ kind: "agent" as const, id }));
+  return [...blocks, ...agents];
+}
+
+/**
+ * Builds new path args after the user picks a directory entry.
+ * ディレクトリ候補選択後の新しいパス引数を組み立てる。
+ */
+export function buildNewArgsFromPick(currentArgs: string, picked: string): string {
+  const { dir, filePrefix } = parsePathCompletionArgs(currentArgs);
+  if (!filePrefix) {
+    return dir ? `${dir}/${picked}` : picked;
+  }
+  const base = dir ? `${dir}/` : "";
+  return `${base}${picked}`;
+}

--- a/src/components/editor/TiptapEditor/slashSuggestionHandle.ts
+++ b/src/components/editor/TiptapEditor/slashSuggestionHandle.ts
@@ -1,0 +1,7 @@
+/**
+ * Imperative handle for slash menu keyboard forwarding from the editor.
+ * エディタからスラッシュメニューへキーボードを渡すための命令型ハンドル。
+ */
+export interface SlashSuggestionHandle {
+  onKeyDown: (event: KeyboardEvent) => boolean;
+}

--- a/src/components/editor/TiptapEditor/slashSuggestionIcons.tsx
+++ b/src/components/editor/TiptapEditor/slashSuggestionIcons.tsx
@@ -1,0 +1,71 @@
+/**
+ * Lucide icon map for slash menu (blocks + agent commands).
+ * スラッシュメニュー用の Lucide アイコンマップ。
+ */
+
+import type { FC, SVGProps } from "react";
+import {
+  Pilcrow,
+  Heading1,
+  Heading2,
+  Heading3,
+  List,
+  ListOrdered,
+  CheckSquare,
+  Quote,
+  Code2,
+  Minus,
+  Table,
+  ImagePlus,
+  GitBranch,
+  Sigma,
+  Radical,
+  Terminal,
+  Bot,
+  FileSearch,
+  Search,
+  ListChecks,
+  FlaskConical,
+  HelpCircle,
+  AlignLeft,
+} from "lucide-react";
+import type { AgentSlashCommandId } from "@/lib/agentSlashCommands/types";
+
+/** Map icon name string → Lucide component / アイコン名 → Lucide コンポーネント */
+export const slashMenuIconMap: Record<string, FC<SVGProps<SVGSVGElement>>> = {
+  Pilcrow,
+  Heading1,
+  Heading2,
+  Heading3,
+  List,
+  ListOrdered,
+  CheckSquare,
+  Quote,
+  Code2,
+  Minus,
+  Table,
+  ImagePlus,
+  GitBranch,
+  Sigma,
+  Radical,
+  Terminal,
+  Bot,
+  FileSearch,
+  Search,
+  ListChecks,
+  FlaskConical,
+  HelpCircle,
+  AlignLeft,
+};
+
+/** Agent row icon names (keys into {@link slashMenuIconMap}). / エージェント行のアイコン名 */
+export const agentSlashIconName: Record<AgentSlashCommandId, string> = {
+  "agent-analyze": "FileSearch",
+  "agent-git-summary": "GitBranch",
+  "agent-run": "Terminal",
+  "agent-research": "Search",
+  "agent-review": "ListChecks",
+  "agent-test": "FlaskConical",
+  "agent-explain": "HelpCircle",
+  "agent-summarize": "AlignLeft",
+};

--- a/src/components/editor/TiptapEditor/slashSuggestionMenuKeyDown.test.ts
+++ b/src/components/editor/TiptapEditor/slashSuggestionMenuKeyDown.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi } from "vitest";
+import { handleSlashSuggestionMenuKeyDown } from "./slashSuggestionMenuKeyDown";
+
+function key(name: string): KeyboardEvent {
+  return new KeyboardEvent("keydown", { key: name });
+}
+
+describe("handleSlashSuggestionMenuKeyDown", () => {
+  it("moves focus from last main row to path section on ArrowDown", () => {
+    const setPathSectionActive = vi.fn();
+    const setPathSelectedIndex = vi.fn();
+    const setSelectedIndex = vi.fn();
+    const ev = key("ArrowDown");
+    const prevent = vi.spyOn(ev, "preventDefault");
+    const ok = handleSlashSuggestionMenuKeyDown(
+      ev,
+      {
+        itemsLength: 2,
+        pathCompletionEnabled: true,
+        pathSuggestions: ["src/"],
+        pathSectionActive: false,
+        pathSelectedIndex: 0,
+        selectedIndex: 1,
+      },
+      {
+        setPathSectionActive,
+        setPathSelectedIndex,
+        setSelectedIndex,
+        applyPathPick: vi.fn(),
+        selectItem: vi.fn(),
+        onClose: vi.fn(),
+      },
+    );
+    expect(ok).toBe(true);
+    expect(prevent).toHaveBeenCalled();
+    expect(setPathSectionActive).toHaveBeenCalledWith(true);
+    expect(setPathSelectedIndex).toHaveBeenCalledWith(0);
+  });
+
+  it("applies path pick on Enter when path section is active", () => {
+    const applyPathPick = vi.fn();
+    const ev = key("Enter");
+    vi.spyOn(ev, "preventDefault");
+    const ok = handleSlashSuggestionMenuKeyDown(
+      ev,
+      {
+        itemsLength: 1,
+        pathCompletionEnabled: true,
+        pathSuggestions: ["foo/", "bar/"],
+        pathSectionActive: true,
+        pathSelectedIndex: 1,
+        selectedIndex: 0,
+      },
+      {
+        setPathSectionActive: vi.fn(),
+        setPathSelectedIndex: vi.fn(),
+        setSelectedIndex: vi.fn(),
+        applyPathPick,
+        selectItem: vi.fn(),
+        onClose: vi.fn(),
+      },
+    );
+    expect(ok).toBe(true);
+    expect(applyPathPick).toHaveBeenCalledWith("bar/");
+  });
+});

--- a/src/components/editor/TiptapEditor/slashSuggestionMenuKeyDown.ts
+++ b/src/components/editor/TiptapEditor/slashSuggestionMenuKeyDown.ts
@@ -1,0 +1,113 @@
+/**
+ * Keyboard routing for {@link SlashSuggestionMenu} (main list vs path completion).
+ * {@link SlashSuggestionMenu} のキーボード（メイン一覧とパス補完の切替）。
+ */
+
+import type { Dispatch, SetStateAction } from "react";
+
+/** Snapshot for slash menu key handling. / スラッシュメニューキー処理用スナップショット */
+export interface SlashSuggestionMenuKeyState {
+  itemsLength: number;
+  pathCompletionEnabled: boolean;
+  pathSuggestions: readonly string[];
+  pathSectionActive: boolean;
+  pathSelectedIndex: number;
+  selectedIndex: number;
+}
+
+/** Setters and actions for slash menu keys. / キー処理用の setter とアクション */
+export interface SlashSuggestionMenuKeyActions {
+  setPathSectionActive: Dispatch<SetStateAction<boolean>>;
+  setPathSelectedIndex: Dispatch<SetStateAction<number>>;
+  setSelectedIndex: Dispatch<SetStateAction<number>>;
+  applyPathPick: (picked: string) => void;
+  selectItem: (index: number) => void | Promise<void>;
+  onClose: () => void;
+}
+
+/**
+ * Handles a key event for the slash menu; returns true if the event was consumed.
+ * スラッシュメニューのキーイベントを処理する。取り込んだら true。
+ */
+export function handleSlashSuggestionMenuKeyDown(
+  event: KeyboardEvent,
+  state: SlashSuggestionMenuKeyState,
+  actions: SlashSuggestionMenuKeyActions,
+): boolean {
+  const pathNav =
+    state.pathCompletionEnabled && state.pathSuggestions.length > 0 && state.itemsLength > 0;
+
+  if (pathNav && state.pathSectionActive) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      actions.setPathSelectedIndex((prev) =>
+        prev >= state.pathSuggestions.length - 1 ? 0 : prev + 1,
+      );
+      return true;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      if (state.pathSelectedIndex <= 0) {
+        actions.setPathSectionActive(false);
+        actions.setSelectedIndex(state.itemsLength - 1);
+      } else {
+        actions.setPathSelectedIndex((p) => p - 1);
+      }
+      return true;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const picked = state.pathSuggestions[state.pathSelectedIndex];
+      if (picked) actions.applyPathPick(picked);
+      return true;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      actions.onClose();
+      return true;
+    }
+    return false;
+  }
+
+  if (state.itemsLength === 0) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      actions.onClose();
+      return true;
+    }
+    return false;
+  }
+
+  if (pathNav && event.key === "ArrowDown" && state.selectedIndex === state.itemsLength - 1) {
+    event.preventDefault();
+    actions.setPathSectionActive(true);
+    actions.setPathSelectedIndex(0);
+    return true;
+  }
+
+  if (event.key === "ArrowUp") {
+    event.preventDefault();
+    actions.setSelectedIndex((prev) => (prev <= 0 ? state.itemsLength - 1 : prev - 1));
+    return true;
+  }
+
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    actions.setSelectedIndex((prev) => (prev >= state.itemsLength - 1 ? 0 : prev + 1));
+    return true;
+  }
+
+  if (event.key === "Enter") {
+    event.preventDefault();
+    void actions.selectItem(state.selectedIndex);
+    return true;
+  }
+
+  if (event.key === "Escape") {
+    event.preventDefault();
+    actions.onClose();
+    return true;
+  }
+
+  return false;
+}

--- a/src/components/editor/TiptapEditor/slashSuggestionMenuProps.ts
+++ b/src/components/editor/TiptapEditor/slashSuggestionMenuProps.ts
@@ -1,0 +1,15 @@
+/**
+ * Props for {@link SlashSuggestionMenu}. / {@link SlashSuggestionMenu} の props
+ */
+
+import type { Editor } from "@tiptap/core";
+
+/** Props for {@link SlashSuggestionMenu}. / {@link SlashSuggestionMenu} の props */
+export interface SlashSuggestionMenuProps {
+  editor: Editor;
+  query: string;
+  range: { from: number; to: number };
+  onClose: () => void;
+  claudeAgentSlashAvailable: boolean;
+  onAgentBusyChange?: (busy: boolean) => void;
+}

--- a/src/components/editor/TiptapEditor/useClaudeAgentSlashAvailability.ts
+++ b/src/components/editor/TiptapEditor/useClaudeAgentSlashAvailability.ts
@@ -4,6 +4,7 @@
  */
 
 import { useEffect, useState } from "react";
+import { isTauriDesktop } from "@/lib/platform";
 
 /**
  * Resolves availability once on mount (matches {@link createClaudeCodeProvider}).
@@ -13,6 +14,10 @@ export function useClaudeAgentSlashAvailability(): boolean {
   const [available, setAvailable] = useState(false);
 
   useEffect(() => {
+    if (!isTauriDesktop()) {
+      setAvailable(false);
+      return;
+    }
     let cancelled = false;
     void (async () => {
       try {

--- a/src/components/editor/TiptapEditor/useClaudeAgentSlashAvailability.ts
+++ b/src/components/editor/TiptapEditor/useClaudeAgentSlashAvailability.ts
@@ -1,0 +1,33 @@
+/**
+ * Whether Claude Code slash agent commands should appear (desktop + CLI installed).
+ * Claude Code スラッシュが表示されるか（デスクトップ + CLI 導入済み）。
+ */
+
+import { useEffect, useState } from "react";
+
+/**
+ * Resolves availability once on mount (matches {@link createClaudeCodeProvider}).
+ * マウント時に 1 回解決する（createClaudeCodeProvider と同条件）。
+ */
+export function useClaudeAgentSlashAvailability(): boolean {
+  const [available, setAvailable] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { createClaudeCodeProvider } = await import("@/lib/aiProviders/claudeCodeProvider");
+        const provider = createClaudeCodeProvider();
+        const ok = await provider.isAvailable();
+        if (!cancelled) setAvailable(ok);
+      } catch {
+        if (!cancelled) setAvailable(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return available;
+}

--- a/src/components/editor/TiptapEditor/useEditorLifecycle.ts
+++ b/src/components/editor/TiptapEditor/useEditorLifecycle.ts
@@ -4,6 +4,7 @@ import { sanitizeTiptapContent } from "@/lib/contentUtils";
 import { useContentSanitizer } from "./useContentSanitizer";
 import { useWikiLinkStatusSync } from "./useWikiLinkStatusSync";
 import { usePasteImageHandler } from "./usePasteImageHandler";
+import { rememberSlashAgentSelection } from "@/lib/agentSlashCommands/slashAgentSelectionCache";
 import type { TiptapEditorProps } from "./types";
 
 interface UseEditorLifecycleOptions {
@@ -48,6 +49,15 @@ export function useEditorLifecycle({
   isEditorInitializedRef,
 }: UseEditorLifecycleOptions) {
   const initialContentAppliedRef = useRef(false);
+
+  useEffect(() => {
+    if (!editor) return;
+    const onSelection = () => rememberSlashAgentSelection(editor);
+    editor.on("selectionUpdate", onSelection);
+    return () => {
+      editor.off("selectionUpdate", onSelection);
+    };
+  }, [editor]);
 
   useEffect(() => {
     if (!focusContentRef || !editor) return;

--- a/src/components/editor/TiptapEditor/useSlashMenuScrollEffects.ts
+++ b/src/components/editor/TiptapEditor/useSlashMenuScrollEffects.ts
@@ -1,0 +1,36 @@
+/**
+ * Scrolls the active slash menu row into view (main list or path section).
+ * スラッシュメニュー（メイン／パス）の選択行をビュー内にスクロール。
+ */
+
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Keeps the selected main-row and path-row buttons scrolled into view.
+ * メイン行とパス行の選択ボタンが見えるようスクロールする。
+ */
+export function useSlashMenuScrollEffects(
+  listRef: RefObject<HTMLDivElement | null>,
+  pathSectionRef: RefObject<HTMLDivElement | null>,
+  selectedIndex: number,
+  pathSectionActive: boolean,
+  pathSelectedIndex: number,
+  pathSuggestionsLength: number,
+): void {
+  useEffect(() => {
+    if (pathSectionActive) return;
+    if (!listRef.current) return;
+    const buttons = listRef.current.querySelectorAll("button");
+    const target = buttons[selectedIndex];
+    if (target) {
+      target.scrollIntoView({ block: "nearest" });
+    }
+  }, [listRef, pathSectionActive, selectedIndex]);
+
+  useEffect(() => {
+    if (!pathSectionActive || !pathSectionRef.current) return;
+    const buttons = pathSectionRef.current.querySelectorAll("button");
+    const target = buttons[pathSelectedIndex];
+    target?.scrollIntoView({ block: "nearest" });
+  }, [pathSectionActive, pathSectionRef, pathSelectedIndex, pathSuggestionsLength]);
+}

--- a/src/components/editor/TiptapEditor/useSlashSuggestionMenu.ts
+++ b/src/components/editor/TiptapEditor/useSlashSuggestionMenu.ts
@@ -1,0 +1,216 @@
+/**
+ * State, effects, and imperative keyboard bridge for {@link SlashSuggestionMenu}.
+ * {@link SlashSuggestionMenu} の状態・副作用・命令型キーボード。
+ */
+
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  type Ref,
+  type RefObject,
+} from "react";
+import { useToast } from "@zedi/ui";
+import { useTranslation } from "react-i18next";
+import type { AgentSlashCommandId } from "@/lib/agentSlashCommands/types";
+import { executeAgentSlashCommand } from "@/lib/agentSlashCommands/executeAgentSlashCommand";
+import { matchAgentSlashByQuery } from "@/lib/agentSlashCommands/parseAgentSlashQuery";
+import { buildNewArgsFromPick, type UnifiedSlashMenuItem } from "./slashAgentMenuHelpers";
+import { useSlashSuggestionMenuData } from "./useSlashSuggestionMenuData";
+import { handleSlashSuggestionMenuKeyDown } from "./slashSuggestionMenuKeyDown";
+import type { SlashSuggestionHandle } from "./slashSuggestionHandle";
+import { useSlashMenuScrollEffects } from "./useSlashMenuScrollEffects";
+import type { SlashSuggestionMenuProps } from "./slashSuggestionMenuProps";
+
+export type { SlashSuggestionMenuProps };
+
+/**
+ * Return shape of {@link useSlashSuggestionMenu}.
+ * {@link useSlashSuggestionMenu} の戻り値。
+ */
+export interface UseSlashSuggestionMenuResult {
+  /** i18n `t`. / i18n の `t` */
+  t: (key: string) => string;
+  /** Merged block + agent rows. / ブロック＋エージェント行 */
+  items: UnifiedSlashMenuItem[];
+  /** Main list scroll container. / メイン一覧のスクロール要素 */
+  listRef: RefObject<HTMLDivElement | null>;
+  /** Path section scroll container. / パス欄のスクロール要素 */
+  pathSectionRef: RefObject<HTMLDivElement | null>;
+  /** Selected main row index. / メイン行の選択インデックス */
+  selectedIndex: number;
+  /** Whether path completion is active. / パス補完が有効か */
+  pathCompletionEnabled: boolean;
+  /** Path name suggestions. / パス名候補 */
+  pathSuggestions: string[];
+  /** Whether keyboard focus is in the path section. / キーボードフォーカスがパス欄か */
+  pathSectionActive: boolean;
+  /** Selected path row index. / パス行の選択インデックス */
+  pathSelectedIndex: number;
+  /** Run block or agent action for a row. / 行のブロック／エージェントを実行 */
+  selectItem: (index: number) => void | Promise<void>;
+  /** Apply a path completion pick. / パス補完の確定 */
+  applyPathPick: (picked: string) => void;
+}
+
+/**
+ * Hook implementation for the slash suggestion menu (split for ESLint max-lines).
+ * ESLint の行数制限のため分離したスラッシュメニュー用フック。
+ * Further logic lives in useSlashSuggestionMenuData, useSlashMenuScrollEffects, slashSuggestionMenuKeyDown.
+ *
+ * @param props - Menu props (editor, query, range, …). / メニュー props
+ * @param ref - Imperative handle for keydown. / keydown 用の命令型ハンドル
+ * @returns Menu state and actions. / メニュー状態とアクション
+ */
+export function useSlashSuggestionMenu(
+  props: SlashSuggestionMenuProps,
+  ref: Ref<SlashSuggestionHandle>,
+): UseSlashSuggestionMenuResult {
+  const { editor, query, range, onClose, claudeAgentSlashAvailable, onAgentBusyChange } = props;
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [pathSectionActive, setPathSectionActive] = useState(false);
+  const [pathSelectedIndex, setPathSelectedIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  const pathSectionRef = useRef<HTMLDivElement>(null);
+
+  const { items, pathCompletionEnabled, pathArgs, pathSuggestions } = useSlashSuggestionMenuData(
+    query,
+    editor,
+    t,
+    claudeAgentSlashAvailable,
+  );
+
+  useEffect(() => {
+    queueMicrotask(() => setSelectedIndex(0));
+    setPathSelectedIndex(0);
+    setPathSectionActive(false);
+  }, [query, pathCompletionEnabled]);
+
+  useEffect(() => {
+    setSelectedIndex((i) => {
+      if (items.length === 0) return 0;
+      return Math.min(i, items.length - 1);
+    });
+  }, [items.length]);
+
+  useEffect(() => {
+    setPathSelectedIndex((i) => {
+      if (pathSuggestions.length === 0) return 0;
+      return Math.min(i, pathSuggestions.length - 1);
+    });
+  }, [pathSuggestions.length]);
+
+  const runAgentCommand = useCallback(
+    async (id: AgentSlashCommandId) => {
+      onClose();
+      onAgentBusyChange?.(true);
+      try {
+        const err = await executeAgentSlashCommand({
+          commandId: id,
+          query,
+          editor,
+          range,
+        });
+        if (err) {
+          toast({
+            title: t("editor.slashAgent.errorTitle"),
+            description: err,
+            variant: "destructive",
+          });
+        }
+      } finally {
+        onAgentBusyChange?.(false);
+      }
+    },
+    [onClose, onAgentBusyChange, query, editor, range, toast, t],
+  );
+
+  const selectItem = useCallback(
+    async (index: number) => {
+      const entry = items[index];
+      if (!entry) return;
+      if (entry.kind === "block") {
+        entry.item.action(editor, range);
+        onClose();
+        return;
+      }
+      await runAgentCommand(entry.id);
+    },
+    [items, editor, range, onClose, runAgentCommand],
+  );
+
+  const applyPathPick = useCallback(
+    (picked: string) => {
+      const m = matchAgentSlashByQuery(query);
+      if (!m) return;
+      const newArgs = buildNewArgsFromPick(pathArgs, picked);
+      const newQuery = `${m.prefix} ${newArgs}`.trim();
+      editor.chain().focus().deleteRange(range).insertContent(`/${newQuery} `).run();
+    },
+    [editor, query, range, pathArgs],
+  );
+
+  useSlashMenuScrollEffects(
+    listRef,
+    pathSectionRef,
+    selectedIndex,
+    pathSectionActive,
+    pathSelectedIndex,
+    pathSuggestions.length,
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      onKeyDown: (event: KeyboardEvent) =>
+        handleSlashSuggestionMenuKeyDown(
+          event,
+          {
+            itemsLength: items.length,
+            pathCompletionEnabled,
+            pathSuggestions,
+            pathSectionActive,
+            pathSelectedIndex,
+            selectedIndex,
+          },
+          {
+            setPathSectionActive,
+            setPathSelectedIndex,
+            setSelectedIndex,
+            applyPathPick,
+            selectItem,
+            onClose,
+          },
+        ),
+    }),
+    [
+      applyPathPick,
+      items.length,
+      onClose,
+      pathCompletionEnabled,
+      pathSectionActive,
+      pathSelectedIndex,
+      pathSuggestions,
+      selectItem,
+      selectedIndex,
+    ],
+  );
+
+  return {
+    t,
+    items,
+    listRef,
+    pathSectionRef,
+    selectedIndex,
+    pathCompletionEnabled,
+    pathSuggestions,
+    pathSectionActive,
+    pathSelectedIndex,
+    selectItem,
+    applyPathPick,
+  };
+}

--- a/src/components/editor/TiptapEditor/useSlashSuggestionMenu.ts
+++ b/src/components/editor/TiptapEditor/useSlashSuggestionMenu.ts
@@ -146,12 +146,15 @@ export function useSlashSuggestionMenu(
   const applyPathPick = useCallback(
     (picked: string) => {
       const m = matchAgentSlashByQuery(query);
-      if (!m) return;
+      if (!m) {
+        onClose();
+        return;
+      }
       const newArgs = buildNewArgsFromPick(pathArgs, picked);
       const newQuery = `${m.prefix} ${newArgs}`.trim();
       editor.chain().focus().deleteRange(range).insertContent(`/${newQuery} `).run();
     },
-    [editor, query, range, pathArgs],
+    [editor, onClose, query, range, pathArgs],
   );
 
   useSlashMenuScrollEffects(

--- a/src/components/editor/TiptapEditor/useSlashSuggestionMenuData.ts
+++ b/src/components/editor/TiptapEditor/useSlashSuggestionMenuData.ts
@@ -1,0 +1,42 @@
+/**
+ * Merged slash items and path-completion suggestions for the slash menu.
+ * スラッシュメニュー用の項目マージとパス補完候補。
+ */
+
+import { useMemo } from "react";
+import type { Editor } from "@tiptap/core";
+import {
+  matchAgentSlashByQuery,
+  shouldOfferPathCompletion,
+} from "@/lib/agentSlashCommands/parseAgentSlashQuery";
+import { mergeSlashItems } from "./slashAgentMenuHelpers";
+import { useWorkspacePathCompletions } from "./useWorkspacePathCompletions";
+
+/**
+ * Resolves menu rows and workspace path suggestions from the current query.
+ * クエリからメニュー行とワークスペースパス候補を解決する。
+ */
+export function useSlashSuggestionMenuData(
+  query: string,
+  editor: Editor,
+  t: (key: string) => string,
+  claudeAgentSlashAvailable: boolean,
+): {
+  items: ReturnType<typeof mergeSlashItems>;
+  pathCompletionEnabled: boolean;
+  pathArgs: string;
+  pathSuggestions: string[];
+} {
+  const items = useMemo(
+    () => mergeSlashItems(query, editor, t, claudeAgentSlashAvailable),
+    [query, editor, t, claudeAgentSlashAvailable],
+  );
+
+  const pathMatch = matchAgentSlashByQuery(query);
+  const pathCompletionEnabled =
+    claudeAgentSlashAvailable && shouldOfferPathCompletion(query) && pathMatch !== null;
+  const pathArgs = pathMatch?.args ?? "";
+  const pathSuggestions = useWorkspacePathCompletions(pathArgs, pathCompletionEnabled);
+
+  return { items, pathCompletionEnabled, pathArgs, pathSuggestions };
+}

--- a/src/components/editor/TiptapEditor/useTiptapEditorController.ts
+++ b/src/components/editor/TiptapEditor/useTiptapEditorController.ts
@@ -13,6 +13,7 @@ import { useEditorLifecycle } from "./useEditorLifecycle";
 import { useTiptapEditorStorageFeatures, useThumbnailController } from "./useTiptapEditorStorage";
 import { useSuggestionControllers } from "./useSuggestionControllers";
 import { useImageUploadController } from "./useImageUploadController";
+import { useClaudeAgentSlashAvailability } from "./useClaudeAgentSlashAvailability";
 import type { TiptapEditorProps } from "./types";
 
 function useEditorControllers(args: {
@@ -158,6 +159,8 @@ export function useTiptapEditorController({
     handleDeleteFromStorage,
   } = useTiptapEditorStorageFeatures(content);
   const suggestionControllers = useSuggestionControllers();
+  const [slashAgentBusy, setSlashAgentBusy] = useState(false);
+  const claudeAgentSlashAvailable = useClaudeAgentSlashAvailability();
   const imageUpload = useImageUploadController({
     editorRef,
     onChange,
@@ -241,5 +244,8 @@ export function useTiptapEditorController({
     storageSetupDialogOpen,
     setStorageSetupDialogOpen,
     handleGoToStorageSettings,
+    slashAgentBusy,
+    claudeAgentSlashAvailable,
+    onSlashAgentBusyChange: setSlashAgentBusy,
   };
 }

--- a/src/components/editor/TiptapEditor/useWorkspacePathCompletions.ts
+++ b/src/components/editor/TiptapEditor/useWorkspacePathCompletions.ts
@@ -1,0 +1,59 @@
+/**
+ * Debounced workspace path suggestions for agent slash args (Tauri only).
+ * エージェントスラッシュ引数向けワークスペースパス候補（Tauri のみ）。
+ */
+
+import { useEffect, useState } from "react";
+import { listWorkspaceDirectoryEntries } from "@/lib/workspace/bridge";
+
+/**
+ * Parses `args` into a directory to list and an optional filename prefix filter.
+ * `args` を列挙するディレクトリとファイル名プレフィックスに分解する。
+ */
+export function parsePathCompletionArgs(args: string): { dir: string; filePrefix: string } {
+  const p = args.trim();
+  if (!p) return { dir: "", filePrefix: "" };
+  const normalized = p.replace(/\\/g, "/");
+  if (normalized.endsWith("/")) {
+    return { dir: normalized.replace(/\/+$/, ""), filePrefix: "" };
+  }
+  const idx = normalized.lastIndexOf("/");
+  if (idx === -1) {
+    return { dir: "", filePrefix: normalized };
+  }
+  return {
+    dir: normalized.slice(0, idx),
+    filePrefix: normalized.slice(idx + 1),
+  };
+}
+
+/**
+ * Loads directory entry names for slash path completion (max 40).
+ * スラッシュのパス補完用にディレクトリエントリを読む（最大 40 件）。
+ */
+export function useWorkspacePathCompletions(args: string, enabled: boolean): string[] {
+  const [items, setItems] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!enabled) {
+      queueMicrotask(() => setItems([]));
+      return;
+    }
+    const { dir, filePrefix } = parsePathCompletionArgs(args);
+    let cancelled = false;
+    const t = window.setTimeout(() => {
+      void listWorkspaceDirectoryEntries(dir).then((names) => {
+        if (cancelled) return;
+        const fp = filePrefix.toLowerCase();
+        const filtered = fp ? names.filter((n) => n.toLowerCase().startsWith(fp)) : names;
+        setItems(filtered.slice(0, 40));
+      });
+    }, 120);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(t);
+    };
+  }, [args, enabled]);
+
+  return items;
+}

--- a/src/components/editor/TiptapEditor/useWorkspacePathCompletions.ts
+++ b/src/components/editor/TiptapEditor/useWorkspacePathCompletions.ts
@@ -42,12 +42,16 @@ export function useWorkspacePathCompletions(args: string, enabled: boolean): str
     const { dir, filePrefix } = parsePathCompletionArgs(args);
     let cancelled = false;
     const t = window.setTimeout(() => {
-      void listWorkspaceDirectoryEntries(dir).then((names) => {
-        if (cancelled) return;
-        const fp = filePrefix.toLowerCase();
-        const filtered = fp ? names.filter((n) => n.toLowerCase().startsWith(fp)) : names;
-        setItems(filtered.slice(0, 40));
-      });
+      void listWorkspaceDirectoryEntries(dir)
+        .then((names) => {
+          if (cancelled) return;
+          const fp = filePrefix.toLowerCase();
+          const filtered = fp ? names.filter((n) => n.toLowerCase().startsWith(fp)) : names;
+          setItems(filtered.slice(0, 40));
+        })
+        .catch(() => {
+          if (!cancelled) setItems([]);
+        });
     }, 120);
     return () => {
       cancelled = true;

--- a/src/components/editor/extensions/slashSuggestionPlugin.ts
+++ b/src/components/editor/extensions/slashSuggestionPlugin.ts
@@ -2,6 +2,10 @@ import { Extension } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 
+/**
+ * UI state for the `/` slash menu (query, range, decorations).
+ * `/` スラッシュメニュー用 UI 状態（クエリ、範囲、装飾）。
+ */
 export interface SlashSuggestionState {
   active: boolean;
   query: string;
@@ -9,9 +13,18 @@ export interface SlashSuggestionState {
   decorations: DecorationSet;
 }
 
+/**
+ * ProseMirror plugin key for slash suggestions.
+ * スラッシュサジェスト用 ProseMirror プラグインキー。
+ */
 export const slashSuggestionPluginKey = new PluginKey<SlashSuggestionState>("slashSuggestion");
 
+/**
+ * Options for {@link SlashSuggestionPlugin}.
+ * {@link SlashSuggestionPlugin} のオプション。
+ */
 export interface SlashSuggestionOptions {
+  /** Called when slash menu state changes. / スラッシュメニュー状態が変わったときに呼ぶ */
   onStateChange?: (state: SlashSuggestionState) => void;
 }
 
@@ -87,7 +100,9 @@ export const SlashSuggestionPlugin = Extension.create<SlashSuggestionOptions>({
 
             // Match "/" at the start of line, or " /" preceded by a space.
             // Capture the query after "/"
-            const match = textBefore.match(/(^|\s)\/([^\s/]*)$/);
+            // Allow spaces after the first token so `/analyze path/to/file` stays active.
+            // 1 語目以降にスペースを許可し、`/analyze path` 入力中もメニューを維持する。
+            const match = textBefore.match(/(^|\s)\/([^\n]*)$/);
 
             if (match) {
               const query = match[2]; // text after "/"

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -2,6 +2,12 @@
   "uploadedImageAlt": "Uploaded image",
   "slashMenuAriaLabel": "Slash command menu",
   "slashNoResults": "No matching commands",
+  "slashAgentRunning": "Running Claude Code…",
+  "slashAgent": {
+    "errorTitle": "Agent command failed"
+  },
+  "slashPathCompletionAriaLabel": "Path suggestions",
+  "slashPathCompletionHint": "Workspace path suggestions",
   "slash": {
     "paragraph": {
       "title": "Paragraph",
@@ -87,6 +93,46 @@
       "title": "Math (block)",
       "description": "Insert block math",
       "aliases": "math block,block math,equation"
+    },
+    "agent-analyze": {
+      "title": "/analyze — analyze code",
+      "description": "Analyze a path with Claude Code and insert the result",
+      "aliases": "analyze,code analysis"
+    },
+    "agent-git-summary": {
+      "title": "/git-summary — recent commits",
+      "description": "Summarize recent git commits and insert",
+      "aliases": "git-summary,git,git log"
+    },
+    "agent-run": {
+      "title": "/run — run shell command",
+      "description": "Run a command and insert stdout/stderr",
+      "aliases": "run,exec,shell,command"
+    },
+    "agent-research": {
+      "title": "/research — web research",
+      "description": "Research a topic and insert a structured summary",
+      "aliases": "research,web,search"
+    },
+    "agent-review": {
+      "title": "/review — code review",
+      "description": "Review code at a path and insert a checklist",
+      "aliases": "review,cr"
+    },
+    "agent-test": {
+      "title": "/test — run tests",
+      "description": "Run tests and insert results",
+      "aliases": "test,vitest,bun test"
+    },
+    "agent-explain": {
+      "title": "/explain — explain selection",
+      "description": "Explain the selected code and insert",
+      "aliases": "explain,selection"
+    },
+    "agent-summarize": {
+      "title": "/summarize — summarize note",
+      "description": "Summarize the note and insert",
+      "aliases": "summarize,summary"
     }
   },
   "recommendation": {

--- a/src/i18n/locales/ja/editor.json
+++ b/src/i18n/locales/ja/editor.json
@@ -2,6 +2,12 @@
   "uploadedImageAlt": "アップロードした画像",
   "slashMenuAriaLabel": "スラッシュコマンドメニュー",
   "slashNoResults": "一致する項目がありません",
+  "slashAgentRunning": "Claude Code を実行中…",
+  "slashAgent": {
+    "errorTitle": "エージェントコマンドに失敗しました"
+  },
+  "slashPathCompletionAriaLabel": "パス候補",
+  "slashPathCompletionHint": "ワークスペース内のパス候補",
   "slash": {
     "paragraph": {
       "title": "段落",
@@ -87,6 +93,46 @@
       "title": "数式（ブロック）",
       "description": "ブロック数式を挿入",
       "aliases": "数式ブロック,block math,ブロック数式,equation"
+    },
+    "agent-analyze": {
+      "title": "/analyze — コード分析",
+      "description": "パスを指定して Claude Code で分析し結果を挿入",
+      "aliases": "analyze,解析,あならいず"
+    },
+    "agent-git-summary": {
+      "title": "/git-summary — コミット要約",
+      "description": "直近の git ログを要約して挿入",
+      "aliases": "git-summary,git,ログ,gitlog"
+    },
+    "agent-run": {
+      "title": "/run — コマンド実行",
+      "description": "シェルコマンドを実行し出力を挿入",
+      "aliases": "run,exec,シェル,command"
+    },
+    "agent-research": {
+      "title": "/research — Web 調査",
+      "description": "トピックを調べ構造化した要約を挿入",
+      "aliases": "research,調査,検索,web"
+    },
+    "agent-review": {
+      "title": "/review — コードレビュー",
+      "description": "パスのコードをレビューしチェックリストを挿入",
+      "aliases": "review,レビュー,指摘"
+    },
+    "agent-test": {
+      "title": "/test — テスト実行",
+      "description": "テストを実行し結果を記録",
+      "aliases": "test,テスト,vitest,bun test"
+    },
+    "agent-explain": {
+      "title": "/explain — 選択を解説",
+      "description": "選択範囲のコードを解説して挿入",
+      "aliases": "explain,解説,説明"
+    },
+    "agent-summarize": {
+      "title": "/summarize — ノート要約",
+      "description": "ノート全体の要約を挿入",
+      "aliases": "summarize,要約,サマリ"
     }
   },
   "recommendation": {

--- a/src/lib/agentSlashCommands/agentSlashEditorText.ts
+++ b/src/lib/agentSlashCommands/agentSlashEditorText.ts
@@ -1,0 +1,24 @@
+/**
+ * Reads plain text from the Tiptap editor for agent slash prompts.
+ * エージェントスラッシュ用に Tiptap からプレーンテキストを読む。
+ */
+
+import type { Editor } from "@tiptap/core";
+
+/**
+ * Collects plain text from the editor for summarization.
+ * 要約用にエディタからプレーンテキストを取得する。
+ */
+export function getEditorPlainText(editor: Editor): string {
+  return editor.getText({ blockSeparator: "\n" });
+}
+
+/**
+ * Returns the current selection as plain text, or empty if collapsed.
+ * 選択範囲のプレーンテキスト。折りたたみなら空。
+ */
+export function getEditorSelectionText(editor: Editor): string {
+  const { from, to } = editor.state.selection;
+  if (from === to) return "";
+  return editor.state.doc.textBetween(from, to, "\n", "\ufffc");
+}

--- a/src/lib/agentSlashCommands/buildAgentSlashPrompt.ts
+++ b/src/lib/agentSlashCommands/buildAgentSlashPrompt.ts
@@ -50,7 +50,7 @@ export function buildAgentSlashPrompt(
       return buildSummarizePrompt(editor, captures);
     default: {
       const _exhaustive: never = id;
-      return String(_exhaustive);
+      throw new Error(`Unhandled agent slash command: ${String(_exhaustive)}`);
     }
   }
 }

--- a/src/lib/agentSlashCommands/buildAgentSlashPrompt.ts
+++ b/src/lib/agentSlashCommands/buildAgentSlashPrompt.ts
@@ -1,0 +1,78 @@
+/**
+ * Builds Claude Code prompts for agent slash commands (Issue #460).
+ * Issue #460 向け Claude Code プロンプトを組み立てる。
+ */
+
+import type { Editor } from "@tiptap/core";
+import type { AgentSlashCommandId, AgentSlashPromptCaptures } from "./types";
+import {
+  buildAnalyzePrompt,
+  buildExplainPrompt,
+  buildGitSummaryPrompt,
+  buildResearchPrompt,
+  buildReviewPrompt,
+  buildRunPrompt,
+  buildSummarizePrompt,
+  buildTestPrompt,
+} from "./buildAgentSlashPromptParts";
+
+export type { AgentSlashPromptCaptures } from "./types";
+export { getEditorPlainText, getEditorSelectionText } from "./agentSlashEditorText";
+
+/**
+ * Builds the user prompt for the given agent slash command.
+ * エージェントスラッシュコマンド用のユーザープロンプトを組み立てる。
+ */
+export function buildAgentSlashPrompt(
+  id: AgentSlashCommandId,
+  args: string,
+  editor: Editor,
+  captures?: AgentSlashPromptCaptures,
+): string {
+  const trimmedArgs = args.trim();
+
+  switch (id) {
+    case "agent-analyze":
+      return buildAnalyzePrompt(trimmedArgs);
+    case "agent-git-summary":
+      return buildGitSummaryPrompt();
+    case "agent-run":
+      return buildRunPrompt(trimmedArgs);
+    case "agent-research":
+      return buildResearchPrompt(trimmedArgs);
+    case "agent-review":
+      return buildReviewPrompt(trimmedArgs);
+    case "agent-test":
+      return buildTestPrompt(trimmedArgs);
+    case "agent-explain":
+      return buildExplainPrompt(editor, captures);
+    case "agent-summarize":
+      return buildSummarizePrompt(editor, captures);
+    default: {
+      const _exhaustive: never = id;
+      return String(_exhaustive);
+    }
+  }
+}
+
+/**
+ * Tool policy per command (narrow Bash when possible).
+ * コマンドごとのツール方針（可能なら Bash のみに絞る）。
+ */
+export function getAgentSlashClaudeOptions(id: AgentSlashCommandId): {
+  maxTurns: number;
+  allowedTools?: string[];
+} {
+  switch (id) {
+    case "agent-explain":
+      return { maxTurns: 8, allowedTools: [] };
+    case "agent-git-summary":
+      return { maxTurns: 10, allowedTools: ["Bash"] };
+    case "agent-run":
+      return { maxTurns: 12, allowedTools: ["Bash"] };
+    case "agent-test":
+      return { maxTurns: 18, allowedTools: ["Bash", "Read"] };
+    default:
+      return { maxTurns: 20 };
+  }
+}

--- a/src/lib/agentSlashCommands/buildAgentSlashPrompt.ts
+++ b/src/lib/agentSlashCommands/buildAgentSlashPrompt.ts
@@ -64,15 +64,25 @@ export function getAgentSlashClaudeOptions(id: AgentSlashCommandId): {
   allowedTools?: string[];
 } {
   switch (id) {
+    case "agent-analyze":
+      return { maxTurns: 20, allowedTools: ["Read"] };
     case "agent-explain":
       return { maxTurns: 8, allowedTools: [] };
     case "agent-git-summary":
       return { maxTurns: 10, allowedTools: ["Bash"] };
+    case "agent-research":
+      return { maxTurns: 20, allowedTools: ["WebSearch", "Read"] };
+    case "agent-review":
+      return { maxTurns: 20, allowedTools: ["Read"] };
     case "agent-run":
       return { maxTurns: 12, allowedTools: ["Bash"] };
+    case "agent-summarize":
+      return { maxTurns: 16, allowedTools: [] };
     case "agent-test":
       return { maxTurns: 18, allowedTools: ["Bash", "Read"] };
-    default:
-      return { maxTurns: 20 };
+    default: {
+      const _exhaustive: never = id;
+      throw new Error(`Unhandled agent slash command: ${String(_exhaustive)}`);
+    }
   }
 }

--- a/src/lib/agentSlashCommands/buildAgentSlashPromptParts.ts
+++ b/src/lib/agentSlashCommands/buildAgentSlashPromptParts.ts
@@ -1,0 +1,92 @@
+/**
+ * Per-command prompt strings for agent slash (extracted to keep complexity low).
+ * エージェントスラッシュ用のコマンド別プロンプト（複雑度低減のため分離）。
+ */
+
+import type { Editor } from "@tiptap/core";
+import type { AgentSlashPromptCaptures } from "./types";
+import { getEditorPlainText, getEditorSelectionText } from "./agentSlashEditorText";
+
+/** Builds the `/analyze` prompt. / `/analyze` 用プロンプト */
+export function buildAnalyzePrompt(trimmedArgs: string): string {
+  return [
+    "You are assisting inside the Zedi note app. Analyze the code at the given path in the workspace.",
+    "Read the file(s), summarize structure, risks, and improvements. Output in Markdown (Japanese preferred for prose, English for identifiers).",
+    trimmedArgs
+      ? `Target path (relative to workspace): ${trimmedArgs}`
+      : "No path was given: infer the most relevant file from the workspace or ask briefly in the output.",
+  ].join("\n");
+}
+
+/** Builds the `/git-summary` prompt. / `/git-summary` 用プロンプト */
+export function buildGitSummaryPrompt(): string {
+  return [
+    "Run `git log -n 20 --oneline` and optionally `git status -sb` in the workspace via Bash.",
+    "Summarize recent commits and current working tree in Markdown bullet points (Japanese).",
+  ].join("\n");
+}
+
+/** Builds the `/run` prompt. / `/run` 用プロンプト */
+export function buildRunPrompt(trimmedArgs: string): string {
+  return [
+    "You can use Bash to run a shell command in the workspace.",
+    "Run the following command, capture stdout/stderr and exit code, then return a fenced code block with the raw output and a short Japanese summary above it.",
+    trimmedArgs
+      ? `Command: ${trimmedArgs}`
+      : "No command was given: reply with a short note asking the user to pass a command after /run.",
+  ].join("\n");
+}
+
+/** Builds the `/research` prompt. / `/research` 用プロンプト */
+export function buildResearchPrompt(trimmedArgs: string): string {
+  return [
+    "Use WebSearch (and Read if needed) to research the topic below.",
+    "Produce a structured Markdown summary: overview, key facts, sources/links, and caveats. Japanese preferred.",
+    trimmedArgs
+      ? `Topic: ${trimmedArgs}`
+      : "No topic was given: ask the user to specify a topic after /research.",
+  ].join("\n");
+}
+
+/** Builds the `/review` prompt. / `/review` 用プロンプト */
+export function buildReviewPrompt(trimmedArgs: string): string {
+  return [
+    "Perform a code review for the path below. Read files with Read tool as needed.",
+    "Output Markdown with: summary, checklist of issues (severity + file:line if known), and positive notes.",
+    trimmedArgs
+      ? `Target path: ${trimmedArgs}`
+      : "No path was given: pick a reasonable default in the repo or state that the path is missing.",
+  ].join("\n");
+}
+
+/** Builds the `/test` prompt. / `/test` 用プロンプト */
+export function buildTestPrompt(trimmedArgs: string): string {
+  return [
+    "Run tests for this repository using Bash (prefer `bun run test:run` or `bun vitest run` with the given path when applicable).",
+    "Return Markdown: command(s) run, exit code, condensed output in fenced code blocks, and a brief Japanese interpretation.",
+    trimmedArgs
+      ? `Focus path or pattern: ${trimmedArgs}`
+      : "No path: run the project's default test script from package.json if present.",
+  ].join("\n");
+}
+
+/** Builds the `/explain` prompt. / `/explain` 用プロンプト */
+export function buildExplainPrompt(editor: Editor, captures?: AgentSlashPromptCaptures): string {
+  const sel = captures?.selectionText ?? getEditorSelectionText(editor);
+  return [
+    "Explain the following code or text clearly for a developer. Use Markdown.",
+    sel
+      ? "Selection:\n```\n" + sel + "\n```"
+      : "No selection: explain that the user should select text in the editor first, in Japanese.",
+  ].join("\n\n");
+}
+
+/** Builds the `/summarize` prompt. / `/summarize` 用プロンプト */
+export function buildSummarizePrompt(editor: Editor, captures?: AgentSlashPromptCaptures): string {
+  const body = captures?.plainText ?? getEditorPlainText(editor);
+  const excerpt = body.length > 12000 ? `${body.slice(0, 12000)}\n\n…(truncated)` : body;
+  return [
+    "Summarize the following note content in Markdown (Japanese). Use headings and bullets.",
+    excerpt ? `Note text:\n${excerpt}` : "The note appears empty.",
+  ].join("\n\n");
+}

--- a/src/lib/agentSlashCommands/executeAgentSlashCommand.ts
+++ b/src/lib/agentSlashCommands/executeAgentSlashCommand.ts
@@ -47,7 +47,13 @@ export async function executeAgentSlashCommand(options: {
 
   const hook = getSlashAgentCommandHook();
   if (hook) {
-    const hooked = await hook({ commandId, args, query, editor });
+    let hooked: { markdown: string } | null;
+    try {
+      hooked = await hook({ commandId, args, query, editor });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return message;
+    }
     if (hooked) {
       editor.chain().focus().deleteRange(range).run();
       const insertPos = editor.state.selection.from;

--- a/src/lib/agentSlashCommands/executeAgentSlashCommand.ts
+++ b/src/lib/agentSlashCommands/executeAgentSlashCommand.ts
@@ -1,0 +1,71 @@
+/**
+ * Runs one agent slash command via Claude Code and inserts the result.
+ * Claude Code 経由でエージェントスラッシュを 1 回実行し、結果を挿入する。
+ */
+
+import type { Editor } from "@tiptap/core";
+import { runClaudeQueryToCompletion } from "@/lib/claudeCode/runQueryToCompletion";
+import {
+  buildAgentSlashPrompt,
+  getAgentSlashClaudeOptions,
+  getEditorPlainText,
+  getEditorSelectionText,
+} from "./buildAgentSlashPrompt";
+import { getSlashAgentCommandHook } from "./hook";
+import { insertSlashAgentMarkdownAt } from "./insertSlashAgentMarkdown";
+import { readSlashAgentInsertPosition } from "./insertPosition";
+import type { AgentSlashCommandId } from "./types";
+import { AGENT_SLASH_PREFIXES, resolveArgsForSelectedAgent } from "./parseAgentSlashQuery";
+
+/**
+ * Executes the agent command and inserts Markdown; returns error message or null on success.
+ * エージェントコマンドを実行して Markdown を挿入する。成功時は null、失敗時はエラー文言。
+ */
+export async function executeAgentSlashCommand(options: {
+  commandId: AgentSlashCommandId;
+  query: string;
+  editor: Editor;
+  range: { from: number; to: number };
+  signal?: AbortSignal;
+}): Promise<string | null> {
+  const { commandId, query, editor, range, signal } = options;
+
+  const meta = AGENT_SLASH_PREFIXES.find((p) => p.id === commandId);
+  const prefix = meta?.prefix ?? "";
+  const args = resolveArgsForSelectedAgent(prefix, meta?.aliases, query);
+
+  const insertAt = range.from;
+  const selectionText = getEditorSelectionText(editor);
+  const plainText = getEditorPlainText(editor);
+
+  const hook = getSlashAgentCommandHook();
+  if (hook) {
+    const hooked = await hook({ commandId, args, query, editor });
+    if (hooked) {
+      editor.chain().focus().deleteRange(range).run();
+      insertSlashAgentMarkdownAt(editor, insertAt, hooked.markdown, readSlashAgentInsertPosition());
+      return null;
+    }
+  }
+
+  editor.chain().focus().deleteRange(range).run();
+
+  const prompt = buildAgentSlashPrompt(commandId, args, editor, { selectionText, plainText });
+  const claudeOpts = getAgentSlashClaudeOptions(commandId);
+  const result = await runClaudeQueryToCompletion(prompt, claudeOpts, signal);
+
+  if (!result.ok) {
+    editor
+      .chain()
+      .focus()
+      .insertContentAt(insertAt, {
+        type: "paragraph",
+        content: [{ type: "text", text: `Claude Code: ${result.error}` }],
+      })
+      .run();
+    return result.error;
+  }
+
+  insertSlashAgentMarkdownAt(editor, insertAt, result.content, readSlashAgentInsertPosition());
+  return null;
+}

--- a/src/lib/agentSlashCommands/executeAgentSlashCommand.ts
+++ b/src/lib/agentSlashCommands/executeAgentSlashCommand.ts
@@ -14,6 +14,10 @@ import {
 import { getSlashAgentCommandHook } from "./hook";
 import { insertSlashAgentMarkdownAt } from "./insertSlashAgentMarkdown";
 import { readSlashAgentInsertPosition } from "./insertPosition";
+import {
+  clearLastSlashAgentSelection,
+  getLastSlashAgentSelection,
+} from "./slashAgentSelectionCache";
 import type { AgentSlashCommandId } from "./types";
 import { AGENT_SLASH_PREFIXES, resolveArgsForSelectedAgent } from "./parseAgentSlashQuery";
 
@@ -34,8 +38,11 @@ export async function executeAgentSlashCommand(options: {
   const prefix = meta?.prefix ?? "";
   const args = resolveArgsForSelectedAgent(prefix, meta?.aliases, query);
 
-  const insertAt = range.from;
-  const selectionText = getEditorSelectionText(editor);
+  const liveSelection = getEditorSelectionText(editor);
+  const selectionText =
+    commandId === "agent-explain"
+      ? liveSelection || getLastSlashAgentSelection(editor)
+      : liveSelection;
   const plainText = getEditorPlainText(editor);
 
   const hook = getSlashAgentCommandHook();
@@ -43,7 +50,14 @@ export async function executeAgentSlashCommand(options: {
     const hooked = await hook({ commandId, args, query, editor });
     if (hooked) {
       editor.chain().focus().deleteRange(range).run();
-      insertSlashAgentMarkdownAt(editor, insertAt, hooked.markdown, readSlashAgentInsertPosition());
+      const insertPos = editor.state.selection.from;
+      insertSlashAgentMarkdownAt(
+        editor,
+        insertPos,
+        hooked.markdown,
+        readSlashAgentInsertPosition(),
+      );
+      if (commandId === "agent-explain") clearLastSlashAgentSelection(editor);
       return null;
     }
   }
@@ -55,10 +69,11 @@ export async function executeAgentSlashCommand(options: {
   const result = await runClaudeQueryToCompletion(prompt, claudeOpts, signal);
 
   if (!result.ok) {
+    const insertPos = editor.state.selection.from;
     editor
       .chain()
       .focus()
-      .insertContentAt(insertAt, {
+      .insertContentAt(insertPos, {
         type: "paragraph",
         content: [{ type: "text", text: `Claude Code: ${result.error}` }],
       })
@@ -66,6 +81,8 @@ export async function executeAgentSlashCommand(options: {
     return result.error;
   }
 
-  insertSlashAgentMarkdownAt(editor, insertAt, result.content, readSlashAgentInsertPosition());
+  const insertPos = editor.state.selection.from;
+  insertSlashAgentMarkdownAt(editor, insertPos, result.content, readSlashAgentInsertPosition());
+  if (commandId === "agent-explain") clearLastSlashAgentSelection(editor);
   return null;
 }

--- a/src/lib/agentSlashCommands/hook.ts
+++ b/src/lib/agentSlashCommands/hook.ts
@@ -1,0 +1,53 @@
+/**
+ * Optional hook for custom slash agent commands (future extension).
+ * 将来拡張用のカスタムスラッシュエージェントコマンド用フック。
+ */
+
+import type { Editor } from "@tiptap/core";
+import type { AgentSlashCommandId } from "./types";
+
+/**
+ * Context passed to {@link SlashAgentCommandHook}.
+ * {@link SlashAgentCommandHook} に渡すコンテキスト。
+ */
+export interface SlashAgentCommandHookContext {
+  /** Matched agent command id. / 一致したエージェントコマンド ID */
+  commandId: AgentSlashCommandId;
+  /** Text after the command prefix (trimmed). / コマンド接頭辞以降のテキスト */
+  args: string;
+  /** Full query after `/` (trimmed). / `/` 以降のクエリ全文 */
+  query: string;
+  editor: Editor;
+}
+
+/**
+ * Return markdown to insert, or `null` to fall back to the built-in Claude prompt.
+ * 挿入する Markdown を返す。`null` なら既定の Claude プロンプトにフォールバック。
+ */
+export type SlashAgentCommandHookResult = { markdown: string } | null;
+
+/**
+ * Custom handler invoked before the built-in Claude Code execution.
+ * 組み込み Claude Code 実行の前に呼ばれるカスタムハンドラ。
+ */
+export type SlashAgentCommandHook = (
+  ctx: SlashAgentCommandHookContext,
+) => Promise<SlashAgentCommandHookResult> | SlashAgentCommandHookResult;
+
+let registeredHook: SlashAgentCommandHook | null = null;
+
+/**
+ * Registers or clears the global hook (e.g. from a plugin layer).
+ * グローバルフックを登録または解除する（プラグイン層などから）。
+ */
+export function registerSlashAgentCommandHook(hook: SlashAgentCommandHook | null): void {
+  registeredHook = hook;
+}
+
+/**
+ * Returns the current hook, if any.
+ * 登録済みフックがあれば返す。
+ */
+export function getSlashAgentCommandHook(): SlashAgentCommandHook | null {
+  return registeredHook;
+}

--- a/src/lib/agentSlashCommands/index.ts
+++ b/src/lib/agentSlashCommands/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Agent slash commands (Tiptap `/` + Claude Code sidecar, Issue #460).
+ * エージェントスラッシュコマンド（Issue #460）。
+ */
+
+export type {
+  AgentSlashCommandId,
+  AgentSlashPromptCaptures,
+  SlashAgentInsertPosition,
+} from "./types";
+export {
+  registerSlashAgentCommandHook,
+  getSlashAgentCommandHook,
+  type SlashAgentCommandHook,
+  type SlashAgentCommandHookContext,
+} from "./hook";
+export { readSlashAgentInsertPosition, writeSlashAgentInsertPosition } from "./insertPosition";
+export {
+  AGENT_SLASH_PREFIXES,
+  extractArgsAfterPrefix,
+  matchAgentSlashByQuery,
+  resolveArgsForSelectedAgent,
+  shouldOfferPathCompletion,
+  PATH_COMPLETABLE_AGENT_IDS,
+} from "./parseAgentSlashQuery";
+export { executeAgentSlashCommand } from "./executeAgentSlashCommand";

--- a/src/lib/agentSlashCommands/insertPosition.ts
+++ b/src/lib/agentSlashCommands/insertPosition.ts
@@ -1,0 +1,35 @@
+/**
+ * Persists insert position for agent slash results (cursor vs end of note).
+ * エージェントスラッシュ結果の挿入位置（カーソル／ノート末尾）の永続化。
+ */
+
+import type { SlashAgentInsertPosition } from "./types";
+
+const STORAGE_KEY = "zedi.slashAgent.insertPosition";
+
+/**
+ * Reads insert position from localStorage; defaults to `cursor`.
+ * localStorage から挿入位置を読む。既定は `cursor`。
+ */
+export function readSlashAgentInsertPosition(): SlashAgentInsertPosition {
+  if (typeof window === "undefined") return "cursor";
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    return v === "end" ? "end" : "cursor";
+  } catch {
+    return "cursor";
+  }
+}
+
+/**
+ * Persists insert position for future slash runs.
+ * 今後のスラッシュ実行用に挿入位置を保存する。
+ */
+export function writeSlashAgentInsertPosition(position: SlashAgentInsertPosition): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, position);
+  } catch {
+    /* ignore quota / private mode */
+  }
+}

--- a/src/lib/agentSlashCommands/insertSlashAgentMarkdown.ts
+++ b/src/lib/agentSlashCommands/insertSlashAgentMarkdown.ts
@@ -1,0 +1,33 @@
+/**
+ * Inserts Markdown from agent slash commands into the Tiptap editor.
+ * エージェントスラッシュの Markdown を Tiptap に挿入する。
+ */
+
+import type { Editor } from "@tiptap/core";
+import { convertMarkdownToTiptapContent } from "@/lib/markdownToTiptap";
+import type { SlashAgentInsertPosition } from "./types";
+
+/**
+ * Inserts Markdown at `insertAt` after the `/...` range was already removed.
+ * `/...` 削除後の位置 `insertAt` に Markdown を挿入する。
+ */
+export function insertSlashAgentMarkdownAt(
+  editor: Editor,
+  insertAt: number,
+  markdown: string,
+  position: SlashAgentInsertPosition,
+): void {
+  const normalized = markdown.trim() || "(empty result)";
+  const docJson = JSON.parse(convertMarkdownToTiptapContent(normalized)) as {
+    content: unknown[];
+  };
+  const content = docJson.content;
+
+  if (position === "end") {
+    const end = editor.state.doc.content.size;
+    editor.chain().focus().insertContentAt(end, content).run();
+    return;
+  }
+
+  editor.chain().focus().insertContentAt(insertAt, content).run();
+}

--- a/src/lib/agentSlashCommands/insertSlashAgentMarkdown.ts
+++ b/src/lib/agentSlashCommands/insertSlashAgentMarkdown.ts
@@ -18,10 +18,20 @@ export function insertSlashAgentMarkdownAt(
   position: SlashAgentInsertPosition,
 ): void {
   const normalized = markdown.trim() || "(empty result)";
-  const docJson = JSON.parse(convertMarkdownToTiptapContent(normalized)) as {
-    content: unknown[];
-  };
-  const content = docJson.content;
+  let content: unknown[];
+  try {
+    const docJson = JSON.parse(convertMarkdownToTiptapContent(normalized)) as {
+      content?: unknown[];
+    };
+    content = Array.isArray(docJson.content) ? docJson.content : [];
+  } catch {
+    content = [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: normalized }],
+      },
+    ];
+  }
 
   if (position === "end") {
     const end = editor.state.doc.content.size;

--- a/src/lib/agentSlashCommands/parseAgentSlashQuery.test.ts
+++ b/src/lib/agentSlashCommands/parseAgentSlashQuery.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractArgsAfterPrefix,
+  matchAgentSlashByQuery,
+  resolveArgsForSelectedAgent,
+  shouldOfferPathCompletion,
+} from "./parseAgentSlashQuery";
+
+describe("extractArgsAfterPrefix", () => {
+  it("returns text after prefix", () => {
+    expect(extractArgsAfterPrefix("analyze", "analyze src/foo")).toBe("src/foo");
+  });
+
+  it("returns empty when only prefix", () => {
+    expect(extractArgsAfterPrefix("analyze", "analyze")).toBe("");
+  });
+});
+
+describe("matchAgentSlashByQuery", () => {
+  it("matches analyze with path", () => {
+    const m = matchAgentSlashByQuery("analyze src/lib.ts");
+    expect(m?.id).toBe("agent-analyze");
+    expect(m?.args).toBe("src/lib.ts");
+  });
+
+  it("matches git alias", () => {
+    const m = matchAgentSlashByQuery("git");
+    expect(m?.id).toBe("agent-git-summary");
+  });
+
+  it("matches partial prefix", () => {
+    const m = matchAgentSlashByQuery("anal");
+    expect(m?.id).toBe("agent-analyze");
+  });
+
+  it("returns null for empty", () => {
+    expect(matchAgentSlashByQuery("")).toBeNull();
+  });
+});
+
+describe("resolveArgsForSelectedAgent", () => {
+  it("resolves args from primary prefix", () => {
+    expect(resolveArgsForSelectedAgent("analyze", undefined, "analyze path")).toBe("path");
+  });
+
+  it("resolves args from alias git", () => {
+    expect(resolveArgsForSelectedAgent("git-summary", ["git"], "git log")).toBe("log");
+  });
+});
+
+describe("shouldOfferPathCompletion", () => {
+  it("is true when path command has space", () => {
+    expect(shouldOfferPathCompletion("analyze ")).toBe(true);
+  });
+
+  it("is false without space", () => {
+    expect(shouldOfferPathCompletion("analyze")).toBe(false);
+  });
+});

--- a/src/lib/agentSlashCommands/parseAgentSlashQuery.ts
+++ b/src/lib/agentSlashCommands/parseAgentSlashQuery.ts
@@ -1,0 +1,119 @@
+/**
+ * Parses `/`-menu query text for agent commands (first token + args).
+ * エージェントコマンド向けに `/` メニューのクエリを解析する（先頭トークン + 引数）。
+ */
+
+import type { AgentSlashCommandId } from "./types";
+
+/** Longest-prefix metadata for each agent command. / 各エージェントコマンドの最長一致メタデータ */
+export const AGENT_SLASH_PREFIXES: ReadonlyArray<{
+  id: AgentSlashCommandId;
+  /** Primary command token after `/` (no leading slash). / `/` 直後の主トークン */
+  prefix: string;
+  /** Extra single-token prefixes for filtering (optional). / フィルタ用の別名トークン */
+  aliases?: readonly string[];
+}> = [
+  { id: "agent-analyze", prefix: "analyze" },
+  { id: "agent-git-summary", prefix: "git-summary", aliases: ["git"] },
+  { id: "agent-run", prefix: "run" },
+  { id: "agent-research", prefix: "research" },
+  { id: "agent-review", prefix: "review" },
+  { id: "agent-test", prefix: "test" },
+  { id: "agent-explain", prefix: "explain" },
+  { id: "agent-summarize", prefix: "summarize" },
+];
+
+/**
+ * Returns args text after the command prefix for a full-line query.
+ * 行全体のクエリから、コマンド接頭辞以降の引数文字列を返す。
+ */
+export function extractArgsAfterPrefix(commandPrefix: string, query: string): string {
+  const trimmed = query.trim();
+  const escaped = commandPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^${escaped}(?:\\s+(.*))?$`, "s");
+  const m = trimmed.match(re);
+  if (!m) return "";
+  return (m[1] ?? "").trim();
+}
+
+/**
+ * Finds which agent command matches the first token of `query` (longest prefix wins).
+ * `query` の先頭トークンに一致するエージェントコマンドを返す（最長一致）。
+ */
+export function matchAgentSlashByQuery(query: string): {
+  id: AgentSlashCommandId;
+  prefix: string;
+  args: string;
+} | null {
+  const trimmed = query.trim();
+  if (!trimmed) return null;
+  const firstToken = trimmed.split(/\s+/)[0] ?? "";
+  if (!firstToken) return null;
+
+  const candidates = [...AGENT_SLASH_PREFIXES].sort((a, b) => b.prefix.length - a.prefix.length);
+
+  for (const c of candidates) {
+    if (firstToken === c.prefix || c.aliases?.includes(firstToken)) {
+      const argsFromPrimary = extractArgsAfterPrefix(c.prefix, trimmed);
+      if (argsFromPrimary || trimmed === c.prefix || trimmed.startsWith(`${c.prefix} `)) {
+        return { id: c.id, prefix: c.prefix, args: argsFromPrimary };
+      }
+      for (const al of c.aliases ?? []) {
+        const fromAlias = extractArgsAfterPrefix(al, trimmed);
+        if (trimmed.startsWith(`${al} `) || trimmed === al) {
+          return { id: c.id, prefix: c.prefix, args: fromAlias };
+        }
+      }
+      return { id: c.id, prefix: c.prefix, args: "" };
+    }
+  }
+
+  for (const c of candidates) {
+    if (c.prefix.startsWith(firstToken) && firstToken.length >= 1) {
+      return { id: c.id, prefix: c.prefix, args: "" };
+    }
+  }
+  return null;
+}
+
+/** Agent commands that support workspace path completion. / ワークスペースパス補完が有効なコマンド */
+export const PATH_COMPLETABLE_AGENT_IDS: ReadonlySet<AgentSlashCommandId> = new Set([
+  "agent-analyze",
+  "agent-review",
+  "agent-test",
+  "agent-run",
+]);
+
+/**
+ * Whether to show path completion rows (args part after a space).
+ * パス補完行を出すか（スペース以降の引数部分）。
+ */
+export function shouldOfferPathCompletion(query: string): boolean {
+  const m = matchAgentSlashByQuery(query);
+  if (!m || !PATH_COMPLETABLE_AGENT_IDS.has(m.id)) return false;
+  return /\s/.test(query);
+}
+
+/**
+ * Resolves args for a known command when the user picked a menu entry.
+ * メニュー選択時に、既知コマンドに対する引数を解決する。
+ */
+export function resolveArgsForSelectedAgent(
+  commandPrefix: string,
+  aliases: readonly string[] | undefined,
+  query: string,
+): string {
+  const trimmed = query.trim();
+  if (!trimmed) return "";
+  const primary = extractArgsAfterPrefix(commandPrefix, trimmed);
+  if (trimmed === commandPrefix || trimmed.startsWith(`${commandPrefix} `)) {
+    return primary;
+  }
+  for (const al of aliases ?? []) {
+    const fromAlias = extractArgsAfterPrefix(al, trimmed);
+    if (trimmed === al || trimmed.startsWith(`${al} `)) {
+      return fromAlias;
+    }
+  }
+  return "";
+}

--- a/src/lib/agentSlashCommands/slashAgentSelectionCache.ts
+++ b/src/lib/agentSlashCommands/slashAgentSelectionCache.ts
@@ -1,0 +1,39 @@
+/**
+ * Remembers the last non-empty editor selection for agent slash `/explain`.
+ * スラッシュ入力で選択が消える前のテキストを保持する（`/explain` 向け）。
+ *
+ * The slash menu only activates with a collapsed selection, so live
+ * `getEditorSelectionText` is often empty when the command runs.
+ * スラッシュメニューはキャレット時のみ有効のため、実行時点では選択テキストが空になりがち。
+ */
+
+import type { Editor } from "@tiptap/core";
+
+const lastNonEmptyByEditor = new WeakMap<Editor, string>();
+
+/**
+ * Updates cached selection text when the user has a non-empty range.
+ * 非空の選択があるときだけキャッシュを更新する。
+ */
+export function rememberSlashAgentSelection(editor: Editor): void {
+  const { from, to } = editor.state.selection;
+  if (from !== to) {
+    lastNonEmptyByEditor.set(editor, editor.state.doc.textBetween(from, to, "\n", "\ufffc"));
+  }
+}
+
+/**
+ * Returns the last remembered non-empty selection text, or empty string.
+ * 直前の非空選択テキストを返す（なければ空）。
+ */
+export function getLastSlashAgentSelection(editor: Editor): string {
+  return lastNonEmptyByEditor.get(editor) ?? "";
+}
+
+/**
+ * Clears the remembered selection for this editor (e.g. after `/explain` runs).
+ * エディタのキャッシュを消す（`/explain` 完了後など）。
+ */
+export function clearLastSlashAgentSelection(editor: Editor): void {
+  lastNonEmptyByEditor.delete(editor);
+}

--- a/src/lib/agentSlashCommands/types.ts
+++ b/src/lib/agentSlashCommands/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Agent slash command kinds (Tiptap `/` menu, Claude Code sidecar).
+ * エージェント用スラッシュコマンド種別（Tiptap `/` メニュー・Claude Code）。
+ */
+
+/**
+ * Stable ids for i18n keys and registry lookups.
+ * i18n キーとレジストリ参照用の安定 ID。
+ */
+export type AgentSlashCommandId =
+  | "agent-analyze"
+  | "agent-git-summary"
+  | "agent-run"
+  | "agent-research"
+  | "agent-review"
+  | "agent-test"
+  | "agent-explain"
+  | "agent-summarize";
+
+/**
+ * Where to insert the model output into the note.
+ * モデル出力をノートのどこに挿入するか。
+ */
+export type SlashAgentInsertPosition = "cursor" | "end";
+
+/**
+ * Text captured before deleting the `/…` range (selection / full note).
+ * `/…` 削除前に取ったテキスト（選択／ノート全文）。
+ */
+export interface AgentSlashPromptCaptures {
+  selectionText?: string;
+  plainText?: string;
+}

--- a/src/lib/workspace/bridge.ts
+++ b/src/lib/workspace/bridge.ts
@@ -1,0 +1,24 @@
+/**
+ * Tauri workspace helpers (directory listing for slash path completion).
+ * スラッシュのパス補完用ディレクトリ一覧（Tauri）。
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { isTauriDesktop } from "@/lib/platform";
+
+/**
+ * Lists names in a directory relative to the app process cwd (repo root in dev).
+ * Directories are returned with a trailing `/`.
+ *
+ * プロセス cwd 基準の相対ディレクトリ内の名前を返す。ディレクトリは末尾 `/`。
+ */
+export async function listWorkspaceDirectoryEntries(relativeDir: string): Promise<string[]> {
+  if (!isTauriDesktop()) return [];
+  try {
+    return await invoke<string[]>("list_workspace_directory_entries", {
+      relativeDir: relativeDir.replace(/\\/g, "/"),
+    });
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## 概要

Tiptap の `/` メニューに Claude Code（デスクトップ sidecar）経由のエージェントコマンドを追加する。ブロック挿入コマンドと共存し、利用可能な環境でのみエージェント行を表示する（Issue #460）。

## 変更点

- **`src/components/editor/TiptapEditor/`**
  - スラッシュメニューを `SlashSuggestionMenu` / `SlashMenuRows` / パス補完セクション等に分割
  - `useClaudeAgentSlashAvailability` で Claude CLI 利用可否を判定
  - エージェント実行中は `SlashAgentLoadingOverlay` を表示
- **`src/lib/agentSlashCommands/`**
  - `/analyze`, `/git-summary`, `/run`, `/research`, `/review`, `/test`, `/explain`, `/summarize` のプロンプト組み立てと `runClaudeQueryToCompletion` 実行
  - 将来拡張用 `registerSlashAgentCommandHook`、挿入位置は localStorage（`zedi.slashAgent.insertPosition`）
- **`src/components/editor/extensions/slashSuggestionPlugin.ts`**
  - クエリにスペースを許可（`/analyze path/to` 入力中もメニュー維持）
- **`src-tauri/`**
  - `list_workspace_directory_entries` でパス補完用ディレクトリ列挙
- **`src/i18n/locales/`**
  - エージェントコマンド用文言（ja/en）
- **`src/lib/workspace/bridge.ts`**
  - Tauri からディレクトリ一覧を invoke

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run test:run`（`parseAgentSlashQuery.test.ts` を含む）
2. デスクトップアプリでノートを開き `/` を入力し、ブロック項目とエージェント項目が並ぶことを確認（Claude 未導入時はエージェント行が出ないこと）
3. 任意のエージェントを選び、実行中オーバーレイと結果挿入を確認（要 Claude Code 環境）

## チェックリスト

- [x] テストがすべてパスする（変更範囲の Vitest を実行済み）
- [x] Lint エラーがない（変更ファイルに対する ESLint）
- [ ] 必要に応じてドキュメントを更新した（該当なし）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

レビュアー向け: スラッシュメニューにエージェント行が増えたため、必要なら Before/After を添付してください。

## 関連 Issue

Closes #460

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Claude Codeエージェント用スラッシュコマンドを8種追加（/analyze、/git-summary、/run、/research、/review、/test、/explain、/summarize）
  * ワークスペースパス補完と候補選択UI、エディタへの挿入位置制御
  * エージェントコマンドのカスタムフック登録機能
  * エージェント実行中のローディングオーバーレイ表示

* **改善**
  * スラッシュメニューの統合表示、キーボード操作性とスクロール挙動を向上
  * 英日ローカライズ文字列を追加

* **テスト**
  * スラッシュ関連のユニット／キーボード処理テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->