### PR TITLE
fix: address PR #499 review comments

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -33,7 +33,8 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v4
+      # Pin to commit SHAs (tags are mutable). Tag comments for upgrades.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install system dependencies (Linux)
         if: matrix.platform == 'ubuntu-22.04'
@@ -43,18 +44,18 @@ jobs:
             libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: "./src-tauri -> target"
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build sidecar
         run: bun run sidecar:build
@@ -65,7 +66,7 @@ jobs:
         run: node scripts/inject-tauri-updater-pubkey.mjs
 
       - name: Build Tauri app and upload to release
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}

--- a/scripts/inject-tauri-updater-pubkey.mjs
+++ b/scripts/inject-tauri-updater-pubkey.mjs
@@ -15,10 +15,21 @@ const repoRoot = path.resolve(__dirname, "..");
 const configPath = path.join(repoRoot, "src-tauri", "tauri.conf.json");
 
 const key = process.env.TAURI_SIGNING_PUBLIC_KEY?.trim();
+// Release job / tag context: missing pubkey must fail (no unsigned release artifacts).
+const isReleaseContext =
+  process.env.GITHUB_ACTIONS === "true" &&
+  (process.env.GITHUB_EVENT_NAME === "release" || process.env.GITHUB_REF?.startsWith("refs/tags/"));
+
 if (!key) {
-  console.log(
-    "TAURI_SIGNING_PUBLIC_KEY is not set; skipping updater pubkey injection (local / unsigned builds).",
-  );
+  const msg =
+    "TAURI_SIGNING_PUBLIC_KEY is not set; skipping updater pubkey injection (local / unsigned builds).";
+  if (isReleaseContext) {
+    console.error(
+      `ERROR: ${msg} In this release context (GitHub Actions release or refs/tags), set TAURI_SIGNING_PUBLIC_KEY so updater signatures can be verified.`,
+    );
+    process.exit(1);
+  }
+  console.log(msg);
   process.exit(0);
 }
 

--- a/src/lib/collaboration/plainTextFromYXmlFragment.test.ts
+++ b/src/lib/collaboration/plainTextFromYXmlFragment.test.ts
@@ -26,6 +26,29 @@ describe("extractPlainTextFromYXmlFragment", () => {
     expect(plain).not.toMatch(/Hello\s*\n/);
   });
 
+  it("does not insert newlines between inline XmlText siblings (bold) / インライン境界では改行を入れない", () => {
+    const doc = new Y.Doc();
+    doc.transact(() => {
+      const fragment = doc.getXmlFragment("default");
+      const paragraph = new Y.XmlElement("paragraph");
+      fragment.push([paragraph]);
+      const t1 = new Y.XmlText();
+      t1.insert(0, "Hello ");
+      paragraph.push([t1]);
+      const bold = new Y.XmlElement("bold");
+      paragraph.push([bold]);
+      const tBold = new Y.XmlText();
+      tBold.insert(0, "world");
+      bold.push([tBold]);
+      const t2 = new Y.XmlText();
+      t2.insert(0, "!");
+      paragraph.push([t2]);
+    });
+    const plain = extractPlainTextFromYXmlFragment(doc.getXmlFragment("default")).trim();
+    expect(plain).not.toMatch(/world\s*\n\s*!/);
+    expect(plain.replace(/\s+/g, " ").trim()).toBe("Hello world !");
+  });
+
   it("separates block-level siblings with newlines / ブロック兄弟間は改行で区切る", () => {
     const doc = new Y.Doc();
     doc.transact(() => {
@@ -42,8 +65,6 @@ describe("extractPlainTextFromYXmlFragment", () => {
       p2.push([b]);
     });
     const plain = extractPlainTextFromYXmlFragment(doc.getXmlFragment("default")).trim();
-    expect(plain).toContain("First");
-    expect(plain).toContain("Second");
-    expect(/\n/.test(plain)).toBe(true);
+    expect(plain).toBe("First\nSecond");
   });
 });

