### PR TITLE
feat: Add markdown paste handler for rich content insertion

### DIFF
--- a/src/components/editor/TiptapEditor/useEditorLifecycle.ts
+++ b/src/components/editor/TiptapEditor/useEditorLifecycle.ts
@@ -4,6 +4,7 @@ import { sanitizeTiptapContent } from "@/lib/contentUtils";
 import { useContentSanitizer } from "./useContentSanitizer";
 import { useWikiLinkStatusSync } from "./useWikiLinkStatusSync";
 import { usePasteImageHandler } from "./usePasteImageHandler";
+import { useMarkdownPasteHandler } from "./useMarkdownPasteHandler";
 import { rememberSlashAgentSelection } from "@/lib/agentSlashCommands/slashAgentSelectionCache";
 import type { TiptapEditorProps } from "./types";
 
@@ -127,6 +128,7 @@ export function useEditorLifecycle({
   ]);
 
   usePasteImageHandler({ editor, handleImageUpload });
+  useMarkdownPasteHandler({ editor });
 
   useEffect(() => {
     if (editor) editor.setEditable(!isReadOnly);

--- a/src/components/editor/TiptapEditor/useEditorLifecycle.ts
+++ b/src/components/editor/TiptapEditor/useEditorLifecycle.ts
@@ -28,8 +28,8 @@ interface UseEditorLifecycleOptions {
 }
 
 /**
- * エディタのライフサイクル管理（コンテンツ同期・読み取り専用切替・画像ペースト・WikiLink 同期）。
- * Manages editor lifecycle: content sync, read-only toggling, image paste handling, and WikiLink status sync.
+ * エディタのライフサイクル管理（コンテンツ同期・読み取り専用切替・画像ペースト・マークダウンペースト・WikiLink 同期）。
+ * Manages editor lifecycle: content sync, read-only toggling, image paste handling, markdown paste handling, and WikiLink status sync.
  */
 export function useEditorLifecycle({
   editor,

--- a/src/components/editor/TiptapEditor/useMarkdownPasteHandler.test.ts
+++ b/src/components/editor/TiptapEditor/useMarkdownPasteHandler.test.ts
@@ -1,0 +1,169 @@
+import { renderHook, act } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
+import { describe, expect, it, vi } from "vitest";
+import { useMarkdownPasteHandler } from "./useMarkdownPasteHandler";
+
+function createPasteEvent({
+  text = "",
+  html = "",
+}: {
+  text?: string;
+  html?: string;
+}): ClipboardEvent {
+  const event = new Event("paste", { bubbles: true, cancelable: true }) as ClipboardEvent;
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      getData: (type: string) => {
+        if (type === "text/plain") return text;
+        if (type === "text/html") return html;
+        return "";
+      },
+    },
+  });
+  return event;
+}
+
+function createMockEditor(hasMarkdown = true) {
+  const dom = document.createElement("div");
+
+  const mockContent = { childCount: 1 };
+  const mockDoc = { content: mockContent };
+  const mockTr = {
+    replaceSelection: vi.fn().mockReturnThis(),
+  };
+
+  const editor = {
+    view: {
+      dom,
+      state: {
+        tr: mockTr,
+      },
+      dispatch: vi.fn(),
+    },
+    state: {
+      schema: {
+        nodeFromJSON: vi.fn(() => mockDoc),
+      },
+    },
+    markdown: hasMarkdown
+      ? {
+          parse: vi.fn(() => ({
+            type: "doc",
+            content: [
+              { type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "Hello" }] },
+            ],
+          })),
+        }
+      : undefined,
+  } as unknown as Editor;
+
+  return { editor, dom, mockTr };
+}
+
+describe("useMarkdownPasteHandler", () => {
+  it("converts pasted markdown text to rich content", () => {
+    const { editor, dom, mockTr } = createMockEditor();
+
+    renderHook(() => useMarkdownPasteHandler({ editor }));
+
+    const event = createPasteEvent({ text: "# Hello World" });
+
+    act(() => {
+      dom.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(
+      (editor as unknown as { markdown: { parse: ReturnType<typeof vi.fn> } }).markdown.parse,
+    ).toHaveBeenCalledWith("# Hello World");
+    expect(editor.view.dispatch).toHaveBeenCalled();
+    expect(mockTr.replaceSelection).toHaveBeenCalled();
+  });
+
+  it("does not intercept plain text without markdown patterns", () => {
+    const { editor, dom } = createMockEditor();
+
+    renderHook(() => useMarkdownPasteHandler({ editor }));
+
+    const event = createPasteEvent({ text: "Just plain text without markdown" });
+
+    act(() => {
+      dom.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("does not intercept when HTML is present (rich paste)", () => {
+    const { editor, dom } = createMockEditor();
+
+    renderHook(() => useMarkdownPasteHandler({ editor }));
+
+    const event = createPasteEvent({
+      text: "# Hello",
+      html: "<h1>Hello</h1>",
+    });
+
+    act(() => {
+      dom.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("handles bold/italic markdown", () => {
+    const { editor, dom } = createMockEditor();
+
+    renderHook(() => useMarkdownPasteHandler({ editor }));
+
+    const event = createPasteEvent({ text: "This is **bold** text" });
+
+    act(() => {
+      dom.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("handles list markdown", () => {
+    const { editor, dom } = createMockEditor();
+
+    renderHook(() => useMarkdownPasteHandler({ editor }));
+
+    const event = createPasteEvent({ text: "- item 1\n- item 2\n- item 3" });
+
+    act(() => {
+      dom.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("handles code block markdown", () => {
+    const { editor, dom } = createMockEditor();
+
+    renderHook(() => useMarkdownPasteHandler({ editor }));
+
+    const event = createPasteEvent({ text: "```js\nconsole.log('hello')\n```" });
+
+    act(() => {
+      dom.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("does nothing when editor.markdown is not available", () => {
+    const { editor, dom } = createMockEditor(false);
+
+    renderHook(() => useMarkdownPasteHandler({ editor }));
+
+    const event = createPasteEvent({ text: "# Hello" });
+
+    act(() => {
+      dom.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/src/components/editor/TiptapEditor/useMarkdownPasteHandler.test.ts
+++ b/src/components/editor/TiptapEditor/useMarkdownPasteHandler.test.ts
@@ -173,6 +173,32 @@ describe("useMarkdownPasteHandler", () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
+  it("falls back to default paste when markdown.parse throws", () => {
+    const dom = document.createElement("div");
+    const insertContent = vi.fn(() => true);
+
+    const editor = {
+      view: { dom },
+      commands: { insertContent },
+      markdown: {
+        parse: vi.fn(() => {
+          throw new Error("parse error");
+        }),
+      },
+    } as unknown as Editor;
+
+    renderHook(() => useMarkdownPasteHandler({ editor }));
+
+    const event = createPasteEvent({ text: "# Hello" });
+
+    act(() => {
+      dom.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(insertContent).not.toHaveBeenCalled();
+  });
+
   it("does nothing when editor.markdown is not available", () => {
     const { editor, dom, insertContent } = createMockEditor(false);
 

--- a/src/components/editor/TiptapEditor/useMarkdownPasteHandler.test.ts
+++ b/src/components/editor/TiptapEditor/useMarkdownPasteHandler.test.ts
@@ -26,43 +26,33 @@ function createPasteEvent({
 function createMockEditor(hasMarkdown = true) {
   const dom = document.createElement("div");
 
-  const mockContent = { childCount: 1 };
-  const mockDoc = { content: mockContent };
-  const mockTr = {
-    replaceSelection: vi.fn().mockReturnThis(),
+  const parsedDoc = {
+    type: "doc",
+    content: [{ type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "Hello" }] }],
   };
+
+  const insertContent = vi.fn(() => true);
 
   const editor = {
     view: {
       dom,
-      state: {
-        tr: mockTr,
-      },
-      dispatch: vi.fn(),
     },
-    state: {
-      schema: {
-        nodeFromJSON: vi.fn(() => mockDoc),
-      },
+    commands: {
+      insertContent,
     },
     markdown: hasMarkdown
       ? {
-          parse: vi.fn(() => ({
-            type: "doc",
-            content: [
-              { type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "Hello" }] },
-            ],
-          })),
+          parse: vi.fn(() => parsedDoc),
         }
       : undefined,
   } as unknown as Editor;
 
-  return { editor, dom, mockTr };
+  return { editor, dom, insertContent, parsedDoc };
 }
 
 describe("useMarkdownPasteHandler", () => {
   it("converts pasted markdown text to rich content", () => {
-    const { editor, dom, mockTr } = createMockEditor();
+    const { editor, dom, insertContent, parsedDoc } = createMockEditor();
 
     renderHook(() => useMarkdownPasteHandler({ editor }));
 
@@ -76,12 +66,11 @@ describe("useMarkdownPasteHandler", () => {
     expect(
       (editor as unknown as { markdown: { parse: ReturnType<typeof vi.fn> } }).markdown.parse,
     ).toHaveBeenCalledWith("# Hello World");
-    expect(editor.view.dispatch).toHaveBeenCalled();
-    expect(mockTr.replaceSelection).toHaveBeenCalled();
+    expect(insertContent).toHaveBeenCalledWith(parsedDoc);
   });
 
   it("does not intercept plain text without markdown patterns", () => {
-    const { editor, dom } = createMockEditor();
+    const { editor, dom, insertContent } = createMockEditor();
 
     renderHook(() => useMarkdownPasteHandler({ editor }));
 
@@ -92,10 +81,11 @@ describe("useMarkdownPasteHandler", () => {
     });
 
     expect(event.defaultPrevented).toBe(false);
+    expect(insertContent).not.toHaveBeenCalled();
   });
 
   it("does not intercept when HTML is present (rich paste)", () => {
-    const { editor, dom } = createMockEditor();
+    const { editor, dom, insertContent } = createMockEditor();
 
     renderHook(() => useMarkdownPasteHandler({ editor }));
 
@@ -109,9 +99,25 @@ describe("useMarkdownPasteHandler", () => {
     });
 
     expect(event.defaultPrevented).toBe(false);
+    expect(insertContent).not.toHaveBeenCalled();
   });
 
-  it("handles bold/italic markdown", () => {
+  it("does not run when another handler already called preventDefault", () => {
+    const { editor, dom, insertContent } = createMockEditor();
+
+    renderHook(() => useMarkdownPasteHandler({ editor }));
+
+    const event = createPasteEvent({ text: "# Hello World" });
+    event.preventDefault();
+
+    act(() => {
+      dom.dispatchEvent(event);
+    });
+
+    expect(insertContent).not.toHaveBeenCalled();
+  });
+
+  it("handles bold markdown", () => {
     const { editor, dom } = createMockEditor();
 
     renderHook(() => useMarkdownPasteHandler({ editor }));
@@ -153,8 +159,22 @@ describe("useMarkdownPasteHandler", () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
+  it("detects indented fenced code blocks (up to 3 spaces)", () => {
+    const { editor, dom } = createMockEditor();
+
+    renderHook(() => useMarkdownPasteHandler({ editor }));
+
+    const event = createPasteEvent({ text: "   ```js\nx\n```" });
+
+    act(() => {
+      dom.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it("does nothing when editor.markdown is not available", () => {
-    const { editor, dom } = createMockEditor(false);
+    const { editor, dom, insertContent } = createMockEditor(false);
 
     renderHook(() => useMarkdownPasteHandler({ editor }));
 
@@ -165,5 +185,6 @@ describe("useMarkdownPasteHandler", () => {
     });
 
     expect(event.defaultPrevented).toBe(false);
+    expect(insertContent).not.toHaveBeenCalled();
   });
 });

--- a/src/components/editor/TiptapEditor/useMarkdownPasteHandler.ts
+++ b/src/components/editor/TiptapEditor/useMarkdownPasteHandler.ts
@@ -65,10 +65,14 @@ export function useMarkdownPasteHandler({ editor }: UseMarkdownPasteHandlerParam
       // Use the parse method provided by @tiptap/markdown
       if (!editor.markdown) return;
 
-      event.preventDefault();
-
-      const parsed = editor.markdown.parse(text);
-      editor.commands.insertContent(parsed);
+      try {
+        const parsed = editor.markdown.parse(text);
+        event.preventDefault();
+        editor.commands.insertContent(parsed);
+      } catch {
+        // パース失敗時は TipTap のデフォルトペースト処理にフォールバック
+        // On parse failure, fall back to TipTap's default paste handling
+      }
     };
 
     const editorElement = editor.view.dom;

--- a/src/components/editor/TiptapEditor/useMarkdownPasteHandler.ts
+++ b/src/components/editor/TiptapEditor/useMarkdownPasteHandler.ts
@@ -1,0 +1,81 @@
+import { useEffect } from "react";
+import type { Editor } from "@tiptap/core";
+import { Slice } from "@tiptap/pm/model";
+
+/**
+ * マークダウンらしいテキストかどうかを簡易判定する。
+ * Heuristically checks whether the given text looks like markdown.
+ *
+ * @param text - 判定対象テキスト / Text to check
+ * @returns マークダウンの特徴が含まれていれば true / true if markdown patterns are detected
+ */
+function looksLikeMarkdown(text: string): boolean {
+  // 見出し / Headings: # / ## / ###
+  if (/^#{1,6}\s/m.test(text)) return true;
+  // リスト / Unordered lists: - item / * item
+  if (/^[\t ]*[-*+]\s/m.test(text)) return true;
+  // 番号付きリスト / Ordered lists: 1. item
+  if (/^[\t ]*\d+\.\s/m.test(text)) return true;
+  // コードブロック / Fenced code blocks: ```
+  if (/^```/m.test(text)) return true;
+  // 引用 / Blockquotes: > text
+  if (/^>\s/m.test(text)) return true;
+  // 太字・斜体 / Bold/italic: **text** / *text* / __text__ / _text_
+  if (/\*\*.+?\*\*|__.+?__/.test(text)) return true;
+  // タスクリスト / Task lists: - [ ] / - [x]
+  if (/^[\t ]*[-*+]\s\[[ xX]\]/m.test(text)) return true;
+  // テーブル / Tables: | col | col |
+  if (/^\|.+\|$/m.test(text) && /^\|[-:| ]+\|$/m.test(text)) return true;
+  // リンク / Links: [text](url)
+  if (/\[.+?\]\(.+?\)/.test(text)) return true;
+
+  return false;
+}
+
+interface UseMarkdownPasteHandlerParams {
+  editor: Editor | null;
+}
+
+/**
+ * ペースト時にマークダウンテキストを検出し、リッチコンテンツとして挿入するフック。
+ * Hook that detects pasted markdown text and inserts it as rich content.
+ *
+ * @param params - エディタインスタンス / Editor instance
+ */
+export function useMarkdownPasteHandler({ editor }: UseMarkdownPasteHandlerParams) {
+  useEffect(() => {
+    if (!editor) return;
+
+    const handlePaste = (event: ClipboardEvent) => {
+      // HTML が含まれている場合はリッチペーストを優先（他アプリからのコピーなど）
+      // If HTML is present, let TipTap handle it as rich paste (e.g., copy from other apps)
+      const html = event.clipboardData?.getData("text/html");
+      if (html) return;
+
+      const text = event.clipboardData?.getData("text/plain");
+      if (!text || !looksLikeMarkdown(text)) return;
+
+      // @tiptap/markdown が提供する parse メソッドを使用
+      // Use the parse method provided by @tiptap/markdown
+      if (!editor.markdown) return;
+
+      event.preventDefault();
+
+      const parsed = editor.markdown.parse(text);
+      const doc = editor.state.schema.nodeFromJSON(parsed);
+      const slice = new Slice(doc.content, 0, 0);
+
+      const tr = editor.view.state.tr.replaceSelection(slice);
+      editor.view.dispatch(tr);
+    };
+
+    const editorElement = editor.view.dom;
+    // usePasteImageHandler よりも後に登録されるため、画像ペーストが先に処理される
+    // Registered after usePasteImageHandler, so image paste is processed first
+    editorElement.addEventListener("paste", handlePaste);
+
+    return () => {
+      editorElement.removeEventListener("paste", handlePaste);
+    };
+  }, [editor]);
+}

--- a/src/components/editor/TiptapEditor/useMarkdownPasteHandler.ts
+++ b/src/components/editor/TiptapEditor/useMarkdownPasteHandler.ts
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 import type { Editor } from "@tiptap/core";
-import { Slice } from "@tiptap/pm/model";
 
 /**
  * マークダウンらしいテキストかどうかを簡易判定する。
@@ -16,11 +15,12 @@ function looksLikeMarkdown(text: string): boolean {
   if (/^[\t ]*[-*+]\s/m.test(text)) return true;
   // 番号付きリスト / Ordered lists: 1. item
   if (/^[\t ]*\d+\.\s/m.test(text)) return true;
-  // コードブロック / Fenced code blocks: ```
-  if (/^```/m.test(text)) return true;
+  // コードブロック / Fenced code blocks (up to 3 leading spaces per CommonMark)
+  if (/^[\t ]{0,3}```/m.test(text)) return true;
   // 引用 / Blockquotes: > text
   if (/^>\s/m.test(text)) return true;
-  // 太字・斜体 / Bold/italic: **text** / *text* / __text__ / _text_
+  // 太字（`**`, `__`）のみ検出（単独の `*` / `_` は誤検知しやすいため除外）
+  // Bold only (`**`, `__`); single `*` / `_` omitted due to false positives (filenames, etc.)
   if (/\*\*.+?\*\*|__.+?__/.test(text)) return true;
   // タスクリスト / Task lists: - [ ] / - [x]
   if (/^[\t ]*[-*+]\s\[[ xX]\]/m.test(text)) return true;
@@ -47,6 +47,12 @@ export function useMarkdownPasteHandler({ editor }: UseMarkdownPasteHandlerParam
     if (!editor) return;
 
     const handlePaste = (event: ClipboardEvent) => {
+      // 同一要素に複数の paste リスナーがあると、先に登録されたハンドラが preventDefault しても
+      // 後続リスナーは呼ばれる。画像 URL などで別ハンドラが処理済みならスキップする。
+      // Multiple listeners on the same element: later listeners still run after preventDefault.
+      // Skip when another handler already handled the paste (e.g. image URL paste).
+      if (event.defaultPrevented) return;
+
       // HTML が含まれている場合はリッチペーストを優先（他アプリからのコピーなど）
       // If HTML is present, let TipTap handle it as rich paste (e.g., copy from other apps)
       const html = event.clipboardData?.getData("text/html");
@@ -62,16 +68,10 @@ export function useMarkdownPasteHandler({ editor }: UseMarkdownPasteHandlerParam
       event.preventDefault();
 
       const parsed = editor.markdown.parse(text);
-      const doc = editor.state.schema.nodeFromJSON(parsed);
-      const slice = new Slice(doc.content, 0, 0);
-
-      const tr = editor.view.state.tr.replaceSelection(slice);
-      editor.view.dispatch(tr);
+      editor.commands.insertContent(parsed);
     };
 
     const editorElement = editor.view.dom;
-    // usePasteImageHandler よりも後に登録されるため、画像ペーストが先に処理される
-    // Registered after usePasteImageHandler, so image paste is processed first
     editorElement.addEventListener("paste", handlePaste);
 
     return () => {


### PR DESCRIPTION
## 概要

マークダウン形式のテキストをペーストした際に、自動的にリッチコンテンツとして変換・挿入する機能を追加しました。プレーンテキストペーストでマークダウン構文を検出し、エディタの markdown パーサーを使用して適切にレンダリングします。

## 変更点

- `useMarkdownPasteHandler` フック を新規作成
  - ペースト時にマークダウンパターンを検出する `looksLikeMarkdown` 関数を実装
  - 見出し、リスト、コードブロック、太字・斜体、テーブル、リンクなど複数のマークダウン構文に対応
  - HTML が含まれている場合はリッチペーストを優先（他アプリからのコピーなど）
  - `@tiptap/markdown` の parse メソッドを使用してマークダウンをパース
  
- `useMarkdownPasteHandler` の包括的なテストスイートを追加
  - マークダウン変換の動作確認
  - プレーンテキスト（マークダウンなし）の非干渉確認
  - HTML ペーストの優先処理確認
  - 複数のマークダウン形式（見出し、リスト、コードブロック）の対応確認
  - markdown 拡張が利用不可の場合の処理確認

- `useEditorLifecycle` に `useMarkdownPasteHandler` を統合

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. エディタにマークダウン形式のテキスト（例：`# Heading`、`- list item`、`**bold**`）をペーストする
2. テキストが自動的にリッチコンテンツとしてレンダリングされることを確認
3. HTML を含むペースト（他アプリからのコピーなど）は従来通り処理されることを確認
4. プレーンテキスト（マークダウン構文なし）はペーストされたまま挿入されることを確認

## チェックリスト

- [x] テストがすべてパスする（169 行のテストスイート追加）
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

https://claude.ai/code/session_01WXdgtoGnQPSaStUeXiyEhB
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エディタに Markdown ペーストハンドラーを追加しました。ユーザーが Markdown 形式のテキストを貼り付けると、自動的に解析されてリッチコンテンツに変換されます。見出し、リスト、コードブロック、太字など一般的な Markdown パターンに対応しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->