### PR TITLE
feat(mcp): add HTTP transport, CLI login, and Web consent page

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,12 @@
+# Gitleaks ignore list
+# gitleaks が検出した誤検知（False positive）を記録するファイル。
+# Records fingerprints of false-positive findings for gitleaks.
+#
+# Format: <commit-sha>:<file-path>:<rule-id>:<line-number>
+# See: https://github.com/gitleaks/gitleaks#gitleaksignore
+
+# server/api/src/__tests__/routes/invite.test.ts:38 の TEST_TOKEN は
+# 招待 API テスト用に埋め込まれたモック文字列であり、本物の API キーではない。
+# The TEST_TOKEN at invite.test.ts:38 is a hard-coded mock string used only for
+# invitation API unit tests — it is not a real API key or secret.
+b1e5dab7fa191b9f317b066099ca3fbb6450c5a7:server/api/src/__tests__/routes/invite.test.ts:generic-api-key:38

--- a/server/api/src/__tests__/routes/invite.test.ts
+++ b/server/api/src/__tests__/routes/invite.test.ts
@@ -35,7 +35,9 @@ import { errorHandler } from "../../middleware/errorHandler.js";
 const TEST_USER_ID = "user-test-123";
 const TEST_USER_EMAIL = "test@example.com";
 const OTHER_USER_EMAIL = "other@example.com";
-const TEST_TOKEN = "abc123def456";
+// Mock invitation token used as a URL path parameter in tests only.
+// テスト用のモック招待トークン（URL パスパラメータとして使用）。本物のシークレットではない。
+const TEST_TOKEN = "abc123def456"; // gitleaks:allow
 const NOTE_ID = "note-test-001";
 
 // ── Mock DB (same proxy-based pattern as notes tests) ──────────────────────

--- a/server/mcp/Dockerfile
+++ b/server/mcp/Dockerfile
@@ -1,0 +1,19 @@
+# Build context: server/mcp (Railway with Root Directory = server/mcp).
+# bun.lock must be present alongside package.json.
+FROM oven/bun:1.3.6-alpine AS builder
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN bun run build
+
+FROM node:24-alpine
+WORKDIR /app
+RUN addgroup -g 1001 -S app && adduser -S app -u 1001
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./
+USER app
+EXPOSE 3100
+CMD ["node", "dist/http.js"]

--- a/server/mcp/bun.lock
+++ b/server/mcp/bun.lock
@@ -5,7 +5,10 @@
     "": {
       "name": "@zedi/mcp-server",
       "dependencies": {
+        "@hono/node-server": "^1.19.11",
         "@modelcontextprotocol/sdk": "^1.0.4",
+        "hono": "^4.12.5",
+        "open": "^10.1.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -153,6 +156,8 @@
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -176,6 +181,12 @@
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -253,7 +264,13 @@
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -315,6 +332,8 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -346,6 +365,8 @@
     "rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -410,6 +431,8 @@
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 

--- a/server/mcp/bun.lock
+++ b/server/mcp/bun.lock
@@ -1,0 +1,418 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@zedi/mcp-server",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.4",
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@types/node": "^25.3.3",
+        "tsx": "^4.21.0",
+        "typescript": "^6.0.2",
+        "vitest": "^4.0.18",
+      },
+    },
+  },
+  "packages": {
+    "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.15", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm" }, "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "ppc64" }, "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "s390x" }, "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.15", "", { "os": "none", "cpu": "arm64" }, "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.15", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.3" }, "cpu": "none" }, "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.4", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.4", "", { "dependencies": { "@vitest/spy": "4.1.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.4", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.4", "", { "dependencies": { "@vitest/utils": "4.1.4", "pathe": "^2.0.3" } }, "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "@vitest/utils": "4.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.4", "", {}, "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
+
+    "vitest": ["vitest@4.1.4", "", { "dependencies": { "@vitest/expect": "4.1.4", "@vitest/mocker": "4.1.4", "@vitest/pretty-format": "4.1.4", "@vitest/runner": "4.1.4", "@vitest/snapshot": "4.1.4", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.4", "@vitest/browser-preview": "4.1.4", "@vitest/browser-webdriverio": "4.1.4", "@vitest/coverage-istanbul": "4.1.4", "@vitest/coverage-v8": "4.1.4", "@vitest/ui": "4.1.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+  }
+}

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@zedi/mcp-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Zedi MCP (Model Context Protocol) server — exposes Zedi data to external Claude Code clients via stdio.",
+  "bin": {
+    "zedi-mcp-stdio": "./dist/stdio.js"
+  },
+  "scripts": {
+    "dev:stdio": "tsx watch src/stdio.ts",
+    "build": "tsc",
+    "start:stdio": "node dist/stdio.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.4",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.3",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.0.18"
+  }
+}

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -3,20 +3,27 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Zedi MCP (Model Context Protocol) server — exposes Zedi data to external Claude Code clients via stdio.",
+  "description": "Zedi MCP (Model Context Protocol) server — exposes Zedi data to external Claude Code clients via stdio and HTTP/SSE.",
   "bin": {
-    "zedi-mcp-stdio": "./dist/stdio.js"
+    "zedi-mcp-stdio": "./dist/stdio.js",
+    "zedi-mcp-http": "./dist/http.js",
+    "zedi-mcp-cli": "./dist/cli/login.js"
   },
   "scripts": {
     "dev:stdio": "tsx watch src/stdio.ts",
+    "dev:http": "tsx watch src/http.ts",
     "build": "tsc",
     "start:stdio": "node dist/stdio.js",
+    "start:http": "node dist/http.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@hono/node-server": "^1.19.11",
     "@modelcontextprotocol/sdk": "^1.0.4",
+    "hono": "^4.12.5",
+    "open": "^10.1.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/server/mcp/railway.json
+++ b/server/mcp/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "node dist/http.js",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5
+  }
+}

