### PR TITLE
fix(api): PR #530 review — invitation resend locks and email

### DIFF
--- a/server/api/src/__tests__/routes/notes/members.test.ts
+++ b/server/api/src/__tests__/routes/notes/members.test.ts
@@ -24,21 +24,19 @@ vi.mock("../../../middleware/auth.js", () => ({
 }));
 
 const mockSendInvitation = vi.fn().mockResolvedValue({ sent: true });
-const mockUpsertInvitationTokenInDb = vi.fn().mockResolvedValue({
-  ok: true,
-  context: {
-    memberEmail: "other@example.com",
-    role: "editor",
-    inviteUrl: "https://zedi-note.app/invite?token=deadbeef",
-    noteTitle: "Test Note",
-    inviterName: "Inviter",
-    locale: "ja",
-  },
+const mockUpsertInvitationTokenInDbThrowing = vi.fn().mockResolvedValue({
+  memberEmail: "other@example.com",
+  role: "editor",
+  inviteUrl: "https://zedi-note.app/invite?token=deadbeef",
+  noteTitle: "Test Note",
+  inviterName: "Inviter",
+  locale: "ja",
 });
 const mockDeliverInvitationEmail = vi.fn().mockResolvedValue({ sent: true });
 vi.mock("../../../services/invitationService.js", () => ({
   sendInvitation: (...args: unknown[]) => mockSendInvitation(...args),
-  upsertInvitationTokenInDb: (...args: unknown[]) => mockUpsertInvitationTokenInDb(...args),
+  upsertInvitationTokenInDbThrowing: (...args: unknown[]) =>
+    mockUpsertInvitationTokenInDbThrowing(...args),
   deliverInvitationEmail: (...args: unknown[]) => mockDeliverInvitationEmail(...args),
 }));
 
@@ -325,7 +323,7 @@ describe("PUT /api/notes/:noteId/members/:memberEmail", () => {
 
 describe("POST /api/notes/:noteId/members/:memberEmail/resend", () => {
   beforeEach(() => {
-    mockUpsertInvitationTokenInDb.mockClear();
+    mockUpsertInvitationTokenInDbThrowing.mockClear();
     mockDeliverInvitationEmail.mockClear();
   });
 
@@ -334,9 +332,9 @@ describe("POST /api/notes/:noteId/members/:memberEmail/resend", () => {
     const { app } = createTestApp([
       [mockNote], // requireNoteOwner
       [{ status: "pending" as const, role: "editor" }], // JOIN … FOR UPDATE
-      [{ title: "Test Note" }], // upsertInvitationTokenInDb → notes
-      [{ name: "Inviter" }], // upsertInvitationTokenInDb → users
-      [], // upsertInvitationTokenInDb → insert
+      [{ title: "Test Note" }], // upsertInvitationTokenInDbThrowing → notes
+      [{ name: "Inviter" }], // upsertInvitationTokenInDbThrowing → users
+      [], // upsertInvitationTokenInDbThrowing → insert
     ]);
 
     const encoded = encodeURIComponent(OTHER_USER_EMAIL);
@@ -348,7 +346,7 @@ describe("POST /api/notes/:noteId/members/:memberEmail/resend", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).toEqual({ resent: true });
-    expect(mockUpsertInvitationTokenInDb).toHaveBeenCalledWith(
+    expect(mockUpsertInvitationTokenInDbThrowing).toHaveBeenCalledWith(
       expect.objectContaining({
         noteId: NOTE_ID,
         memberEmail: OTHER_USER_EMAIL,
@@ -373,7 +371,7 @@ describe("POST /api/notes/:noteId/members/:memberEmail/resend", () => {
     });
 
     expect(res.status).toBe(400);
-    expect(mockUpsertInvitationTokenInDb).not.toHaveBeenCalled();
+    expect(mockUpsertInvitationTokenInDbThrowing).not.toHaveBeenCalled();
   });
 
   it("should return 404 when member does not exist", async () => {

--- a/server/api/src/__tests__/routes/notes/members.test.ts
+++ b/server/api/src/__tests__/routes/notes/members.test.ts
@@ -1,7 +1,7 @@
 /**
  * ノートメンバー管理ルートのテスト
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Context, Next } from "hono";
 import type { AppEnv } from "../../../types/index.js";
 
@@ -24,10 +24,22 @@ vi.mock("../../../middleware/auth.js", () => ({
 }));
 
 const mockSendInvitation = vi.fn().mockResolvedValue({ sent: true });
-const mockResendInvitation = vi.fn().mockResolvedValue({ sent: true });
+const mockUpsertInvitationTokenInDb = vi.fn().mockResolvedValue({
+  ok: true,
+  context: {
+    memberEmail: "other@example.com",
+    role: "editor",
+    inviteUrl: "https://zedi-note.app/invite?token=deadbeef",
+    noteTitle: "Test Note",
+    inviterName: "Inviter",
+    locale: "ja",
+  },
+});
+const mockDeliverInvitationEmail = vi.fn().mockResolvedValue({ sent: true });
 vi.mock("../../../services/invitationService.js", () => ({
   sendInvitation: (...args: unknown[]) => mockSendInvitation(...args),
-  resendInvitation: (...args: unknown[]) => mockResendInvitation(...args),
+  upsertInvitationTokenInDb: (...args: unknown[]) => mockUpsertInvitationTokenInDb(...args),
+  deliverInvitationEmail: (...args: unknown[]) => mockDeliverInvitationEmail(...args),
 }));
 
 import {
@@ -312,13 +324,19 @@ describe("PUT /api/notes/:noteId/members/:memberEmail", () => {
 // ── POST /api/notes/:noteId/members/:memberEmail/resend ────────────────────
 
 describe("POST /api/notes/:noteId/members/:memberEmail/resend", () => {
+  beforeEach(() => {
+    mockUpsertInvitationTokenInDb.mockClear();
+    mockDeliverInvitationEmail.mockClear();
+  });
+
   it("should resend invitation for a pending member", async () => {
     const mockNote = createMockNote();
-    const pendingMember = createMockMember({ status: "pending", role: "editor" });
     const { app } = createTestApp([
       [mockNote], // requireNoteOwner
-      [], // tx.execute SELECT … FOR UPDATE
-      [pendingMember], // select noteMembers (pending check)
+      [{ status: "pending" as const, role: "editor" }], // JOIN … FOR UPDATE
+      [{ title: "Test Note" }], // upsertInvitationTokenInDb → notes
+      [{ name: "Inviter" }], // upsertInvitationTokenInDb → users
+      [], // upsertInvitationTokenInDb → insert
     ]);
 
     const encoded = encodeURIComponent(OTHER_USER_EMAIL);
@@ -330,7 +348,7 @@ describe("POST /api/notes/:noteId/members/:memberEmail/resend", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).toEqual({ resent: true });
-    expect(mockResendInvitation).toHaveBeenCalledWith(
+    expect(mockUpsertInvitationTokenInDb).toHaveBeenCalledWith(
       expect.objectContaining({
         noteId: NOTE_ID,
         memberEmail: OTHER_USER_EMAIL,
@@ -338,15 +356,14 @@ describe("POST /api/notes/:noteId/members/:memberEmail/resend", () => {
         invitedByUserId: TEST_USER_ID,
       }),
     );
+    expect(mockDeliverInvitationEmail).toHaveBeenCalled();
   });
 
   it("should return 400 when member is not pending", async () => {
     const mockNote = createMockNote();
-    const acceptedMember = createMockMember({ status: "accepted" });
     const { app } = createTestApp([
       [mockNote], // requireNoteOwner
-      [], // FOR UPDATE
-      [acceptedMember], // select noteMembers (not pending)
+      [{ status: "accepted" as const, role: "viewer" }], // JOIN … FOR UPDATE
     ]);
 
     const encoded = encodeURIComponent(OTHER_USER_EMAIL);
@@ -356,14 +373,14 @@ describe("POST /api/notes/:noteId/members/:memberEmail/resend", () => {
     });
 
     expect(res.status).toBe(400);
+    expect(mockUpsertInvitationTokenInDb).not.toHaveBeenCalled();
   });
 
   it("should return 404 when member does not exist", async () => {
     const mockNote = createMockNote();
     const { app } = createTestApp([
       [mockNote], // requireNoteOwner
-      [], // FOR UPDATE
-      [], // select noteMembers → empty
+      [], // JOIN … FOR UPDATE → empty
     ]);
 
     const encoded = encodeURIComponent("unknown@example.com");

--- a/server/api/src/__tests__/routes/notes/setup.ts
+++ b/server/api/src/__tests__/routes/notes/setup.ts
@@ -10,28 +10,18 @@ import noteRoutes from "../../../routes/notes/index.js";
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
-export /**
- *
- */
-const TEST_USER_ID = "user-test-123";
-export /**
- *
- */
-const TEST_USER_EMAIL = "test@example.com";
-export /**
- *
- */
-const OTHER_USER_ID = "user-other-456";
-export /**
- *
- */
-const OTHER_USER_EMAIL = "other@example.com";
+/** モック認証で使うユーザー ID / Mock auth user id */
+export const TEST_USER_ID = "user-test-123";
+/** モック認証で使うメール / Mock auth email */
+export const TEST_USER_EMAIL = "test@example.com";
+/** 別ユーザーのモック ID / Second mock user id */
+export const OTHER_USER_ID = "user-other-456";
+/** 別ユーザーのモックメール / Second mock user email */
+export const OTHER_USER_EMAIL = "other@example.com";
 
 // ── Mock Data Factories ─────────────────────────────────────────────────────
 
-/**
- *
- */
+/** テスト用ノート行のデフォルト / Default mock note row */
 export function createMockNote(overrides: Record<string, unknown> = {}) {
   return {
     id: "note-test-001",
@@ -48,9 +38,7 @@ export function createMockNote(overrides: Record<string, unknown> = {}) {
   };
 }
 
-/**
- *
- */
+/** テスト用ページ行のデフォルト / Default mock page row */
 export function createMockPageRow(overrides: Record<string, unknown> = {}) {
   return {
     id: "page-test-001",
@@ -70,9 +58,7 @@ export function createMockPageRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
-/**
- *
- */
+/** テスト用ページ一覧行のデフォルト / Default mock page list row */
 export function createMockPageListRow(overrides: Record<string, unknown> = {}) {
   return {
     page_id: "page-test-001",
@@ -101,9 +87,7 @@ export function createMockMember(overrides: Record<string, unknown> = {}) {
 
 // ── Mock DB ─────────────────────────────────────────────────────────────────
 
-/**
- *
- */
+/** プロキシ DB モックが記録するチェーン情報 / Recorded chain info from proxy DB mock */
 export interface ChainInfo {
   startMethod: string;
   startArgs: unknown[];
@@ -172,17 +156,9 @@ export function createMockDb(results: unknown[]) {
 
 // ── Test App Factory ────────────────────────────────────────────────────────
 
-/**
- *
- */
+/** `dbResults` の順にクエリ結果を返すテスト用 Hono アプリを組み立てる。 */
 export function createTestApp(dbResults: unknown[]) {
-  /**
-   *
-   */
   const { db, chains } = createMockDb(dbResults);
-  /**
-   *
-   */
   const app = new Hono<AppEnv>();
 
   app.use("*", async (c, next) => {
@@ -196,9 +172,7 @@ export function createTestApp(dbResults: unknown[]) {
 
 // ── Auth Headers ────────────────────────────────────────────────────────────
 
-/**
- *
- */
+/** テスト用の認証ヘッダ / Test auth headers */
 export function authHeaders(userId = TEST_USER_ID, userEmail = TEST_USER_EMAIL) {
   return {
     "x-test-user-id": userId,

--- a/server/api/src/routes/notes/members.ts
+++ b/server/api/src/routes/notes/members.ts
@@ -10,12 +10,16 @@
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { eq, and, asc, sql } from "drizzle-orm";
-import { noteMembers } from "../../schema/index.js";
+import { noteInvitations, noteMembers } from "../../schema/index.js";
 import { authRequired } from "../../middleware/auth.js";
 import type { AppEnv } from "../../types/index.js";
 import type { NoteMemberRole } from "./types.js";
 import { requireNoteOwner, getNoteRole } from "./helpers.js";
-import { sendInvitation, resendInvitation } from "../../services/invitationService.js";
+import {
+  deliverInvitationEmail,
+  sendInvitation,
+  upsertInvitationTokenInDb,
+} from "../../services/invitationService.js";
 
 const app = new Hono<AppEnv>();
 
@@ -123,48 +127,56 @@ app.post("/:noteId/members/:memberEmail/resend", authRequired, async (c) => {
   // オーナーのみ実行可能 / Only the owner can resend invitations
   await requireNoteOwner(db, noteId, userId, "Only the owner can resend invitations");
 
-  // pending 確認とトークン更新を同一トランザクションで行い、受諾との競合で usedAt が不整合になるのを防ぐ。
-  // Lock the member row (FOR UPDATE) then resend so accept cannot interleave between check and upsert.
-  const result = await db.transaction(async (tx) => {
-    await tx.execute(
-      sql`
-        SELECT 1 FROM ${noteMembers}
-        WHERE ${noteMembers.noteId} = ${noteId}
-          AND ${noteMembers.memberEmail} = ${memberEmail}
-          AND ${noteMembers.isDeleted} = FALSE
-        FOR UPDATE
-      `,
-    );
-
-    const [member] = await tx
-      .select({ status: noteMembers.status, role: noteMembers.role })
-      .from(noteMembers)
-      .where(
+  // pending 確認とトークン upsert を同一トランザクションで行い、受諾との競合で usedAt が不整合になるのを防ぐ。
+  // Single JOIN ... FOR UPDATE locks invitation + member rows in one statement (consistent order vs accept flow).
+  // メール送信はコミット後（外部 API）に行い、行ロックを長く握らない。
+  // Send email after commit so row locks are not held during the external email API call.
+  const upsertResult = await db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({
+        status: noteMembers.status,
+        role: noteMembers.role,
+      })
+      .from(noteInvitations)
+      .innerJoin(
+        noteMembers,
         and(
-          eq(noteMembers.noteId, noteId),
-          eq(noteMembers.memberEmail, memberEmail),
+          eq(noteMembers.noteId, noteInvitations.noteId),
+          eq(noteMembers.memberEmail, noteInvitations.memberEmail),
           eq(noteMembers.isDeleted, false),
         ),
       )
+      .where(and(eq(noteInvitations.noteId, noteId), eq(noteInvitations.memberEmail, memberEmail)))
+      .for("update")
       .limit(1);
 
-    if (!member) {
-      throw new HTTPException(404, { message: "Member not found" });
+    if (!row) {
+      throw new HTTPException(404, { message: "Member or invitation not found" });
     }
-    if (member.status !== "pending") {
+    if (row.status !== "pending") {
       throw new HTTPException(400, {
         message: "Invitation can only be resent for pending members",
       });
     }
 
-    return resendInvitation({
+    return upsertInvitationTokenInDb({
       db: tx,
       noteId,
       memberEmail,
-      role: member.role,
+      role: row.role,
       invitedByUserId: userId,
     });
   });
+
+  if (!upsertResult.ok) {
+    console.warn(
+      `[members] Resend invitation DB step failed for ${memberEmail}:`,
+      upsertResult.error,
+    );
+    return c.json({ resent: false });
+  }
+
+  const result = await deliverInvitationEmail(upsertResult.context);
 
   if (!result.sent) {
     console.warn(`[members] Resend invitation to ${memberEmail} failed:`, result.error);

--- a/server/api/src/routes/notes/members.ts
+++ b/server/api/src/routes/notes/members.ts
@@ -18,7 +18,7 @@ import { requireNoteOwner, getNoteRole } from "./helpers.js";
 import {
   deliverInvitationEmail,
   sendInvitation,
-  upsertInvitationTokenInDb,
+  upsertInvitationTokenInDbThrowing,
 } from "../../services/invitationService.js";
 
 const app = new Hono<AppEnv>();
@@ -128,30 +128,36 @@ app.post("/:noteId/members/:memberEmail/resend", authRequired, async (c) => {
   await requireNoteOwner(db, noteId, userId, "Only the owner can resend invitations");
 
   // pending 確認とトークン upsert を同一トランザクションで行い、受諾との競合で usedAt が不整合になるのを防ぐ。
-  // Single JOIN ... FOR UPDATE locks invitation + member rows in one statement (consistent order vs accept flow).
-  // メール送信はコミット後（外部 API）に行い、行ロックを長く握らない。
-  // Send email after commit so row locks are not held during the external email API call.
-  const upsertResult = await db.transaction(async (tx) => {
+  // `note_members` を起点に LEFT JOIN（招待行が無いレガシー pending も再送可能）。FOR UPDATE でメンバー行をロックし、存在すれば招待行もロック。
+  // Start from note_members with LEFT JOIN so pending members without a note_invitations row can still resend; FOR UPDATE locks member and invitation when present.
+  // メール送信はコミット後（外部 API）。DB 失敗は upsertInvitationTokenInDbThrowing の例外で tx をロールバック。
+  // Send email after commit; DB failures throw so the transaction rolls back.
+  const emailContext = await db.transaction(async (tx) => {
     const [row] = await tx
       .select({
         status: noteMembers.status,
         role: noteMembers.role,
       })
-      .from(noteInvitations)
-      .innerJoin(
-        noteMembers,
+      .from(noteMembers)
+      .leftJoin(
+        noteInvitations,
         and(
-          eq(noteMembers.noteId, noteInvitations.noteId),
-          eq(noteMembers.memberEmail, noteInvitations.memberEmail),
+          eq(noteInvitations.noteId, noteMembers.noteId),
+          eq(noteInvitations.memberEmail, noteMembers.memberEmail),
+        ),
+      )
+      .where(
+        and(
+          eq(noteMembers.noteId, noteId),
+          eq(noteMembers.memberEmail, memberEmail),
           eq(noteMembers.isDeleted, false),
         ),
       )
-      .where(and(eq(noteInvitations.noteId, noteId), eq(noteInvitations.memberEmail, memberEmail)))
       .for("update")
       .limit(1);
 
     if (!row) {
-      throw new HTTPException(404, { message: "Member or invitation not found" });
+      throw new HTTPException(404, { message: "Member not found" });
     }
     if (row.status !== "pending") {
       throw new HTTPException(400, {
@@ -159,7 +165,7 @@ app.post("/:noteId/members/:memberEmail/resend", authRequired, async (c) => {
       });
     }
 
-    return upsertInvitationTokenInDb({
+    return upsertInvitationTokenInDbThrowing({
       db: tx,
       noteId,
       memberEmail,
@@ -168,15 +174,7 @@ app.post("/:noteId/members/:memberEmail/resend", authRequired, async (c) => {
     });
   });
 
-  if (!upsertResult.ok) {
-    console.warn(
-      `[members] Resend invitation DB step failed for ${memberEmail}:`,
-      upsertResult.error,
-    );
-    return c.json({ resent: false });
-  }
-
-  const result = await deliverInvitationEmail(upsertResult.context);
+  const result = await deliverInvitationEmail(emailContext);
 
   if (!result.sent) {
     console.warn(`[members] Resend invitation to ${memberEmail} failed:`, result.error);

--- a/server/api/src/services/invitationService.ts
+++ b/server/api/src/services/invitationService.ts
@@ -56,17 +56,45 @@ export interface SendInvitationResult {
 }
 
 /**
- * 招待トークンを生成し、メールを送信する
- * Generate an invitation token and send the email
+ * メール送信用に DB でトークンを upsert し、テンプレートへ渡すコンテキストを組み立てる。
+ * Build email context by upserting a token in the DB (no external I/O).
  *
- * @param params - 送信パラメータ / Sending parameters
- * @returns 送信結果 / Sending result
+ * 再送ルートではトランザクション内で呼び、コミット後に `deliverInvitationEmail` を実行する。
+ * For resend, call inside a transaction, then `deliverInvitationEmail` after commit.
  */
-export async function sendInvitation(params: SendInvitationParams): Promise<SendInvitationResult> {
+export interface InvitationEmailContext {
+  /** 宛先 / Recipient */
+  memberEmail: string;
+  /** 付与ロール / Assigned role */
+  role: string;
+  /** 招待 URL / Invitation URL including token */
+  inviteUrl: string;
+  /** ノート表示名 / Note title for template */
+  noteTitle: string;
+  /** 招待者表示名 / Inviter display name */
+  inviterName: string;
+  /** メールロケール / Email locale */
+  locale: Locale;
+}
+
+/**
+ * `upsertInvitationTokenInDb` の結果（成功時はメール送信前のコンテキスト）
+ * Result of DB upsert before sending email.
+ */
+export type UpsertInvitationTokenResult =
+  | { ok: true; context: InvitationEmailContext }
+  | { ok: false; error: string };
+
+/**
+ * トークンを生成して DB に保存し、メール送信用コンテキストを返す（メールは送らない）。
+ * Generate a token, upsert into DB, return context for email (does not send email).
+ */
+export async function upsertInvitationTokenInDb(
+  params: SendInvitationParams,
+): Promise<UpsertInvitationTokenResult> {
   const { db, noteId, memberEmail, role, invitedByUserId } = params;
 
   try {
-    // ノートタイトルを取得 / Fetch note title
     const [note] = await db
       .select({ title: notes.title })
       .from(notes)
@@ -74,7 +102,6 @@ export async function sendInvitation(params: SendInvitationParams): Promise<Send
       .limit(1);
     const noteTitle = note?.title ?? "Untitled";
 
-    // 招待者の名前を取得 / Fetch inviter's display name
     const [inviter] = await db
       .select({ name: users.name })
       .from(users)
@@ -82,7 +109,6 @@ export async function sendInvitation(params: SendInvitationParams): Promise<Send
       .limit(1);
     const inviterName = inviter?.name ?? "Unknown";
 
-    // トークン生成 + DB 保存（upsert） / Generate token + upsert into DB
     const token = generateToken();
     const expiresAt = new Date(Date.now() + TOKEN_TTL_MS);
 
@@ -94,14 +120,41 @@ export async function sendInvitation(params: SendInvitationParams): Promise<Send
         set: { token, expiresAt, usedAt: null },
       });
 
-    // 招待 URL を構築 / Build invitation URL
     const baseUrl = getOptionalEnv("APP_URL", "https://zedi-note.app");
     const inviteUrl = `${baseUrl}/invite?token=${token}`;
-
-    // デフォルトロケール（ユーザーテーブルに locale なし） / Default locale (no locale column in users table)
     const locale: Locale = "ja";
 
-    // メールをレンダリングして送信 / Render and send email
+    return {
+      ok: true,
+      context: {
+        memberEmail,
+        role,
+        inviteUrl,
+        noteTitle,
+        inviterName,
+        locale,
+      },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[invitationService] Unexpected error upserting invitation for ${memberEmail}:`,
+      message,
+    );
+    return { ok: false, error: message };
+  }
+}
+
+/**
+ * `InvitationEmailContext` に基づき HTML メールを送信する。
+ * Send the invitation HTML email using a pre-built context.
+ */
+export async function deliverInvitationEmail(
+  context: InvitationEmailContext,
+): Promise<SendInvitationResult> {
+  const { memberEmail, role, inviteUrl, noteTitle, inviterName, locale } = context;
+
+  try {
     const subject = getInviteNoteSubject({
       inviterName,
       noteTitle,
@@ -134,6 +187,21 @@ export async function sendInvitation(params: SendInvitationParams): Promise<Send
     );
     return { sent: false, error: message };
   }
+}
+
+/**
+ * 招待トークンを生成し、メールを送信する
+ * Generate an invitation token and send the email
+ *
+ * @param params - 送信パラメータ / Sending parameters
+ * @returns 送信結果 / Sending result
+ */
+export async function sendInvitation(params: SendInvitationParams): Promise<SendInvitationResult> {
+  const built = await upsertInvitationTokenInDb(params);
+  if (!built.ok) {
+    return { sent: false, error: built.error };
+  }
+  return deliverInvitationEmail(built.context);
 }
 
 /**

--- a/server/api/src/services/invitationService.ts
+++ b/server/api/src/services/invitationService.ts
@@ -86,63 +86,83 @@ export type UpsertInvitationTokenResult =
   | { ok: false; error: string };
 
 /**
+ * トークン upsert の本体。例外は呼び出し元へ伝播する（トランザクション内ではロールバック用）。
+ * Core token upsert; errors propagate (so transactions roll back).
+ */
+async function upsertInvitationTokenDbImpl(
+  params: SendInvitationParams,
+): Promise<InvitationEmailContext> {
+  const { db, noteId, memberEmail, role, invitedByUserId } = params;
+
+  const [note] = await db
+    .select({ title: notes.title })
+    .from(notes)
+    .where(eq(notes.id, noteId))
+    .limit(1);
+  const noteTitle = note?.title ?? "Untitled";
+
+  const [inviter] = await db
+    .select({ name: users.name })
+    .from(users)
+    .where(eq(users.id, invitedByUserId))
+    .limit(1);
+  const inviterName = inviter?.name ?? "Unknown";
+
+  const token = generateToken();
+  const expiresAt = new Date(Date.now() + TOKEN_TTL_MS);
+
+  await db
+    .insert(noteInvitations)
+    .values({ noteId, memberEmail, token, expiresAt })
+    .onConflictDoUpdate({
+      target: [noteInvitations.noteId, noteInvitations.memberEmail],
+      set: { token, expiresAt, usedAt: null },
+    });
+
+  const baseUrl = getOptionalEnv("APP_URL", "https://zedi-note.app");
+  const inviteUrl = `${baseUrl}/invite?token=${token}`;
+  const locale: Locale = "ja";
+
+  return {
+    memberEmail,
+    role,
+    inviteUrl,
+    noteTitle,
+    inviterName,
+    locale,
+  };
+}
+
+/**
  * トークンを生成して DB に保存し、メール送信用コンテキストを返す（メールは送らない）。
+ * 失敗時は `{ ok: false }` を返し、例外は飲み込む（バックグラウンド `sendInvitation` 向け）。
  * Generate a token, upsert into DB, return context for email (does not send email).
+ * On failure returns `{ ok: false }` (for background `sendInvitation`).
  */
 export async function upsertInvitationTokenInDb(
   params: SendInvitationParams,
 ): Promise<UpsertInvitationTokenResult> {
-  const { db, noteId, memberEmail, role, invitedByUserId } = params;
-
   try {
-    const [note] = await db
-      .select({ title: notes.title })
-      .from(notes)
-      .where(eq(notes.id, noteId))
-      .limit(1);
-    const noteTitle = note?.title ?? "Untitled";
-
-    const [inviter] = await db
-      .select({ name: users.name })
-      .from(users)
-      .where(eq(users.id, invitedByUserId))
-      .limit(1);
-    const inviterName = inviter?.name ?? "Unknown";
-
-    const token = generateToken();
-    const expiresAt = new Date(Date.now() + TOKEN_TTL_MS);
-
-    await db
-      .insert(noteInvitations)
-      .values({ noteId, memberEmail, token, expiresAt })
-      .onConflictDoUpdate({
-        target: [noteInvitations.noteId, noteInvitations.memberEmail],
-        set: { token, expiresAt, usedAt: null },
-      });
-
-    const baseUrl = getOptionalEnv("APP_URL", "https://zedi-note.app");
-    const inviteUrl = `${baseUrl}/invite?token=${token}`;
-    const locale: Locale = "ja";
-
-    return {
-      ok: true,
-      context: {
-        memberEmail,
-        role,
-        inviteUrl,
-        noteTitle,
-        inviterName,
-        locale,
-      },
-    };
+    const context = await upsertInvitationTokenDbImpl(params);
+    return { ok: true, context };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(
-      `[invitationService] Unexpected error upserting invitation for ${memberEmail}:`,
+      `[invitationService] Unexpected error upserting invitation for ${params.memberEmail}:`,
       message,
     );
     return { ok: false, error: message };
   }
+}
+
+/**
+ * トランザクション内で使用する。DB 失敗は例外として伝播し、tx をロールバックさせる。
+ * Use inside a transaction: DB failures propagate so the transaction rolls back.
+ */
+export async function upsertInvitationTokenInDbThrowing(
+  params: SendInvitationParams,
+): Promise<InvitationEmailContext> {
+  return upsertInvitationTokenDbImpl(params);
 }
 
 /**
@@ -202,19 +222,4 @@ export async function sendInvitation(params: SendInvitationParams): Promise<Send
     return { sent: false, error: built.error };
   }
   return deliverInvitationEmail(built.context);
-}
-
-/**
- * 招待メールを再送信する（トークン再生成 + expires_at リセット）
- * Resend an invitation email (regenerate token + reset expires_at)
- *
- * @param params - 送信パラメータ / Sending parameters
- * @returns 送信結果 / Sending result
- */
-export async function resendInvitation(
-  params: SendInvitationParams,
-): Promise<SendInvitationResult> {
-  // 再送信はトークン再生成を伴うため、sendInvitation と同じロジックで OK
-  // Resend uses the same logic since it regenerates the token
-  return sendInvitation(params);
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "zedi"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "dirs 5.0.1",
  "serde",


### PR DESCRIPTION
## 概要

PR #530（および #526）のレビューコメントに対応。招待再送のロック順・トランザクション範囲・テスト用 setup の JSDoc を整理。

## 変更点

- `members` 再送: `note_invitations` と `note_members` を **1 つの JOIN ... FOR UPDATE** で取得（レビュー指摘のクエリ統合 + accept フローとのロック順の整合）
- `invitationService`: `upsertInvitationTokenInDb` と `deliverInvitationEmail` に分割し、**メール送信はトランザクションコミット後**
- `setup.ts`: 空の JSDoc を削除し、意味のある1行コメントに置換

## 関連

- Closes review threads on #530

## チェックリスト

- [x] `server/api` 対象 Vitest 実行済み
- [x] 変更ファイル ESLint 通過

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated invitation-related test suites to reflect refactored invitation handling flow and improved test isolation with per-test mock state reset.
  * Exported shared test credentials for use across test modules.

* **Refactor**
  * Improved invitation system architecture by decoupling token/database operations from email delivery, enhancing robustness and flexibility of the resend invitation feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->