### PR TITLE
feat: add invitation acceptance UI page with 6 states

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import Onboarding from "./pages/Onboarding";
 import AIChatHistory from "./pages/AIChatHistory";
 import AIChatLanding from "./pages/AIChatLanding";
 import AIChatDetail from "./pages/AIChatDetail";
+import InvitePage from "./pages/InvitePage";
 import { GlobalSearchProvider } from "./contexts/GlobalSearchContext";
 import { GlobalShortcutsProvider } from "./components/layout/GlobalShortcutsProvider";
 import { ProtectedRoute } from "./components/auth/ProtectedRoute";
@@ -70,6 +71,7 @@ const App = () => (
                     <Route path="/auth/callback" element={<AuthCallback />} />
                     <Route path="/auth/extension" element={<ExtensionAuth />} />
                     <Route path="/auth/extension-callback" element={<ExtensionAuthCallback />} />
+                    <Route path="/invite" element={<InvitePage />} />
                     <Route path="/note/:noteId" element={<NoteView />} />
                     <Route path="/note/:noteId/settings" element={<NoteSettings />} />
                     <Route path="/note/:noteId/members" element={<NoteMembers />} />

--- a/src/hooks/useInvitation.ts
+++ b/src/hooks/useInvitation.ts
@@ -1,0 +1,41 @@
+/**
+ * React Query hooks for the invitation acceptance flow.
+ * 招待受諾フローの React Query フック。
+ */
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { createApiClient } from "@/lib/api";
+import type { InvitationInfoResponse, AcceptInvitationResponse } from "@/lib/api/types";
+
+/** Query key factory for invitation queries. */
+export const invitationKeys = {
+  all: ["invitation"] as const,
+  detail: (token: string) => [...invitationKeys.all, token] as const,
+};
+
+/**
+ * Fetch invitation info by token (no auth required).
+ * トークンで招待情報を取得する（認証不要）。
+ */
+export function useInvitation(token: string) {
+  const api = createApiClient();
+
+  return useQuery<InvitationInfoResponse>({
+    queryKey: invitationKeys.detail(token),
+    queryFn: () => api.getInvitation(token),
+    enabled: !!token,
+    retry: false,
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+/**
+ * Accept an invitation (auth required).
+ * 招待を承認する（認証必須）。
+ */
+export function useAcceptInvitation() {
+  const api = createApiClient();
+
+  return useMutation<AcceptInvitationResponse, Error, { token: string }>({
+    mutationFn: ({ token }) => api.acceptInvitation(token),
+  });
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -21,6 +21,7 @@ import jaOnboarding from "./locales/ja/onboarding.json";
 import jaTour from "./locales/ja/tour.json";
 import jaHome from "./locales/ja/home.json";
 import jaAiChat from "./locales/ja/aiChat.json";
+import jaInvite from "./locales/ja/invite.json";
 import enCommon from "./locales/en/common.json";
 import enSettings from "./locales/en/settings.json";
 import enGeneralSettings from "./locales/en/generalSettings.json";
@@ -38,6 +39,7 @@ import enOnboarding from "./locales/en/onboarding.json";
 import enTour from "./locales/en/tour.json";
 import enHome from "./locales/en/home.json";
 import enAiChat from "./locales/en/aiChat.json";
+import enInvite from "./locales/en/invite.json";
 
 const ja = {
   common: jaCommon,
@@ -57,6 +59,7 @@ const ja = {
   tour: jaTour,
   home: jaHome,
   aiChat: jaAiChat,
+  invite: jaInvite,
 };
 
 const en = {
@@ -77,6 +80,7 @@ const en = {
   tour: enTour,
   home: enHome,
   aiChat: enAiChat,
+  invite: enInvite,
 };
 
 // localStorage の設定から初期言語を取得

--- a/src/i18n/locales/en/invite.json
+++ b/src/i18n/locales/en/invite.json
@@ -1,0 +1,20 @@
+{
+  "loading": "Loading invitation...",
+  "noteInvitation": "Note Invitation",
+  "invitedBy": "Invited by {{inviterName}}",
+  "roleViewer": "Viewer",
+  "roleEditor": "Editor",
+  "roleLabel": "Role: {{role}}",
+  "joinNote": "Join Note",
+  "joining": "Joining...",
+  "signInToAccept": "Sign in to accept this invitation",
+  "signInWithGoogle": "Sign in with Google",
+  "signInWithGitHub": "Sign in with GitHub",
+  "emailMismatch": "This invitation is for {{email}}. Please sign in with the correct account.",
+  "signOutAndRetry": "Sign out and try again",
+  "expired": "This invitation link has expired. Please ask the inviter to resend it.",
+  "invalid": "Invalid invitation link.",
+  "alreadyAccepted": "This invitation has already been accepted.",
+  "acceptError": "Failed to accept invitation. Please try again.",
+  "goToNote": "Open Note"
+}

--- a/src/i18n/locales/ja/invite.json
+++ b/src/i18n/locales/ja/invite.json
@@ -1,0 +1,20 @@
+{
+  "loading": "招待情報を読み込み中...",
+  "noteInvitation": "ノートへの招待",
+  "invitedBy": "{{inviterName}} さんからの招待",
+  "roleViewer": "閲覧者",
+  "roleEditor": "編集者",
+  "roleLabel": "ロール: {{role}}",
+  "joinNote": "ノートに参加する",
+  "joining": "参加中...",
+  "signInToAccept": "招待を承認するにはサインインしてください",
+  "signInWithGoogle": "Google でサインイン",
+  "signInWithGitHub": "GitHub でサインイン",
+  "emailMismatch": "この招待は {{email}} 宛てです。該当のアカウントでログインし直してください。",
+  "signOutAndRetry": "ログアウトしてやり直す",
+  "expired": "この招待リンクは有効期限が切れています。招待者に再送信を依頼してください。",
+  "invalid": "無効な招待リンクです。",
+  "alreadyAccepted": "この招待は既に承認されています。",
+  "acceptError": "招待の承認に失敗しました。再度お試しください。",
+  "goToNote": "ノートを開く"
+}

--- a/src/lib/api/apiClient.ts
+++ b/src/lib/api/apiClient.ts
@@ -19,6 +19,8 @@ import type {
   SnapshotListResponse,
   SnapshotDetailResponse,
   RestoreSnapshotResponse,
+  InvitationInfoResponse,
+  AcceptInvitationResponse,
 } from "./types";
 
 export type { NoteListItem };
@@ -397,6 +399,24 @@ export function createApiClient(options?: Partial<ApiClientOptions>) {
         body: { url },
       });
       return html;
+    },
+
+    // ── Invitation ───────────────────────────────────────────────────────
+
+    /** GET /api/invite/:token — トークン検証 + 招待情報取得（認証不要）/ Validate token & get invitation info (no auth). */
+    async getInvitation(token: string): Promise<InvitationInfoResponse> {
+      return reqOptionalAuth<InvitationInfoResponse>(
+        "GET",
+        `/api/invite/${encodeURIComponent(token)}`,
+      );
+    },
+
+    /** POST /api/invite/:token/accept — 招待承認（認証必須）/ Accept invitation (auth required). */
+    async acceptInvitation(token: string): Promise<AcceptInvitationResponse> {
+      return req<AcceptInvitationResponse>(
+        "POST",
+        `/api/invite/${encodeURIComponent(token)}/accept`,
+      );
     },
   };
 }

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -229,3 +229,21 @@ export interface NoteMemberItem {
   created_at: string;
   updated_at: string;
 }
+
+/** GET /api/invite/:token response. */
+export interface InvitationInfoResponse {
+  noteId: string;
+  noteTitle: string;
+  inviterName: string;
+  role: "viewer" | "editor";
+  memberEmail: string;
+  isExpired: boolean;
+  isUsed: boolean;
+}
+
+/** POST /api/invite/:token/accept response. */
+export interface AcceptInvitationResponse {
+  noteId: string;
+  role: string;
+  status: "accepted";
+}

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -10,7 +10,7 @@ import { useSession } from "@/lib/auth/authClient";
 
 const SESSION_WAIT_TIMEOUT_MS = 15_000;
 /** 認証後に許可されるリダイレクトパス（CodeQL: オープンリダイレクト防止）。Allowed post-auth redirect paths (CodeQL: avoid open redirect). */
-const ALLOWED_RETURN_PATHS = ["/home"] as const;
+const ALLOWED_RETURN_PATHS = ["/home", "/invite"] as const;
 
 /**
  * returnTo を検証し、安全なリダイレクト先を返す。pathname は許可リストの定数のみ使用し CodeQL を満たす。

--- a/src/pages/InvitePage.tsx
+++ b/src/pages/InvitePage.tsx
@@ -8,7 +8,15 @@
 import React, { useCallback } from "react";
 import { Link, useSearchParams, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@zedi/ui";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  useToast,
+} from "@zedi/ui";
 import { signIn } from "@/lib/auth";
 import { useAuth, useUser } from "@/hooks/useAuth";
 import { useInvitation, useAcceptInvitation } from "@/hooks/useInvitation";
@@ -29,45 +37,53 @@ const InviteSkeleton: React.FC = () => (
 );
 
 /**
- * Social sign-in button (Google / GitHub).
- * ソーシャルサインインボタン。
+ * Google icon SVG.
+ * Google アイコン SVG。
+ */
+const GoogleIcon: React.FC = () => (
+  <svg className="h-5 w-5" viewBox="0 0 24 24" aria-hidden>
+    <path
+      fill="currentColor"
+      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+    />
+    <path
+      fill="currentColor"
+      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+    />
+    <path
+      fill="currentColor"
+      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+    />
+    <path
+      fill="currentColor"
+      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+    />
+  </svg>
+);
+
+/**
+ * GitHub icon SVG.
+ * GitHub アイコン SVG。
+ */
+const GitHubIcon: React.FC = () => (
+  <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden>
+    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+  </svg>
+);
+
+/**
+ * Social sign-in button (Google / GitHub) using the shared UI Button.
+ * ソーシャルサインインボタン（共有 UI Button を使用）。
  */
 const SocialButton: React.FC<{
   provider: "google" | "github";
   label: string;
   onClick: () => void;
 }> = ({ provider, label, onClick }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    className="border-border bg-card text-foreground hover:bg-accent/50 flex w-full items-center justify-center gap-2 rounded-md border px-4 py-2.5 font-medium shadow-sm transition-colors duration-200 hover:shadow-md"
-  >
-    {provider === "google" ? (
-      <svg className="h-5 w-5" viewBox="0 0 24 24" aria-hidden>
-        <path
-          fill="currentColor"
-          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-        />
-        <path
-          fill="currentColor"
-          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-        />
-        <path
-          fill="currentColor"
-          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-        />
-        <path
-          fill="currentColor"
-          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-        />
-      </svg>
-    ) : (
-      <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden>
-        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-      </svg>
-    )}
+  <Button variant="outline" className="w-full gap-2" size="lg" onClick={onClick}>
+    {provider === "google" ? <GoogleIcon /> : <GitHubIcon />}
     {label}
-  </button>
+  </Button>
 );
 
 /**
@@ -251,6 +267,7 @@ const InviteContent: React.FC<{
  */
 const InvitePage: React.FC = () => {
   const { t } = useTranslation();
+  const { toast } = useToast();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const token = searchParams.get("token") ?? "";
@@ -274,11 +291,11 @@ const InvitePage: React.FC = () => {
       const callbackURL = `${baseCallback}?returnTo=${encodeURIComponent(currentPagePath)}`;
       try {
         await signIn.social({ provider, callbackURL });
-      } catch (err) {
-        if (err instanceof Error) console.warn("Social sign-in failed:", err.message);
+      } catch {
+        toast({ variant: "destructive", description: t("auth.signIn.error") });
       }
     },
-    [currentPagePath],
+    [currentPagePath, toast, t],
   );
 
   const handleAccept = useCallback(async () => {

--- a/src/pages/InvitePage.tsx
+++ b/src/pages/InvitePage.tsx
@@ -1,0 +1,358 @@
+/**
+ * Invitation acceptance page — `/invite?token=xxx`.
+ * Manages 6 states: loading, signed-out, email-match, email-mismatch, expired, invalid.
+ *
+ * 招待受諾ページ — `/invite?token=xxx`。
+ * 6 つの状態を管理: ローディング中、未ログイン、メール一致、メール不一致、期限切れ、無効。
+ */
+import React, { useCallback } from "react";
+import { Link, useSearchParams, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@zedi/ui";
+import { signIn } from "@/lib/auth";
+import { useAuth, useUser } from "@/hooks/useAuth";
+import { useInvitation, useAcceptInvitation } from "@/hooks/useInvitation";
+import { ApiError } from "@/lib/api/apiClient";
+import type { InvitationInfoResponse } from "@/lib/api/types";
+
+/**
+ * Skeleton loader for invitation page.
+ * 招待ページのスケルトンローダー。
+ */
+const InviteSkeleton: React.FC = () => (
+  <div className="animate-pulse space-y-4">
+    <div className="bg-muted h-6 w-48 rounded" />
+    <div className="bg-muted h-4 w-64 rounded" />
+    <div className="bg-muted h-4 w-32 rounded" />
+    <div className="bg-muted mt-6 h-10 w-full rounded" />
+  </div>
+);
+
+/**
+ * Social sign-in button (Google / GitHub).
+ * ソーシャルサインインボタン。
+ */
+const SocialButton: React.FC<{
+  provider: "google" | "github";
+  label: string;
+  onClick: () => void;
+}> = ({ provider, label, onClick }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="border-border bg-card text-foreground hover:bg-accent/50 flex w-full items-center justify-center gap-2 rounded-md border px-4 py-2.5 font-medium shadow-sm transition-colors duration-200 hover:shadow-md"
+  >
+    {provider === "google" ? (
+      <svg className="h-5 w-5" viewBox="0 0 24 24" aria-hidden>
+        <path
+          fill="currentColor"
+          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+        />
+        <path
+          fill="currentColor"
+          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        />
+        <path
+          fill="currentColor"
+          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        />
+        <path
+          fill="currentColor"
+          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        />
+      </svg>
+    ) : (
+      <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden>
+        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+      </svg>
+    )}
+    {label}
+  </button>
+);
+
+/**
+ * Page layout wrapper for the invite page.
+ * 招待ページのレイアウトラッパー。
+ */
+const InviteLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="bg-background flex min-h-screen flex-col">
+    <header className="border-border/50 border-b">
+      <div className="container mx-auto flex h-16 items-center px-4">
+        <Link
+          to="/"
+          className="from-primary to-primary/70 bg-gradient-to-r bg-clip-text text-xl font-bold tracking-tight text-transparent"
+        >
+          Zedi
+        </Link>
+      </div>
+    </header>
+    <main className="flex flex-1 items-center justify-center p-4">
+      <Card className="w-full max-w-md">{children}</Card>
+    </main>
+    <footer className="border-border/50 border-t py-4">
+      <div className="text-foreground/60 container mx-auto px-4 text-center text-sm">
+        <p>&copy; {new Date().getFullYear()} Zedi. All rights reserved.</p>
+      </div>
+    </footer>
+  </div>
+);
+
+/**
+ * Message-only card content (loading, error, expired, invalid).
+ * メッセージのみのカード内容。
+ */
+const InviteMessage: React.FC<{ message: string; variant?: "default" | "error" }> = ({
+  message,
+  variant = "default",
+}) => {
+  const { t } = useTranslation();
+  return (
+    <>
+      <CardHeader>
+        <CardTitle>{t("invite.noteInvitation")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className={variant === "error" ? "text-destructive" : "text-muted-foreground"}>
+          {message}
+        </p>
+      </CardContent>
+    </>
+  );
+};
+
+/**
+ * Invitation detail content — renders the appropriate state view.
+ * 招待詳細コンテンツ — 適切な状態ビューをレンダリングする。
+ */
+const InviteContent: React.FC<{
+  invitation: InvitationInfoResponse;
+  token: string;
+  isSignedIn: boolean;
+  userEmail: string | null;
+  onSignOut: () => void;
+  onAccept: () => void;
+  acceptPending: boolean;
+  acceptError: Error | null;
+  onSocialSignIn: (provider: "google" | "github") => () => void;
+}> = ({
+  invitation,
+  isSignedIn,
+  userEmail,
+  onSignOut,
+  onAccept,
+  acceptPending,
+  acceptError,
+  onSocialSignIn,
+}) => {
+  const { t } = useTranslation();
+  const roleName = invitation.role === "editor" ? t("invite.roleEditor") : t("invite.roleViewer");
+
+  // Already used
+  if (invitation.isUsed) {
+    return (
+      <>
+        <CardHeader>
+          <CardTitle>{invitation.noteTitle}</CardTitle>
+          <CardDescription>
+            {t("invite.invitedBy", { inviterName: invitation.inviterName })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-muted-foreground">{t("invite.alreadyAccepted")}</p>
+          <Button className="w-full" asChild>
+            <Link to={`/note/${invitation.noteId}`}>{t("invite.goToNote")}</Link>
+          </Button>
+        </CardContent>
+      </>
+    );
+  }
+
+  // Signed out
+  if (!isSignedIn) {
+    return (
+      <>
+        <CardHeader>
+          <CardTitle>{invitation.noteTitle}</CardTitle>
+          <CardDescription>
+            {t("invite.invitedBy", { inviterName: invitation.inviterName })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-muted-foreground text-sm">
+            {t("invite.roleLabel", { role: roleName })}
+          </p>
+          <p className="text-foreground/70 text-sm">{t("invite.signInToAccept")}</p>
+          <div className="space-y-3">
+            <SocialButton
+              provider="google"
+              label={t("invite.signInWithGoogle")}
+              onClick={onSocialSignIn("google")}
+            />
+            <SocialButton
+              provider="github"
+              label={t("invite.signInWithGitHub")}
+              onClick={onSocialSignIn("github")}
+            />
+          </div>
+        </CardContent>
+      </>
+    );
+  }
+
+  // Email mismatch
+  if (userEmail && userEmail.toLowerCase() !== invitation.memberEmail.toLowerCase()) {
+    return (
+      <>
+        <CardHeader>
+          <CardTitle>{invitation.noteTitle}</CardTitle>
+          <CardDescription>
+            {t("invite.invitedBy", { inviterName: invitation.inviterName })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-destructive text-sm">
+            {t("invite.emailMismatch", { email: invitation.memberEmail })}
+          </p>
+          <Button variant="outline" className="w-full" onClick={onSignOut}>
+            {t("invite.signOutAndRetry")}
+          </Button>
+        </CardContent>
+      </>
+    );
+  }
+
+  // Signed in, email matches
+  return (
+    <>
+      <CardHeader>
+        <CardTitle>{invitation.noteTitle}</CardTitle>
+        <CardDescription>
+          {t("invite.invitedBy", { inviterName: invitation.inviterName })}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-muted-foreground text-sm">{t("invite.roleLabel", { role: roleName })}</p>
+        {acceptError && (
+          <p className="text-destructive text-sm" role="alert">
+            {t("invite.acceptError")}
+          </p>
+        )}
+        <Button className="w-full" onClick={onAccept} disabled={acceptPending}>
+          {acceptPending ? t("invite.joining") : t("invite.joinNote")}
+        </Button>
+      </CardContent>
+    </>
+  );
+};
+
+/**
+ * Invitation acceptance page component.
+ * 招待受諾ページコンポーネント。
+ */
+const InvitePage: React.FC = () => {
+  const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get("token") ?? "";
+
+  const { isLoaded, isSignedIn, signOut: authSignOut } = useAuth();
+  const { user } = useUser();
+  const userEmail = user?.primaryEmailAddress?.emailAddress ?? null;
+
+  const {
+    data: invitation,
+    isLoading: invitationLoading,
+    error: invitationError,
+  } = useInvitation(token);
+  const acceptMutation = useAcceptInvitation();
+
+  const currentPagePath = `/invite?token=${encodeURIComponent(token)}`;
+
+  const handleSocialSignIn = useCallback(
+    (provider: "google" | "github") => async () => {
+      const baseCallback = `${window.location.origin}/auth/callback`;
+      const callbackURL = `${baseCallback}?returnTo=${encodeURIComponent(currentPagePath)}`;
+      try {
+        await signIn.social({ provider, callbackURL });
+      } catch (err) {
+        if (err instanceof Error) console.warn("Social sign-in failed:", err.message);
+      }
+    },
+    [currentPagePath],
+  );
+
+  const handleAccept = useCallback(async () => {
+    if (!token) return;
+    try {
+      const result = await acceptMutation.mutateAsync({ token });
+      navigate(`/note/${result.noteId}`);
+    } catch {
+      // Error is handled via acceptMutation.error
+    }
+  }, [token, acceptMutation, navigate]);
+
+  const handleSignOutAndRetry = useCallback(async () => {
+    await authSignOut();
+  }, [authSignOut]);
+
+  // Loading
+  if (!isLoaded || (!invitation && invitationLoading)) {
+    return (
+      <InviteLayout>
+        <CardHeader>
+          <CardTitle>{t("invite.noteInvitation")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <InviteSkeleton />
+        </CardContent>
+      </InviteLayout>
+    );
+  }
+
+  // Invalid token
+  if (!token || (invitationError instanceof ApiError && invitationError.status === 404)) {
+    return (
+      <InviteLayout>
+        <InviteMessage message={t("invite.invalid")} />
+      </InviteLayout>
+    );
+  }
+
+  // Network / unexpected error
+  if (invitationError) {
+    return (
+      <InviteLayout>
+        <InviteMessage message={invitationError.message} variant="error" />
+      </InviteLayout>
+    );
+  }
+
+  if (!invitation) return null;
+
+  // Expired
+  if (invitation.isExpired) {
+    return (
+      <InviteLayout>
+        <InviteMessage message={t("invite.expired")} />
+      </InviteLayout>
+    );
+  }
+
+  return (
+    <InviteLayout>
+      <InviteContent
+        invitation={invitation}
+        token={token}
+        isSignedIn={isSignedIn ?? false}
+        userEmail={userEmail}
+        onSignOut={handleSignOutAndRetry}
+        onAccept={handleAccept}
+        acceptPending={acceptMutation.isPending}
+        acceptError={acceptMutation.error}
+        onSocialSignIn={handleSocialSignIn}
+      />
+    </InviteLayout>
+  );
+};
+
+export default InvitePage;


### PR DESCRIPTION
## Changes

Adds a new invitation acceptance page (`/invite`) with comprehensive state management for users to accept note invitations via token-based links.

### New Features

- **InvitePage component** — Handles invitation acceptance flow with 6 distinct states:
  - Loading state with skeleton loader
  - Not signed in — prompts social sign-in (Google/GitHub)
  - Email mismatch — shows validation error with sign-out option
  - Email match — displays acceptance confirmation
  - Already accepted — redirects to note
  - Expired/Invalid — shows appropriate error messages

- **useInvitation hook** — React Query hook for fetching invitation info (no auth required) and accepting invitations (auth required)

- **API endpoints**:
  - `GET /api/invite/:token` — Fetch invitation info
  - `POST /api/invite/:token/accept` — Accept invitation

- **i18n support** — Added English and Japanese translations for all invitation-related UI text

### Files Added/Modified

- `src/pages/InvitePage.tsx` — New invitation page component
- `src/hooks/useInvitation.ts` — New React Query hooks
- `src/lib/api/apiClient.ts` — New API methods
- `src/lib/api/types.ts` — New response types
- `src/i18n/locales/{en,ja}/invite.json` — Translations
- `src/App.tsx` — New route `/invite`
- `src/pages/AuthCallback.tsx` — Added `/invite` to allowed redirect paths
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