--- a/server/mcp/src/__tests__/client/httpClient.test.ts
+++ b/server/mcp/src/__tests__/client/httpClient.test.ts
@@ -1,0 +1,287 @@
+/**
+ * HttpZediClient のユニットテスト
+ *
+ * - URL / method / body / Authorization ヘッダの検証
+ * - 4xx / 5xx → ZediApiError 変換
+ * - ネットワークエラー → ZediApiError(status=0)
+ *
+ * Tests for HttpZediClient: request shaping, error normalization.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Mock } from "vitest";
+import { HttpZediClient } from "../../client/httpClient.js";
+import { ZediApiError } from "../../client/errors.js";
+
+const BASE = "https://api.zedi.test";
+const TOKEN = "test-jwt";
+
+/**
+ * テスト用ヘルパ: モック関数の n 番目の呼び出し引数を返す。未呼び出しなら例外。
+ * Test helper: returns the n-th call's arguments or throws if not called.
+ */
+function callArgs(mock: Mock, index = 0): unknown[] {
+  const call = mock.mock.calls[index];
+  if (!call) throw new Error(`mock not called at index ${index}`);
+  return call as unknown[];
+}
+
+function makeJsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeTextResponse(status: number, text: string): Response {
+  return new Response(text, { status, headers: { "Content-Type": "text/plain" } });
+}
+
+describe("HttpZediClient request shaping", () => {
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+  let client: HttpZediClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn<typeof fetch>();
+    client = new HttpZediClient({ baseUrl: BASE, token: TOKEN, fetch: fetchMock });
+  });
+
+  it("getCurrentUser sends GET to /api/users/me with Bearer token", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse(200, { id: "u1", email: "a@b.c", name: "Alice", image: null }),
+    );
+    const user = await client.getCurrentUser();
+    expect(user.id).toBe("u1");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = callArgs(fetchMock as unknown as Mock);
+    expect(url).toBe(`${BASE}/api/users/me`);
+    expect((init as RequestInit).method).toBe("GET");
+    const headers = new Headers((init as RequestInit).headers);
+    expect(headers.get("Authorization")).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("createPage sends POST with JSON body to /api/pages", async () => {
+    const expected = {
+      id: "p1",
+      owner_id: "u1",
+      title: "Hello",
+      content_preview: null,
+      thumbnail_url: null,
+      source_url: null,
+      source_page_id: null,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      is_deleted: false,
+    };
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(201, expected));
+    const result = await client.createPage({ title: "Hello" });
+    expect(result.id).toBe("p1");
+    const [url, init] = callArgs(fetchMock as unknown as Mock);
+    expect(url).toBe(`${BASE}/api/pages`);
+    expect((init as RequestInit).method).toBe("POST");
+    const headers = new Headers((init as RequestInit).headers);
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect((init as RequestInit).body).toBe(JSON.stringify({ title: "Hello" }));
+  });
+
+  it("updatePageContent sends PUT to /api/pages/:id/content", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, { version: 7 }));
+    const result = await client.updatePageContent("p1", {
+      ydoc_state: "BASE64STATE",
+      expected_version: 6,
+      content_text: "hi",
+    });
+    expect(result.version).toBe(7);
+    const [url, init] = callArgs(fetchMock as unknown as Mock);
+    expect(url).toBe(`${BASE}/api/pages/p1/content`);
+    expect((init as RequestInit).method).toBe("PUT");
+  });
+
+  it("deletePage sends DELETE to /api/pages/:id", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, { id: "p1", deleted: true }));
+    const result = await client.deletePage("p1");
+    expect(result.deleted).toBe(true);
+    const [url, init] = callArgs(fetchMock as unknown as Mock);
+    expect(url).toBe(`${BASE}/api/pages/p1`);
+    expect((init as RequestInit).method).toBe("DELETE");
+  });
+
+  it("listNotes sends GET to /api/notes", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, []));
+    const list = await client.listNotes();
+    expect(Array.isArray(list)).toBe(true);
+    expect(callArgs(fetchMock as unknown as Mock)[0]).toBe(`${BASE}/api/notes`);
+  });
+
+  it("createNote POSTs to /api/notes", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse(201, {
+        id: "n1",
+        owner_id: "u1",
+        title: "T",
+        visibility: "private",
+        edit_permission: "owner_only",
+        is_official: false,
+        view_count: 0,
+        created_at: "x",
+        updated_at: "y",
+      }),
+    );
+    const n = await client.createNote({ title: "T" });
+    expect(n.id).toBe("n1");
+    expect(callArgs(fetchMock as unknown as Mock)[0]).toBe(`${BASE}/api/notes`);
+    expect((callArgs(fetchMock as unknown as Mock)[1] as RequestInit).method).toBe("POST");
+  });
+
+  it("updateNote PUTs to /api/notes/:id", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse(200, {
+        id: "n1",
+        owner_id: "u1",
+        title: "T2",
+        visibility: "private",
+        edit_permission: "owner_only",
+        is_official: false,
+        view_count: 0,
+        created_at: "x",
+        updated_at: "y",
+      }),
+    );
+    await client.updateNote("n1", { title: "T2" });
+    const [url, init] = callArgs(fetchMock as unknown as Mock);
+    expect(url).toBe(`${BASE}/api/notes/n1`);
+    expect((init as RequestInit).method).toBe("PUT");
+  });
+
+  it("deleteNote DELETEs /api/notes/:id", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, { deleted: true }));
+    await client.deleteNote("n1");
+    const [url, init] = callArgs(fetchMock as unknown as Mock);
+    expect(url).toBe(`${BASE}/api/notes/n1`);
+    expect((init as RequestInit).method).toBe("DELETE");
+  });
+
+  it("addPageToNote POSTs to /api/notes/:noteId/pages", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, { ok: true }));
+    await client.addPageToNote("n1", { page_id: "p1" });
+    expect(callArgs(fetchMock as unknown as Mock)[0]).toBe(`${BASE}/api/notes/n1/pages`);
+  });
+
+  it("removePageFromNote DELETEs /api/notes/:noteId/pages/:pageId", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, { ok: true }));
+    await client.removePageFromNote("n1", "p1");
+    expect(callArgs(fetchMock as unknown as Mock)[0]).toBe(`${BASE}/api/notes/n1/pages/p1`);
+    expect((callArgs(fetchMock as unknown as Mock)[1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("reorderNotePages PUTs to /api/notes/:noteId/pages", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, { ok: true }));
+    await client.reorderNotePages("n1", ["p1", "p2"]);
+    expect(callArgs(fetchMock as unknown as Mock)[0]).toBe(`${BASE}/api/notes/n1/pages`);
+    expect((callArgs(fetchMock as unknown as Mock)[1] as RequestInit).method).toBe("PUT");
+  });
+
+  it("listNoteMembers GETs /api/notes/:noteId/members", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, []));
+    await client.listNoteMembers("n1");
+    expect(callArgs(fetchMock as unknown as Mock)[0]).toBe(`${BASE}/api/notes/n1/members`);
+  });
+
+  it("addNoteMember POSTs /api/notes/:noteId/members", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, { ok: true }));
+    await client.addNoteMember("n1", { email: "x@y.z", role: "viewer" });
+    expect(callArgs(fetchMock as unknown as Mock)[0]).toBe(`${BASE}/api/notes/n1/members`);
+    expect((callArgs(fetchMock as unknown as Mock)[1] as RequestInit).method).toBe("POST");
+  });
+
+  it("updateNoteMember PUTs /api/notes/:noteId/members/:email", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, { ok: true }));
+    await client.updateNoteMember("n1", "x@y.z", "editor");
+    expect(callArgs(fetchMock as unknown as Mock)[0]).toBe(
+      `${BASE}/api/notes/n1/members/${encodeURIComponent("x@y.z")}`,
+    );
+    expect((callArgs(fetchMock as unknown as Mock)[1] as RequestInit).method).toBe("PUT");
+  });
+
+  it("removeNoteMember DELETEs /api/notes/:noteId/members/:email", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, { ok: true }));
+    await client.removeNoteMember("n1", "x@y.z");
+    expect(callArgs(fetchMock as unknown as Mock)[0]).toBe(
+      `${BASE}/api/notes/n1/members/${encodeURIComponent("x@y.z")}`,
+    );
+    expect((callArgs(fetchMock as unknown as Mock)[1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("search GETs /api/search with q, scope, limit", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, { results: [] }));
+    await client.search("hello world", "shared", 50);
+    const url = callArgs(fetchMock as unknown as Mock)[0] as string;
+    expect(url).toContain(`${BASE}/api/search?`);
+    expect(url).toContain("q=hello+world");
+    expect(url).toContain("scope=shared");
+    expect(url).toContain("limit=50");
+  });
+
+  it("clipUrl POSTs /api/mcp/clip with the URL", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, { page_id: "p9", title: "X" }));
+    const r = await client.clipUrl("https://example.com/a");
+    expect(r.page_id).toBe("p9");
+    expect(callArgs(fetchMock as unknown as Mock)[0]).toBe(`${BASE}/api/mcp/clip`);
+    expect((callArgs(fetchMock as unknown as Mock)[1] as RequestInit).body).toBe(
+      JSON.stringify({ url: "https://example.com/a" }),
+    );
+  });
+});
+
+describe("HttpZediClient error normalization", () => {
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+  let client: HttpZediClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn<typeof fetch>();
+    client = new HttpZediClient({ baseUrl: BASE, token: TOKEN, fetch: fetchMock });
+  });
+
+  it("throws ZediApiError with JSON message for 4xx", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(404, { message: "Page not found" }));
+    await expect(client.getPageContent("missing")).rejects.toMatchObject({
+      name: "ZediApiError",
+      status: 404,
+      message: "Page not found",
+    });
+  });
+
+  it("throws ZediApiError with text body for non-JSON 5xx", async () => {
+    fetchMock.mockResolvedValueOnce(makeTextResponse(500, "boom"));
+    await expect(client.getCurrentUser()).rejects.toMatchObject({
+      name: "ZediApiError",
+      status: 500,
+    });
+  });
+
+  it("throws ZediApiError(status=0) for fetch network failure", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    let error: unknown;
+    try {
+      await client.getCurrentUser();
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(ZediApiError);
+    expect((error as ZediApiError).status).toBe(0);
+    expect((error as ZediApiError).message).toMatch(/ECONNREFUSED|network/i);
+  });
+
+  it("normalizes baseUrl trailing slash", async () => {
+    const localFetch = vi.fn<typeof fetch>();
+    const c = new HttpZediClient({
+      baseUrl: `${BASE}/`,
+      token: TOKEN,
+      fetch: localFetch,
+    });
+    localFetch.mockResolvedValueOnce(
+      makeJsonResponse(200, { id: "u1", email: null, name: null, image: null }),
+    );
+    await c.getCurrentUser();
+    expect(callArgs(localFetch as unknown as Mock)[0]).toBe(`${BASE}/api/users/me`);
+  });
+});

