### PR TITLE
fix: FABメニュー閉時に不可視領域がタッチ・スクロールをブロックする問題を修正

### DIFF
--- a/src/components/ai-chat/ContentWithAIChat.tsx
+++ b/src/components/ai-chat/ContentWithAIChat.tsx
@@ -91,7 +91,7 @@ export function ContentWithAIChat({
       <>
         {children}
         {floatingAction && (
-          <div className="fixed right-0 bottom-0 z-40 flex flex-col items-end gap-1 p-2 pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)]">
+          <div className="pointer-events-none fixed right-0 bottom-0 z-40 flex flex-col items-end gap-1 p-2 pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)]">
             {floatingAction}
           </div>
         )}
@@ -118,7 +118,7 @@ export function ContentWithAIChat({
       </div>
       {floatingAction && (
         <div
-          className="fixed bottom-0 z-40 flex flex-col items-end gap-1 p-2 pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)]"
+          className="pointer-events-none fixed bottom-0 z-40 flex flex-col items-end gap-1 p-2 pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)]"
           style={{
             // Local / global のどちらでも開いているときはパネル幅ぶん左に寄せる
             right: isOpen ? "var(--ai-chat-width)" : 0,

--- a/src/components/layout/FABMenu.tsx
+++ b/src/components/layout/FABMenu.tsx
@@ -109,7 +109,7 @@ export const FABMenu: React.FC<FABMenuProps> = ({
         className={cn(
           "fixed inset-0 z-30 bg-black/35",
           "transition-opacity duration-200",
-          open ? "opacity-100" : "pointer-events-none opacity-0",
+          open ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0",
         )}
         onClick={() => onOpenChange(false)}
       />
@@ -120,7 +120,7 @@ export const FABMenu: React.FC<FABMenuProps> = ({
       <div
         className={cn(
           "relative z-40 flex flex-col items-end gap-3",
-          !open && "pointer-events-none",
+          open ? "pointer-events-auto" : "pointer-events-none",
         )}
       >
         {/* メニューアイテム（上方向に展開） */}


### PR DESCRIPTION
ContentWithAIChatのFABラッパーコンテナにpointer-events-noneを追加し、
メニュー非展開時に不可視のメニュー領域がユーザー操作を遮断しないようにした。
FABMenu側ではpointer-eventsの継承を考慮し、メニュー展開時に明示的に
pointer-events-autoを設定するよう変更。

fix: prevent invisible FAB menu area from blocking touch/scroll

Add pointer-events-none to the fixed FAB wrapper in ContentWithAIChat so the
invisible menu area doesn't block user interactions when the menu is closed.
Explicitly set pointer-events-auto on FABMenu overlay and container when open,
since pointer-events is an inherited CSS property.

https://claude.ai/code/session_01DofQ7BSQxzrvXRpnd38iKQ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed pointer event handling for floating action buttons (FAB) across mobile and desktop layouts to ensure users can reliably interact with these floating elements.
* Improved menu overlay interaction behavior with better pointer event management for proper responsiveness when the menu transitions between open and closed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->