### PR TITLE
fix(editor): マークダウン貼り付け時にHTML存在でスキップされる問題を修正

### DIFF
--- a/src/components/editor/TiptapEditor/useMarkdownPasteHandler.test.ts
+++ b/src/components/editor/TiptapEditor/useMarkdownPasteHandler.test.ts
@@ -84,14 +84,32 @@ describe("useMarkdownPasteHandler", () => {
     expect(insertContent).not.toHaveBeenCalled();
   });
 
-  it("does not intercept when HTML is present (rich paste)", () => {
-    const { editor, dom, insertContent } = createMockEditor();
+  it("parses markdown even when HTML is present (e.g. pasting from VS Code)", () => {
+    const { editor, dom, insertContent, parsedDoc } = createMockEditor();
 
     renderHook(() => useMarkdownPasteHandler({ editor }));
 
     const event = createPasteEvent({
       text: "# Hello",
-      html: "<h1>Hello</h1>",
+      html: '<meta charset="utf-8"><div style="color:#d4d4d4">## Hello</div>',
+    });
+
+    act(() => {
+      dom.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(insertContent).toHaveBeenCalledWith(parsedDoc);
+  });
+
+  it("does not intercept when HTML is present but text has no markdown patterns", () => {
+    const { editor, dom, insertContent } = createMockEditor();
+
+    renderHook(() => useMarkdownPasteHandler({ editor }));
+
+    const event = createPasteEvent({
+      text: "Just plain text",
+      html: "<p>Just plain text</p>",
     });
 
     act(() => {

--- a/src/components/editor/TiptapEditor/useMarkdownPasteHandler.ts
+++ b/src/components/editor/TiptapEditor/useMarkdownPasteHandler.ts
@@ -53,11 +53,6 @@ export function useMarkdownPasteHandler({ editor }: UseMarkdownPasteHandlerParam
       // Skip when another handler already handled the paste (e.g. image URL paste).
       if (event.defaultPrevented) return;
 
-      // HTML が含まれている場合はリッチペーストを優先（他アプリからのコピーなど）
-      // If HTML is present, let TipTap handle it as rich paste (e.g., copy from other apps)
-      const html = event.clipboardData?.getData("text/html");
-      if (html) return;
-
       const text = event.clipboardData?.getData("text/plain");
       if (!text || !looksLikeMarkdown(text)) return;
 


### PR DESCRIPTION
クリップボードにHTMLが含まれている場合（VS Code等からのコピー）でも、
プレーンテキストがマークダウンパターンを含んでいればマークダウンとして
解析・スタイル適用するよう変更。

Fix markdown paste handler skipping parse when clipboard contains HTML.
Previously, pasting from editors like VS Code (which include HTML in
clipboard) would bypass markdown parsing entirely, resulting in
unstyled plain text.

https://claude.ai/code/session_01XgUWNUxeMzPNsm6Y1Q9ihK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown paste handling to properly detect and process markdown text even when HTML content is also present in the clipboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->