### PR TITLE
fix: address PR #499 review comments

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -2,10 +2,14 @@
 # 各プラットフォーム向けの Tauri デスクトップアプリをビルドし、
 # リリースアセットとしてアップロードする。
 # 自動更新用の latest.json も生成・アップロードする（署名キー設定時のみ）。
+# リリース時は GitHub Secrets の TAURI_SIGNING_PUBLIC_KEY（公開鍵文字列）を
+# tauri.conf.json の plugins.updater.pubkey に注入する（scripts/inject-tauri-updater-pubkey.mjs）。
+# TAURI_SIGNING_PRIVATE_KEY と対になる公開鍵を設定すること。
 #
 # Builds Tauri desktop apps for all platforms when a GitHub Release is
 # published (by Release Please) and uploads them as release assets.
 # Also generates latest.json for the Tauri updater (when signing key is set).
+# Injects `plugins.updater.pubkey` from the `TAURI_SIGNING_PUBLIC_KEY` secret before build.
 name: Build & Release Desktop App
 
 on:
@@ -54,6 +58,11 @@ jobs:
 
       - name: Build sidecar
         run: bun run sidecar:build
+
+      - name: Inject Tauri updater public key
+        env:
+          TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
+        run: node scripts/inject-tauri-updater-pubkey.mjs
 
       - name: Build Tauri app and upload to release
         uses: tauri-apps/tauri-action@v0

