### PR TITLE
fix(api): lock member row during invitation resend (PR #524)

### DIFF
--- a/server/api/src/__tests__/routes/notes/members.test.ts
+++ b/server/api/src/__tests__/routes/notes/members.test.ts
@@ -317,6 +317,7 @@ describe("POST /api/notes/:noteId/members/:memberEmail/resend", () => {
     const pendingMember = createMockMember({ status: "pending", role: "editor" });
     const { app } = createTestApp([
       [mockNote], // requireNoteOwner
+      [], // tx.execute SELECT … FOR UPDATE
       [pendingMember], // select noteMembers (pending check)
     ]);
 
@@ -344,6 +345,7 @@ describe("POST /api/notes/:noteId/members/:memberEmail/resend", () => {
     const acceptedMember = createMockMember({ status: "accepted" });
     const { app } = createTestApp([
       [mockNote], // requireNoteOwner
+      [], // FOR UPDATE
       [acceptedMember], // select noteMembers (not pending)
     ]);
 
@@ -360,6 +362,7 @@ describe("POST /api/notes/:noteId/members/:memberEmail/resend", () => {
     const mockNote = createMockNote();
     const { app } = createTestApp([
       [mockNote], // requireNoteOwner
+      [], // FOR UPDATE
       [], // select noteMembers → empty
     ]);
 

--- a/server/api/src/__tests__/routes/notes/setup.ts
+++ b/server/api/src/__tests__/routes/notes/setup.ts
@@ -10,13 +10,28 @@ import noteRoutes from "../../../routes/notes/index.js";
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
-export const TEST_USER_ID = "user-test-123";
-export const TEST_USER_EMAIL = "test@example.com";
-export const OTHER_USER_ID = "user-other-456";
-export const OTHER_USER_EMAIL = "other@example.com";
+export /**
+ *
+ */
+const TEST_USER_ID = "user-test-123";
+export /**
+ *
+ */
+const TEST_USER_EMAIL = "test@example.com";
+export /**
+ *
+ */
+const OTHER_USER_ID = "user-other-456";
+export /**
+ *
+ */
+const OTHER_USER_EMAIL = "other@example.com";
 
 // ── Mock Data Factories ─────────────────────────────────────────────────────
 
+/**
+ *
+ */
 export function createMockNote(overrides: Record<string, unknown> = {}) {
   return {
     id: "note-test-001",
@@ -33,6 +48,9 @@ export function createMockNote(overrides: Record<string, unknown> = {}) {
   };
 }
 
+/**
+ *
+ */
 export function createMockPageRow(overrides: Record<string, unknown> = {}) {
   return {
     id: "page-test-001",
@@ -52,6 +70,9 @@ export function createMockPageRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
+/**
+ *
+ */
 export function createMockPageListRow(overrides: Record<string, unknown> = {}) {
   return {
     page_id: "page-test-001",
@@ -80,6 +101,9 @@ export function createMockMember(overrides: Record<string, unknown> = {}) {
 
 // ── Mock DB ─────────────────────────────────────────────────────────────────
 
+/**
+ *
+ */
 export interface ChainInfo {
   startMethod: string;
   startArgs: unknown[];
@@ -126,6 +150,14 @@ export function createMockDb(results: unknown[]) {
       if (prop === "transaction") {
         return (fn: (tx: typeof db) => Promise<unknown>) => fn(db);
       }
+      if (prop === "execute") {
+        return (...args: unknown[]) => {
+          const idx = chainIndex++;
+          const ops: { method: string; args: unknown[] }[] = [];
+          chains.push({ startMethod: "execute", startArgs: args, ops });
+          return makeChainProxy(idx, ops);
+        };
+      }
       return (...args: unknown[]) => {
         const idx = chainIndex++;
         const ops: { method: string; args: unknown[] }[] = [];
@@ -140,8 +172,17 @@ export function createMockDb(results: unknown[]) {
 
 // ── Test App Factory ────────────────────────────────────────────────────────
 
+/**
+ *
+ */
 export function createTestApp(dbResults: unknown[]) {
+  /**
+   *
+   */
   const { db, chains } = createMockDb(dbResults);
+  /**
+   *
+   */
   const app = new Hono<AppEnv>();
 
   app.use("*", async (c, next) => {
@@ -155,6 +196,9 @@ export function createTestApp(dbResults: unknown[]) {
 
 // ── Auth Headers ────────────────────────────────────────────────────────────
 
+/**
+ *
+ */
 export function authHeaders(userId = TEST_USER_ID, userEmail = TEST_USER_EMAIL) {
   return {
     "x-test-user-id": userId,

--- a/server/api/src/routes/notes/members.ts
+++ b/server/api/src/routes/notes/members.ts
@@ -123,35 +123,47 @@ app.post("/:noteId/members/:memberEmail/resend", authRequired, async (c) => {
   // オーナーのみ実行可能 / Only the owner can resend invitations
   await requireNoteOwner(db, noteId, userId, "Only the owner can resend invitations");
 
-  // メンバーが pending か確認 / Verify member is in pending status
-  const [member] = await db
-    .select({ status: noteMembers.status, role: noteMembers.role })
-    .from(noteMembers)
-    .where(
-      and(
-        eq(noteMembers.noteId, noteId),
-        eq(noteMembers.memberEmail, memberEmail),
-        eq(noteMembers.isDeleted, false),
-      ),
-    )
-    .limit(1);
+  // pending 確認とトークン更新を同一トランザクションで行い、受諾との競合で usedAt が不整合になるのを防ぐ。
+  // Lock the member row (FOR UPDATE) then resend so accept cannot interleave between check and upsert.
+  const result = await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`
+        SELECT 1 FROM ${noteMembers}
+        WHERE ${noteMembers.noteId} = ${noteId}
+          AND ${noteMembers.memberEmail} = ${memberEmail}
+          AND ${noteMembers.isDeleted} = FALSE
+        FOR UPDATE
+      `,
+    );
 
-  if (!member) {
-    throw new HTTPException(404, { message: "Member not found" });
-  }
-  if (member.status !== "pending") {
-    throw new HTTPException(400, {
-      message: "Invitation can only be resent for pending members",
+    const [member] = await tx
+      .select({ status: noteMembers.status, role: noteMembers.role })
+      .from(noteMembers)
+      .where(
+        and(
+          eq(noteMembers.noteId, noteId),
+          eq(noteMembers.memberEmail, memberEmail),
+          eq(noteMembers.isDeleted, false),
+        ),
+      )
+      .limit(1);
+
+    if (!member) {
+      throw new HTTPException(404, { message: "Member not found" });
+    }
+    if (member.status !== "pending") {
+      throw new HTTPException(400, {
+        message: "Invitation can only be resent for pending members",
+      });
+    }
+
+    return resendInvitation({
+      db: tx,
+      noteId,
+      memberEmail,
+      role: member.role,
+      invitedByUserId: userId,
     });
-  }
-
-  // トークン再生成 + メール再送信 / Regenerate token + resend email
-  const result = await resendInvitation({
-    db,
-    noteId,
-    memberEmail,
-    role: member.role,
-    invitedByUserId: userId,
   });
 
   if (!result.sent) {

--- a/server/api/src/services/invitationService.ts
+++ b/server/api/src/services/invitationService.ts
@@ -29,7 +29,10 @@ function generateToken(): string {
  * Parameters for sending an invitation email
  */
 export interface SendInvitationParams {
-  /** データベース接続 / Database connection */
+  /**
+   * データベース接続（`db.transaction` 内のクライアントでも可）
+   * Database connection (may be a transaction-scoped client)
+   */
   db: Database;
   /** ノート ID / Note ID */
   noteId: string;


### PR DESCRIPTION
## Context
Addresses Devin review on PR #524 (`invitationService.ts`): resend could reset `used_at` after a concurrent accept, leaving inconsistent state.

## Change
- Wrap resend in `db.transaction`
- `SELECT … FOR UPDATE` on `note_members` before `resendInvitation` / token upsert so accept cannot interleave
- Test mock: support `db.execute` (used for the lock query)
- JSDoc: `SendInvitationParams.db` may be a transaction client

## Related
- PR #524 (release), prior fixes in #525 if merged separately

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