--- a/server/mcp/src/__tests__/config.test.ts
+++ b/server/mcp/src/__tests__/config.test.ts
@@ -1,0 +1,75 @@
+/**
+ * config.ts のテスト
+ *
+ * - プラットフォームごとのパス解決
+ * - JSON 読み込み, 不在/不正の処理
+ *
+ * Tests for config path resolution and JSON loader.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadMcpClientConfig, resolveMcpClientConfigPath } from "../config.js";
+
+describe("resolveMcpClientConfigPath", () => {
+  it("returns APPDATA path on win32 when APPDATA is set", () => {
+    if (process.platform !== "win32") return;
+    const path = resolveMcpClientConfigPath({ APPDATA: "C:/AppData" });
+    expect(path).toContain("AppData");
+    expect(path.endsWith("zedi\\mcp.json") || path.endsWith("zedi/mcp.json")).toBe(true);
+  });
+
+  it("uses XDG_CONFIG_HOME on non-win32 when set", () => {
+    if (process.platform === "win32") return;
+    const path = resolveMcpClientConfigPath({ XDG_CONFIG_HOME: "/tmp/cfg" });
+    expect(path).toBe("/tmp/cfg/zedi/mcp.json");
+  });
+
+  it("falls back to ~/.config on non-win32 when XDG is unset", () => {
+    if (process.platform === "win32") return;
+    const path = resolveMcpClientConfigPath({});
+    expect(path).toContain(".config/zedi/mcp.json");
+  });
+});
+
+describe("loadMcpClientConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "zedi-mcp-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null when file does not exist", () => {
+    expect(loadMcpClientConfig(join(tmpDir, "missing.json"))).toBeNull();
+  });
+
+  it("returns null when file has invalid JSON", () => {
+    const file = join(tmpDir, "bad.json");
+    writeFileSync(file, "{not-json", "utf-8");
+    expect(loadMcpClientConfig(file)).toBeNull();
+  });
+
+  it("returns null when required fields are missing", () => {
+    const file = join(tmpDir, "partial.json");
+    writeFileSync(file, JSON.stringify({ apiUrl: "https://x" }), "utf-8");
+    expect(loadMcpClientConfig(file)).toBeNull();
+  });
+
+  it("returns parsed config on success", () => {
+    const dir = join(tmpDir, "zedi");
+    mkdirSync(dir);
+    const file = join(dir, "mcp.json");
+    writeFileSync(
+      file,
+      JSON.stringify({ apiUrl: "https://api.example.com", token: "tkn" }),
+      "utf-8",
+    );
+    const result = loadMcpClientConfig(file);
+    expect(result).toEqual({ apiUrl: "https://api.example.com", token: "tkn" });
+  });
+});

--- a/server/mcp/src/__tests__/http.test.ts
+++ b/server/mcp/src/__tests__/http.test.ts
@@ -1,0 +1,44 @@
+/**
+ * http.ts のテスト
+ *
+ * - /health は 200 + ok
+ * - /mcp に Authorization なしで POST すると 401
+ *
+ * Tests for the HTTP transport entry point — health and unauthorized handling.
+ * Full MCP-over-HTTP smoke test is intentionally deferred to manual verification
+ * to keep the test suite hermetic.
+ */
+import { describe, it, expect } from "vitest";
+import { createHttpApp } from "../http.js";
+
+describe("createHttpApp", () => {
+  it("GET /health returns ok", async () => {
+    const app = createHttpApp("https://api.example.com");
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; server: string; apiUrl: string };
+    expect(body.ok).toBe(true);
+    expect(body.server).toBe("zedi-mcp");
+    expect(body.apiUrl).toBe("https://api.example.com");
+  });
+
+  it("POST /mcp without Authorization returns 401", async () => {
+    const app = createHttpApp("https://api.example.com");
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /mcp with malformed Bearer returns 401", async () => {
+    const app = createHttpApp("https://api.example.com");
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: "Basic xyz" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/mcp/src/__tests__/server.test.ts
+++ b/server/mcp/src/__tests__/server.test.ts
@@ -1,0 +1,162 @@
+/**
+ * createMcpServer のエンドツーエンド近似テスト
+ *
+ * - InMemoryTransport で MCP クライアント ⇄ サーバを直結し、
+ *   listTools / callTool が想定通り動くことを確認する
+ * - ZediClient はモックして、tools が正しい引数で呼び出されるかも検証する
+ *
+ * Near end-to-end tests for createMcpServer using the in-memory transport.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMcpServer } from "../server.js";
+import { ALL_TOOL_NAMES } from "../tools/index.js";
+import type { ZediClient } from "../client/ZediClient.js";
+import { ZediApiError } from "../client/errors.js";
+
+/** Build a fully-mocked ZediClient where every method is a vi.fn(). / 全メソッドをモック化した ZediClient を生成する */
+function createMockClient(): ZediClient {
+  return {
+    getCurrentUser: vi.fn(),
+    getPageContent: vi.fn(),
+    createPage: vi.fn(),
+    updatePageContent: vi.fn(),
+    deletePage: vi.fn(),
+    listNotes: vi.fn(),
+    getNote: vi.fn(),
+    createNote: vi.fn(),
+    updateNote: vi.fn(),
+    deleteNote: vi.fn(),
+    addPageToNote: vi.fn(),
+    removePageFromNote: vi.fn(),
+    reorderNotePages: vi.fn(),
+    listNotePages: vi.fn(),
+    listNoteMembers: vi.fn(),
+    addNoteMember: vi.fn(),
+    updateNoteMember: vi.fn(),
+    removeNoteMember: vi.fn(),
+    search: vi.fn(),
+    clipUrl: vi.fn(),
+  };
+}
+
+async function connectClientToServer(client: ZediClient): Promise<Client> {
+  const server = createMcpServer(client);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const mcpClient = new Client({ name: "test-client", version: "0.0.0" }, { capabilities: {} });
+  await mcpClient.connect(clientTransport);
+  return mcpClient;
+}
+
+describe("createMcpServer", () => {
+  let mockClient: ZediClient;
+  let mcpClient: Client;
+
+  beforeEach(async () => {
+    mockClient = createMockClient();
+    mcpClient = await connectClientToServer(mockClient);
+  });
+
+  it("registers every tool listed in ALL_TOOL_NAMES", async () => {
+    const list = await mcpClient.listTools();
+    const names = list.tools.map((t) => t.name).sort();
+    expect(names).toEqual([...ALL_TOOL_NAMES].sort());
+  });
+
+  it("zedi_get_current_user calls client.getCurrentUser and returns JSON content", async () => {
+    vi.mocked(mockClient.getCurrentUser).mockResolvedValue({
+      id: "user-1",
+      email: "a@b.c",
+      name: "Alice",
+      image: null,
+    });
+    const result = await mcpClient.callTool({ name: "zedi_get_current_user", arguments: {} });
+    expect(mockClient.getCurrentUser).toHaveBeenCalledOnce();
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0]?.type).toBe("text");
+    const parsed = JSON.parse(content[0]?.text ?? "");
+    expect(parsed.id).toBe("user-1");
+  });
+
+  it("zedi_create_page forwards arguments to client.createPage", async () => {
+    vi.mocked(mockClient.createPage).mockResolvedValue({
+      id: "page-1",
+      owner_id: "user-1",
+      title: "Hello",
+      content_preview: null,
+      thumbnail_url: null,
+      source_url: null,
+      source_page_id: null,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      is_deleted: false,
+    });
+    const result = await mcpClient.callTool({
+      name: "zedi_create_page",
+      arguments: { title: "Hello" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockClient.createPage).toHaveBeenCalledWith({ title: "Hello" });
+  });
+
+  it("zedi_search forwards query, scope, and limit", async () => {
+    vi.mocked(mockClient.search).mockResolvedValue([
+      { id: "p1", title: "match", content_preview: null, updated_at: "2026-01-01T00:00:00Z" },
+    ]);
+    const result = await mcpClient.callTool({
+      name: "zedi_search",
+      arguments: { query: "hello", scope: "shared", limit: 10 },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockClient.search).toHaveBeenCalledWith("hello", "shared", 10);
+  });
+
+  it("zedi_update_page_content includes expected_version", async () => {
+    vi.mocked(mockClient.updatePageContent).mockResolvedValue({ version: 5 });
+    const result = await mcpClient.callTool({
+      name: "zedi_update_page_content",
+      arguments: {
+        page_id: "p1",
+        ydoc_state: "BASE64",
+        expected_version: 4,
+        content_text: "x",
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockClient.updatePageContent).toHaveBeenCalledWith("p1", {
+      ydoc_state: "BASE64",
+      expected_version: 4,
+      content_text: "x",
+    });
+  });
+
+  it("converts ZediApiError into an isError result", async () => {
+    vi.mocked(mockClient.getCurrentUser).mockRejectedValue(new ZediApiError(404, "user not found"));
+    const result = await mcpClient.callTool({ name: "zedi_get_current_user", arguments: {} });
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ text?: string }>;
+    expect(content[0]?.text).toContain("HTTP 404");
+    expect(content[0]?.text).toContain("user not found");
+  });
+
+  it("network errors (status=0) become an isError result with 'network' label", async () => {
+    vi.mocked(mockClient.getCurrentUser).mockRejectedValue(new ZediApiError(0, "ECONNREFUSED"));
+    const result = await mcpClient.callTool({ name: "zedi_get_current_user", arguments: {} });
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ text?: string }>;
+    expect(content[0]?.text).toContain("network");
+  });
+
+  it("zedi_clip_url forwards URL to client.clipUrl", async () => {
+    vi.mocked(mockClient.clipUrl).mockResolvedValue({ page_id: "p9", title: "X" });
+    const result = await mcpClient.callTool({
+      name: "zedi_clip_url",
+      arguments: { url: "https://example.com/a" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockClient.clipUrl).toHaveBeenCalledWith("https://example.com/a");
+  });
+});

--- a/server/mcp/src/cli/login.ts
+++ b/server/mcp/src/cli/login.ts
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Zedi MCP CLI — PKCE ログインコマンド
+ *
+ * 使い方:
+ *   bunx \@zedi/mcp-server login \[--api-url https://api.example.com\]
+ *   bunx \@zedi/mcp-server whoami
+ *
+ * login の流れ:
+ *   1. ランダム code_verifier を生成し SHA256 で code_challenge を計算
+ *   2. ローカル HTTP サーバを起動して `code` の受け取りを待つ
+ *   3. ブラウザで `<api>/mcp/authorize` を開く
+ *   4. ユーザーが Web 側で承認 → ローカルコールバックに `?code=...` でリダイレクト
+ *   5. `POST /api/mcp/session` で code + verifier を JWT に交換
+ *   6. JWT を `~/.config/zedi/mcp.json` (Windows: `%APPDATA%\zedi\mcp.json`) に保存
+ *
+ * PKCE login CLI for the Zedi MCP server. Persists the issued JWT to disk.
+ */
+import { createServer } from "node:http";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { createHash, randomBytes } from "node:crypto";
+import open from "open";
+import { HttpZediClient } from "../client/httpClient.js";
+import {
+  loadMcpClientConfig,
+  resolveMcpClientConfigPath,
+  type McpClientConfig,
+} from "../config.js";
+
+const DEFAULT_API_URL = "https://api.zedi.app";
+
+interface LoginOptions {
+  apiUrl: string;
+}
+
+/**
+ * argv[2] 以降をパースし、コマンド名とオプションを返す。
+ * Parses argv[2..] into a command and options.
+ */
+function parseArgs(argv: string[]): { command: string; options: LoginOptions } {
+  const command = argv[2] ?? "login";
+  let apiUrl = process.env.ZEDI_API_URL ?? DEFAULT_API_URL;
+  for (let i = 3; i < argv.length; i++) {
+    const value = argv[i + 1];
+    if (argv[i] === "--api-url" && value !== undefined) {
+      apiUrl = value;
+      i++;
+    }
+  }
+  return { command, options: { apiUrl } };
+}
+
+function generateVerifier(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+function challengeFromVerifier(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+async function login(options: LoginOptions): Promise<void> {
+  const verifier = generateVerifier();
+  const challenge = challengeFromVerifier(verifier);
+  const state = randomBytes(16).toString("base64url");
+
+  // Start an ephemeral local HTTP server, learn its port via the listen callback,
+  // build the authorize URL with that redirect_uri, then open the browser.
+  // ローカルサーバを起動 → listen コールバックでポート確定 → ブラウザを開いて承認を待つ。
+  const { code, redirectUri } = await new Promise<{ code: string; redirectUri: string }>(
+    (resolve, reject) => {
+      const server = createServer((req, res) => {
+        const url = new URL(req.url ?? "/", "http://127.0.0.1");
+        if (url.pathname !== "/callback") {
+          res.statusCode = 404;
+          res.end("not found");
+          return;
+        }
+        const c = url.searchParams.get("code");
+        const s = url.searchParams.get("state");
+        if (!c || s !== state) {
+          res.statusCode = 400;
+          res.end("invalid callback");
+          return;
+        }
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "text/html; charset=utf-8");
+        res.end(
+          "<html><body><h2>Zedi MCP authorized</h2><p>You can close this window.</p></body></html>",
+        );
+        const addr = server.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+        server.close();
+        resolve({ code: c, redirectUri: `http://127.0.0.1:${port}/callback` });
+      });
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+        const redirectUri = `http://127.0.0.1:${port}/callback`;
+        const authorizeUrl = new URL("/mcp/authorize", options.apiUrl);
+        authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+        authorizeUrl.searchParams.set("code_challenge", challenge);
+        authorizeUrl.searchParams.set("state", state);
+        authorizeUrl.searchParams.set("scopes", "mcp:read,mcp:write");
+        console.log(`Opening browser:\n  ${authorizeUrl.toString()}`);
+        open(authorizeUrl.toString()).catch((err) => {
+          console.error(`Failed to open browser automatically: ${(err as Error).message}`);
+          console.error(`Please open the URL above manually.`);
+        });
+      });
+    },
+  );
+
+  // Exchange code → JWT
+  // code を JWT に交換する。
+  const sessionUrl = new URL("/api/mcp/session", options.apiUrl);
+  const tokenRes = await fetch(sessionUrl.toString(), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "authorization_code",
+      code,
+      code_verifier: verifier,
+      redirect_uri: redirectUri,
+    }),
+  });
+  if (!tokenRes.ok) {
+    const text = await tokenRes.text();
+    throw new Error(`Token exchange failed (${tokenRes.status}): ${text}`);
+  }
+  const tokenBody = (await tokenRes.json()) as { access_token?: string };
+  if (!tokenBody.access_token) {
+    throw new Error("Token exchange returned no access_token");
+  }
+
+  const cfg: McpClientConfig = { apiUrl: options.apiUrl, token: tokenBody.access_token };
+  const cfgPath = resolveMcpClientConfigPath();
+  mkdirSync(dirname(cfgPath), { recursive: true });
+  writeFileSync(cfgPath, JSON.stringify(cfg, null, 2) + "\n", { encoding: "utf-8", mode: 0o600 });
+  console.log(`Saved Zedi MCP credentials to ${cfgPath}`);
+  console.log("You can now register the stdio server with Claude Code.");
+}
+
+async function whoami(options: LoginOptions): Promise<void> {
+  const cfg = loadMcpClientConfig();
+  const apiUrl = cfg?.apiUrl ?? options.apiUrl;
+  const token = cfg?.token;
+  if (!token) {
+    console.error("Not logged in. Run `zedi-mcp-cli login` first.");
+    process.exit(1);
+  }
+  const client = new HttpZediClient({ baseUrl: apiUrl, token });
+  const user = await client.getCurrentUser();
+  console.log(JSON.stringify(user, null, 2));
+}
+
+async function main() {
+  const { command, options } = parseArgs(process.argv);
+  switch (command) {
+    case "login":
+      await login(options);
+      break;
+    case "whoami":
+      await whoami(options);
+      break;
+    default:
+      console.error(`Unknown command: ${command}. Available: login, whoami`);
+      process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("[zedi-mcp-cli] fatal:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/server/mcp/src/client/ZediClient.ts
+++ b/server/mcp/src/client/ZediClient.ts
@@ -1,0 +1,214 @@
+/**
+ * ZediClient — MCP ツールが Zedi REST API を呼ぶための抽象インターフェース
+ *
+ * - すべてのメソッドは server/api の HTTP エンドポイントに対応する
+ * - 戻り値は API レスポンス JSON をそのまま (型のみ宣言)
+ * - エラー時は `ZediApiError` を throw する (実装側責務)
+ *
+ * Abstract client interface used by MCP tools. Mocked in unit tests; HttpZediClient implements it.
+ */
+
+// ── User ────────────────────────────────────────────────────────────────────
+
+/** 現在認証中のユーザー情報。Current authenticated user. */
+export interface CurrentUser {
+  id: string;
+  email: string | null;
+  name: string | null;
+  image: string | null;
+}
+
+// ── Pages ───────────────────────────────────────────────────────────────────
+
+/** ページ作成の入力 / Input for creating a new page. */
+export interface CreatePageInput {
+  title?: string;
+  content_preview?: string;
+  source_page_id?: string;
+  source_url?: string;
+  thumbnail_url?: string | null;
+}
+
+/** ページ作成・取得の戻り値 / Page metadata returned by create/get. */
+export interface PageRow {
+  id: string;
+  owner_id: string;
+  title: string | null;
+  content_preview: string | null;
+  thumbnail_url: string | null;
+  source_url: string | null;
+  source_page_id: string | null;
+  created_at: string;
+  updated_at: string;
+  is_deleted: boolean;
+}
+
+/** ページ本文 (Y.Doc) / Page Y.Doc content. */
+export interface PageContent {
+  ydoc_state: string;
+  version: number;
+  content_text?: string | null;
+  updated_at?: string;
+}
+
+/** ページ本文更新の入力 / Input for updating page content. */
+export interface UpdatePageContentInput {
+  ydoc_state: string;
+  expected_version: number;
+  content_text?: string;
+  content_preview?: string;
+  title?: string;
+}
+
+// ── Notes ───────────────────────────────────────────────────────────────────
+
+/** ノートの可視性 / Note visibility. */
+export type NoteVisibility = "private" | "public" | "unlisted" | "restricted";
+
+/** ノートの編集権限 / Note edit permission. */
+export type NoteEditPermission = "owner_only" | "members_editors" | "any_logged_in";
+
+/** ノート作成入力 / Input for creating a note. */
+export interface CreateNoteInput {
+  title?: string;
+  visibility?: NoteVisibility;
+  edit_permission?: NoteEditPermission;
+  is_official?: boolean;
+}
+
+/** ノート更新入力 / Input for updating a note. */
+export interface UpdateNoteInput {
+  title?: string;
+  visibility?: NoteVisibility;
+  edit_permission?: NoteEditPermission;
+  is_official?: boolean;
+}
+
+/** ノート行 / Note row returned by API. */
+export interface NoteRow {
+  id: string;
+  owner_id: string;
+  title: string | null;
+  visibility: NoteVisibility;
+  edit_permission: NoteEditPermission;
+  is_official: boolean;
+  view_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/** ノート一覧アイテム (役割と件数つき) / Note list item with role and counts. */
+export interface NoteListItem extends NoteRow {
+  role: "owner" | "editor" | "viewer";
+  page_count: number;
+  member_count: number;
+}
+
+// ── Note pages ──────────────────────────────────────────────────────────────
+
+/** ノート内のページ追加入力 / Input for adding a page to a note. */
+export interface AddPageToNoteInput {
+  page_id?: string;
+  title?: string;
+  source_url?: string;
+}
+
+// ── Note members ────────────────────────────────────────────────────────────
+
+/** ノートメンバー役割 / Note member role. */
+export type NoteMemberRole = "viewer" | "editor";
+
+/** メンバー追加入力 / Input for adding a member. */
+export interface AddNoteMemberInput {
+  email: string;
+  role: NoteMemberRole;
+}
+
+// ── Search ──────────────────────────────────────────────────────────────────
+
+/** 検索結果アイテム / Search result row. */
+export interface SearchResultItem {
+  id: string;
+  title: string | null;
+  content_preview: string | null;
+  updated_at: string;
+  content_text?: string | null;
+}
+
+// ── Clip ────────────────────────────────────────────────────────────────────
+
+/** Clip 結果 / Clip result. */
+export interface ClipResult {
+  page_id: string;
+  title: string;
+  thumbnail_url?: string;
+}
+
+// ── Client interface ────────────────────────────────────────────────────────
+
+/**
+ * Zedi REST API クライアント抽象。
+ * MCP ツールはこのインターフェースにのみ依存し、テストではモック化する。
+ *
+ * Abstract client used by MCP tools; mocked in tests, implemented by HttpZediClient at runtime.
+ */
+export interface ZediClient {
+  /** 現在のユーザー情報を取得する。Get current user. */
+  getCurrentUser(): Promise<CurrentUser>;
+
+  // Pages
+  /** ページ本文 (Y.Doc) を取得する。Get page Y.Doc content. */
+  getPageContent(pageId: string): Promise<PageContent>;
+  /** 新規ページを作成する。Create a new page. */
+  createPage(input: CreatePageInput): Promise<PageRow>;
+  /** ページ本文を更新する (楽観的ロック)。Update page content with optimistic lock. */
+  updatePageContent(pageId: string, input: UpdatePageContentInput): Promise<{ version: number }>;
+  /** ページを論理削除する。Soft-delete a page. */
+  deletePage(pageId: string): Promise<{ id: string; deleted: boolean }>;
+
+  // Notes
+  /** ノート一覧を取得する (own + shared)。List notes. */
+  listNotes(): Promise<NoteListItem[]>;
+  /** ノート詳細を取得する。Get note detail. */
+  getNote(noteId: string): Promise<unknown>;
+  /** ノートを作成する。Create note. */
+  createNote(input: CreateNoteInput): Promise<NoteRow>;
+  /** ノートを更新する。Update note. */
+  updateNote(noteId: string, input: UpdateNoteInput): Promise<NoteRow>;
+  /** ノートを論理削除する。Soft-delete note. */
+  deleteNote(noteId: string): Promise<{ deleted: boolean }>;
+
+  // Note pages
+  /** ノートにページを追加する。Add a page to note. */
+  addPageToNote(noteId: string, input: AddPageToNoteInput): Promise<unknown>;
+  /** ノートからページを取り除く。Remove page from note. */
+  removePageFromNote(noteId: string, pageId: string): Promise<unknown>;
+  /** ノート内のページ順を並び替える。Reorder pages in a note. */
+  reorderNotePages(noteId: string, pageIds: string[]): Promise<unknown>;
+  /** ノート内のページ一覧。List note pages. */
+  listNotePages(noteId: string): Promise<unknown>;
+
+  // Note members
+  /** ノートのメンバー一覧。List note members. */
+  listNoteMembers(noteId: string): Promise<unknown>;
+  /** ノートにメンバーを追加する。Add note member. */
+  addNoteMember(noteId: string, input: AddNoteMemberInput): Promise<unknown>;
+  /** ノートメンバーの役割を更新する。Update note member role. */
+  updateNoteMember(noteId: string, email: string, role: NoteMemberRole): Promise<unknown>;
+  /** ノートからメンバーを取り除く。Remove note member. */
+  removeNoteMember(noteId: string, email: string): Promise<unknown>;
+
+  // Search
+  /**
+   * 全文検索を行う。
+   * @param query - 検索文字列。
+   * @param scope - "own" (自分のページ) または "shared" (共有を含む)。
+   * @param limit - 上限件数。
+   * Full-text search across own/shared pages.
+   */
+  search(query: string, scope?: "own" | "shared", limit?: number): Promise<SearchResultItem[]>;
+
+  // Clip
+  /** URL をクリップしてページを生成する。Clip a URL into a new page. */
+  clipUrl(url: string): Promise<ClipResult>;
+}

--- a/server/mcp/src/client/errors.ts
+++ b/server/mcp/src/client/errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Zedi REST API 呼び出しの正規化エラー
+ *
+ * すべての HTTP 4xx/5xx 応答および fetch 自体の失敗 (ネットワークエラー) を
+ * `ZediApiError` にまとめる。MCP ツール側はこれを `isError: true` の応答に変換する。
+ *
+ * Normalized error class for Zedi REST API calls; MCP tools convert this to error responses.
+ */
+export class ZediApiError extends Error {
+  /**
+   * 新しい ZediApiError を生成する。Constructs a new ZediApiError.
+   *
+   * @param status - HTTP ステータスコード (ネットワーク失敗時は 0)。
+   * @param message - サーバーからのメッセージ、もしくは fetch 失敗の説明。
+   * @param body - サーバー応答本文 (パース可能なら JSON、不可なら文字列)。デバッグ用途。
+   */
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly body?: unknown,
+  ) {
+    super(message);
+    this.name = "ZediApiError";
+  }
+}

--- a/server/mcp/src/client/httpClient.ts
+++ b/server/mcp/src/client/httpClient.ts
@@ -1,0 +1,260 @@
+/**
+ * HttpZediClient — Zedi REST API への fetch ベースクライアント実装
+ *
+ * - すべてのリクエストに `Authorization: Bearer <token>` を付与する
+ * - 4xx / 5xx 応答は `ZediApiError` に正規化する
+ * - ネットワーク失敗 (fetch reject) は `ZediApiError(status=0)` に正規化する
+ * - テスト可能性のため `fetch` 実装を DI できる
+ *
+ * fetch-based implementation of `ZediClient` for the Zedi REST API.
+ */
+import { ZediApiError } from "./errors.js";
+import type {
+  ZediClient,
+  CurrentUser,
+  CreatePageInput,
+  PageRow,
+  PageContent,
+  UpdatePageContentInput,
+  CreateNoteInput,
+  UpdateNoteInput,
+  NoteRow,
+  NoteListItem,
+  AddPageToNoteInput,
+  AddNoteMemberInput,
+  NoteMemberRole,
+  SearchResultItem,
+  ClipResult,
+} from "./ZediClient.js";
+
+/** HttpZediClient のコンストラクタオプション / Options for HttpZediClient. */
+export interface HttpZediClientOptions {
+  /** Zedi API の baseUrl。末尾スラッシュは正規化される。 */
+  baseUrl: string;
+  /** MCP JWT。`Authorization: Bearer ...` に付与される。 */
+  token: string;
+  /** テスト用 fetch 注入。省略時は globalThis.fetch を使用。 */
+  fetch?: typeof fetch;
+}
+
+/** HttpZediClient 本体 / Main HttpZediClient class. */
+export class HttpZediClient implements ZediClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly fetchImpl: typeof fetch;
+
+  /**
+   * 新しい HttpZediClient を生成する。Constructs a new HttpZediClient.
+   *
+   * @param opts - baseUrl, token, optional fetch を含むオプション。
+   */
+  constructor(opts: HttpZediClientOptions) {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    this.token = opts.token;
+    this.fetchImpl = opts.fetch ?? globalThis.fetch;
+  }
+
+  // ── core request helper ──────────────────────────────────────────────────
+
+  /**
+   * 共通の HTTP リクエスト処理。エラーは ZediApiError に正規化する。
+   * Internal request helper that normalizes errors into ZediApiError.
+   */
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    query?: Record<string, string | number | undefined>,
+  ): Promise<T> {
+    let url = `${this.baseUrl}${path}`;
+    if (query) {
+      const params = new URLSearchParams();
+      for (const [k, v] of Object.entries(query)) {
+        if (v !== undefined && v !== null) params.set(k, String(v));
+      }
+      const qs = params.toString();
+      if (qs) url += `?${qs}`;
+    }
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.token}`,
+      Accept: "application/json",
+    };
+    const init: RequestInit = { method, headers };
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+      init.body = JSON.stringify(body);
+    }
+
+    let res: Response;
+    try {
+      res = await this.fetchImpl(url, init);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "network error";
+      throw new ZediApiError(0, message);
+    }
+
+    const text = await res.text();
+    let parsed: unknown = undefined;
+    if (text) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        parsed = text;
+      }
+    }
+
+    if (!res.ok) {
+      const message =
+        (parsed && typeof parsed === "object" && "message" in parsed
+          ? String((parsed as { message: unknown }).message)
+          : null) ?? (typeof parsed === "string" ? parsed : `HTTP ${res.status}`);
+      throw new ZediApiError(res.status, message, parsed);
+    }
+
+    return parsed as T;
+  }
+
+  // ── User ─────────────────────────────────────────────────────────────────
+
+  /** {@inheritDoc ZediClient.getCurrentUser} */
+  getCurrentUser(): Promise<CurrentUser> {
+    return this.request<CurrentUser>("GET", "/api/users/me");
+  }
+
+  // ── Pages ────────────────────────────────────────────────────────────────
+
+  /** {@inheritDoc ZediClient.getPageContent} */
+  getPageContent(pageId: string): Promise<PageContent> {
+    return this.request<PageContent>("GET", `/api/pages/${encodeURIComponent(pageId)}/content`);
+  }
+
+  /** {@inheritDoc ZediClient.createPage} */
+  createPage(input: CreatePageInput): Promise<PageRow> {
+    return this.request<PageRow>("POST", "/api/pages", input);
+  }
+
+  /** {@inheritDoc ZediClient.updatePageContent} */
+  updatePageContent(pageId: string, input: UpdatePageContentInput): Promise<{ version: number }> {
+    return this.request<{ version: number }>(
+      "PUT",
+      `/api/pages/${encodeURIComponent(pageId)}/content`,
+      input,
+    );
+  }
+
+  /** {@inheritDoc ZediClient.deletePage} */
+  deletePage(pageId: string): Promise<{ id: string; deleted: boolean }> {
+    return this.request<{ id: string; deleted: boolean }>(
+      "DELETE",
+      `/api/pages/${encodeURIComponent(pageId)}`,
+    );
+  }
+
+  // ── Notes ────────────────────────────────────────────────────────────────
+
+  /** {@inheritDoc ZediClient.listNotes} */
+  listNotes(): Promise<NoteListItem[]> {
+    return this.request<NoteListItem[]>("GET", "/api/notes");
+  }
+
+  /** {@inheritDoc ZediClient.getNote} */
+  getNote(noteId: string): Promise<unknown> {
+    return this.request("GET", `/api/notes/${encodeURIComponent(noteId)}`);
+  }
+
+  /** {@inheritDoc ZediClient.createNote} */
+  createNote(input: CreateNoteInput): Promise<NoteRow> {
+    return this.request<NoteRow>("POST", "/api/notes", input);
+  }
+
+  /** {@inheritDoc ZediClient.updateNote} */
+  updateNote(noteId: string, input: UpdateNoteInput): Promise<NoteRow> {
+    return this.request<NoteRow>("PUT", `/api/notes/${encodeURIComponent(noteId)}`, input);
+  }
+
+  /** {@inheritDoc ZediClient.deleteNote} */
+  deleteNote(noteId: string): Promise<{ deleted: boolean }> {
+    return this.request<{ deleted: boolean }>("DELETE", `/api/notes/${encodeURIComponent(noteId)}`);
+  }
+
+  // ── Note pages ───────────────────────────────────────────────────────────
+
+  /** {@inheritDoc ZediClient.addPageToNote} */
+  addPageToNote(noteId: string, input: AddPageToNoteInput): Promise<unknown> {
+    return this.request("POST", `/api/notes/${encodeURIComponent(noteId)}/pages`, input);
+  }
+
+  /** {@inheritDoc ZediClient.removePageFromNote} */
+  removePageFromNote(noteId: string, pageId: string): Promise<unknown> {
+    return this.request(
+      "DELETE",
+      `/api/notes/${encodeURIComponent(noteId)}/pages/${encodeURIComponent(pageId)}`,
+    );
+  }
+
+  /** {@inheritDoc ZediClient.reorderNotePages} */
+  reorderNotePages(noteId: string, pageIds: string[]): Promise<unknown> {
+    return this.request("PUT", `/api/notes/${encodeURIComponent(noteId)}/pages`, {
+      page_ids: pageIds,
+    });
+  }
+
+  /** {@inheritDoc ZediClient.listNotePages} */
+  listNotePages(noteId: string): Promise<unknown> {
+    return this.request("GET", `/api/notes/${encodeURIComponent(noteId)}/pages`);
+  }
+
+  // ── Note members ─────────────────────────────────────────────────────────
+
+  /** {@inheritDoc ZediClient.listNoteMembers} */
+  listNoteMembers(noteId: string): Promise<unknown> {
+    return this.request("GET", `/api/notes/${encodeURIComponent(noteId)}/members`);
+  }
+
+  /** {@inheritDoc ZediClient.addNoteMember} */
+  addNoteMember(noteId: string, input: AddNoteMemberInput): Promise<unknown> {
+    return this.request("POST", `/api/notes/${encodeURIComponent(noteId)}/members`, input);
+  }
+
+  /** {@inheritDoc ZediClient.updateNoteMember} */
+  updateNoteMember(noteId: string, email: string, role: NoteMemberRole): Promise<unknown> {
+    return this.request(
+      "PUT",
+      `/api/notes/${encodeURIComponent(noteId)}/members/${encodeURIComponent(email)}`,
+      { role },
+    );
+  }
+
+  /** {@inheritDoc ZediClient.removeNoteMember} */
+  removeNoteMember(noteId: string, email: string): Promise<unknown> {
+    return this.request(
+      "DELETE",
+      `/api/notes/${encodeURIComponent(noteId)}/members/${encodeURIComponent(email)}`,
+    );
+  }
+
+  // ── Search ───────────────────────────────────────────────────────────────
+
+  /** {@inheritDoc ZediClient.search} */
+  async search(
+    query: string,
+    scope: "own" | "shared" = "own",
+    limit = 20,
+  ): Promise<SearchResultItem[]> {
+    const result = await this.request<{ results: SearchResultItem[] }>(
+      "GET",
+      "/api/search",
+      undefined,
+      { q: query, scope, limit },
+    );
+    return result.results ?? [];
+  }
+
+  // ── Clip ─────────────────────────────────────────────────────────────────
+
+  /** {@inheritDoc ZediClient.clipUrl} */
+  clipUrl(url: string): Promise<ClipResult> {
+    return this.request<ClipResult>("POST", "/api/mcp/clip", { url });
+  }
+}

--- a/server/mcp/src/config.ts
+++ b/server/mcp/src/config.ts
@@ -1,0 +1,54 @@
+/**
+ * MCP クライアント設定ファイルの読み込み
+ *
+ * stdio エントリポイントは環境変数 (`ZEDI_API_URL`, `ZEDI_MCP_TOKEN`) を最優先で参照し、
+ * 未設定の場合はユーザーホームの設定ファイルを読み込む。
+ *
+ * - macOS / Linux: `$XDG_CONFIG_HOME/zedi/mcp.json` または `~/.config/zedi/mcp.json`
+ * - Windows: `%APPDATA%\zedi\mcp.json`
+ *
+ * MCP client config file resolver — loads `apiUrl` / `token` from disk when env vars are unset.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+/** 設定ファイルの形 / Shape of the persisted MCP client config. */
+export interface McpClientConfig {
+  apiUrl: string;
+  token: string;
+}
+
+/**
+ * プラットフォーム別の設定ファイルパスを解決する。
+ * Resolves the platform-specific MCP client config file path.
+ */
+export function resolveMcpClientConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  if (process.platform === "win32") {
+    const appData = env.APPDATA;
+    if (appData) return join(appData, "zedi", "mcp.json");
+    return join(homedir(), "AppData", "Roaming", "zedi", "mcp.json");
+  }
+  const xdg = env.XDG_CONFIG_HOME;
+  if (xdg) return join(xdg, "zedi", "mcp.json");
+  return join(homedir(), ".config", "zedi", "mcp.json");
+}
+
+/**
+ * 設定ファイルを読み込む。存在しない・パース失敗時は null を返す。
+ * Loads and parses the MCP client config file; returns null on missing file or parse error.
+ */
+export function loadMcpClientConfig(path?: string): McpClientConfig | null {
+  const target = path ?? resolveMcpClientConfigPath();
+  if (!existsSync(target)) return null;
+  try {
+    const raw = readFileSync(target, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<McpClientConfig>;
+    if (typeof parsed.apiUrl !== "string" || typeof parsed.token !== "string") {
+      return null;
+    }
+    return { apiUrl: parsed.apiUrl, token: parsed.token };
+  } catch {
+    return null;
+  }
+}

--- a/server/mcp/src/http.ts
+++ b/server/mcp/src/http.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Zedi MCP — HTTP / Streamable HTTP エントリーポイント
+ *
+ * Hono + `WebStandardStreamableHTTPServerTransport` を使い、外部 Claude Code クライアントから
+ * リモート接続を受け付ける。Railway などの単独サービスとしてデプロイする想定。
+ *
+ * 環境変数:
+ *   ZEDI_API_URL    バックエンド REST API の URL (例: http://api.railway.internal:3000)
+ *   PORT            待ち受けポート (default: 3100)
+ *   MCP_HOST        待ち受けホスト (default: 0.0.0.0)
+ *
+ * リクエストはセッションごとに以下の流れで処理する:
+ *   1. クライアントが `Authorization: Bearer <MCP JWT>` ヘッダ付きでアクセス
+ *   2. ヘッダから JWT を取り出し、新しい `HttpZediClient` を生成
+ *   3. リクエストごとに新しい `McpServer` を建て、トランスポートを通して応答する
+ *      (ステートレスモード — sessionIdGenerator: undefined)
+ *
+ * HTTP entry point for the Zedi MCP server using Streamable HTTP transport.
+ * Each request gets its own per-token client + server instance (stateless).
+ */
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { createMcpServer } from "./server.js";
+import { HttpZediClient } from "./client/httpClient.js";
+
+const DEFAULT_API_URL = "https://api.zedi.app";
+
+function extractBearer(authHeader: string | undefined): string | null {
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  const token = authHeader.slice(7).trim();
+  return token || null;
+}
+
+/**
+ * リクエストごとに `HttpZediClient` と `McpServer` を生成し、トランスポートで応答する。
+ * Per-request handler: builds an isolated MCP server bound to the caller's bearer token.
+ */
+async function handleMcpRequest(rawRequest: Request, apiUrl: string): Promise<Response> {
+  const token = extractBearer(rawRequest.headers.get("Authorization") ?? undefined);
+  if (!token) {
+    return new Response(
+      JSON.stringify({ error: "unauthorized", message: "Bearer token required" }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const client = new HttpZediClient({ baseUrl: apiUrl, token });
+  const server = createMcpServer(client);
+  // Stateless mode: each HTTP exchange creates its own ephemeral session.
+  // セッションは持たず、リクエストごとに新規生成する。
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
+  await server.connect(transport);
+
+  try {
+    return await transport.handleRequest(rawRequest);
+  } finally {
+    // Best-effort cleanup; the per-request server isn't reused.
+    // 使い捨てサーバーは後始末のみする。
+    await server.close().catch(() => {});
+  }
+}
+
+/**
+ * Hono アプリを生成する。テストから呼べるよう関数として export する。
+ * Builds the Hono app; exported for testing.
+ */
+export function createHttpApp(apiUrl: string): Hono {
+  const app = new Hono();
+
+  app.get("/health", (c) => c.json({ ok: true, server: "zedi-mcp", apiUrl }));
+
+  app.all("/mcp", async (c) => handleMcpRequest(c.req.raw, apiUrl));
+
+  return app;
+}
+
+async function main() {
+  const apiUrl = process.env.ZEDI_API_URL ?? DEFAULT_API_URL;
+  const port = parseInt(process.env.PORT ?? "3100", 10);
+  const host = process.env.MCP_HOST ?? "0.0.0.0";
+
+  const app = createHttpApp(apiUrl);
+
+  serve({ fetch: app.fetch, port, hostname: host }, (info) => {
+    // HTTP transport は stdout を使用しないため通常の console.log で問題ない。
+    console.log("========================================");
+    console.log("  Zedi MCP HTTP Server Started");
+    console.log("========================================");
+    console.log(`  Host:    ${host}`);
+    console.log(`  Port:    ${info.port}`);
+    console.log(`  API URL: ${apiUrl}`);
+    console.log(`  Health:  http://localhost:${info.port}/health`);
+    console.log(`  MCP:     http://localhost:${info.port}/mcp`);
+    console.log("========================================");
+  });
+}
+
+// Only run main when invoked as the entry point.
+// このファイルが直接実行された場合のみ main() を呼ぶ (テスト時は呼ばない)。
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith("http.js")) {
+  main().catch((err) => {
+    console.error("[zedi-mcp-http] fatal:", err);
+    process.exit(1);
+  });
+}

--- a/server/mcp/src/index.ts
+++ b/server/mcp/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * \@zedi/mcp-server — public exports
+ *
+ * 外部から `import { createMcpServer, HttpZediClient } from "@zedi/mcp-server"` で利用するための
+ * エントリーポイント。
+ *
+ * Library entry point for the Zedi MCP server.
+ */
+export { createMcpServer, ZEDI_MCP_SERVER_INFO } from "./server.js";
+export { ALL_TOOL_NAMES } from "./tools/index.js";
+export { HttpZediClient } from "./client/httpClient.js";
+export type { HttpZediClientOptions } from "./client/httpClient.js";
+export type { ZediClient } from "./client/ZediClient.js";
+export { ZediApiError } from "./client/errors.js";
+export { loadMcpClientConfig, resolveMcpClientConfigPath, type McpClientConfig } from "./config.js";

--- a/server/mcp/src/server.ts
+++ b/server/mcp/src/server.ts
@@ -1,0 +1,32 @@
+/**
+ * Zedi MCP サーバーファクトリ
+ *
+ * `createMcpServer(client)` で MCP の `McpServer` インスタンスを生成し、
+ * Zedi のすべてのツールを登録した状態で返す。トランスポート (stdio / HTTP) は
+ * 呼び出し側で `server.connect(transport)` する。
+ *
+ * Factory that builds a Zedi McpServer instance with all tools registered.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZediClient } from "./client/ZediClient.js";
+import { registerAllTools } from "./tools/index.js";
+
+/** Server metadata advertised to MCP clients. / クライアントに公開するサーバーメタ情報 */
+export const ZEDI_MCP_SERVER_INFO = {
+  name: "zedi-mcp-server",
+  version: "0.1.0",
+} as const;
+
+/**
+ * 渡された `ZediClient` に対して MCP サーバーを生成し、すべてのツールを登録して返す。
+ * Creates a Zedi MCP server bound to the given client and registers all tools.
+ */
+export function createMcpServer(client: ZediClient): McpServer {
+  const server = new McpServer(ZEDI_MCP_SERVER_INFO, {
+    capabilities: {
+      tools: {},
+    },
+  });
+  registerAllTools(server, client);
+  return server;
+}

--- a/server/mcp/src/stdio.ts
+++ b/server/mcp/src/stdio.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * Zedi MCP — stdio エントリーポイント
+ *
+ * 環境変数:
+ *   ZEDI_API_URL    Zedi REST API のベース URL (default: https://api.zedi.app)
+ *   ZEDI_MCP_TOKEN  MCP JWT (必須)
+ *
+ * 設定ファイル ($XDG_CONFIG_HOME/zedi/mcp.json or APPDATA env path) からも読み込める。
+ * 環境変数の方が優先される。
+ *
+ * Stdio entry point for the Zedi MCP server. Reads token + base URL from env or config file.
+ */
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createMcpServer } from "./server.js";
+import { HttpZediClient } from "./client/httpClient.js";
+import { loadMcpClientConfig } from "./config.js";
+
+const DEFAULT_API_URL = "https://api.zedi.app";
+
+async function main() {
+  const cfg = loadMcpClientConfig();
+  const apiUrl = process.env.ZEDI_API_URL ?? cfg?.apiUrl ?? DEFAULT_API_URL;
+  const token = process.env.ZEDI_MCP_TOKEN ?? cfg?.token;
+
+  if (!token) {
+    // stdio プロトコルを壊さないよう必ず stderr に出す。
+    // Errors must go to stderr so we don't corrupt the JSON-RPC stdout stream.
+    console.error(
+      "[zedi-mcp] No token configured. Set ZEDI_MCP_TOKEN env var or run 'zedi-mcp-cli login'.",
+    );
+    process.exit(1);
+  }
+
+  const client = new HttpZediClient({ baseUrl: apiUrl, token });
+  const server = createMcpServer(client);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`[zedi-mcp] stdio server connected (api=${apiUrl})`);
+}
+
+main().catch((err) => {
+  console.error("[zedi-mcp] fatal:", err);
+  process.exit(1);
+});

