### PR TITLE
fix: address PR #524 review comments

### DIFF
--- a/server/api/src/__tests__/routes/invite.test.ts
+++ b/server/api/src/__tests__/routes/invite.test.ts
@@ -250,12 +250,13 @@ describe("GET /api/invite/:token", () => {
 describe("POST /api/invite/:token/accept", () => {
   it("should accept invitation when email matches", async () => {
     const invitation = createMockInvitation();
+    const claimed = { noteId: NOTE_ID, memberEmail: TEST_USER_EMAIL };
     const updatedMember = { role: "editor", status: "accepted" };
 
     const { app } = createTestApp([
       [invitation], // select noteInvitations
+      [claimed], // update noteInvitations (claim) → returning
       [updatedMember], // update noteMembers → returning
-      [], // update noteInvitations (used_at)
     ]);
 
     const res = await app.request(`/api/invite/${TEST_TOKEN}/accept`, {
@@ -342,9 +343,11 @@ describe("POST /api/invite/:token/accept", () => {
 
   it("should return 404 when member record was soft-deleted", async () => {
     const invitation = createMockInvitation();
+    const claimed = { noteId: NOTE_ID, memberEmail: TEST_USER_EMAIL };
 
     const { app } = createTestApp([
       [invitation], // select noteInvitations
+      [claimed], // claim invitation
       [], // update noteMembers → returning empty (soft-deleted)
     ]);
 
@@ -371,16 +374,36 @@ describe("POST /api/invite/:token/accept", () => {
     expect(res.status).toBe(401);
   });
 
+  it("should return 400 when user email is missing", async () => {
+    const invitation = createMockInvitation();
+    const { app } = createTestApp([[invitation]]);
+
+    const res = await app.request(`/api/invite/${TEST_TOKEN}/accept`, {
+      method: "POST",
+      headers: {
+        "x-test-user-id": TEST_USER_ID,
+        "Content-Type": "application/json",
+      },
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      error: "Could not determine your email address. Please log in again.",
+    });
+  });
+
   it("should handle case-insensitive email matching", async () => {
     const invitation = createMockInvitation({
       memberEmail: "TEST@EXAMPLE.COM", // uppercase
     });
+    const claimed = { noteId: NOTE_ID, memberEmail: "TEST@EXAMPLE.COM" };
     const updatedMember = { role: "viewer", status: "accepted" };
 
     const { app } = createTestApp([
       [invitation], // select noteInvitations
+      [claimed], // claim invitation (returning row)
       [updatedMember], // update noteMembers → returning
-      [], // update noteInvitations (used_at)
     ]);
 
     const res = await app.request(`/api/invite/${TEST_TOKEN}/accept`, {

--- a/server/api/src/__tests__/services/snapshotService.test.ts
+++ b/server/api/src/__tests__/services/snapshotService.test.ts
@@ -2,7 +2,7 @@
  * snapshotService のテスト
  * Tests for snapshotService (API-side auto-snapshot logic)
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createMockDb } from "../createMockDb.js";
 import { maybeCreateSnapshot } from "../../services/snapshotService.js";
 
@@ -20,6 +20,10 @@ describe("maybeCreateSnapshot", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("前回スナップショットがない場合、スナップショットを作成する / creates snapshot when no prior snapshot exists", async () => {

--- a/server/api/src/routes/invite.ts
+++ b/server/api/src/routes/invite.ts
@@ -7,7 +7,7 @@
  */
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { eq, and } from "drizzle-orm";
+import { eq, and, isNull, gt } from "drizzle-orm";
 import { noteInvitations, noteMembers, notes, users } from "../schema/index.js";
 import { authRequired } from "../middleware/auth.js";
 import type { AppEnv } from "../types/index.js";
@@ -112,15 +112,56 @@ app.post("/:token/accept", authRequired, async (c) => {
   }
 
   // メール一致チェック / Check email match
-  if (userEmail?.toLowerCase() !== invitation.memberEmail.toLowerCase()) {
+  if (!userEmail?.trim()) {
+    throw new HTTPException(400, {
+      message: "Could not determine your email address. Please log in again.",
+    });
+  }
+  if (userEmail.toLowerCase() !== invitation.memberEmail.toLowerCase()) {
     throw new HTTPException(400, {
       message: "Please log in with the invited email address",
     });
   }
 
-  // トランザクションで noteMembers + noteInvitations を一括更新
-  // Update noteMembers + noteInvitations atomically in a transaction
+  // トランザクション内でトークンを先にクレームし、単一利用を原子的に保証する。
+  // Claim the token inside the transaction so concurrent accepts cannot both succeed.
   const [updatedMember] = await db.transaction(async (tx) => {
+    const [claimed] = await tx
+      .update(noteInvitations)
+      .set({ usedAt: new Date() })
+      .where(
+        and(
+          eq(noteInvitations.token, token),
+          isNull(noteInvitations.usedAt),
+          gt(noteInvitations.expiresAt, new Date()),
+        ),
+      )
+      .returning({
+        noteId: noteInvitations.noteId,
+        memberEmail: noteInvitations.memberEmail,
+      });
+
+    if (!claimed) {
+      const [invState] = await tx
+        .select({
+          usedAt: noteInvitations.usedAt,
+          expiresAt: noteInvitations.expiresAt,
+        })
+        .from(noteInvitations)
+        .where(eq(noteInvitations.token, token))
+        .limit(1);
+      if (!invState) {
+        throw new HTTPException(404, { message: "Invalid invitation link" });
+      }
+      if (invState.usedAt !== null) {
+        throw new HTTPException(409, { message: "Invitation already accepted" });
+      }
+      if (invState.expiresAt < new Date()) {
+        throw new HTTPException(410, { message: "Invitation has expired" });
+      }
+      throw new HTTPException(409, { message: "Invitation already accepted" });
+    }
+
     const [m] = await tx
       .update(noteMembers)
       .set({
@@ -130,8 +171,8 @@ app.post("/:token/accept", authRequired, async (c) => {
       })
       .where(
         and(
-          eq(noteMembers.noteId, invitation.noteId),
-          eq(noteMembers.memberEmail, invitation.memberEmail),
+          eq(noteMembers.noteId, claimed.noteId),
+          eq(noteMembers.memberEmail, claimed.memberEmail),
           eq(noteMembers.isDeleted, false),
         ),
       )
@@ -143,11 +184,6 @@ app.post("/:token/accept", authRequired, async (c) => {
     if (!m) {
       throw new HTTPException(404, { message: "Member record not found" });
     }
-
-    await tx
-      .update(noteInvitations)
-      .set({ usedAt: new Date() })
-      .where(eq(noteInvitations.token, token));
 
     return [m];
   });

--- a/src/pages/NoteMembers/index.tsx
+++ b/src/pages/NoteMembers/index.tsx
@@ -96,8 +96,12 @@ const NoteMembers: React.FC = () => {
   const handleResendInvitation = async (email: string) => {
     if (!noteId) return;
     try {
-      await resendInvitationMutation.mutateAsync({ noteId, memberEmail: email });
-      toast({ title: t("notes.resendInvitationSuccess") });
+      const result = await resendInvitationMutation.mutateAsync({ noteId, memberEmail: email });
+      if (result.resent) {
+        toast({ title: t("notes.resendInvitationSuccess") });
+      } else {
+        toast({ title: t("notes.resendInvitationFailed"), variant: "destructive" });
+      }
     } catch (error) {
       console.error("Failed to resend invitation:", error);
       toast({ title: t("notes.resendInvitationFailed"), variant: "destructive" });


### PR DESCRIPTION
## Summary
Addresses automated review feedback on the develop→main release PR (#524).

- **Invite accept**: Atomic token claim inside the transaction (single-use under concurrency); explicit 400 when session email is missing.
- **Tests**: `vi.useRealTimers()` in `afterEach` for snapshot service tests.
- **Note members UI**: Destructive toast when resend returns `{ resent: false }`.

## Out of scope (reply on #524)
- Fire-and-forget `sendInvitation`: `getDb()` is a singleton pool — not request-scoped.
- Hocuspocus HTTP 500: response body is generic; errors logged server-side only.
- Redis cross-replica invalidation: requires a separate design/PR.
- Snapshot pruning frequency: performance follow-up if needed.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
