### PR TITLE
ci: silence gitleaks false positive on invite test mock token

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,12 @@
+# Gitleaks ignore list
+# gitleaks が検出した誤検知（False positive）を記録するファイル。
+# Records fingerprints of false-positive findings for gitleaks.
+#
+# Format: <commit-sha>:<file-path>:<rule-id>:<line-number>
+# See: https://github.com/gitleaks/gitleaks#gitleaksignore
+
+# server/api/src/__tests__/routes/invite.test.ts:38 の TEST_TOKEN は
+# 招待 API テスト用に埋め込まれたモック文字列であり、本物の API キーではない。
+# The TEST_TOKEN at invite.test.ts:38 is a hard-coded mock string used only for
+# invitation API unit tests — it is not a real API key or secret.
+b1e5dab7fa191b9f317b066099ca3fbb6450c5a7:server/api/src/__tests__/routes/invite.test.ts:generic-api-key:38

--- a/server/api/src/__tests__/routes/invite.test.ts
+++ b/server/api/src/__tests__/routes/invite.test.ts
@@ -35,7 +35,9 @@ import { errorHandler } from "../../middleware/errorHandler.js";
 const TEST_USER_ID = "user-test-123";
 const TEST_USER_EMAIL = "test@example.com";
 const OTHER_USER_EMAIL = "other@example.com";
-const TEST_TOKEN = "abc123def456";
+// Mock invitation token used as a URL path parameter in tests only.
+// テスト用のモック招待トークン（URL パスパラメータとして使用）。本物のシークレットではない。
+const TEST_TOKEN = "abc123def456"; // gitleaks:allow
 const NOTE_ID = "note-test-001";
 
 // ── Mock DB (same proxy-based pattern as notes tests) ──────────────────────


### PR DESCRIPTION
The security job introduced in CI (gitleaks) flagged the hard-coded
mock TEST_TOKEN in server/api/src/__tests__/routes/invite.test.ts as a
generic-api-key. It is not a real secret — only a path parameter used
in unit tests. Added a targeted .gitleaksignore entry for the historical
commit and an inline `gitleaks:allow` marker to prevent future
regressions, and clarified the intent with a bilingual comment.

https://github.com/otomatty/zedi/actions/runs/24274795632/job/70886640601
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to exclude known false-positive detections in test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->