--- a/scripts/inject-tauri-updater-pubkey.mjs
+++ b/scripts/inject-tauri-updater-pubkey.mjs
@@ -1,0 +1,33 @@
+/**
+ * Injects `plugins.updater.pubkey` in `src-tauri/tauri.conf.json` when
+ * `TAURI_SIGNING_PUBLIC_KEY` is set (e.g. GitHub Actions secret for release builds).
+ * Public key must match the private key used to sign updater artifacts.
+ *
+ * `TAURI_SIGNING_PUBLIC_KEY` が設定されているときだけ `tauri.conf.json` の
+ * `plugins.updater.pubkey` を上書きする（リリース CI 用）。公開鍵は署名用秘密鍵と対になる。
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const configPath = path.join(repoRoot, "src-tauri", "tauri.conf.json");
+
+const key = process.env.TAURI_SIGNING_PUBLIC_KEY?.trim();
+if (!key) {
+  console.log(
+    "TAURI_SIGNING_PUBLIC_KEY is not set; skipping updater pubkey injection (local / unsigned builds).",
+  );
+  process.exit(0);
+}
+
+const raw = fs.readFileSync(configPath, "utf8");
+const j = JSON.parse(raw);
+j.plugins = j.plugins ?? {};
+j.plugins.updater = j.plugins.updater ?? {};
+j.plugins.updater.pubkey = key;
+fs.writeFileSync(configPath, `${JSON.stringify(j, null, 2)}\n`);
+console.log(
+  "Injected TAURI_SIGNING_PUBLIC_KEY into src-tauri/tauri.conf.json (plugins.updater.pubkey).",
+);

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -11,6 +11,7 @@ import { IndexeddbPersistence } from "y-indexeddb";
 import { Awareness } from "y-protocols/awareness";
 import type { UserPresence, ConnectionStatus, CollaborationState } from "./types";
 import { getUserColor } from "./types";
+import { extractPlainTextFromYXmlFragment } from "./plainTextFromYXmlFragment";
 
 /**
  * コラボレーションの動作モード。
@@ -293,32 +294,7 @@ export class CollaborationManager {
    * XmlFragment からプレーンテキストを抽出
    */
   private extractText(fragment: Y.XmlFragment): string {
-    const parts: string[] = [];
-    const walk = (node: Y.XmlFragment | Y.XmlElement | Y.XmlText) => {
-      if (node instanceof Y.XmlText) {
-        // toDelta() を使い書式属性なしの純粋なテキストのみを抽出する。
-        // toString() / toJSON() は <bold> 等の HTML タグを返すため使用しない。
-        // Use toDelta() to extract pure text without formatting attributes.
-        // toString() / toJSON() return HTML-like tags (<bold>, etc.) so we avoid them.
-        for (const op of node.toDelta()) {
-          if (typeof op.insert === "string") {
-            parts.push(op.insert);
-          }
-        }
-      } else {
-        for (const child of node.toArray()) {
-          if (
-            child instanceof Y.XmlText ||
-            child instanceof Y.XmlElement ||
-            child instanceof Y.XmlFragment
-          ) {
-            walk(child);
-          }
-        }
-      }
-    };
-    walk(fragment);
-    return parts.join("\n").trim();
+    return extractPlainTextFromYXmlFragment(fragment);
   }
 
   private async connectWebSocket() {

--- a/src/lib/collaboration/plainTextFromYXmlFragment.test.ts
+++ b/src/lib/collaboration/plainTextFromYXmlFragment.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { extractPlainTextFromYXmlFragment } from "./plainTextFromYXmlFragment";
+
+describe("extractPlainTextFromYXmlFragment", () => {
+  it("returns empty string for an empty fragment / 空の fragment では空文字を返す", () => {
+    const doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+    expect(extractPlainTextFromYXmlFragment(fragment)).toBe("");
+  });
+
+  it("does not insert newlines between delta ops inside one XmlText (Tiptap marks) / 同一 XmlText 内の複数 op 間に改行を入れない", () => {
+    const doc = new Y.Doc();
+    doc.transact(() => {
+      const fragment = doc.getXmlFragment("default");
+      const p = new Y.XmlElement("paragraph");
+      fragment.push([p]);
+      const t = new Y.XmlText();
+      t.insert(0, "Hello ");
+      t.insert(6, "world", { bold: true });
+      t.insert(11, "!");
+      p.push([t]);
+    });
+    const plain = extractPlainTextFromYXmlFragment(doc.getXmlFragment("default")).trim();
+    expect(plain).toBe("Hello world!");
+    expect(plain).not.toMatch(/Hello\s*\n/);
+  });
+
+  it("separates block-level siblings with newlines / ブロック兄弟間は改行で区切る", () => {
+    const doc = new Y.Doc();
+    doc.transact(() => {
+      const fragment = doc.getXmlFragment("default");
+      const p1 = new Y.XmlElement("paragraph");
+      fragment.push([p1]);
+      const a = new Y.XmlText();
+      a.insert(0, "First");
+      p1.push([a]);
+      const p2 = new Y.XmlElement("paragraph");
+      fragment.push([p2]);
+      const b = new Y.XmlText();
+      b.insert(0, "Second");
+      p2.push([b]);
+    });
+    const plain = extractPlainTextFromYXmlFragment(doc.getXmlFragment("default")).trim();
+    expect(plain).toContain("First");
+    expect(plain).toContain("Second");
+    expect(/\n/.test(plain)).toBe(true);
+  });
+});

--- a/src/lib/collaboration/plainTextFromYXmlFragment.ts
+++ b/src/lib/collaboration/plainTextFromYXmlFragment.ts
@@ -1,0 +1,43 @@
+import * as Y from "yjs";
+
+/**
+ * ページの Y.Xml フラグメントからプレーンテキストを抽出する（クライアント側）。
+ * `Y.XmlText.toString()` / `toJSON()` は書式を HTML 風タグで返すため使わず、`toDelta()` の
+ * `insert` 文字列のみを集める。
+ *
+ * 同一 `Y.XmlText` 内で書式の切り替えがあると `toDelta()` は複数 op になる。
+ * それらを個別に区切って `join("\n")` すると op 間に誤った改行が入るため、**ノード内では
+ * 文字列を連結してから** 1 エントリとして扱う（`server/hocuspocus` の `extractTextFromYXml` と同様）。
+ *
+ * Extract plain text from the page `Y.XmlFragment` on the client.
+ * Avoid `Y.XmlText.toString()` / `toJSON()` (HTML-like tags); use `toDelta()` string inserts only.
+ * Concatenate all string inserts within a single `Y.XmlText` before joining block-level parts with newlines.
+ */
+export function extractPlainTextFromYXmlFragment(fragment: Y.XmlFragment): string {
+  const parts: string[] = [];
+  const walk = (node: Y.XmlFragment | Y.XmlElement | Y.XmlText) => {
+    if (node instanceof Y.XmlText) {
+      let plain = "";
+      for (const op of node.toDelta()) {
+        if (typeof op.insert === "string") {
+          plain += op.insert;
+        }
+      }
+      if (plain.length > 0) {
+        parts.push(plain);
+      }
+    } else {
+      for (const child of node.toArray()) {
+        if (
+          child instanceof Y.XmlText ||
+          child instanceof Y.XmlElement ||
+          child instanceof Y.XmlFragment
+        ) {
+          walk(child);
+        }
+      }
+    }
+  };
+  walk(fragment);
+  return parts.join("\n").trim();
+}


### PR DESCRIPTION
## 概要

`develop` → `main` のリリース PR #499 に対するレビュー（`Y.XmlText` の `toDelta()` 取り扱い、Tauri updater の `pubkey`）への対応です。

_Follow-up for review comments on release PR #499._

## 変更点

- `src/lib/collaboration/`: 同一 `Y.XmlText` 内の複数 delta op を連結してから `parts` に 1 回だけ追加（`parts.join("\n")` で op 間に誤改行が入らないようにする）。`server/hocuspocus` の `extractTextFromYXml` と同様の連結方針。
- `scripts/inject-tauri-updater-pubkey.mjs` + `.github/workflows/tauri-release.yml`: リリースビルド時に `TAURI_SIGNING_PUBLIC_KEY`（GitHub Secret）を `plugins.updater.pubkey` に注入。未設定時はスキップ（従来どおり）。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run test:run`
2. `bun run lint` / `bun run format:check`（ローカルに未追跡の `.claude/worktrees/` 等があると全体チェックがノイズになる場合は、変更ファイルに限定して確認）

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない（変更ファイル）
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## 運用メモ（マージ後）

- 本番デスクトップの自動更新を有効にするには、リポジトリの **Secrets** に `TAURI_SIGNING_PUBLIC_KEY` を追加し（`TAURI_SIGNING_PRIVATE_KEY` 対の公開鍵）、リリースワークフローで注入されることを確認してください。

## 関連 Issue

Related to #499

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