--- a/server/mcp/src/tools/helpers.ts
+++ b/server/mcp/src/tools/helpers.ts
@@ -1,0 +1,65 @@
+/**
+ * MCP ツール共通ヘルパ
+ *
+ * - `wrapToolHandler` で ZediApiError をキャッチして MCP の `isError: true` 応答に変換する
+ * - `textResult` / `jsonResult` で簡潔に CallToolResult を組み立てる
+ *
+ * Shared helpers for MCP tools — error wrapping and result formatting.
+ */
+import { ZediApiError } from "../client/errors.js";
+
+/** MCP ツールが返す content アイテム / Single content item in a tool result. */
+export interface TextContent {
+  type: "text";
+  text: string;
+}
+
+/**
+ * MCP ツールが返す結果 / Tool call result shape consumed by the SDK.
+ *
+ * Index signature is required to match the SDK's structural CallToolResult type.
+ * SDK の `CallToolResult` 型に合わせるためインデックスシグネチャを持つ。
+ */
+export interface ToolResult {
+  content: TextContent[];
+  isError?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * ハンドラを呼び出し、`ZediApiError` を MCP のエラー応答 (`isError: true`) に変換する。
+ * Wraps a tool handler so that ZediApiError is converted into an MCP error result.
+ */
+export async function wrapToolHandler<A>(
+  handler: (args: A) => Promise<ToolResult>,
+  args: A,
+): Promise<ToolResult> {
+  try {
+    return await handler(args);
+  } catch (err) {
+    if (err instanceof ZediApiError) {
+      const status = err.status === 0 ? "network" : `HTTP ${err.status}`;
+      return {
+        isError: true,
+        content: [{ type: "text", text: `Zedi API error (${status}): ${err.message}` }],
+      };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      isError: true,
+      content: [{ type: "text", text: `Unexpected error: ${message}` }],
+    };
+  }
+}
+
+/** プレーンテキスト応答を作る / Build a plain text tool result. */
+export function textResult(text: string): ToolResult {
+  return { content: [{ type: "text", text }] };
+}
+
+/** 任意の JSON シリアライズ可能な値を整形して返す / Build a JSON-formatted tool result. */
+export function jsonResult(data: unknown): ToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+  };
+}

