### PR TITLE
feat: Add WikiLink paste rule to support [[Title]] syntax

### DIFF
--- a/src/components/editor/extensions/WikiLinkExtension.test.ts
+++ b/src/components/editor/extensions/WikiLinkExtension.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { WikiLink, WIKI_LINK_PASTE_REGEX } from "./WikiLinkExtension";
+
+/**
+ * Tests for WikiLink paste rule.
+ * WikiLink のペーストルールのテスト。
+ */
+describe("WikiLinkExtension paste rule", () => {
+  describe("WIKI_LINK_PASTE_REGEX", () => {
+    it("should match a basic [[Title]] pattern", () => {
+      const text = "[[MyPage]]";
+      const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe("MyPage");
+    });
+
+    it("should match multiple [[WikiLink]] patterns in text", () => {
+      const text = "See [[PageA]] and [[PageB]] for details";
+      const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
+      expect(matches).toHaveLength(2);
+      expect(matches[0][1]).toBe("PageA");
+      expect(matches[1][1]).toBe("PageB");
+    });
+
+    it("should match titles with spaces", () => {
+      const text = "[[My Page Title]]";
+      const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe("My Page Title");
+    });
+
+    it("should match titles with Japanese characters", () => {
+      const text = "[[日本語ページ]]";
+      const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe("日本語ページ");
+    });
+
+    it("should not match empty brackets [[]]", () => {
+      const text = "[[]]";
+      const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
+      expect(matches).toHaveLength(0);
+    });
+
+    it("should not match whitespace-only titles [[ ]]", () => {
+      const text = "[[ ]]";
+      const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
+      // The regex matches but the title is whitespace-only; the paste rule
+      // handler trims and skips empty titles at the attribute level.
+      // Regex itself captures the content between brackets.
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1].trim()).toBe("");
+    });
+
+    it("should not match single brackets [Title]", () => {
+      const text = "[Title]";
+      const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
+      expect(matches).toHaveLength(0);
+    });
+
+    it("should handle nested brackets [[[Title]]] gracefully", () => {
+      // With `[[[Title]]]`, the regex greedily matches `[[Title]]` starting
+      // at position 1, so captured group 1 includes the leading `[`.
+      // The paste rule trims titles; this is acceptable edge-case behavior.
+      // `[[[Title]]]` は通常ペーストされないため、エッジケースとして許容する。
+      const text = "[[[Title]]]";
+      const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
+      expect(matches).toHaveLength(1);
+    });
+  });
+
+  describe("WikiLink extension configuration", () => {
+    it("should have addPasteRules defined", () => {
+      const extension = WikiLink.configure({});
+      // The extension config should have paste rules
+      expect(extension.config.addPasteRules).toBeDefined();
+      expect(typeof extension.config.addPasteRules).toBe("function");
+    });
+
+    it("should keep existing functionality (parseHTML, renderHTML)", () => {
+      const extension = WikiLink.configure({});
+      expect(extension.config.parseHTML).toBeDefined();
+      expect(extension.config.renderHTML).toBeDefined();
+      expect(extension.config.addAttributes).toBeDefined();
+    });
+  });
+});

--- a/src/components/editor/extensions/WikiLinkExtension.test.ts
+++ b/src/components/editor/extensions/WikiLinkExtension.test.ts
@@ -58,14 +58,14 @@ describe("WikiLinkExtension paste rule", () => {
       expect(matches).toHaveLength(0);
     });
 
-    it("should handle nested brackets [[[Title]]] gracefully", () => {
-      // With `[[[Title]]]`, the regex greedily matches `[[Title]]` starting
-      // at position 1, so captured group 1 includes the leading `[`.
-      // The paste rule trims titles; this is acceptable edge-case behavior.
-      // `[[[Title]]]` は通常ペーストされないため、エッジケースとして許容する。
+    it("should not capture brackets inside title with [[[Title]]]", () => {
+      // The improved regex `[^\[\]]` excludes both `[` and `]` from capture,
+      // so `[[[Title]]]` correctly matches only `[[Title]]` with capture "Title".
+      // 改善した正規表現により、`[[[Title]]]` でも正しく "Title" だけをキャプチャする。
       const text = "[[[Title]]]";
       const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
       expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe("Title");
     });
   });
 

