### PR TITLE
feat(editor): add Claude HTML artifact embed (sandboxed iframe)

### DIFF
--- a/src/components/editor/HtmlArtifactNodeView.test.tsx
+++ b/src/components/editor/HtmlArtifactNodeView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HtmlArtifactNodeView } from "./HtmlArtifactNodeView";
 import type { NodeViewProps } from "@tiptap/react";
@@ -55,6 +55,22 @@ describe("HtmlArtifactNodeView", () => {
 
     const iframe = getIframe();
     expect(iframe.getAttribute("sandbox")).not.toContain("allow-same-origin");
+  });
+
+  it("ignores resize postMessage when event.source is not this artifact iframe", () => {
+    const props = createMockProps({ content: "<div>x</div>" });
+    render(<HtmlArtifactNodeView {...props} />);
+
+    const iframe = getIframe();
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "zedi-artifact-resize", height: 40 },
+          source: window,
+        }),
+      );
+    });
+    expect(iframe.style.height).toBe("300px");
   });
 
   it("displays the title when provided", () => {

--- a/src/components/editor/HtmlArtifactNodeView.test.tsx
+++ b/src/components/editor/HtmlArtifactNodeView.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HtmlArtifactNodeView } from "./HtmlArtifactNodeView";
+import type { NodeViewProps } from "@tiptap/react";
+
+vi.mock("@/lib/htmlArtifact/wrapHtml", () => ({
+  wrapArtifactHtml: (html: string) => `<!DOCTYPE html><body>${html}</body>`,
+}));
+
+function createMockProps(attrs: Record<string, unknown> = {}, editable = true): NodeViewProps {
+  return {
+    node: {
+      attrs: { content: "", title: "", ...attrs },
+      type: { name: "htmlArtifact" },
+    },
+    updateAttributes: vi.fn(),
+    deleteNode: vi.fn(),
+    selected: false,
+    editor: { isEditable: editable },
+    getPos: vi.fn(),
+    extension: {} as never,
+    HTMLAttributes: {},
+    decorations: [],
+    innerDecorations: {} as never,
+  } as unknown as NodeViewProps;
+}
+
+function getIframe(): HTMLIFrameElement {
+  const iframe = document.querySelector("iframe");
+  if (!iframe) throw new Error("iframe not found");
+  return iframe;
+}
+
+describe("HtmlArtifactNodeView", () => {
+  it("renders an empty state when content is empty", () => {
+    const props = createMockProps({ content: "" });
+    render(<HtmlArtifactNodeView {...props} />);
+
+    expect(screen.getByText("HTML アーティファクトが空です")).toBeInTheDocument();
+  });
+
+  it("renders a sandboxed iframe when content is provided", () => {
+    const props = createMockProps({ content: "<p>Hello</p>" });
+    render(<HtmlArtifactNodeView {...props} />);
+
+    const iframe = getIframe();
+    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(iframe.getAttribute("srcdoc")).toContain("<p>Hello</p>");
+  });
+
+  it("does not include allow-same-origin in sandbox", () => {
+    const props = createMockProps({ content: "<div>test</div>" });
+    render(<HtmlArtifactNodeView {...props} />);
+
+    const iframe = getIframe();
+    expect(iframe.getAttribute("sandbox")).not.toContain("allow-same-origin");
+  });
+
+  it("displays the title when provided", () => {
+    const props = createMockProps({ content: "<div>x</div>", title: "SIR Model" });
+    render(<HtmlArtifactNodeView {...props} />);
+
+    expect(screen.getByText("SIR Model")).toBeInTheDocument();
+  });
+
+  it("enters editing mode and calls updateAttributes on save", async () => {
+    const user = userEvent.setup();
+    const props = createMockProps({ content: "<p>old</p>" });
+    render(<HtmlArtifactNodeView {...props} />);
+
+    const editButton = screen.getByTitle("編集");
+    await user.click(editButton);
+
+    expect(screen.getByText("HTML アーティファクトを編集")).toBeInTheDocument();
+
+    const textarea = screen.getByRole("textbox");
+    await user.clear(textarea);
+    await user.type(textarea, "<p>new</p>");
+
+    const saveButtons = screen.getAllByRole("button");
+    const saveButton = saveButtons.find((b) => b.querySelector(".lucide-check"));
+    expect(saveButton).toBeTruthy();
+    if (saveButton) await user.click(saveButton);
+
+    expect(props.updateAttributes).toHaveBeenCalledWith({ content: "<p>new</p>" });
+  });
+
+  it("hides toolbar buttons when editor is not editable", () => {
+    const props = createMockProps({ content: "<div>test</div>" }, false);
+    render(<HtmlArtifactNodeView {...props} />);
+
+    expect(screen.queryByTitle("編集")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("削除")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/editor/HtmlArtifactNodeView.test.tsx
+++ b/src/components/editor/HtmlArtifactNodeView.test.tsx
@@ -4,6 +4,25 @@ import userEvent from "@testing-library/user-event";
 import { HtmlArtifactNodeView } from "./HtmlArtifactNodeView";
 import type { NodeViewProps } from "@tiptap/react";
 
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        "editor.htmlArtifact.editHeading": "HTML アーティファクトを編集",
+        "editor.htmlArtifact.emptyState": "HTML アーティファクトが空です",
+        "editor.htmlArtifact.placeholder": "<div>Hello World</div>",
+        "editor.htmlArtifact.iframeTitle": "HTML アーティファクト",
+        "editor.htmlArtifact.fullscreen": "拡大表示",
+        "editor.htmlArtifact.edit": "編集",
+        "editor.htmlArtifact.delete": "削除",
+        "editor.htmlArtifact.cancel": "キャンセル",
+        "editor.htmlArtifact.save": "保存",
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
 vi.mock("@/lib/htmlArtifact/wrapHtml", () => ({
   wrapArtifactHtml: (html: string) => `<!DOCTYPE html><body>${html}</body>`,
 }));
@@ -71,6 +90,50 @@ describe("HtmlArtifactNodeView", () => {
       );
     });
     expect(iframe.style.height).toBe("300px");
+  });
+
+  it("ignores resize postMessage when height is not finite", () => {
+    const props = createMockProps({ content: "<div>x</div>" });
+    render(<HtmlArtifactNodeView {...props} />);
+
+    const iframe = getIframe();
+    const mockSource = {};
+    Object.defineProperty(iframe, "contentWindow", {
+      value: mockSource,
+      configurable: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "zedi-artifact-resize", height: Number.NaN },
+          source: mockSource,
+        }),
+      );
+    });
+    expect(iframe.style.height).toBe("300px");
+  });
+
+  it("clamps resize height to a maximum", () => {
+    const props = createMockProps({ content: "<div>x</div>" });
+    render(<HtmlArtifactNodeView {...props} />);
+
+    const iframe = getIframe();
+    const mockSource = {};
+    Object.defineProperty(iframe, "contentWindow", {
+      value: mockSource,
+      configurable: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "zedi-artifact-resize", height: 1_000_000 },
+          source: mockSource,
+        }),
+      );
+    });
+    expect(iframe.style.height).toBe("4000px");
   });
 
   it("displays the title when provided", () => {

--- a/src/components/editor/HtmlArtifactNodeView.tsx
+++ b/src/components/editor/HtmlArtifactNodeView.tsx
@@ -1,0 +1,182 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
+import { Button } from "@zedi/ui";
+import { Textarea } from "@zedi/ui";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@zedi/ui";
+import { Code2, Maximize2, Pencil, Trash2, Check, X } from "lucide-react";
+import { wrapArtifactHtml } from "@/lib/htmlArtifact/wrapHtml";
+
+const DEFAULT_HEIGHT = 300;
+const MIN_HEIGHT = 80;
+
+/**
+ * HTML アーティファクトの NodeView コンポーネント。
+ * sandboxed iframe でインタラクティブ HTML を安全にレンダリングする。
+ *
+ * NodeView component for HTML artifacts.
+ * Renders interactive HTML safely inside a sandboxed iframe.
+ */
+export const HtmlArtifactNodeView: React.FC<NodeViewProps> = ({
+  node,
+  updateAttributes,
+  deleteNode,
+  selected,
+  editor,
+}) => {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const fullscreenIframeRef = useRef<HTMLIFrameElement>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editContent, setEditContent] = useState("");
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [iframeHeight, setIframeHeight] = useState(DEFAULT_HEIGHT);
+
+  const content = node.attrs.content as string;
+  const title = (node.attrs.title as string) || "";
+  const wrappedHtml = content ? wrapArtifactHtml(content) : "";
+  const isEditable = editor.isEditable;
+
+  const handleMessage = useCallback((event: MessageEvent) => {
+    if (
+      event.data &&
+      typeof event.data === "object" &&
+      event.data.type === "zedi-artifact-resize" &&
+      typeof event.data.height === "number"
+    ) {
+      const newHeight = Math.max(MIN_HEIGHT, event.data.height + 32);
+      setIframeHeight(newHeight);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [handleMessage]);
+
+  const handleStartEdit = () => {
+    setEditContent(content);
+    setIsEditing(true);
+  };
+
+  const handleSave = () => {
+    updateAttributes({ content: editContent });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditContent("");
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <NodeViewWrapper className="html-artifact-node" data-type="html-artifact">
+        <div className="bg-muted/30 rounded-lg border p-4">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-muted-foreground text-sm font-medium">
+              HTML アーティファクトを編集
+            </span>
+            <div className="flex gap-1">
+              <Button size="sm" variant="ghost" onClick={handleCancel}>
+                <X className="h-4 w-4" />
+              </Button>
+              <Button size="sm" variant="ghost" onClick={handleSave}>
+                <Check className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+          <Textarea
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
+            className="min-h-[200px] font-mono text-sm"
+            placeholder="<div>Hello World</div>"
+          />
+        </div>
+      </NodeViewWrapper>
+    );
+  }
+
+  if (!content) {
+    return (
+      <NodeViewWrapper className="html-artifact-node" data-type="html-artifact">
+        <div className="text-muted-foreground flex h-32 items-center justify-center rounded-lg border border-dashed">
+          <span className="text-sm">HTML アーティファクトが空です</span>
+        </div>
+      </NodeViewWrapper>
+    );
+  }
+
+  return (
+    <NodeViewWrapper className="html-artifact-node" data-type="html-artifact">
+      <div
+        className={`group relative rounded-lg border bg-white dark:bg-gray-900 ${
+          selected ? "ring-primary ring-2" : ""
+        }`}
+      >
+        {/* ヘッダー */}
+        {title && (
+          <div className="text-muted-foreground flex items-center gap-2 border-b px-3 py-1.5 text-xs">
+            <Code2 className="h-3.5 w-3.5" />
+            <span>{title}</span>
+          </div>
+        )}
+
+        {/* ツールバー */}
+        {isEditable && (
+          <div className="absolute top-2 right-2 z-10 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setIsFullscreen(true)}
+              title="拡大表示"
+            >
+              <Maximize2 className="h-4 w-4" />
+            </Button>
+            <Button size="sm" variant="ghost" onClick={handleStartEdit} title="編集">
+              <Pencil className="h-4 w-4" />
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={deleteNode}
+              title="削除"
+              className="text-destructive hover:text-destructive"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+
+        {/* iframe レンダリング */}
+        <div className="overflow-hidden rounded-b-lg">
+          <iframe
+            ref={iframeRef}
+            sandbox="allow-scripts"
+            srcDoc={wrappedHtml}
+            title={title || "HTML Artifact"}
+            className="w-full border-0"
+            style={{ height: `${iframeHeight}px` }}
+          />
+        </div>
+
+        {/* フルスクリーンダイアログ */}
+        <Dialog open={isFullscreen} onOpenChange={setIsFullscreen}>
+          <DialogContent className="max-h-[90vh] max-w-[90vw] overflow-auto p-0">
+            <DialogHeader className="px-4 pt-4">
+              <DialogTitle>{title || "HTML Artifact"}</DialogTitle>
+            </DialogHeader>
+            <div className="px-4 pb-4">
+              <iframe
+                ref={fullscreenIframeRef}
+                sandbox="allow-scripts"
+                srcDoc={wrappedHtml}
+                title={title || "HTML Artifact"}
+                className="w-full border-0"
+                style={{ height: "70vh" }}
+              />
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </NodeViewWrapper>
+  );
+};

--- a/src/components/editor/HtmlArtifactNodeView.tsx
+++ b/src/components/editor/HtmlArtifactNodeView.tsx
@@ -36,15 +36,19 @@ export const HtmlArtifactNodeView: React.FC<NodeViewProps> = ({
   const isEditable = editor.isEditable;
 
   const handleMessage = useCallback((event: MessageEvent) => {
+    const inlineWin = iframeRef.current?.contentWindow;
+    const fullscreenWin = fullscreenIframeRef.current?.contentWindow;
     if (
-      event.data &&
-      typeof event.data === "object" &&
-      event.data.type === "zedi-artifact-resize" &&
-      typeof event.data.height === "number"
+      (event.source !== inlineWin && event.source !== fullscreenWin) ||
+      !event.data ||
+      typeof event.data !== "object" ||
+      event.data.type !== "zedi-artifact-resize" ||
+      typeof event.data.height !== "number"
     ) {
-      const newHeight = Math.max(MIN_HEIGHT, event.data.height + 32);
-      setIframeHeight(newHeight);
+      return;
     }
+    const newHeight = Math.max(MIN_HEIGHT, event.data.height + 32);
+    setIframeHeight(newHeight);
   }, []);
 
   useEffect(() => {

--- a/src/components/editor/HtmlArtifactNodeView.tsx
+++ b/src/components/editor/HtmlArtifactNodeView.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
 import { Button } from "@zedi/ui";
 import { Textarea } from "@zedi/ui";
@@ -8,6 +9,8 @@ import { wrapArtifactHtml } from "@/lib/htmlArtifact/wrapHtml";
 
 const DEFAULT_HEIGHT = 300;
 const MIN_HEIGHT = 80;
+/** Upper bound for iframe height from postMessage (avoids layout blow-ups). / postMessage 由来の iframe 高さの上限（レイアウト破綻を防ぐ）。 */
+const MAX_HEIGHT = 4000;
 
 /**
  * HTML アーティファクトの NodeView コンポーネント。
@@ -16,6 +19,7 @@ const MIN_HEIGHT = 80;
  * NodeView component for HTML artifacts.
  * Renders interactive HTML safely inside a sandboxed iframe.
  */
+// eslint-disable-next-line max-lines-per-function -- TipTap NodeView: postMessage resize, iframe, fullscreen dialog, i18n, and a11y in one place.
 export const HtmlArtifactNodeView: React.FC<NodeViewProps> = ({
   node,
   updateAttributes,
@@ -23,6 +27,7 @@ export const HtmlArtifactNodeView: React.FC<NodeViewProps> = ({
   selected,
   editor,
 }) => {
+  const { t } = useTranslation();
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const fullscreenIframeRef = useRef<HTMLIFrameElement>(null);
   const [isEditing, setIsEditing] = useState(false);
@@ -34,6 +39,7 @@ export const HtmlArtifactNodeView: React.FC<NodeViewProps> = ({
   const title = (node.attrs.title as string) || "";
   const wrappedHtml = content ? wrapArtifactHtml(content) : "";
   const isEditable = editor.isEditable;
+  const iframeTitle = title || t("editor.htmlArtifact.iframeTitle");
 
   const handleMessage = useCallback((event: MessageEvent) => {
     const inlineWin = iframeRef.current?.contentWindow;
@@ -43,11 +49,13 @@ export const HtmlArtifactNodeView: React.FC<NodeViewProps> = ({
       !event.data ||
       typeof event.data !== "object" ||
       event.data.type !== "zedi-artifact-resize" ||
-      typeof event.data.height !== "number"
+      typeof event.data.height !== "number" ||
+      !Number.isFinite(event.data.height)
     ) {
       return;
     }
-    const newHeight = Math.max(MIN_HEIGHT, event.data.height + 32);
+    const padded = Math.round(event.data.height + 32);
+    const newHeight = Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, padded));
     setIframeHeight(newHeight);
   }, []);
 
@@ -77,13 +85,27 @@ export const HtmlArtifactNodeView: React.FC<NodeViewProps> = ({
         <div className="bg-muted/30 rounded-lg border p-4">
           <div className="mb-2 flex items-center justify-between">
             <span className="text-muted-foreground text-sm font-medium">
-              HTML アーティファクトを編集
+              {t("editor.htmlArtifact.editHeading")}
             </span>
             <div className="flex gap-1">
-              <Button size="sm" variant="ghost" onClick={handleCancel}>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={handleCancel}
+                type="button"
+                aria-label={t("editor.htmlArtifact.cancel")}
+                title={t("editor.htmlArtifact.cancel")}
+              >
                 <X className="h-4 w-4" />
               </Button>
-              <Button size="sm" variant="ghost" onClick={handleSave}>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={handleSave}
+                type="button"
+                aria-label={t("editor.htmlArtifact.save")}
+                title={t("editor.htmlArtifact.save")}
+              >
                 <Check className="h-4 w-4" />
               </Button>
             </div>
@@ -92,7 +114,7 @@ export const HtmlArtifactNodeView: React.FC<NodeViewProps> = ({
             value={editContent}
             onChange={(e) => setEditContent(e.target.value)}
             className="min-h-[200px] font-mono text-sm"
-            placeholder="<div>Hello World</div>"
+            placeholder={t("editor.htmlArtifact.placeholder")}
           />
         </div>
       </NodeViewWrapper>
@@ -103,7 +125,7 @@ export const HtmlArtifactNodeView: React.FC<NodeViewProps> = ({
     return (
       <NodeViewWrapper className="html-artifact-node" data-type="html-artifact">
         <div className="text-muted-foreground flex h-32 items-center justify-center rounded-lg border border-dashed">
-          <span className="text-sm">HTML アーティファクトが空です</span>
+          <span className="text-sm">{t("editor.htmlArtifact.emptyState")}</span>
         </div>
       </NodeViewWrapper>
     );
@@ -116,7 +138,6 @@ export const HtmlArtifactNodeView: React.FC<NodeViewProps> = ({
           selected ? "ring-primary ring-2" : ""
         }`}
       >
-        {/* ヘッダー */}
         {title && (
           <div className="text-muted-foreground flex items-center gap-2 border-b px-3 py-1.5 text-xs">
             <Code2 className="h-3.5 w-3.5" />
@@ -124,25 +145,35 @@ export const HtmlArtifactNodeView: React.FC<NodeViewProps> = ({
           </div>
         )}
 
-        {/* ツールバー */}
         {isEditable && (
           <div className="absolute top-2 right-2 z-10 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
             <Button
               size="sm"
               variant="ghost"
+              type="button"
               onClick={() => setIsFullscreen(true)}
-              title="拡大表示"
+              title={t("editor.htmlArtifact.fullscreen")}
+              aria-label={t("editor.htmlArtifact.fullscreen")}
             >
               <Maximize2 className="h-4 w-4" />
             </Button>
-            <Button size="sm" variant="ghost" onClick={handleStartEdit} title="編集">
+            <Button
+              size="sm"
+              variant="ghost"
+              type="button"
+              onClick={handleStartEdit}
+              title={t("editor.htmlArtifact.edit")}
+              aria-label={t("editor.htmlArtifact.edit")}
+            >
               <Pencil className="h-4 w-4" />
             </Button>
             <Button
               size="sm"
               variant="ghost"
+              type="button"
               onClick={deleteNode}
-              title="削除"
+              title={t("editor.htmlArtifact.delete")}
+              aria-label={t("editor.htmlArtifact.delete")}
               className="text-destructive hover:text-destructive"
             >
               <Trash2 className="h-4 w-4" />
@@ -150,30 +181,28 @@ export const HtmlArtifactNodeView: React.FC<NodeViewProps> = ({
           </div>
         )}
 
-        {/* iframe レンダリング */}
         <div className="overflow-hidden rounded-b-lg">
           <iframe
             ref={iframeRef}
             sandbox="allow-scripts"
             srcDoc={wrappedHtml}
-            title={title || "HTML Artifact"}
+            title={iframeTitle}
             className="w-full border-0"
             style={{ height: `${iframeHeight}px` }}
           />
         </div>
 
-        {/* フルスクリーンダイアログ */}
         <Dialog open={isFullscreen} onOpenChange={setIsFullscreen}>
           <DialogContent className="max-h-[90vh] max-w-[90vw] overflow-auto p-0">
             <DialogHeader className="px-4 pt-4">
-              <DialogTitle>{title || "HTML Artifact"}</DialogTitle>
+              <DialogTitle>{iframeTitle}</DialogTitle>
             </DialogHeader>
             <div className="px-4 pb-4">
               <iframe
                 ref={fullscreenIframeRef}
                 sandbox="allow-scripts"
                 srcDoc={wrappedHtml}
-                title={title || "HTML Artifact"}
+                title={iframeTitle}
                 className="w-full border-0"
                 style={{ height: "70vh" }}
               />

--- a/src/components/editor/TiptapEditor/editorConfig.ts
+++ b/src/components/editor/TiptapEditor/editorConfig.ts
@@ -23,6 +23,7 @@ import { FileReference } from "../extensions/FileReferenceExtension";
 import { Mermaid } from "../extensions/MermaidExtension";
 import { YouTubeEmbed } from "../extensions/YouTubeEmbedExtension";
 import { McpResource } from "../extensions/McpResourceExtension";
+import { HtmlArtifact } from "../extensions/HtmlArtifactExtension";
 import {
   WikiLinkSuggestionPlugin,
   type WikiLinkSuggestionState,
@@ -226,6 +227,8 @@ export function createEditorExtensions(options: EditorExtensionsOptions): Extens
     // --- YouTube Embed ---
     YouTubeEmbed,
     McpResource,
+    // --- HTML Artifact (Claude interactive HTML) ---
+    HtmlArtifact,
     // Y.js リアルタイムコラボレーション（オプション）
     ...(options.collaboration
       ? [

--- a/src/components/editor/TiptapEditor/slashCommandItems.ts
+++ b/src/components/editor/TiptapEditor/slashCommandItems.ts
@@ -143,6 +143,33 @@ export const slashCommandItems: SlashCommandItem[] = [
         .run(),
   },
   {
+    id: "htmlArtifact",
+    icon: "Code2",
+    isAvailable: (editor) =>
+      !!editor.extensionManager.extensions.find((e) => e.name === "htmlArtifact"),
+    action: (editor, range) => {
+      const html = window.prompt(
+        i18n.t("editor.slash.htmlArtifact.prompt", {
+          defaultValue: "HTML コードを貼り付けてください",
+        }),
+        "",
+      );
+      if (html === null) return;
+      const trimmed = html.trim();
+      if (!trimmed) return;
+      const title = window.prompt(
+        i18n.t("editor.slash.htmlArtifact.promptTitle", { defaultValue: "タイトル（省略可）" }),
+        "",
+      );
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertHtmlArtifact({ content: trimmed, title: title?.trim() || "" })
+        .run();
+    },
+  },
+  {
     id: "mcpResource",
     icon: "Plug",
     isAvailable: (editor) =>

--- a/src/components/editor/extensions/ExecutableCodeBlockExtension.ts
+++ b/src/components/editor/extensions/ExecutableCodeBlockExtension.ts
@@ -17,16 +17,10 @@ export interface ExecutableCodeBlockOptions {
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     /**
-     * Executable code block commands (nested shape matches Tiptap `UnionCommands` merging).
-     * ネスト形は Tiptap の `UnionCommands` がチェーンへ正しく載せるため（Mermaid 等と同様）。
+     * Inserts an executable code block (Claude Code / Bash).
+     * 実行可能コードブロック（Claude Code / Bash）を挿入する。
      */
-    executableCodeBlock: {
-      /**
-       * Inserts an executable code block (Claude Code / Bash).
-       * 実行可能コードブロック（Claude Code / Bash）を挿入する。
-       */
-      insertExecutableCodeBlock: (attrs?: { language?: string }) => ReturnType;
-    };
+    insertExecutableCodeBlock: (attrs?: { language?: string }) => ReturnType;
   }
 }
 

--- a/src/components/editor/extensions/ExecutableCodeBlockExtension.ts
+++ b/src/components/editor/extensions/ExecutableCodeBlockExtension.ts
@@ -17,10 +17,16 @@ export interface ExecutableCodeBlockOptions {
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     /**
-     * Inserts an executable code block (Claude Code / Bash).
-     * 実行可能コードブロック（Claude Code / Bash）を挿入する。
+     * Executable code block commands (nested shape matches Tiptap `UnionCommands` merging).
+     * ネスト形は Tiptap の `UnionCommands` がチェーンへ正しく載せるため（Mermaid 等と同様）。
      */
-    insertExecutableCodeBlock: (attrs?: { language?: string }) => ReturnType;
+    executableCodeBlock: {
+      /**
+       * Inserts an executable code block (Claude Code / Bash).
+       * 実行可能コードブロック（Claude Code / Bash）を挿入する。
+       */
+      insertExecutableCodeBlock: (attrs?: { language?: string }) => ReturnType;
+    };
   }
 }
 

--- a/src/components/editor/extensions/HtmlArtifactExtension.ts
+++ b/src/components/editor/extensions/HtmlArtifactExtension.ts
@@ -12,16 +12,18 @@ export interface HtmlArtifactOptions {
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
-    /**
-     * HTML アーティファクトを挿入する。
-     * Insert an HTML artifact block.
-     */
-    insertHtmlArtifact: (attrs: { content: string; title?: string }) => ReturnType;
-    /**
-     * HTML アーティファクトの属性を更新する。
-     * Update an HTML artifact's attributes.
-     */
-    updateHtmlArtifact: (attrs: { content?: string; title?: string }) => ReturnType;
+    htmlArtifact: {
+      /**
+       * HTML アーティファクトを挿入する。
+       * Insert an HTML artifact block.
+       */
+      insertHtmlArtifact: (attrs: { content: string; title?: string }) => ReturnType;
+      /**
+       * HTML アーティファクトの属性を更新する。
+       * Update an HTML artifact's attributes.
+       */
+      updateHtmlArtifact: (attrs: { content?: string; title?: string }) => ReturnType;
+    };
   }
 }
 

--- a/src/components/editor/extensions/HtmlArtifactExtension.ts
+++ b/src/components/editor/extensions/HtmlArtifactExtension.ts
@@ -1,0 +1,105 @@
+import { Node, mergeAttributes } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import { HtmlArtifactNodeView } from "../HtmlArtifactNodeView";
+
+/**
+ * HTML アーティファクトノードのオプション。
+ * Options for the HTML artifact node extension.
+ */
+export interface HtmlArtifactOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    htmlArtifact: {
+      /**
+       * HTML アーティファクトを挿入する。
+       * Insert an HTML artifact block.
+       */
+      insertHtmlArtifact: (attrs: { content: string; title?: string }) => ReturnType;
+      /**
+       * HTML アーティファクトの属性を更新する。
+       * Update an HTML artifact's attributes.
+       */
+      updateHtmlArtifact: (attrs: { content?: string; title?: string }) => ReturnType;
+    };
+  }
+}
+
+/**
+ * Claude 等の AI が出力するインタラクティブ HTML（SVG / Canvas / Script）を
+ * sandboxed iframe で安全に埋め込むための TipTap ノード拡張。
+ *
+ * TipTap node extension that safely embeds interactive HTML (SVG / Canvas / Script)
+ * output by Claude or other AIs via a sandboxed iframe.
+ */
+export const HtmlArtifact = Node.create<HtmlArtifactOptions>({
+  name: "htmlArtifact",
+
+  group: "block",
+
+  atom: true,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  addAttributes() {
+    return {
+      content: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-content") || "",
+        renderHTML: (attributes) => ({
+          "data-content": attributes.content,
+        }),
+      },
+      title: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-title") || "",
+        renderHTML: (attributes) => (attributes.title ? { "data-title": attributes.title } : {}),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'div[data-type="html-artifact"]',
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        "data-type": "html-artifact",
+      }),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(HtmlArtifactNodeView);
+  },
+
+  addCommands() {
+    return {
+      insertHtmlArtifact:
+        ({ content, title }) =>
+        ({ commands }) => {
+          return commands.insertContent({
+            type: this.name,
+            attrs: { content, title: title ?? "" },
+          });
+        },
+      updateHtmlArtifact:
+        (attrs) =>
+        ({ commands }) => {
+          return commands.updateAttributes(this.name, attrs);
+        },
+    };
+  },
+});

--- a/src/components/editor/extensions/HtmlArtifactExtension.ts
+++ b/src/components/editor/extensions/HtmlArtifactExtension.ts
@@ -12,18 +12,16 @@ export interface HtmlArtifactOptions {
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
-    htmlArtifact: {
-      /**
-       * HTML アーティファクトを挿入する。
-       * Insert an HTML artifact block.
-       */
-      insertHtmlArtifact: (attrs: { content: string; title?: string }) => ReturnType;
-      /**
-       * HTML アーティファクトの属性を更新する。
-       * Update an HTML artifact's attributes.
-       */
-      updateHtmlArtifact: (attrs: { content?: string; title?: string }) => ReturnType;
-    };
+    /**
+     * HTML アーティファクトを挿入する。
+     * Insert an HTML artifact block.
+     */
+    insertHtmlArtifact: (attrs: { content: string; title?: string }) => ReturnType;
+    /**
+     * HTML アーティファクトの属性を更新する。
+     * Update an HTML artifact's attributes.
+     */
+    updateHtmlArtifact: (attrs: { content?: string; title?: string }) => ReturnType;
   }
 }
 

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -117,6 +117,13 @@
       "description": "Insert block math",
       "aliases": "math block,block math,equation"
     },
+    "htmlArtifact": {
+      "title": "HTML Artifact",
+      "description": "Embed interactive HTML (Claude output, etc.)",
+      "aliases": "html,artifact,embed,interactive,claude",
+      "prompt": "Paste your HTML code",
+      "promptTitle": "Title (optional)"
+    },
     "mcpResource": {
       "title": "MCP Resource",
       "description": "Embed external data from an MCP server",

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -31,6 +31,17 @@
   },
   "slashPathCompletionAriaLabel": "Path suggestions",
   "slashPathCompletionHint": "Workspace path suggestions",
+  "htmlArtifact": {
+    "editHeading": "Edit HTML artifact",
+    "emptyState": "This HTML artifact is empty.",
+    "placeholder": "<div>Hello World</div>",
+    "iframeTitle": "HTML Artifact",
+    "fullscreen": "Expand",
+    "edit": "Edit",
+    "delete": "Delete",
+    "cancel": "Cancel",
+    "save": "Save"
+  },
   "slash": {
     "paragraph": {
       "title": "Paragraph",

--- a/src/i18n/locales/ja/editor.json
+++ b/src/i18n/locales/ja/editor.json
@@ -117,6 +117,13 @@
       "description": "ブロック数式を挿入",
       "aliases": "数式ブロック,block math,ブロック数式,equation"
     },
+    "htmlArtifact": {
+      "title": "HTML アーティファクト",
+      "description": "インタラクティブな HTML を埋め込む（Claude 出力等）",
+      "aliases": "html,artifact,アーティファクト,埋め込み,interactive,claude",
+      "prompt": "HTML コードを貼り付けてください",
+      "promptTitle": "タイトル（省略可）"
+    },
     "mcpResource": {
       "title": "MCP リソース",
       "description": "MCP サーバーから外部データを埋め込む",

--- a/src/i18n/locales/ja/editor.json
+++ b/src/i18n/locales/ja/editor.json
@@ -31,6 +31,17 @@
   },
   "slashPathCompletionAriaLabel": "パス候補",
   "slashPathCompletionHint": "ワークスペース内のパス候補",
+  "htmlArtifact": {
+    "editHeading": "HTML アーティファクトを編集",
+    "emptyState": "HTML アーティファクトが空です",
+    "placeholder": "<div>Hello World</div>",
+    "iframeTitle": "HTML アーティファクト",
+    "fullscreen": "拡大表示",
+    "edit": "編集",
+    "delete": "削除",
+    "cancel": "キャンセル",
+    "save": "保存"
+  },
   "slash": {
     "paragraph": {
       "title": "段落",

--- a/src/lib/contentUtils.test.ts
+++ b/src/lib/contentUtils.test.ts
@@ -210,12 +210,34 @@ describe("sanitizeTiptapContent", () => {
         { type: "codeBlock", content: [{ type: "text", text: "code" }] },
         { type: "horizontalRule" },
         { type: "mermaid", attrs: { code: "graph TD" } },
+        { type: "htmlArtifact", attrs: { content: "<p>hello</p>", title: "test" } },
       ],
     });
 
     const result = sanitizeTiptapContent(contentWithAllNodes);
     expect(result.hadErrors).toBe(false);
     expect(result.removedNodeTypes).toEqual([]);
+  });
+
+  it("should preserve htmlArtifact nodes", () => {
+    const content = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "htmlArtifact",
+          attrs: { content: "<div>interactive</div>", title: "My Artifact" },
+        },
+      ],
+    });
+
+    const result = sanitizeTiptapContent(content);
+    expect(result.hadErrors).toBe(false);
+    expect(result.removedNodeTypes).toEqual([]);
+
+    const parsed = JSON.parse(result.content);
+    expect(parsed.content[0].type).toBe("htmlArtifact");
+    expect(parsed.content[0].attrs.content).toBe("<div>interactive</div>");
+    expect(parsed.content[0].attrs.title).toBe("My Artifact");
   });
 
   it("should support task list nodes", () => {

--- a/src/lib/contentUtils.ts
+++ b/src/lib/contentUtils.ts
@@ -44,7 +44,10 @@ const SUPPORTED_MARK_TYPES = new Set([
   "textStyle",
 ]);
 
-/** Result of sanitizing Tiptap JSON (unsupported nodes/marks removed). */
+/**
+ * Result of sanitizing Tiptap JSON (unsupported nodes/marks removed).
+ * Tiptap JSON のサニタイズ結果（未対応ノード/マーク除去後）。
+ */
 export interface SanitizeResult {
   content: string;
   hadErrors: boolean;
@@ -338,6 +341,7 @@ function validateNode(node: Record<string, unknown>, errors: string[]): void {
 
 /**
  * Extract plain text from Tiptap JSON content.
+ * Tiptap JSON からプレーンテキストを抽出する。
  */
 export function extractPlainText(content: string): string {
   if (!content) return "";
@@ -371,11 +375,15 @@ function extractTextFromNode(node: unknown): string {
   return "";
 }
 
-/** Max length for page list preview text. */
+/**
+ * Max length for page list preview text.
+ * ページ一覧プレビュー文字列の最大長。
+ */
 export const PAGE_LIST_PREVIEW_LENGTH = 120;
 
 /**
  * Get a preview snippet of the content (whitespace collapsed, optional truncation).
+ * コンテンツのプレビュー断片を返す（空白を畳み、必要なら省略）。
  */
 export function getContentPreview(content: string, maxLength: number = 100): string {
   const plainText = extractPlainText(content);
@@ -386,12 +394,18 @@ export function getContentPreview(content: string, maxLength: number = 100): str
   return trimmed.slice(0, maxLength).trim() + "...";
 }
 
-/** Standard preview for page list UI. */
+/**
+ * Standard preview for page list UI.
+ * ページ一覧 UI 用の標準プレビュー。
+ */
 export function getPageListPreview(content: string): string {
   return getContentPreview(content, PAGE_LIST_PREVIEW_LENGTH);
 }
 
-/** Extract first image URL from Tiptap JSON or plain text. */
+/**
+ * Extract first image URL from Tiptap JSON or plain text.
+ * Tiptap JSON またはプレーンテキストから先頭の画像 URL を取得する。
+ */
 export function extractFirstImage(content: string): string | null {
   if (!content) return null;
 
@@ -428,7 +442,10 @@ function findFirstImage(node: unknown): string | null {
   return null;
 }
 
-/** Extract wiki links `[[Link Text]]` from content. */
+/**
+ * Extract wiki links `[[Link Text]]` from content.
+ * コンテンツから `[[リンク文字]]` 形式の wiki リンクを抽出する。
+ */
 export function extractWikiLinks(content: string): string[] {
   const plainText = extractPlainText(content);
   const matches = plainText.match(/\[\[([^\]]+)\]\]/g);
@@ -438,7 +455,10 @@ export function extractWikiLinks(content: string): string[] {
   return matches.map((match) => match.slice(2, -2).trim());
 }
 
-/** Generate an auto title from the first line of plain text. */
+/**
+ * Generate an auto title from the first line of plain text.
+ * プレーンテキストの先頭行から自動タイトルを生成する。
+ */
 export function generateAutoTitle(content: string): string {
   const plainText = extractPlainText(content);
   const firstLine = plainText.split("\n")[0]?.trim() || "";

--- a/src/lib/contentUtils.ts
+++ b/src/lib/contentUtils.ts
@@ -25,6 +25,8 @@ const SUPPORTED_NODE_TYPES = new Set([
   // Phase 4: 数式
   "math",
   "mathBlock",
+  // HTML Artifact (Claude interactive HTML)
+  "htmlArtifact",
 ]);
 
 // Supported mark types in zedi's Tiptap schema
@@ -42,6 +44,9 @@ const SUPPORTED_MARK_TYPES = new Set([
   "textStyle",
 ]);
 
+/**
+ *
+ */
 export interface SanitizeResult {
   content: string;
   hadErrors: boolean;
@@ -334,10 +339,16 @@ function validateNode(node: Record<string, unknown>, errors: string[]): void {
 }
 
 // Extract plain text from Tiptap JSON content
+/**
+ *
+ */
 export function extractPlainText(content: string): string {
   if (!content) return "";
 
   try {
+    /**
+     *
+     */
     const doc = JSON.parse(content);
     return extractTextFromNode(doc);
   } catch {
@@ -366,11 +377,23 @@ function extractTextFromNode(node: unknown): string {
   return "";
 }
 
-export const PAGE_LIST_PREVIEW_LENGTH = 120;
+export /**
+ *
+ */
+const PAGE_LIST_PREVIEW_LENGTH = 120;
 
 // Get a preview snippet of the content
+/**
+ *
+ */
 export function getContentPreview(content: string, maxLength: number = 100): string {
+  /**
+   *
+   */
   const plainText = extractPlainText(content);
+  /**
+   *
+   */
   const trimmed = plainText.trim().replace(/\s+/g, " ");
 
   if (trimmed.length <= maxLength) return trimmed;
@@ -379,19 +402,31 @@ export function getContentPreview(content: string, maxLength: number = 100): str
 }
 
 // Standard preview for page list UI
+/**
+ *
+ */
 export function getPageListPreview(content: string): string {
   return getContentPreview(content, PAGE_LIST_PREVIEW_LENGTH);
 }
 
 // Extract first image URL from Tiptap content
+/**
+ *
+ */
 export function extractFirstImage(content: string): string | null {
   if (!content) return null;
 
   try {
+    /**
+     *
+     */
     const doc = JSON.parse(content);
     return findFirstImage(doc);
   } catch {
     // Check for image URLs in plain text
+    /**
+     *
+     */
     const imgMatch = content.match(/https?:\/\/[^\s]+\.(jpg|jpeg|png|gif|webp)/i);
     return imgMatch ? imgMatch[0] : null;
   }
@@ -421,8 +456,17 @@ function findFirstImage(node: unknown): string | null {
 }
 
 // Extract wiki links [[Link Text]] from content
+/**
+ *
+ */
 export function extractWikiLinks(content: string): string[] {
+  /**
+   *
+   */
   const plainText = extractPlainText(content);
+  /**
+   *
+   */
   const matches = plainText.match(/\[\[([^\]]+)\]\]/g);
 
   if (!matches) return [];
@@ -431,8 +475,17 @@ export function extractWikiLinks(content: string): string[] {
 }
 
 // Generate auto title from content
+/**
+ *
+ */
 export function generateAutoTitle(content: string): string {
+  /**
+   *
+   */
   const plainText = extractPlainText(content);
+  /**
+   *
+   */
   const firstLine = plainText.split("\n")[0]?.trim() || "";
 
   if (!firstLine) return "無題のページ";

--- a/src/lib/contentUtils.ts
+++ b/src/lib/contentUtils.ts
@@ -44,9 +44,7 @@ const SUPPORTED_MARK_TYPES = new Set([
   "textStyle",
 ]);
 
-/**
- *
- */
+/** Result of sanitizing Tiptap JSON (unsupported nodes/marks removed). */
 export interface SanitizeResult {
   content: string;
   hadErrors: boolean;
@@ -338,17 +336,13 @@ function validateNode(node: Record<string, unknown>, errors: string[]): void {
   }
 }
 
-// Extract plain text from Tiptap JSON content
 /**
- *
+ * Extract plain text from Tiptap JSON content.
  */
 export function extractPlainText(content: string): string {
   if (!content) return "";
 
   try {
-    /**
-     *
-     */
     const doc = JSON.parse(content);
     return extractTextFromNode(doc);
   } catch {
@@ -377,23 +371,14 @@ function extractTextFromNode(node: unknown): string {
   return "";
 }
 
-export /**
- *
- */
-const PAGE_LIST_PREVIEW_LENGTH = 120;
+/** Max length for page list preview text. */
+export const PAGE_LIST_PREVIEW_LENGTH = 120;
 
-// Get a preview snippet of the content
 /**
- *
+ * Get a preview snippet of the content (whitespace collapsed, optional truncation).
  */
 export function getContentPreview(content: string, maxLength: number = 100): string {
-  /**
-   *
-   */
   const plainText = extractPlainText(content);
-  /**
-   *
-   */
   const trimmed = plainText.trim().replace(/\s+/g, " ");
 
   if (trimmed.length <= maxLength) return trimmed;
@@ -401,32 +386,20 @@ export function getContentPreview(content: string, maxLength: number = 100): str
   return trimmed.slice(0, maxLength).trim() + "...";
 }
 
-// Standard preview for page list UI
-/**
- *
- */
+/** Standard preview for page list UI. */
 export function getPageListPreview(content: string): string {
   return getContentPreview(content, PAGE_LIST_PREVIEW_LENGTH);
 }
 
-// Extract first image URL from Tiptap content
-/**
- *
- */
+/** Extract first image URL from Tiptap JSON or plain text. */
 export function extractFirstImage(content: string): string | null {
   if (!content) return null;
 
   try {
-    /**
-     *
-     */
     const doc = JSON.parse(content);
     return findFirstImage(doc);
   } catch {
     // Check for image URLs in plain text
-    /**
-     *
-     */
     const imgMatch = content.match(/https?:\/\/[^\s]+\.(jpg|jpeg|png|gif|webp)/i);
     return imgMatch ? imgMatch[0] : null;
   }
@@ -455,18 +428,9 @@ function findFirstImage(node: unknown): string | null {
   return null;
 }
 
-// Extract wiki links [[Link Text]] from content
-/**
- *
- */
+/** Extract wiki links `[[Link Text]]` from content. */
 export function extractWikiLinks(content: string): string[] {
-  /**
-   *
-   */
   const plainText = extractPlainText(content);
-  /**
-   *
-   */
   const matches = plainText.match(/\[\[([^\]]+)\]\]/g);
 
   if (!matches) return [];
@@ -474,18 +438,9 @@ export function extractWikiLinks(content: string): string[] {
   return matches.map((match) => match.slice(2, -2).trim());
 }
 
-// Generate auto title from content
-/**
- *
- */
+/** Generate an auto title from the first line of plain text. */
 export function generateAutoTitle(content: string): string {
-  /**
-   *
-   */
   const plainText = extractPlainText(content);
-  /**
-   *
-   */
   const firstLine = plainText.split("\n")[0]?.trim() || "";
 
   if (!firstLine) return "無題のページ";

--- a/src/lib/htmlArtifact/defaultTheme.test.ts
+++ b/src/lib/htmlArtifact/defaultTheme.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  LIGHT_THEME_VARS,
+  DARK_THEME_VARS,
+  SVG_DIAGRAM_STYLES,
+  buildCssVarBlock,
+} from "./defaultTheme";
+
+describe("defaultTheme", () => {
+  describe("LIGHT_THEME_VARS", () => {
+    it("should contain essential CSS variables", () => {
+      expect(LIGHT_THEME_VARS["--color-text-secondary"]).toBeDefined();
+      expect(LIGHT_THEME_VARS["--color-border-tertiary"]).toBeDefined();
+      expect(LIGHT_THEME_VARS["--border-radius-md"]).toBeDefined();
+      expect(LIGHT_THEME_VARS["--font-mono"]).toBeDefined();
+    });
+
+    it("should have string values for all variables", () => {
+      for (const [key, value] of Object.entries(LIGHT_THEME_VARS)) {
+        expect(typeof value).toBe("string");
+        expect(value.length).toBeGreaterThan(0);
+        expect(key.startsWith("--")).toBe(true);
+      }
+    });
+  });
+
+  describe("DARK_THEME_VARS", () => {
+    it("should contain essential CSS variables", () => {
+      expect(DARK_THEME_VARS["--color-text-secondary"]).toBeDefined();
+      expect(DARK_THEME_VARS["--color-border-tertiary"]).toBeDefined();
+    });
+
+    it("should differ from light theme in color values", () => {
+      expect(DARK_THEME_VARS["--color-text-primary"]).not.toBe(
+        LIGHT_THEME_VARS["--color-text-primary"],
+      );
+      expect(DARK_THEME_VARS["--color-bg-primary"]).not.toBe(
+        LIGHT_THEME_VARS["--color-bg-primary"],
+      );
+    });
+  });
+
+  describe("buildCssVarBlock", () => {
+    it("should produce valid CSS variable declarations", () => {
+      const result = buildCssVarBlock({ "--color-a": "red", "--color-b": "blue" });
+      expect(result).toContain("--color-a: red;");
+      expect(result).toContain("--color-b: blue;");
+    });
+
+    it("should return empty string for empty input", () => {
+      expect(buildCssVarBlock({})).toBe("");
+    });
+
+    it("should indent each line with two spaces", () => {
+      const result = buildCssVarBlock({ "--x": "1" });
+      expect(result).toBe("  --x: 1;");
+    });
+  });
+
+  describe("SVG_DIAGRAM_STYLES", () => {
+    it("should define Claude diagram color classes", () => {
+      expect(SVG_DIAGRAM_STYLES).toContain(".c-blue");
+      expect(SVG_DIAGRAM_STYLES).toContain(".c-coral");
+      expect(SVG_DIAGRAM_STYLES).toContain(".c-teal");
+      expect(SVG_DIAGRAM_STYLES).toContain(".c-purple");
+      expect(SVG_DIAGRAM_STYLES).toContain(".c-amber");
+      expect(SVG_DIAGRAM_STYLES).toContain(".c-green");
+    });
+
+    it("should define text helper classes", () => {
+      expect(SVG_DIAGRAM_STYLES).toContain("text.th");
+      expect(SVG_DIAGRAM_STYLES).toContain("text.ts");
+    });
+  });
+});

--- a/src/lib/htmlArtifact/defaultTheme.ts
+++ b/src/lib/htmlArtifact/defaultTheme.ts
@@ -1,0 +1,72 @@
+/**
+ * Claude アーティファクト HTML で使用される CSS 変数のデフォルト値。
+ * Claude のテーマシステムと互換性を保つために定義する。
+ *
+ * Default CSS variable values used in Claude artifact HTML.
+ * Defined to maintain compatibility with Claude's theme system.
+ */
+
+/** ライトモード用の CSS 変数 / Light mode CSS variables */
+export const LIGHT_THEME_VARS: Record<string, string> = {
+  "--color-text-primary": "#1a1a1a",
+  "--color-text-secondary": "#6b7280",
+  "--color-text-tertiary": "#9ca3af",
+  "--color-bg-primary": "#ffffff",
+  "--color-bg-secondary": "#f9fafb",
+  "--color-bg-tertiary": "#f3f4f6",
+  "--color-border-primary": "#d1d5db",
+  "--color-border-secondary": "#e5e7eb",
+  "--color-border-tertiary": "#e5e7eb",
+  "--color-accent": "#2563eb",
+  "--border-radius-sm": "4px",
+  "--border-radius-md": "8px",
+  "--border-radius-lg": "12px",
+  "--font-mono": "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
+  "--font-sans": "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+};
+
+/** ダークモード用の CSS 変数 / Dark mode CSS variables */
+export const DARK_THEME_VARS: Record<string, string> = {
+  "--color-text-primary": "#f3f4f6",
+  "--color-text-secondary": "#9ca3af",
+  "--color-text-tertiary": "#6b7280",
+  "--color-bg-primary": "#111827",
+  "--color-bg-secondary": "#1f2937",
+  "--color-bg-tertiary": "#374151",
+  "--color-border-primary": "#4b5563",
+  "--color-border-secondary": "#374151",
+  "--color-border-tertiary": "#374151",
+  "--color-accent": "#3b82f6",
+};
+
+/**
+ * CSS 変数マップを :root セレクタ用の CSS 文字列に変換する。
+ * Converts a CSS variable map to a CSS string for the :root selector.
+ */
+export function buildCssVarBlock(vars: Record<string, string>): string {
+  return Object.entries(vars)
+    .map(([key, value]) => `  ${key}: ${value};`)
+    .join("\n");
+}
+
+/**
+ * Claude SVG ダイアグラムで使用されるクラス定義。
+ * Class definitions used in Claude SVG diagrams.
+ */
+export const SVG_DIAGRAM_STYLES = `
+/* Claude SVG diagram class definitions */
+.c-blue rect { fill: #dbeafe; stroke: #3b82f6; }
+.c-blue text { fill: #1e40af; }
+.c-coral rect { fill: #fee2e2; stroke: #ef4444; }
+.c-coral text { fill: #991b1b; }
+.c-teal rect { fill: #ccfbf1; stroke: #14b8a6; }
+.c-teal text { fill: #065f46; }
+.c-purple rect { fill: #ede9fe; stroke: #8b5cf6; }
+.c-purple text { fill: #5b21b6; }
+.c-amber rect { fill: #fef3c7; stroke: #f59e0b; }
+.c-amber text { fill: #92400e; }
+.c-green rect { fill: #dcfce7; stroke: #22c55e; }
+.c-green text { fill: #166534; }
+text.th { font-size: 14px; font-weight: 600; }
+text.ts { font-size: 11px; fill: var(--color-text-secondary); }
+`;

--- a/src/lib/htmlArtifact/wrapHtml.test.ts
+++ b/src/lib/htmlArtifact/wrapHtml.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { wrapArtifactHtml } from "./wrapHtml";
+
+describe("wrapArtifactHtml", () => {
+  it("should wrap a simple HTML fragment into a full document", () => {
+    const html = "<p>Hello</p>";
+    const result = wrapArtifactHtml(html);
+
+    expect(result).toContain("<!DOCTYPE html>");
+    expect(result).toContain("<html");
+    expect(result).toContain("<head>");
+    expect(result).toContain("<body>");
+    expect(result).toContain("<p>Hello</p>");
+  });
+
+  it("should include Claude CSS variable defaults in :root", () => {
+    const result = wrapArtifactHtml("<div>test</div>");
+
+    expect(result).toContain("--color-text-secondary");
+    expect(result).toContain("--color-border-tertiary");
+    expect(result).toContain("--border-radius-md");
+    expect(result).toContain("--font-mono");
+  });
+
+  it("should include dark mode media query", () => {
+    const result = wrapArtifactHtml("<div>test</div>");
+
+    expect(result).toContain("prefers-color-scheme: dark");
+  });
+
+  it("should include resize observer script for iframe height auto-adjustment", () => {
+    const result = wrapArtifactHtml("<div>test</div>");
+
+    expect(result).toContain("ResizeObserver");
+    expect(result).toContain("zedi-artifact-resize");
+    expect(result).toContain("parent.postMessage");
+  });
+
+  it("should set charset to utf-8", () => {
+    const result = wrapArtifactHtml("<div>test</div>");
+
+    expect(result).toContain('charset="utf-8"');
+  });
+
+  it("should preserve SVG content", () => {
+    const svg = '<svg viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>';
+    const result = wrapArtifactHtml(svg);
+
+    expect(result).toContain(svg);
+  });
+
+  it("should preserve script tags from the fragment", () => {
+    const html =
+      '<div id="app"></div><script>document.getElementById("app").textContent="OK";</script>';
+    const result = wrapArtifactHtml(html);
+
+    expect(result).toContain('<script>document.getElementById("app").textContent="OK";</script>');
+  });
+
+  it("should preserve style tags from the fragment", () => {
+    const html = "<style>.foo { color: red; }</style><div class='foo'>red text</div>";
+    const result = wrapArtifactHtml(html);
+
+    expect(result).toContain("<style>.foo { color: red; }</style>");
+  });
+
+  it("should preserve canvas elements", () => {
+    const html = '<canvas id="cv"></canvas>';
+    const result = wrapArtifactHtml(html);
+
+    expect(result).toContain('<canvas id="cv"></canvas>');
+  });
+
+  it("should include SVG class definitions for Claude diagram styling", () => {
+    const result = wrapArtifactHtml("<svg></svg>");
+
+    expect(result).toContain(".c-blue");
+    expect(result).toContain(".c-coral");
+    expect(result).toContain(".c-teal");
+  });
+
+  it("should handle empty input", () => {
+    const result = wrapArtifactHtml("");
+
+    expect(result).toContain("<!DOCTYPE html>");
+    expect(result).toContain("<body>");
+  });
+});

--- a/src/lib/htmlArtifact/wrapHtml.ts
+++ b/src/lib/htmlArtifact/wrapHtml.ts
@@ -1,0 +1,67 @@
+/**
+ * Claude アーティファクト HTML フラグメントを完全な HTML ドキュメントに変換する。
+ * sandboxed iframe の srcdoc として使用される。
+ *
+ * Wraps a Claude artifact HTML fragment into a full HTML document
+ * for use as the srcdoc of a sandboxed iframe.
+ */
+
+import {
+  LIGHT_THEME_VARS,
+  DARK_THEME_VARS,
+  SVG_DIAGRAM_STYLES,
+  buildCssVarBlock,
+} from "./defaultTheme";
+
+/**
+ * HTML フラグメントを完全なドキュメントにラップする。
+ * Claude テーマ CSS 変数のデフォルト値と iframe 高さ自動調整スクリプトを注入する。
+ *
+ * Wraps an HTML fragment into a complete document.
+ * Injects Claude theme CSS variable defaults and an iframe height auto-resize script.
+ *
+ * @param fragmentHtml - 生の HTML フラグメント / Raw HTML fragment
+ * @returns 完全な HTML ドキュメント文字列 / Full HTML document string
+ */
+export function wrapArtifactHtml(fragmentHtml: string): string {
+  const lightVars = buildCssVarBlock(LIGHT_THEME_VARS);
+  const darkVars = buildCssVarBlock(DARK_THEME_VARS);
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root {
+${lightVars}
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+${darkVars}
+      }
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 16px;
+      font-family: var(--font-sans);
+      color: var(--color-text-primary);
+      background: var(--color-bg-primary);
+    }
+${SVG_DIAGRAM_STYLES}
+  </style>
+</head>
+<body>
+  ${fragmentHtml}
+  <script>
+    new ResizeObserver(function() {
+      parent.postMessage(
+        { type: 'zedi-artifact-resize', height: document.body.scrollHeight },
+        '*'
+      );
+    }).observe(document.body);
+  </script>
+</body>
+</html>`;
+}

--- a/src/lib/wikiGenerator.ts
+++ b/src/lib/wikiGenerator.ts
@@ -107,8 +107,6 @@ export async function generateWikiContentStream(
       case "google":
         await generateWithGoogle(settings, title, callbacks, abortSignal);
         break;
-      case "claude-code":
-        throw new Error("Wiki generation is not supported with Claude Code provider.");
       default: {
         const _exhaustive: never = settings.provider;
         throw new Error(`Unknown provider: ${_exhaustive}`);


### PR DESCRIPTION
## 概要

Claude などが出力するインタラクティブ HTML（`<style>` / SVG / canvas / `<script>`）を、TipTap の `htmlArtifact` ノードとしてページに埋め込めるようにしました。`sandbox=\"allow-scripts\"` の iframe（`allow-same-origin` なし）で親アプリと分離して表示します。

## 変更点

### `src/lib/htmlArtifact/`
- `defaultTheme.ts` — Claude 互換の CSS 変数（ライト/ダーク）
- `wrapHtml.ts` — フラグメントを完全 HTML にラップし、高さ通知用スクリプトを付与
- 上記の単体テスト

### `src/components/editor/`
- `HtmlArtifactExtension.ts` — TipTap ノード（`content`, `title`）
- `HtmlArtifactNodeView.tsx` — iframe 表示・編集・全画面・`postMessage` による高さ調整
- `editorConfig.ts` — 拡張の登録
- `slashCommandItems.ts` — スラッシュコマンド（HTML 貼り付け + 任意タイトル）

### その他
- `contentUtils.ts` / `contentUtils.test.ts` — サニタイザーで `htmlArtifact` を許可
- `src/i18n/locales/*/editor.json` — スラッシュメニュー文言（ja/en）
- `ExecutableCodeBlockExtension.ts` — `insertExecutableCodeBlock` のモジュール拡張をネスト形に修正（Tiptap `UnionCommands` と整合）
- `wikiGenerator.ts` — 先頭分岐で既に処理されるため到達不能だった `claude-code` の `switch` ケースを削除

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. ノート/ページを開き、スラッシュメニューから「HTML アーティファクト」（検索: `html`, `artifact`）を選択する。
2. プロンプトに Claude 形式の HTML フラグメントを貼り付け、任意でタイトルを入力して挿入する。
3. iframe 内でスライダーや canvas が動作することを確認する（編集・削除・拡大表示ボタンはホバーで表示）。
4. ローカルで `bun run test:run` が通ることを確認する。

## チェックリスト

- [x] テストがすべてパスする（`bun run test:run` を実行済み）
- [x] Lint エラーがない（pre-commit で eslint を通過）
- [ ] 必要に応じてドキュメントを更新した（本 PR では未対応）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

UI に HTML アーティファクトブロックとスラッシュコマンドが追加されています。必要に応じて Before/After を追記してください。

## 関連 Issue

<!-- 該当があれば記入 -->

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * HTMLアーティファクト機能を追加。スラッシュメニューからインタラクティブなHTML埋め込みを挿入可能。サンドボックス化されたiframeで安全にレンダリング。フルスクリーン表示とコンテンツの自動リサイズに対応。ダークモード対応のテーマシステムを実装。

* **Tests**
  * HTMLアーティファクト関連の包括的なテストスイートを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->