--- a/server/mcp/src/tools/index.ts
+++ b/server/mcp/src/tools/index.ts
@@ -1,0 +1,380 @@
+/**
+ * MCP ツール登録
+ *
+ * `registerAllTools(server, client)` を呼ぶと、Zedi が公開するすべての MCP ツールが登録される。
+ * すべてのツールは `ZediClient` インターフェース経由で REST API を呼び出す。
+ *
+ * Registers all Zedi MCP tools on the given McpServer instance.
+ */
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { ZediClient } from "../client/ZediClient.js";
+import { wrapToolHandler, jsonResult } from "./helpers.js";
+
+const NoteVisibilityEnum = z.enum(["private", "public", "unlisted", "restricted"]);
+const NoteEditPermissionEnum = z.enum(["owner_only", "members_editors", "any_logged_in"]);
+const NoteMemberRoleEnum = z.enum(["viewer", "editor"]);
+const SearchScopeEnum = z.enum(["own", "shared"]);
+
+/**
+ * 全 MCP ツールを `server` に登録する。
+ * Registers every Zedi MCP tool on the given server.
+ */
+export function registerAllTools(server: McpServer, client: ZediClient): void {
+  // ── User ────────────────────────────────────────────────────────────────
+  server.registerTool(
+    "zedi_get_current_user",
+    {
+      title: "Get current Zedi user",
+      description: "Returns the currently authenticated user's profile (id, email, name).",
+      inputSchema: {},
+    },
+    async () =>
+      wrapToolHandler(async () => {
+        const user = await client.getCurrentUser();
+        return jsonResult(user);
+      }, {}),
+  );
+
+  // ── Pages ───────────────────────────────────────────────────────────────
+  server.registerTool(
+    "zedi_get_page",
+    {
+      title: "Get page content",
+      description:
+        "Fetches the Y.Doc state and content_text for a single page. Use this to read a page's body.",
+      inputSchema: { page_id: z.string().min(1) },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ page_id }) => {
+        const content = await client.getPageContent(page_id);
+        return jsonResult(content);
+      }, args),
+  );
+
+  server.registerTool(
+    "zedi_create_page",
+    {
+      title: "Create page",
+      description: "Creates a new empty page (no Y.Doc body). Returns the created page metadata.",
+      inputSchema: {
+        title: z.string().optional(),
+        content_preview: z.string().optional(),
+        source_url: z.string().url().optional(),
+        thumbnail_url: z.string().url().nullable().optional(),
+      },
+    },
+    async (args) =>
+      wrapToolHandler(async (input) => {
+        const page = await client.createPage(input);
+        return jsonResult(page);
+      }, args),
+  );
+
+  server.registerTool(
+    "zedi_update_page_content",
+    {
+      title: "Update page content",
+      description:
+        "Updates a page's Y.Doc state with optimistic locking. `expected_version` must match the current version on the server.",
+      inputSchema: {
+        page_id: z.string().min(1),
+        ydoc_state: z.string().min(1),
+        expected_version: z.number().int().nonnegative(),
+        content_text: z.string().optional(),
+        content_preview: z.string().optional(),
+        title: z.string().optional(),
+      },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ page_id, ...rest }) => {
+        const result = await client.updatePageContent(page_id, rest);
+        return jsonResult(result);
+      }, args),
+  );
+
+  server.registerTool(
+    "zedi_delete_page",
+    {
+      title: "Delete page (soft)",
+      description: "Soft-deletes a page. The page is marked as deleted but data is retained.",
+      inputSchema: { page_id: z.string().min(1) },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ page_id }) => {
+        const result = await client.deletePage(page_id);
+        return jsonResult(result);
+      }, args),
+  );
+
+  // ── Notes ───────────────────────────────────────────────────────────────
+  server.registerTool(
+    "zedi_list_notes",
+    {
+      title: "List notes",
+      description: "Lists all notes the current user owns or is a member of.",
+      inputSchema: {},
+    },
+    async () =>
+      wrapToolHandler(async () => {
+        const notes = await client.listNotes();
+        return jsonResult(notes);
+      }, {}),
+  );
+
+  server.registerTool(
+    "zedi_get_note",
+    {
+      title: "Get note",
+      description: "Returns a note's details, including its current pages and the caller's role.",
+      inputSchema: { note_id: z.string().min(1) },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ note_id }) => {
+        const note = await client.getNote(note_id);
+        return jsonResult(note);
+      }, args),
+  );
+
+  server.registerTool(
+    "zedi_create_note",
+    {
+      title: "Create note",
+      description: "Creates a new note. Defaults to private visibility and owner-only edit.",
+      inputSchema: {
+        title: z.string().optional(),
+        visibility: NoteVisibilityEnum.optional(),
+        edit_permission: NoteEditPermissionEnum.optional(),
+        is_official: z.boolean().optional(),
+      },
+    },
+    async (args) =>
+      wrapToolHandler(async (input) => {
+        const note = await client.createNote(input);
+        return jsonResult(note);
+      }, args),
+  );
+
+  server.registerTool(
+    "zedi_update_note",
+    {
+      title: "Update note",
+      description: "Updates a note's metadata (title, visibility, edit permission).",
+      inputSchema: {
+        note_id: z.string().min(1),
+        title: z.string().optional(),
+        visibility: NoteVisibilityEnum.optional(),
+        edit_permission: NoteEditPermissionEnum.optional(),
+        is_official: z.boolean().optional(),
+      },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ note_id, ...rest }) => {
+        const note = await client.updateNote(note_id, rest);
+        return jsonResult(note);
+      }, args),
+  );
+
+  server.registerTool(
+    "zedi_delete_note",
+    {
+      title: "Delete note (soft)",
+      description: "Soft-deletes a note. The note is marked as deleted but data is retained.",
+      inputSchema: { note_id: z.string().min(1) },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ note_id }) => {
+        const result = await client.deleteNote(note_id);
+        return jsonResult(result);
+      }, args),
+  );
+
+  // ── Note pages ──────────────────────────────────────────────────────────
+  server.registerTool(
+    "zedi_list_note_pages",
+    {
+      title: "List pages in a note",
+      description: "Lists pages currently attached to a note in their sort order.",
+      inputSchema: { note_id: z.string().min(1) },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ note_id }) => jsonResult(await client.listNotePages(note_id)), args),
+  );
+
+  server.registerTool(
+    "zedi_add_page_to_note",
+    {
+      title: "Add page to note",
+      description:
+        "Adds an existing page to a note (by page_id) or creates a new page in the note.",
+      inputSchema: {
+        note_id: z.string().min(1),
+        page_id: z.string().optional(),
+        title: z.string().optional(),
+        source_url: z.string().url().optional(),
+      },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ note_id, ...rest }) => {
+        const result = await client.addPageToNote(note_id, rest);
+        return jsonResult(result);
+      }, args),
+  );
+
+  server.registerTool(
+    "zedi_remove_page_from_note",
+    {
+      title: "Remove page from note",
+      description:
+        "Removes a page from a note. The page itself is not deleted, only the linkage is removed.",
+      inputSchema: { note_id: z.string().min(1), page_id: z.string().min(1) },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ note_id, page_id }) => {
+        const result = await client.removePageFromNote(note_id, page_id);
+        return jsonResult(result);
+      }, args),
+  );
+
+  server.registerTool(
+    "zedi_reorder_note_pages",
+    {
+      title: "Reorder pages in a note",
+      description: "Reorders the pages of a note. `page_ids` must include all current pages.",
+      inputSchema: {
+        note_id: z.string().min(1),
+        page_ids: z.array(z.string().min(1)).min(1),
+      },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ note_id, page_ids }) => {
+        const result = await client.reorderNotePages(note_id, page_ids);
+        return jsonResult(result);
+      }, args),
+  );
+
+  // ── Note members ────────────────────────────────────────────────────────
+  server.registerTool(
+    "zedi_list_note_members",
+    {
+      title: "List note members",
+      description: "Lists members of a note, including role and acceptance status.",
+      inputSchema: { note_id: z.string().min(1) },
+    },
+    async (args) =>
+      wrapToolHandler(
+        async ({ note_id }) => jsonResult(await client.listNoteMembers(note_id)),
+        args,
+      ),
+  );
+
+  server.registerTool(
+    "zedi_add_note_member",
+    {
+      title: "Invite a member to a note",
+      description: "Invites a user (by email) to a note with the given role.",
+      inputSchema: {
+        note_id: z.string().min(1),
+        email: z.string().email(),
+        role: NoteMemberRoleEnum,
+      },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ note_id, email, role }) => {
+        const result = await client.addNoteMember(note_id, { email, role });
+        return jsonResult(result);
+      }, args),
+  );
+
+  server.registerTool(
+    "zedi_update_note_member",
+    {
+      title: "Update note member role",
+      description: "Updates the role of an existing note member.",
+      inputSchema: {
+        note_id: z.string().min(1),
+        email: z.string().email(),
+        role: NoteMemberRoleEnum,
+      },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ note_id, email, role }) => {
+        const result = await client.updateNoteMember(note_id, email, role);
+        return jsonResult(result);
+      }, args),
+  );
+
+  server.registerTool(
+    "zedi_remove_note_member",
+    {
+      title: "Remove note member",
+      description: "Removes a member from a note.",
+      inputSchema: { note_id: z.string().min(1), email: z.string().email() },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ note_id, email }) => {
+        const result = await client.removeNoteMember(note_id, email);
+        return jsonResult(result);
+      }, args),
+  );
+
+  // ── Search ──────────────────────────────────────────────────────────────
+  server.registerTool(
+    "zedi_search",
+    {
+      title: "Full-text search",
+      description:
+        "Searches pages by title and content. Use `scope: own` for own pages or `shared` to include shared notes.",
+      inputSchema: {
+        query: z.string().min(1),
+        scope: SearchScopeEnum.optional(),
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ query, scope, limit }) => {
+        const results = await client.search(query, scope, limit);
+        return jsonResult(results);
+      }, args),
+  );
+
+  // ── Clip ────────────────────────────────────────────────────────────────
+  server.registerTool(
+    "zedi_clip_url",
+    {
+      title: "Clip URL into a new page",
+      description:
+        "Fetches a public web URL, runs Readability, and creates a new page with the cleaned content.",
+      inputSchema: { url: z.string().url() },
+    },
+    async (args) =>
+      wrapToolHandler(async ({ url }) => {
+        const result = await client.clipUrl(url);
+        return jsonResult(result);
+      }, args),
+  );
+}
+
+/** Zedi MCP サーバーが公開するツール名一覧 (テスト/UI 用)。 / List of all tool names exposed by the Zedi MCP server. */
+export const ALL_TOOL_NAMES = [
+  "zedi_get_current_user",
+  "zedi_get_page",
+  "zedi_create_page",
+  "zedi_update_page_content",
+  "zedi_delete_page",
+  "zedi_list_notes",
+  "zedi_get_note",
+  "zedi_create_note",
+  "zedi_update_note",
+  "zedi_delete_note",
+  "zedi_list_note_pages",
+  "zedi_add_page_to_note",
+  "zedi_remove_page_from_note",
+  "zedi_reorder_note_pages",
+  "zedi_list_note_members",
+  "zedi_add_note_member",
+  "zedi_update_note_member",
+  "zedi_remove_note_member",
+  "zedi_search",
+  "zedi_clip_url",
+] as const;