--- a/src/components/editor/extensions/WikiLinkExtension.ts
+++ b/src/components/editor/extensions/WikiLinkExtension.ts
@@ -1,6 +1,18 @@
-import { Mark, mergeAttributes } from "@tiptap/core";
+import { Mark, markPasteRule, mergeAttributes } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 
+/**
+ * Regex to match completed WikiLink patterns `[[Title]]` in pasted text.
+ * Captures the title (non-empty, no `]` characters) inside the brackets.
+ *
+ * 貼り付けテキスト中の完成済み WikiLink パターン `[[Title]]` にマッチする正規表現。
+ * ブラケット内のタイトル（空でなく `]` を含まない）をキャプチャする。
+ */
+export const WIKI_LINK_PASTE_REGEX = /\[\[([^\]]+)\]\]/g;
+
+/**
+ *
+ */
 export interface WikiLinkOptions {
   HTMLAttributes: Record<string, unknown>;
   onLinkClick?: (title: string) => void;
@@ -20,7 +32,10 @@ declare module "@tiptap/core" {
   }
 }
 
-export const WikiLink = Mark.create<WikiLinkOptions>({
+export /**
+ *
+ */
+const WikiLink = Mark.create<WikiLinkOptions>({
   name: "wikiLink",
 
   priority: 1000,
@@ -67,12 +82,21 @@ export const WikiLink = Mark.create<WikiLinkOptions>({
   },
 
   renderHTML({ HTMLAttributes }) {
+    /**
+     *
+     */
     const exists =
       HTMLAttributes["data-exists"] === "true" || HTMLAttributes["data-exists"] === true;
+    /**
+     *
+     */
     const referenced =
       HTMLAttributes["data-referenced"] === "true" || HTMLAttributes["data-referenced"] === true;
 
     // Determine CSS class based on link status
+    /**
+     *
+     */
     let className = "wiki-link";
     if (!exists) {
       className = referenced ? "wiki-link-referenced" : "wiki-link-ghost";
@@ -88,6 +112,23 @@ export const WikiLink = Mark.create<WikiLinkOptions>({
     ];
   },
 
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: WIKI_LINK_PASTE_REGEX,
+        type: this.type,
+        getAttributes: (match) => {
+          /**
+           *
+           */
+          const title = (match[1] ?? "").trim();
+          if (!title) return false;
+          return { title, exists: false, referenced: false };
+        },
+      }),
+    ];
+  },
+
   addKeyboardShortcuts() {
     return {
       "Mod-[": () => false, // Prevent default
@@ -95,6 +136,9 @@ export const WikiLink = Mark.create<WikiLinkOptions>({
   },
 
   addProseMirrorPlugins() {
+    /**
+     *
+     */
     const { onLinkClick } = this.options;
 
     return [
@@ -104,12 +148,21 @@ export const WikiLink = Mark.create<WikiLinkOptions>({
           handleClick: (_view, _pos, event) => {
             if (!onLinkClick) return false;
 
+            /**
+             *
+             */
             const target = event.target as HTMLElement;
 
             // Check if clicked on a wiki-link element
+            /**
+             *
+             */
             const wikiLinkElement = target.closest("[data-wiki-link]") as HTMLElement | null;
             if (!wikiLinkElement) return false;
 
+            /**
+             *
+             */
             const title = wikiLinkElement.getAttribute("data-title");
 
             if (title) {

--- a/src/components/editor/extensions/WikiLinkExtension.ts
+++ b/src/components/editor/extensions/WikiLinkExtension.ts
@@ -3,15 +3,16 @@ import { Plugin, PluginKey } from "@tiptap/pm/state";
 
 /**
  * Regex to match completed WikiLink patterns `[[Title]]` in pasted text.
- * Captures the title (non-empty, no `]` characters) inside the brackets.
+ * Captures the title (non-empty, no `[` or `]` characters) inside the brackets.
  *
  * 貼り付けテキスト中の完成済み WikiLink パターン `[[Title]]` にマッチする正規表現。
- * ブラケット内のタイトル（空でなく `]` を含まない）をキャプチャする。
+ * ブラケット内のタイトル（空でなく `[` や `]` を含まない）をキャプチャする。
  */
-export const WIKI_LINK_PASTE_REGEX = /\[\[([^\]]+)\]\]/g;
+export const WIKI_LINK_PASTE_REGEX = /\[\[([^[\]]+)\]\]/g;
 
 /**
- *
+ * Options for the WikiLink mark extension.
+ * WikiLink マーク拡張のオプション。
  */
 export interface WikiLinkOptions {
   HTMLAttributes: Record<string, unknown>;
@@ -32,10 +33,11 @@ declare module "@tiptap/core" {
   }
 }
 
-export /**
- *
+/**
+ * Tiptap mark extension for WikiLinks (`[[Title]]`).
+ * WikiLink（`[[Title]]`）用の Tiptap マーク拡張。
  */
-const WikiLink = Mark.create<WikiLinkOptions>({
+export const WikiLink = Mark.create<WikiLinkOptions>({
   name: "wikiLink",
 
   priority: 1000,
@@ -82,21 +84,12 @@ const WikiLink = Mark.create<WikiLinkOptions>({
   },
 
   renderHTML({ HTMLAttributes }) {
-    /**
-     *
-     */
     const exists =
       HTMLAttributes["data-exists"] === "true" || HTMLAttributes["data-exists"] === true;
-    /**
-     *
-     */
     const referenced =
       HTMLAttributes["data-referenced"] === "true" || HTMLAttributes["data-referenced"] === true;
 
     // Determine CSS class based on link status
-    /**
-     *
-     */
     let className = "wiki-link";
     if (!exists) {
       className = referenced ? "wiki-link-referenced" : "wiki-link-ghost";
@@ -118,9 +111,6 @@ const WikiLink = Mark.create<WikiLinkOptions>({
         find: WIKI_LINK_PASTE_REGEX,
         type: this.type,
         getAttributes: (match) => {
-          /**
-           *
-           */
           const title = (match[1] ?? "").trim();
           if (!title) return false;
           return { title, exists: false, referenced: false };
@@ -136,9 +126,6 @@ const WikiLink = Mark.create<WikiLinkOptions>({
   },
 
   addProseMirrorPlugins() {
-    /**
-     *
-     */
     const { onLinkClick } = this.options;
 
     return [
@@ -148,21 +135,12 @@ const WikiLink = Mark.create<WikiLinkOptions>({
           handleClick: (_view, _pos, event) => {
             if (!onLinkClick) return false;
 
-            /**
-             *
-             */
             const target = event.target as HTMLElement;
 
             // Check if clicked on a wiki-link element
-            /**
-             *
-             */
             const wikiLinkElement = target.closest("[data-wiki-link]") as HTMLElement | null;
             if (!wikiLinkElement) return false;
 
-            /**
-             *
-             */
             const title = wikiLinkElement.getAttribute("data-title");
 
             if (title) {


### PR DESCRIPTION
## 概要

WikiLink 拡張機能にペーストルール機能を追加し、ユーザーが `[[Title]]` 形式のテキストを貼り付けた際に自動的に WikiLink マークに変換されるようにしました。また、包括的なユニットテストを追加しました。

## 変更点

- **WikiLinkExtension.ts**
  - `WIKI_LINK_PASTE_REGEX` 定数を追加：`[[Title]]` パターンをマッチングする正規表現
  - `addPasteRules()` メソッドを実装：`markPasteRule` を使用してペースト時の自動変換を実現
  - ペースト時に空のタイトルをフィルタリングし、新規リンク（`exists: false`）として初期化

- **WikiLinkExtension.test.ts** (新規)
  - `WIKI_LINK_PASTE_REGEX` の動作を検証するテストスイート
  - 基本的なパターン、複数マッチ、スペース、日本語文字、エッジケースをカバー
  - 拡張機能の設定が正しく定義されていることを確認

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm test` または `vitest` を実行して、新しいテストスイートが全てパスすることを確認
2. エディタで `[[PageTitle]]` 形式のテキストを貼り付けて、自動的に WikiLink に変換されることを確認
3. 空のブラケット `[[]]` や不正な形式は変換されないことを確認

## チェックリスト

- [x] テストがすべてパスする（新規テストスイート追加）
- [x] Lint エラーがない
- [x] 既存機能（parseHTML、renderHTML）は変更なし

https://claude.ai/code/session_01XMnr7j27Q3zjRnxGnfqee8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
