### PR TITLE
Add content preview sync to page list display

### DIFF
--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -16,6 +16,23 @@ import type { AppEnv } from "../types/index.js";
 
 const app = new Hono<AppEnv>();
 
+/**
+ * PUT /content リクエストから pages テーブルの更新セットを構築し、変更があれば適用する。
+ * Build and apply pages-table updates (title, content_preview, updated_at) from PUT body.
+ */
+async function applyPagesMetadataUpdate(
+  db: { update: Database["update"] },
+  pageId: string,
+  body: { title?: string; content_preview?: string },
+): Promise<void> {
+  const set: Record<string, unknown> = {};
+  if (body.title !== undefined) set.title = body.title;
+  if (body.content_preview !== undefined) set.contentPreview = body.content_preview;
+  if (Object.keys(set).length === 0) return;
+  set.updatedAt = new Date();
+  await db.update(pages).set(set).where(eq(pages.id, pageId));
+}
+
 // ── GET /pages/:id/content ──────────────────────────────────────────────────
 app.get("/:id/content", authRequired, async (c) => {
   const pageId = c.req.param("id");
@@ -120,12 +137,7 @@ app.put("/:id/content", authRequired, async (c) => {
         const insertedRow = inserted[0];
         if (!insertedRow) throw new HTTPException(500, { message: "Insert failed" });
 
-        const pagesUpdate: Record<string, unknown> = { updatedAt: new Date() };
-        if (body.title !== undefined) pagesUpdate.title = body.title;
-        if (body.content_preview !== undefined) pagesUpdate.contentPreview = body.content_preview;
-        if (Object.keys(pagesUpdate).length > 1) {
-          await tx.update(pages).set(pagesUpdate).where(eq(pages.id, pageId));
-        }
+        await applyPagesMetadataUpdate(tx, pageId, body);
 
         return { done: true as const, version: insertedRow.version ?? 1 };
       });
@@ -163,14 +175,7 @@ app.put("/:id/content", authRequired, async (c) => {
     const updatedRow = updated[0];
     if (!updatedRow) throw new HTTPException(500, { message: "Update failed" });
 
-    {
-      const pagesUpdate: Record<string, unknown> = { updatedAt: new Date() };
-      if (body.title !== undefined) pagesUpdate.title = body.title;
-      if (body.content_preview !== undefined) pagesUpdate.contentPreview = body.content_preview;
-      if (Object.keys(pagesUpdate).length > 1) {
-        await db.update(pages).set(pagesUpdate).where(eq(pages.id, pageId));
-      }
-    }
+    await applyPagesMetadataUpdate(db, pageId, body);
 
     return c.json({ version: updatedRow.version ?? 0 });
   }
@@ -195,14 +200,7 @@ app.put("/:id/content", authRequired, async (c) => {
     })
     .returning();
 
-  {
-    const pagesUpdate: Record<string, unknown> = { updatedAt: new Date() };
-    if (body.title !== undefined) pagesUpdate.title = body.title;
-    if (body.content_preview !== undefined) pagesUpdate.contentPreview = body.content_preview;
-    if (Object.keys(pagesUpdate).length > 1) {
-      await db.update(pages).set(pagesUpdate).where(eq(pages.id, pageId));
-    }
-  }
+  await applyPagesMetadataUpdate(db, pageId, body);
 
   const resultRow = result[0];
   if (!resultRow) throw new HTTPException(500, { message: "Upsert failed" });

--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -73,6 +73,7 @@ app.put("/:id/content", authRequired, async (c) => {
     ydoc_state: string; // base64-encoded Y.Doc state
     expected_version?: number;
     content_text?: string;
+    content_preview?: string;
     title?: string;
   }>();
 
@@ -119,11 +120,11 @@ app.put("/:id/content", authRequired, async (c) => {
         const insertedRow = inserted[0];
         if (!insertedRow) throw new HTTPException(500, { message: "Insert failed" });
 
-        if (body.title !== undefined) {
-          await tx
-            .update(pages)
-            .set({ title: body.title, updatedAt: new Date() })
-            .where(eq(pages.id, pageId));
+        const pagesUpdate: Record<string, unknown> = { updatedAt: new Date() };
+        if (body.title !== undefined) pagesUpdate.title = body.title;
+        if (body.content_preview !== undefined) pagesUpdate.contentPreview = body.content_preview;
+        if (Object.keys(pagesUpdate).length > 1) {
+          await tx.update(pages).set(pagesUpdate).where(eq(pages.id, pageId));
         }
 
         return { done: true as const, version: insertedRow.version ?? 1 };
@@ -162,11 +163,13 @@ app.put("/:id/content", authRequired, async (c) => {
     const updatedRow = updated[0];
     if (!updatedRow) throw new HTTPException(500, { message: "Update failed" });
 
-    if (body.title !== undefined) {
-      await db
-        .update(pages)
-        .set({ title: body.title, updatedAt: new Date() })
-        .where(eq(pages.id, pageId));
+    {
+      const pagesUpdate: Record<string, unknown> = { updatedAt: new Date() };
+      if (body.title !== undefined) pagesUpdate.title = body.title;
+      if (body.content_preview !== undefined) pagesUpdate.contentPreview = body.content_preview;
+      if (Object.keys(pagesUpdate).length > 1) {
+        await db.update(pages).set(pagesUpdate).where(eq(pages.id, pageId));
+      }
     }
 
     return c.json({ version: updatedRow.version ?? 0 });
@@ -192,11 +195,13 @@ app.put("/:id/content", authRequired, async (c) => {
     })
     .returning();
 
-  if (body.title !== undefined) {
-    await db
-      .update(pages)
-      .set({ title: body.title, updatedAt: new Date() })
-      .where(eq(pages.id, pageId));
+  {
+    const pagesUpdate: Record<string, unknown> = { updatedAt: new Date() };
+    if (body.title !== undefined) pagesUpdate.title = body.title;
+    if (body.content_preview !== undefined) pagesUpdate.contentPreview = body.content_preview;
+    if (Object.keys(pagesUpdate).length > 1) {
+      await db.update(pages).set(pagesUpdate).where(eq(pages.id, pageId));
+    }
   }
 
   const resultRow = result[0];

--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -12,7 +12,7 @@ import { HTTPException } from "hono/http-exception";
 import { eq, and, sql } from "drizzle-orm";
 import { pages, pageContents } from "../schema/index.js";
 import { authRequired } from "../middleware/auth.js";
-import type { AppEnv } from "../types/index.js";
+import type { AppEnv, Database } from "../types/index.js";
 
 const app = new Hono<AppEnv>();
 

--- a/server/hocuspocus/src/index.ts
+++ b/server/hocuspocus/src/index.ts
@@ -193,21 +193,62 @@ async function loadDocumentFromDb(pageId: string): Promise<Y.Doc> {
   }
 }
 
+/**
+ * Y.Doc の XmlFragment からプレーンテキストを再帰的に抽出するヘルパー。
+ * Recursively extract plain text from a Y.Doc XmlFragment.
+ */
+function extractTextFromFragment(node: Y.XmlFragment): string {
+  let text = "";
+
+  for (let i = 0; i < node.length; i++) {
+    const child = node.get(i);
+    if (child instanceof Y.XmlText) {
+      text += child.toString();
+    } else if (child instanceof Y.XmlElement) {
+      text += extractTextFromFragment(child) + "\n";
+    }
+  }
+  return text;
+}
+
+const CONTENT_PREVIEW_MAX_LENGTH = 120;
+
+/**
+ * Y.Doc からコンテンツプレビューを生成する。
+ * Generate content preview (first 120 chars) from a Y.Doc.
+ */
+function buildContentPreview(document: Y.Doc): string {
+  const fragment = document.getXmlFragment("default");
+  const raw = extractTextFromFragment(fragment);
+  const trimmed = raw.trim().replace(/\s+/g, " ");
+  if (trimmed.length <= CONTENT_PREVIEW_MAX_LENGTH) return trimmed;
+  return trimmed.slice(0, CONTENT_PREVIEW_MAX_LENGTH).trim() + "...";
+}
+
 async function saveDocumentToDb(pageId: string, document: Y.Doc): Promise<void> {
   const encodedState = Buffer.from(Y.encodeStateAsUpdate(document));
+  const contentText = extractTextFromFragment(document.getXmlFragment("default"));
+  const contentPreview = buildContentPreview(document);
   const client = await getPool().connect();
   try {
     await client.query(
       `
         INSERT INTO page_contents (page_id, ydoc_state, version, content_text, updated_at)
-        VALUES ($1, $2, 1, '', NOW())
+        VALUES ($1, $2, 1, $3, NOW())
         ON CONFLICT (page_id) DO UPDATE
           SET ydoc_state = EXCLUDED.ydoc_state,
               version = page_contents.version + 1,
+              content_text = EXCLUDED.content_text,
               updated_at = NOW()
       `,
-      [pageId, encodedState],
+      [pageId, encodedState, contentText],
     );
+    // ページ一覧用のプレビューを pages テーブルにも同期
+    // Sync content preview to the pages table for page list display
+    await client.query(`UPDATE pages SET content_preview = $1, updated_at = NOW() WHERE id = $2`, [
+      contentPreview,
+      pageId,
+    ]);
   } finally {
     client.release();
   }

--- a/server/hocuspocus/src/index.ts
+++ b/server/hocuspocus/src/index.ts
@@ -214,13 +214,11 @@ function extractTextFromFragment(node: Y.XmlFragment): string {
 const CONTENT_PREVIEW_MAX_LENGTH = 120;
 
 /**
- * Y.Doc からコンテンツプレビューを生成する。
- * Generate content preview (first 120 chars) from a Y.Doc.
+ * プレーンテキストからコンテンツプレビュー（先頭120文字）を生成する。
+ * Generate content preview (first 120 chars) from plain text.
  */
-function buildContentPreview(document: Y.Doc): string {
-  const fragment = document.getXmlFragment("default");
-  const raw = extractTextFromFragment(fragment);
-  const trimmed = raw.trim().replace(/\s+/g, " ");
+function buildContentPreview(text: string): string {
+  const trimmed = text.trim().replace(/\s+/g, " ");
   if (trimmed.length <= CONTENT_PREVIEW_MAX_LENGTH) return trimmed;
   return trimmed.slice(0, CONTENT_PREVIEW_MAX_LENGTH).trim() + "...";
 }
@@ -228,9 +226,10 @@ function buildContentPreview(document: Y.Doc): string {
 async function saveDocumentToDb(pageId: string, document: Y.Doc): Promise<void> {
   const encodedState = Buffer.from(Y.encodeStateAsUpdate(document));
   const contentText = extractTextFromFragment(document.getXmlFragment("default"));
-  const contentPreview = buildContentPreview(document);
+  const contentPreview = buildContentPreview(contentText);
   const client = await getPool().connect();
   try {
+    await client.query("BEGIN");
     await client.query(
       `
         INSERT INTO page_contents (page_id, ydoc_state, version, content_text, updated_at)
@@ -249,6 +248,10 @@ async function saveDocumentToDb(pageId: string, document: Y.Doc): Promise<void> 
       contentPreview,
       pageId,
     ]);
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
   } finally {
     client.release();
   }

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -28,6 +28,12 @@ const DUPLICATION_RATIO_THRESHOLD = 1.5;
 const KEEPALIVE_PAYLOAD_LIMIT = 63 * 1024;
 
 /**
+ * ページ一覧用プレビューの最大文字数。
+ * Maximum character length for page list content preview.
+ */
+const CONTENT_PREVIEW_MAX_LENGTH = 120;
+
+/**
  * Y.js ドキュメントの管理・永続化・リアルタイム同期を担当するマネージャー。
  * Manages Y.js document lifecycle, IndexedDB persistence, and real-time sync.
  */
@@ -198,12 +204,20 @@ export class CollaborationManager {
   }
 
   /**
-   * PUT /content 用 JSON ボディ。ydoc_state / content_text に加え、setPageTitle 済みなら title を含む。
+   * PUT /content 用 JSON ボディ。ydoc_state / content_text / content_preview に加え、setPageTitle 済みなら title を含む。
+   * Build JSON body for PUT /content. Includes ydoc_state, content_text, content_preview, and optionally title.
    */
   private buildPutContentBody(ydocStateB64: string, contentText: string): Record<string, string> {
+    const trimmed = contentText.trim().replace(/\s+/g, " ");
+    const contentPreview =
+      trimmed.length <= CONTENT_PREVIEW_MAX_LENGTH
+        ? trimmed
+        : trimmed.slice(0, CONTENT_PREVIEW_MAX_LENGTH).trim() + "...";
+
     const payload: Record<string, string> = {
       ydoc_state: ydocStateB64,
       content_text: contentText,
+      content_preview: contentPreview,
     };
     if (this.pageTitle !== null) {
       payload.title = this.pageTitle;


### PR DESCRIPTION
## 概要

ページ一覧表示用のコンテンツプレビュー機能を追加します。Y.Doc から抽出したテキストの最初の120文字をプレビューとして `pages` テーブルに同期し、ページ一覧の表示を改善します。

## 変更点

- **hocuspocus/src/index.ts**
  - `extractTextFromFragment()`: Y.Doc の XmlFragment からプレーンテキストを再帰的に抽出するヘルパー関数を追加
  - `buildContentPreview()`: Y.Doc からコンテンツプレビュー（最大120文字）を生成する関数を追加
  - `saveDocumentToDb()`: ドキュメント保存時に `content_text` と `content_preview` を `pages` テーブルに同期するロジックを追加

- **server/api/src/routes/pages.ts**
  - PUT `/content` エンドポイントで `content_preview` パラメータを受け入れるよう対応
  - 3箇所の pages テーブル更新ロジックを統一し、`title` と `content_preview` の両方を条件付きで更新できるように改善

- **src/lib/collaboration/CollaborationManager.ts**
  - `CONTENT_PREVIEW_MAX_LENGTH` 定数を追加（120文字）
  - `buildPutContentBody()`: PUT リクエストボディに `content_preview` を含めるよう拡張

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)

## テスト方法

1. ドキュメントを編集してコンテンツを追加
2. 自動保存が実行され、`pages` テーブルの `content_preview` カラムに最初の120文字が保存されることを確認
3. ページ一覧表示でプレビューが正しく表示されることを確認
4. 120文字を超えるコンテンツの場合、末尾に「...」が付加されることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

https://claude.ai/code/session_01WPpwEVBuAB2MGshdr7Xi5S
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