--- a/src/lib/collaboration/plainTextFromYXmlFragment.ts
+++ b/src/lib/collaboration/plainTextFromYXmlFragment.ts
@@ -31,14 +31,15 @@ function isInlineXmlElement(node: Y.XmlElement): boolean {
 /**
  * Y.Doc の XmlFragment（または XmlElement 根）からプレーンテキストを再帰的に抽出する。
  * `server/hocuspocus` の `extractTextFromYXml` と同じ走査・接尾辞ルール（インラインはスペース、ブロックは改行）。
+ * 子の列挙は `toArray()` を使う（`get(i)` をループで繰り返すと兄弟が多いときに二乗になりうるため）。
  *
  * Recursively extract plain text matching `extractTextFromYXml` in `server/hocuspocus`.
+ * Iterate children with `toArray()` to avoid repeated `get(i)` scans over siblings.
  */
 function extractTextFromYXml(node: Y.XmlFragment | Y.XmlElement): string {
   let text = "";
 
-  for (let i = 0; i < node.length; i++) {
-    const child = node.get(i);
+  for (const child of node.toArray()) {
     if (child instanceof Y.XmlText) {
       for (const op of child.toDelta()) {
         if (typeof op.insert === "string") {

--- a/src/lib/collaboration/plainTextFromYXmlFragment.ts
+++ b/src/lib/collaboration/plainTextFromYXmlFragment.ts
@@ -1,43 +1,67 @@
 import * as Y from "yjs";
 
 /**
+ * TipTap / ProseMirror のマーク相当で、Y.Xml 上に子要素として現れるインライン名。
+ * `server/hocuspocus/src/extractPlainTextFromYXml.ts` の `INLINE_XML_ELEMENT_NAMES` と同じ集合を保つこと。
+ *
+ * Mark-like XmlElement names; must stay aligned with
+ * `server/hocuspocus/src/extractPlainTextFromYXml.ts` (`INLINE_XML_ELEMENT_NAMES`).
+ */
+const INLINE_XML_ELEMENT_NAMES = new Set<string>([
+  "bold",
+  "italic",
+  "strike",
+  "code",
+  "link",
+  "underline",
+  "highlight",
+  "subscript",
+  "superscript",
+  "textStyle",
+]);
+
+/**
+ * インライン要素かどうかを nodeName で判定する。
+ * Determine whether an XmlElement is inline-only (trailing space after subtree, not newline).
+ */
+function isInlineXmlElement(node: Y.XmlElement): boolean {
+  return INLINE_XML_ELEMENT_NAMES.has(node.nodeName);
+}
+
+/**
+ * Y.Doc の XmlFragment（または XmlElement 根）からプレーンテキストを再帰的に抽出する。
+ * `server/hocuspocus` の `extractTextFromYXml` と同じ走査・接尾辞ルール（インラインはスペース、ブロックは改行）。
+ *
+ * Recursively extract plain text matching `extractTextFromYXml` in `server/hocuspocus`.
+ */
+function extractTextFromYXml(node: Y.XmlFragment | Y.XmlElement): string {
+  let text = "";
+
+  for (let i = 0; i < node.length; i++) {
+    const child = node.get(i);
+    if (child instanceof Y.XmlText) {
+      for (const op of child.toDelta()) {
+        if (typeof op.insert === "string") {
+          text += op.insert;
+        }
+      }
+    } else if (child instanceof Y.XmlElement) {
+      const inner = extractTextFromYXml(child);
+      const suffix = isInlineXmlElement(child) ? " " : "\n";
+      text += inner + suffix;
+    }
+  }
+  return text;
+}
+
+/**
  * ページの Y.Xml フラグメントからプレーンテキストを抽出する（クライアント側）。
  * `Y.XmlText.toString()` / `toJSON()` は書式を HTML 風タグで返すため使わず、`toDelta()` の
- * `insert` 文字列のみを集める。
+ * `insert` 文字列のみを集める。ブロック / インライン境界はサーバーと同じ `INLINE_XML_ELEMENT_NAMES` に依存する。
  *
- * 同一 `Y.XmlText` 内で書式の切り替えがあると `toDelta()` は複数 op になる。
- * それらを個別に区切って `join("\n")` すると op 間に誤った改行が入るため、**ノード内では
- * 文字列を連結してから** 1 エントリとして扱う（`server/hocuspocus` の `extractTextFromYXml` と同様）。
- *
- * Extract plain text from the page `Y.XmlFragment` on the client.
- * Avoid `Y.XmlText.toString()` / `toJSON()` (HTML-like tags); use `toDelta()` string inserts only.
- * Concatenate all string inserts within a single `Y.XmlText` before joining block-level parts with newlines.
+ * Extract plain text from the page `Y.XmlFragment` on the client, aligned with the hocuspocus
+ * `extractTextFromYXml` implementation for `content_text` / `content_preview` consistency.
  */
 export function extractPlainTextFromYXmlFragment(fragment: Y.XmlFragment): string {
-  const parts: string[] = [];
-  const walk = (node: Y.XmlFragment | Y.XmlElement | Y.XmlText) => {
-    if (node instanceof Y.XmlText) {
-      let plain = "";
-      for (const op of node.toDelta()) {
-        if (typeof op.insert === "string") {
-          plain += op.insert;
-        }
-      }
-      if (plain.length > 0) {
-        parts.push(plain);
-      }
-    } else {
-      for (const child of node.toArray()) {
-        if (
-          child instanceof Y.XmlText ||
-          child instanceof Y.XmlElement ||
-          child instanceof Y.XmlFragment
-        ) {
-          walk(child);
-        }
-      }
-    }
-  };
-  walk(fragment);
-  return parts.join("\n").trim();
+  return extractTextFromYXml(fragment).trim();
 }


### PR DESCRIPTION
## 概要

[Release PR #499](https://github.com/otomatty/zedi/pull/499) の CodeRabbit / Devin の未返信レビューに対応しました。

_Addresses open review threads on release PR #499 (CodeRabbit, Devin)._ 

## 変更点

- `.github/workflows/tauri-release.yml`: 各 `uses` をコミット SHA 固定、`bun install --frozen-lockfile` に統一
- `scripts/inject-tauri-updater-pubkey.mjs`: GitHub Actions のリリース / `refs/tags/` コンテキストで `TAURI_SIGNING_PUBLIC_KEY` 未設定時は `exit(1)`（ローカルは従来どおりスキップ）
- `plainTextFromYXmlFragment.ts`: `server/hocuspocus` の `extractTextFromYXml` と同じインライン / ブロック境界（`INLINE_XML_ELEMENT_NAMES`）で抽出
- テスト: ブロック区切りを厳密一致、インライン兄弟の改行なしケースを追加

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bunx vitest run src/lib/collaboration/plainTextFromYXmlFragment.test.ts`
2. `bun run lint`（リポジトリ全体の警告は既存のまま）

## 関連 Issue

Related to #499

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
