### PR TITLE
feat: add invitation acceptance API endpoints

### DIFF
--- a/server/api/src/__tests__/routes/invite.test.ts
+++ b/server/api/src/__tests__/routes/invite.test.ts
@@ -132,16 +132,19 @@ function createMockInvitation(overrides: Record<string, unknown> = {}) {
 
 describe("GET /api/invite/:token", () => {
   it("should return invitation info for a valid token", async () => {
-    const invitation = createMockInvitation();
-    const noteRow = { title: "Test Note" };
-    const memberRow = { invitedByUserId: "inviter-001", role: "editor" };
-    const inviterRow = { name: "Alice" };
+    // JOIN クエリで1回のDB呼び出し / Single joined query result
+    const joinedRow = {
+      noteId: NOTE_ID,
+      memberEmail: TEST_USER_EMAIL,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      usedAt: null,
+      noteTitle: "Test Note",
+      role: "editor",
+      inviterName: "Alice",
+    };
 
     const { app } = createTestApp([
-      [invitation], // select noteInvitations
-      [noteRow], // select notes (title)
-      [memberRow], // select noteMembers (inviter + role)
-      [inviterRow], // select users (inviter name)
+      [joinedRow], // single joined select
     ]);
 
     const res = await app.request(`/api/invite/${TEST_TOKEN}`);
@@ -159,14 +162,17 @@ describe("GET /api/invite/:token", () => {
   });
 
   it("should return isExpired: true for an expired invitation", async () => {
-    const invitation = createMockInvitation({
-      expiresAt: new Date("2020-01-01T00:00:00Z"), // past date
-    });
-    const noteRow = { title: "Expired Note" };
-    const memberRow = { invitedByUserId: "inviter-001", role: "viewer" };
-    const inviterRow = { name: "Bob" };
+    const joinedRow = {
+      noteId: NOTE_ID,
+      memberEmail: TEST_USER_EMAIL,
+      expiresAt: new Date("2020-01-01T00:00:00Z"),
+      usedAt: null,
+      noteTitle: "Expired Note",
+      role: "viewer",
+      inviterName: "Bob",
+    };
 
-    const { app } = createTestApp([[invitation], [noteRow], [memberRow], [inviterRow]]);
+    const { app } = createTestApp([[joinedRow]]);
 
     const res = await app.request(`/api/invite/${TEST_TOKEN}`);
 
@@ -179,7 +185,7 @@ describe("GET /api/invite/:token", () => {
 
   it("should return 404 for an invalid token", async () => {
     const { app } = createTestApp([
-      [], // select noteInvitations → empty
+      [], // select → empty (no matching token)
     ]);
 
     const res = await app.request("/api/invite/invalid-token");
@@ -187,13 +193,20 @@ describe("GET /api/invite/:token", () => {
     expect(res.status).toBe(404);
   });
 
-  it("should return default values when note or inviter not found", async () => {
-    const invitation = createMockInvitation();
+  it("should return default values when note or member is null (LEFT JOIN)", async () => {
+    // LEFT JOIN でノート・メンバーが見つからない場合 null が返る
+    const joinedRow = {
+      noteId: NOTE_ID,
+      memberEmail: TEST_USER_EMAIL,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      usedAt: null,
+      noteTitle: null,
+      role: null,
+      inviterName: null,
+    };
 
     const { app } = createTestApp([
-      [invitation], // select noteInvitations
-      [], // select notes → empty
-      [], // select noteMembers → empty
+      [joinedRow], // single joined select with nulls
     ]);
 
     const res = await app.request(`/api/invite/${TEST_TOKEN}`);

--- a/server/api/src/__tests__/routes/invite.test.ts
+++ b/server/api/src/__tests__/routes/invite.test.ts
@@ -316,6 +316,26 @@ describe("POST /api/invite/:token/accept", () => {
     });
   });
 
+  it("should return 404 when member record was soft-deleted", async () => {
+    const invitation = createMockInvitation();
+
+    const { app } = createTestApp([
+      [invitation], // select noteInvitations
+      [], // update noteMembers → returning empty (soft-deleted)
+    ]);
+
+    const res = await app.request(`/api/invite/${TEST_TOKEN}/accept`, {
+      method: "POST",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      error: "Member record not found",
+    });
+  });
+
   it("should return 401 without auth", async () => {
     const { app } = createTestApp([]);
 

--- a/server/api/src/__tests__/routes/invite.test.ts
+++ b/server/api/src/__tests__/routes/invite.test.ts
@@ -158,6 +158,30 @@ describe("GET /api/invite/:token", () => {
       role: "editor",
       memberEmail: TEST_USER_EMAIL,
       isExpired: false,
+      isUsed: false,
+    });
+  });
+
+  it("should return isUsed: true for an already accepted invitation", async () => {
+    const joinedRow = {
+      noteId: NOTE_ID,
+      memberEmail: TEST_USER_EMAIL,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      usedAt: new Date("2026-03-01T00:00:00Z"),
+      noteTitle: "Used Note",
+      role: "viewer",
+      inviterName: "Alice",
+    };
+
+    const { app } = createTestApp([[joinedRow]]);
+
+    const res = await app.request(`/api/invite/${TEST_TOKEN}`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      isUsed: true,
+      isExpired: false,
     });
   });
 

--- a/server/api/src/__tests__/routes/invite.test.ts
+++ b/server/api/src/__tests__/routes/invite.test.ts
@@ -1,0 +1,340 @@
+/**
+ * 招待受諾フロー API のテスト
+ * Tests for invitation acceptance flow API
+ */
+import { describe, it, expect, vi } from "vitest";
+import { Hono } from "hono";
+import type { Context, Next } from "hono";
+import type { AppEnv } from "../../types/index.js";
+
+// ── Auth mock ──────────────────────────────────────────────────────────────
+
+vi.mock("../../middleware/auth.js", () => ({
+  authRequired: async (c: Context<AppEnv>, next: Next) => {
+    const userId = c.req.header("x-test-user-id");
+    const userEmail = c.req.header("x-test-user-email");
+    if (!userId) return c.json({ message: "Unauthorized" }, 401);
+    c.set("userId", userId);
+    if (userEmail) c.set("userEmail", userEmail);
+    await next();
+  },
+  authOptional: async (c: Context<AppEnv>, next: Next) => {
+    const userId = c.req.header("x-test-user-id");
+    const userEmail = c.req.header("x-test-user-email");
+    if (userId) c.set("userId", userId);
+    if (userEmail) c.set("userEmail", userEmail);
+    await next();
+  },
+}));
+
+import inviteRoutes from "../../routes/invite.js";
+import { errorHandler } from "../../middleware/errorHandler.js";
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const TEST_USER_ID = "user-test-123";
+const TEST_USER_EMAIL = "test@example.com";
+const OTHER_USER_EMAIL = "other@example.com";
+const TEST_TOKEN = "abc123def456";
+const NOTE_ID = "note-test-001";
+
+// ── Mock DB (same proxy-based pattern as notes tests) ──────────────────────
+
+interface ChainInfo {
+  startMethod: string;
+  startArgs: unknown[];
+  ops: { method: string; args: unknown[] }[];
+}
+
+function createMockDb(results: unknown[]) {
+  let chainIndex = 0;
+  const chains: ChainInfo[] = [];
+
+  function makeChainProxy(
+    resultIdx: number,
+    ops: { method: string; args: unknown[] }[],
+  ): Promise<unknown> & Record<string, (...args: unknown[]) => unknown> {
+    return new Proxy({} as Record<string, (...args: unknown[]) => unknown>, {
+      get(_, prop: string) {
+        if (prop === "then") {
+          const result = results[resultIdx];
+          return (resolve?: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+            Promise.resolve(result).then(resolve, reject);
+        }
+        if (prop === "catch") {
+          const result = results[resultIdx];
+          return (reject?: (e: unknown) => unknown) => Promise.resolve(result).catch(reject);
+        }
+        if (prop === "finally") {
+          const result = results[resultIdx];
+          return (fn?: () => void) => Promise.resolve(result).finally(fn);
+        }
+        return (...args: unknown[]) => {
+          ops.push({ method: prop, args });
+          return makeChainProxy(resultIdx, ops);
+        };
+      },
+    }) as Promise<unknown> & Record<string, (...args: unknown[]) => unknown>;
+  }
+
+  const db = new Proxy({} as Record<string, (...args: unknown[]) => unknown>, {
+    get(_, prop: string) {
+      if (prop === "transaction") {
+        return (fn: (tx: typeof db) => Promise<unknown>) => fn(db);
+      }
+      return (...args: unknown[]) => {
+        const idx = chainIndex++;
+        const ops: { method: string; args: unknown[] }[] = [];
+        chains.push({ startMethod: prop, startArgs: args, ops });
+        return makeChainProxy(idx, ops);
+      };
+    },
+  });
+
+  return { db, chains };
+}
+
+function createTestApp(dbResults: unknown[]) {
+  const { db, chains } = createMockDb(dbResults);
+  const app = new Hono<AppEnv>();
+
+  app.use("*", async (c, next) => {
+    c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+    await next();
+  });
+
+  app.onError(errorHandler);
+  app.route("/api/invite", inviteRoutes);
+  return { app, chains };
+}
+
+function authHeaders(userId = TEST_USER_ID, userEmail = TEST_USER_EMAIL) {
+  return {
+    "x-test-user-id": userId,
+    "x-test-user-email": userEmail,
+    "Content-Type": "application/json",
+  };
+}
+
+// ── Mock Factories ─────────────────────────────────────────────────────────
+
+function createMockInvitation(overrides: Record<string, unknown> = {}) {
+  return {
+    noteId: NOTE_ID,
+    memberEmail: TEST_USER_EMAIL,
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days from now
+    usedAt: null,
+    ...overrides,
+  };
+}
+
+// ── GET /api/invite/:token ─────────────────────────────────────────────────
+
+describe("GET /api/invite/:token", () => {
+  it("should return invitation info for a valid token", async () => {
+    const invitation = createMockInvitation();
+    const noteRow = { title: "Test Note" };
+    const memberRow = { invitedByUserId: "inviter-001", role: "editor" };
+    const inviterRow = { name: "Alice" };
+
+    const { app } = createTestApp([
+      [invitation], // select noteInvitations
+      [noteRow], // select notes (title)
+      [memberRow], // select noteMembers (inviter + role)
+      [inviterRow], // select users (inviter name)
+    ]);
+
+    const res = await app.request(`/api/invite/${TEST_TOKEN}`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      noteId: NOTE_ID,
+      noteTitle: "Test Note",
+      inviterName: "Alice",
+      role: "editor",
+      memberEmail: TEST_USER_EMAIL,
+      isExpired: false,
+    });
+  });
+
+  it("should return isExpired: true for an expired invitation", async () => {
+    const invitation = createMockInvitation({
+      expiresAt: new Date("2020-01-01T00:00:00Z"), // past date
+    });
+    const noteRow = { title: "Expired Note" };
+    const memberRow = { invitedByUserId: "inviter-001", role: "viewer" };
+    const inviterRow = { name: "Bob" };
+
+    const { app } = createTestApp([[invitation], [noteRow], [memberRow], [inviterRow]]);
+
+    const res = await app.request(`/api/invite/${TEST_TOKEN}`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      isExpired: true,
+    });
+  });
+
+  it("should return 404 for an invalid token", async () => {
+    const { app } = createTestApp([
+      [], // select noteInvitations → empty
+    ]);
+
+    const res = await app.request("/api/invite/invalid-token");
+
+    expect(res.status).toBe(404);
+  });
+
+  it("should return default values when note or inviter not found", async () => {
+    const invitation = createMockInvitation();
+
+    const { app } = createTestApp([
+      [invitation], // select noteInvitations
+      [], // select notes → empty
+      [], // select noteMembers → empty
+    ]);
+
+    const res = await app.request(`/api/invite/${TEST_TOKEN}`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      noteTitle: "Untitled",
+      inviterName: "Unknown",
+      role: "viewer",
+    });
+  });
+});
+
+// ── POST /api/invite/:token/accept ─────────────────────────────────────────
+
+describe("POST /api/invite/:token/accept", () => {
+  it("should accept invitation when email matches", async () => {
+    const invitation = createMockInvitation();
+    const updatedMember = { role: "editor", status: "accepted" };
+
+    const { app } = createTestApp([
+      [invitation], // select noteInvitations
+      [updatedMember], // update noteMembers → returning
+      [], // update noteInvitations (used_at)
+    ]);
+
+    const res = await app.request(`/api/invite/${TEST_TOKEN}/accept`, {
+      method: "POST",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      noteId: NOTE_ID,
+      role: "editor",
+      status: "accepted",
+    });
+  });
+
+  it("should return 404 for an invalid token", async () => {
+    const { app } = createTestApp([
+      [], // select noteInvitations → empty
+    ]);
+
+    const res = await app.request("/api/invite/invalid-token/accept", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("should return 410 for an expired invitation", async () => {
+    const invitation = createMockInvitation({
+      expiresAt: new Date("2020-01-01T00:00:00Z"),
+    });
+
+    const { app } = createTestApp([
+      [invitation], // select noteInvitations
+    ]);
+
+    const res = await app.request(`/api/invite/${TEST_TOKEN}/accept`, {
+      method: "POST",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(410);
+  });
+
+  it("should return 409 for an already used invitation", async () => {
+    const invitation = createMockInvitation({
+      usedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const { app } = createTestApp([
+      [invitation], // select noteInvitations
+    ]);
+
+    const res = await app.request(`/api/invite/${TEST_TOKEN}/accept`, {
+      method: "POST",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("should return 400 when email does not match", async () => {
+    const invitation = createMockInvitation({
+      memberEmail: OTHER_USER_EMAIL, // different from TEST_USER_EMAIL
+    });
+
+    const { app } = createTestApp([
+      [invitation], // select noteInvitations
+    ]);
+
+    const res = await app.request(`/api/invite/${TEST_TOKEN}/accept`, {
+      method: "POST",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      error: "Please log in with the invited email address",
+    });
+  });
+
+  it("should return 401 without auth", async () => {
+    const { app } = createTestApp([]);
+
+    const res = await app.request(`/api/invite/${TEST_TOKEN}/accept`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("should handle case-insensitive email matching", async () => {
+    const invitation = createMockInvitation({
+      memberEmail: "TEST@EXAMPLE.COM", // uppercase
+    });
+    const updatedMember = { role: "viewer", status: "accepted" };
+
+    const { app } = createTestApp([
+      [invitation], // select noteInvitations
+      [updatedMember], // update noteMembers → returning
+      [], // update noteInvitations (used_at)
+    ]);
+
+    const res = await app.request(`/api/invite/${TEST_TOKEN}/accept`, {
+      method: "POST",
+      headers: authHeaders(TEST_USER_ID, "test@example.com"), // lowercase
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      status: "accepted",
+    });
+  });
+});

--- a/server/api/src/app.ts
+++ b/server/api/src/app.ts
@@ -18,6 +18,7 @@ import searchRoutes from "./routes/search.js";
 import mediaRoutes from "./routes/media.js";
 import clipRoutes from "./routes/clip.js";
 import extRoutes from "./routes/ext.js";
+import inviteRoutes from "./routes/invite.js";
 import aiChatRoutes from "./routes/ai/chat.js";
 import aiModelsRoutes from "./routes/ai/models.js";
 import aiUsageRoutes from "./routes/ai/usage.js";
@@ -92,6 +93,9 @@ export function createApp(): Hono<AppEnv> {
 
   // Notes
   app.route("/api/notes", noteRoutes);
+
+  // Invitation acceptance (public + auth)
+  app.route("/api/invite", inviteRoutes);
 
   // Search
   app.route("/api/search", searchRoutes);

--- a/server/api/src/routes/invite.ts
+++ b/server/api/src/routes/invite.ts
@@ -139,6 +139,10 @@ app.post("/:token/accept", authRequired, async (c) => {
         status: noteMembers.status,
       });
 
+    if (!m) {
+      throw new HTTPException(404, { message: "Member record not found" });
+    }
+
     await tx
       .update(noteInvitations)
       .set({ usedAt: new Date() })
@@ -149,7 +153,7 @@ app.post("/:token/accept", authRequired, async (c) => {
 
   return c.json({
     noteId: invitation.noteId,
-    role: updatedMember?.role ?? "viewer",
+    role: updatedMember.role,
     status: "accepted",
   });
 });

--- a/server/api/src/routes/invite.ts
+++ b/server/api/src/routes/invite.ts
@@ -18,68 +18,53 @@ const app = new Hono<AppEnv>();
 
 /**
  * トークンを検証し、招待情報を返す。認証不要。
+ * JOIN で1クエリにまとめ、DB 往復を削減する。
+ *
  * Validate token and return invitation info. No auth required.
+ * Uses a single joined query to reduce DB round-trips.
  */
 app.get("/:token", async (c) => {
   const token = c.req.param("token");
   const db = c.get("db");
 
-  // トークンで招待レコードを検索 / Find invitation by token
-  const [invitation] = await db
+  // トークン + ノート + メンバー + 招待者を JOIN で一括取得
+  // Fetch invitation + note + member + inviter in a single joined query
+  const [data] = await db
     .select({
       noteId: noteInvitations.noteId,
       memberEmail: noteInvitations.memberEmail,
       expiresAt: noteInvitations.expiresAt,
       usedAt: noteInvitations.usedAt,
+      noteTitle: notes.title,
+      role: noteMembers.role,
+      inviterName: users.name,
     })
     .from(noteInvitations)
+    .leftJoin(notes, eq(notes.id, noteInvitations.noteId))
+    .leftJoin(
+      noteMembers,
+      and(
+        eq(noteMembers.noteId, noteInvitations.noteId),
+        eq(noteMembers.memberEmail, noteInvitations.memberEmail),
+        eq(noteMembers.isDeleted, false),
+      ),
+    )
+    .leftJoin(users, eq(users.id, noteMembers.invitedByUserId))
     .where(eq(noteInvitations.token, token))
     .limit(1);
 
-  if (!invitation) {
+  if (!data) {
     throw new HTTPException(404, { message: "Invalid invitation link" });
   }
 
-  // ノート情報を取得 / Fetch note info
-  const [note] = await db
-    .select({ title: notes.title })
-    .from(notes)
-    .where(eq(notes.id, invitation.noteId))
-    .limit(1);
-
-  // 招待者情報を取得 / Fetch inviter info
-  const [member] = await db
-    .select({
-      invitedByUserId: noteMembers.invitedByUserId,
-      role: noteMembers.role,
-    })
-    .from(noteMembers)
-    .where(
-      and(
-        eq(noteMembers.noteId, invitation.noteId),
-        eq(noteMembers.memberEmail, invitation.memberEmail),
-      ),
-    )
-    .limit(1);
-
-  let inviterName = "Unknown";
-  if (member?.invitedByUserId) {
-    const [inviter] = await db
-      .select({ name: users.name })
-      .from(users)
-      .where(eq(users.id, member.invitedByUserId))
-      .limit(1);
-    inviterName = inviter?.name ?? "Unknown";
-  }
-
-  const isExpired = invitation.expiresAt < new Date();
+  const isExpired = data.expiresAt < new Date();
 
   return c.json({
-    noteId: invitation.noteId,
-    noteTitle: note?.title ?? "Untitled",
-    inviterName,
-    role: member?.role ?? "viewer",
-    memberEmail: invitation.memberEmail,
+    noteId: data.noteId,
+    noteTitle: data.noteTitle ?? "Untitled",
+    inviterName: data.inviterName ?? "Unknown",
+    role: data.role ?? "viewer",
+    memberEmail: data.memberEmail,
     isExpired,
   });
 });
@@ -88,7 +73,10 @@ app.get("/:token", async (c) => {
 
 /**
  * 招待を承認する。認証必須。
+ * noteMembers と noteInvitations の更新をトランザクションで実行する。
+ *
  * Accept an invitation. Auth required.
+ * Updates to noteMembers and noteInvitations are wrapped in a transaction.
  */
 app.post("/:token/accept", authRequired, async (c) => {
   const token = c.req.param("token");
@@ -129,30 +117,35 @@ app.post("/:token/accept", authRequired, async (c) => {
     });
   }
 
-  // メンバーステータスを accepted に更新 / Update member status to accepted
-  const [updatedMember] = await db
-    .update(noteMembers)
-    .set({
-      status: "accepted",
-      acceptedUserId: userId,
-      updatedAt: new Date(),
-    })
-    .where(
-      and(
-        eq(noteMembers.noteId, invitation.noteId),
-        eq(noteMembers.memberEmail, invitation.memberEmail),
-      ),
-    )
-    .returning({
-      role: noteMembers.role,
-      status: noteMembers.status,
-    });
+  // トランザクションで noteMembers + noteInvitations を一括更新
+  // Update noteMembers + noteInvitations atomically in a transaction
+  const [updatedMember] = await db.transaction(async (tx) => {
+    const [m] = await tx
+      .update(noteMembers)
+      .set({
+        status: "accepted",
+        acceptedUserId: userId,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(noteMembers.noteId, invitation.noteId),
+          eq(noteMembers.memberEmail, invitation.memberEmail),
+          eq(noteMembers.isDeleted, false),
+        ),
+      )
+      .returning({
+        role: noteMembers.role,
+        status: noteMembers.status,
+      });
 
-  // 招待トークンの used_at を更新 / Update invitation used_at
-  await db
-    .update(noteInvitations)
-    .set({ usedAt: new Date() })
-    .where(eq(noteInvitations.token, token));
+    await tx
+      .update(noteInvitations)
+      .set({ usedAt: new Date() })
+      .where(eq(noteInvitations.token, token));
+
+    return [m];
+  });
 
   return c.json({
     noteId: invitation.noteId,

--- a/server/api/src/routes/invite.ts
+++ b/server/api/src/routes/invite.ts
@@ -1,0 +1,164 @@
+/**
+ * 招待受諾フロー API
+ * Invitation acceptance flow API
+ *
+ * GET  /invite/:token        — トークン検証 + 招待情報取得（認証不要）
+ * POST /invite/:token/accept — 招待承認（認証必須）
+ */
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { eq, and } from "drizzle-orm";
+import { noteInvitations, noteMembers, notes, users } from "../schema/index.js";
+import { authRequired } from "../middleware/auth.js";
+import type { AppEnv } from "../types/index.js";
+
+const app = new Hono<AppEnv>();
+
+// ── GET /invite/:token ─────────────────────────────────────────────────────
+
+/**
+ * トークンを検証し、招待情報を返す。認証不要。
+ * Validate token and return invitation info. No auth required.
+ */
+app.get("/:token", async (c) => {
+  const token = c.req.param("token");
+  const db = c.get("db");
+
+  // トークンで招待レコードを検索 / Find invitation by token
+  const [invitation] = await db
+    .select({
+      noteId: noteInvitations.noteId,
+      memberEmail: noteInvitations.memberEmail,
+      expiresAt: noteInvitations.expiresAt,
+      usedAt: noteInvitations.usedAt,
+    })
+    .from(noteInvitations)
+    .where(eq(noteInvitations.token, token))
+    .limit(1);
+
+  if (!invitation) {
+    throw new HTTPException(404, { message: "Invalid invitation link" });
+  }
+
+  // ノート情報を取得 / Fetch note info
+  const [note] = await db
+    .select({ title: notes.title })
+    .from(notes)
+    .where(eq(notes.id, invitation.noteId))
+    .limit(1);
+
+  // 招待者情報を取得 / Fetch inviter info
+  const [member] = await db
+    .select({
+      invitedByUserId: noteMembers.invitedByUserId,
+      role: noteMembers.role,
+    })
+    .from(noteMembers)
+    .where(
+      and(
+        eq(noteMembers.noteId, invitation.noteId),
+        eq(noteMembers.memberEmail, invitation.memberEmail),
+      ),
+    )
+    .limit(1);
+
+  let inviterName = "Unknown";
+  if (member?.invitedByUserId) {
+    const [inviter] = await db
+      .select({ name: users.name })
+      .from(users)
+      .where(eq(users.id, member.invitedByUserId))
+      .limit(1);
+    inviterName = inviter?.name ?? "Unknown";
+  }
+
+  const isExpired = invitation.expiresAt < new Date();
+
+  return c.json({
+    noteId: invitation.noteId,
+    noteTitle: note?.title ?? "Untitled",
+    inviterName,
+    role: member?.role ?? "viewer",
+    memberEmail: invitation.memberEmail,
+    isExpired,
+  });
+});
+
+// ── POST /invite/:token/accept ─────────────────────────────────────────────
+
+/**
+ * 招待を承認する。認証必須。
+ * Accept an invitation. Auth required.
+ */
+app.post("/:token/accept", authRequired, async (c) => {
+  const token = c.req.param("token");
+  const userId = c.get("userId");
+  const userEmail = c.get("userEmail");
+  const db = c.get("db");
+
+  // トークンで招待レコードを検索 / Find invitation by token
+  const [invitation] = await db
+    .select({
+      noteId: noteInvitations.noteId,
+      memberEmail: noteInvitations.memberEmail,
+      expiresAt: noteInvitations.expiresAt,
+      usedAt: noteInvitations.usedAt,
+    })
+    .from(noteInvitations)
+    .where(eq(noteInvitations.token, token))
+    .limit(1);
+
+  if (!invitation) {
+    throw new HTTPException(404, { message: "Invalid invitation link" });
+  }
+
+  // 期限切れチェック / Check expiration
+  if (invitation.expiresAt < new Date()) {
+    throw new HTTPException(410, { message: "Invitation has expired" });
+  }
+
+  // 使用済みチェック / Check if already used
+  if (invitation.usedAt !== null) {
+    throw new HTTPException(409, { message: "Invitation already accepted" });
+  }
+
+  // メール一致チェック / Check email match
+  if (userEmail?.toLowerCase() !== invitation.memberEmail.toLowerCase()) {
+    throw new HTTPException(400, {
+      message: "Please log in with the invited email address",
+    });
+  }
+
+  // メンバーステータスを accepted に更新 / Update member status to accepted
+  const [updatedMember] = await db
+    .update(noteMembers)
+    .set({
+      status: "accepted",
+      acceptedUserId: userId,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(noteMembers.noteId, invitation.noteId),
+        eq(noteMembers.memberEmail, invitation.memberEmail),
+      ),
+    )
+    .returning({
+      role: noteMembers.role,
+      status: noteMembers.status,
+    });
+
+  // 招待トークンの used_at を更新 / Update invitation used_at
+  await db
+    .update(noteInvitations)
+    .set({ usedAt: new Date() })
+    .where(eq(noteInvitations.token, token));
+
+  return c.json({
+    noteId: invitation.noteId,
+    role: updatedMember?.role ?? "viewer",
+    status: "accepted",
+  });
+});
+
+export default app;

--- a/server/api/src/routes/invite.ts
+++ b/server/api/src/routes/invite.ts
@@ -66,6 +66,7 @@ app.get("/:token", async (c) => {
     role: data.role ?? "viewer",
     memberEmail: data.memberEmail,
     isExpired,
+    isUsed: data.usedAt !== null,
   });
 });
 


### PR DESCRIPTION
## Changes

Adds invitation acceptance flow API with two new endpoints:

- **GET `/api/invite/:token`** - Validates invitation token and returns invitation details (note title, inviter name, role, member email, expiration status). Public endpoint, no auth required.
- **POST `/api/invite/:token/accept`** - Accepts an invitation with auth validation. Checks token validity, expiration, prior usage, and email match before updating member status and marking invitation as used.

## Implementation

- New route handler: `server/api/src/routes/invite.ts`
- Comprehensive test suite: `server/api/src/__tests__/routes/invite.test.ts` (340 lines)
- Integrated into main app router
- Case-insensitive email matching
- Proper HTTP status codes (404, 410, 409, 400, 401)
- Transaction-safe database updates

## Files Modified

- `server/api/src/app.ts` - Register invite routes
- `server/api/src/routes/invite.ts` - New invitation endpoint handlers
- `server/api/src/__tests__/routes/invite.test.ts` - Full test coverage
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