--- a/server/mcp/tsconfig.json
+++ b/server/mcp/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noUncheckedIndexedAccess": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/server/mcp/vitest.config.ts
+++ b/server/mcp/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.{test,spec}.ts"],
+  },
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import SignIn from "./pages/SignIn";
 import AuthCallback from "./pages/AuthCallback";
 import ExtensionAuth from "./pages/ExtensionAuth";
 import ExtensionAuthCallback from "./pages/ExtensionAuthCallback";
+import McpAuthorize from "./pages/McpAuthorize";
 import PageEditorPage from "./pages/PageEditor";
 import Settings from "./pages/Settings";
 import Pricing from "./pages/Pricing";
@@ -71,6 +72,7 @@ const App = () => (
                     <Route path="/auth/callback" element={<AuthCallback />} />
                     <Route path="/auth/extension" element={<ExtensionAuth />} />
                     <Route path="/auth/extension-callback" element={<ExtensionAuthCallback />} />
+                    <Route path="/mcp/authorize" element={<McpAuthorize />} />
                     <Route path="/invite" element={<InvitePage />} />
                     <Route path="/note/:noteId" element={<NoteView />} />
                     <Route path="/note/:noteId/settings" element={<NoteSettings />} />

--- a/src/pages/McpAuthorize.tsx
+++ b/src/pages/McpAuthorize.tsx
@@ -1,0 +1,160 @@
+/**
+ * MCP authorization consent page / MCP 認可同意ページ
+ *
+ * Reached from `zedi-mcp-cli login`. Required query params:
+ *   - redirect_uri  (loopback URL on user's machine)
+ *   - code_challenge (PKCE)
+ *   - state         (CSRF guard)
+ *   - scopes        (comma-separated, e.g. "mcp:read,mcp:write")
+ *
+ * Behavior:
+ *   1. If the user is signed in (Better Auth cookie), show a consent screen
+ *      listing the granted scopes.
+ *   2. On approval, POST `/api/mcp/authorize-code` to receive a one-time `code`,
+ *      then redirect the browser to `redirect_uri?code=...&state=...`.
+ *
+ * MCP authorization consent page used by the local CLI login flow.
+ */
+import React, { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+function getApiBase(): string {
+  const env = import.meta.env.VITE_API_BASE_URL;
+  if (typeof env === "string" && env.trim() !== "") return env.trim().replace(/\/$/, "");
+  if (typeof window !== "undefined") return window.location.origin;
+  return "";
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+/**
+ * MCP authorization consent page component.
+ * MCP 認可同意ページコンポーネント。
+ */
+const McpAuthorize: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const redirectUri = searchParams.get("redirect_uri") ?? "";
+  const codeChallenge = searchParams.get("code_challenge") ?? "";
+  const state = searchParams.get("state") ?? "";
+  const scopesParam = searchParams.get("scopes") ?? "mcp:read,mcp:write";
+
+  const scopes = useMemo(
+    () =>
+      scopesParam
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    [scopesParam],
+  );
+
+  const paramError =
+    !redirectUri || !codeChallenge ? "redirect_uri and code_challenge are required" : null;
+
+  const onApprove = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const base = getApiBase();
+      const res = await fetch(`${base}/api/mcp/authorize-code`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          redirect_uri: redirectUri,
+          code_challenge: codeChallenge,
+          state,
+          scopes,
+        }),
+      });
+      if (res.status === 401) {
+        // Send the user through Better Auth and bring them back here.
+        // 未ログインなら Better Auth のサインイン経由で戻ってくる。
+        const here = window.location.href;
+        window.location.href = `/sign-in?redirect=${encodeURIComponent(here)}`;
+        return;
+      }
+      if (!res.ok) {
+        const data: unknown = await res.json().catch(() => ({}));
+        const message =
+          isObject(data) && typeof data.message === "string"
+            ? data.message
+            : `Request failed: ${res.status}`;
+        setError(message);
+        return;
+      }
+      const body: unknown = await res.json();
+      if (!isObject(body) || typeof body.code !== "string" || body.code.length === 0) {
+        setError("Invalid authorize-code response");
+        return;
+      }
+      const { code } = body as { code: string };
+      const target = new URL(redirectUri);
+      target.searchParams.set("code", code);
+      target.searchParams.set("state", state);
+      setDone(true);
+      window.location.replace(target.toString());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Connection failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Render error state when params are malformed.
+  // パラメータ不備の場合はエラー表示。
+  useEffect(() => {
+    if (paramError) setError(paramError);
+  }, [paramError]);
+
+  if (done) {
+    return (
+      <div className="bg-background flex min-h-screen flex-col items-center justify-center p-4">
+        <p className="text-muted-foreground">Authorized. You can close this tab.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-background flex min-h-screen flex-col items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-lg border p-6 shadow-sm">
+        <h1 className="mb-2 text-xl font-semibold">Authorize Zedi MCP Server</h1>
+        <p className="text-muted-foreground mb-4 text-sm">
+          A local Claude Code instance is requesting access to your Zedi data.
+        </p>
+        <div className="mb-4">
+          <p className="mb-1 text-sm font-medium">Requested scopes:</p>
+          <ul className="list-inside list-disc text-sm">
+            {scopes.map((s) => (
+              <li key={s}>
+                <code>{s}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="text-muted-foreground mb-4 text-xs">
+          <p>
+            <span className="font-medium">Redirect URI: </span>
+            <code className="break-all">{redirectUri}</code>
+          </p>
+        </div>
+        {error ? <p className="text-destructive mb-4 text-sm">{error}</p> : null}
+        <button
+          type="button"
+          onClick={onApprove}
+          disabled={loading || !!paramError}
+          className="bg-primary text-primary-foreground w-full rounded-md px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50"
+        >
+          {loading ? "Authorizing…" : "Approve"}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default McpAuthorize;


### PR DESCRIPTION
## Summary

Completes the Zedi MCP server stack by adding the **remote HTTP transport**, the **PKCE-based CLI login flow**, and the in-app **consent page** that ties them together. This is **PR 3 of 3** in the MCP-server stack.

> **Base branch:** This PR stacks on #555 (`feature/mcp-server-stdio`), which stacks on #554 (`feature/mcp-auth-foundation`). Please merge those first.

### What's added

#### `server/mcp` runtime
- **`http.ts`** (`bin: zedi-mcp-http`) — Hono + WebStandard Streamable HTTP transport. Per-request `HttpZediClient` + `McpServer` (stateless mode); the caller's Bearer token is passed through to the Zedi REST API. Designed to deploy as a separate Railway service.
- **`cli/login.ts`** (`bin: zedi-mcp-cli`) — `login` and `whoami` subcommands. Spins up an ephemeral loopback HTTP server, opens the browser to \`<api>/mcp/authorize\`, exchanges the returned code for a JWT, and persists \`{ apiUrl, token }\` to \`~/.config/zedi/mcp.json\` (Windows: \`%APPDATA%\zedi\mcp.json\`) with mode 0600.

#### Deployment
- **`Dockerfile`** + **`railway.json`** — separate Railway service for the HTTP transport (port 3100, healthcheck \`/health\`).
- **`package.json`** — adds the \`zedi-mcp-http\` and \`zedi-mcp-cli\` bin entries and \`@hono/node-server\`/\`hono\`/\`open\` deps that the new entries need.

#### Web app
- **`src/pages/McpAuthorize.tsx`** — \`/mcp/authorize\` consent screen reached from the CLI. Reads \`redirect_uri\`, \`code_challenge\`, \`state\`, \`scopes\` from the query, POSTs \`/api/mcp/authorize-code\` with the Better Auth session, and redirects back to the loopback URL with the returned \`code\`. If the user is not signed in, it bounces them through Better Auth and back.
- **`src/App.tsx`** — registers the \`/mcp/authorize\` route.

#### Tests
- **`__tests__/http.test.ts`** (3) — health endpoint + 401 on missing/malformed Bearer.

Full MCP-over-HTTP smoke testing is intentionally deferred to manual verification to keep the suite hermetic.

### End-to-end flow (after all 3 PRs merged)

1. User runs \`bunx zedi-mcp-cli login\` on their laptop
2. CLI opens browser → \`/mcp/authorize\` consent screen
3. User clicks Approve → CLI receives JWT and saves it to disk
4. User registers \`zedi-mcp-stdio\` in their Claude Code config
5. Claude Code can now call any of the 20 \`zedi_*\` tools

### Stacked PR

1. #554 — server/api auth foundation
2. #555 — server/mcp package + stdio transport
3. **This PR** — HTTP transport + CLI login + consent page (you are here)

## Test plan

- [x] \`cd server/mcp && bun run typecheck\` — clean
- [x] \`cd server/mcp && bun run test\` — 39 pass (3 new HTTP tests)
- [x] \`bunx prettier --check\` on touched files — clean
- [x] \`bunx eslint server/mcp/src src/pages/McpAuthorize.tsx\` — clean
- [ ] Manual: \`bun run dev\` (Web) + \`bun run dev:http\` (MCP HTTP) → run \`zedi-mcp-cli login\` and verify the full PKCE flow
- [ ] Manual: deploy \`server/mcp\` as a new Railway service and confirm \`/health\` responds and \`/mcp\` accepts a JWT-authenticated MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
