### PR TITLE
fix(ci): release please リリース PR で Cargo.lock を再生成する

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,10 @@
 # Release Please: main へのプッシュ内容に応じてリリース PR を main に作成します。
 # Release PR マージ時にタグと GitHub Release も自動作成します。
 # Conventional Commits (feat:, fix:, BREAKING CHANGE:) に応じてメジャー / マイナー / パッチが自動判定されます。
+#
+# Release Please は Cargo.toml のバージョンをテキスト置換で更新するが、
+# Cargo.lock は再生成しない。update-cargo-lock ジョブでリリース PR 上の
+# Cargo.lock を再生成してコミットする (#579)。
 name: Release Please
 
 on:
@@ -16,15 +20,47 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    outputs:
+      pr-branch: ${{ steps.rp.outputs.prs_created == 'true' && fromJSON(steps.rp.outputs.pr).headBranchName || '' }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Run Release Please
+        id: rp
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
+
+  update-cargo-lock:
+    name: Update Cargo.lock on release PR
+    needs: release-please
+    if: needs.release-please.outputs.pr-branch != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.pr-branch }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Regenerate Cargo.lock
+        working-directory: src-tauri
+        run: cargo generate-lockfile
+
+      - name: Commit updated Cargo.lock
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet src-tauri/Cargo.lock; then
+            git add src-tauri/Cargo.lock
+            git commit -m "chore: update Cargo.lock for release"
+            git push
+          else
+            echo "Cargo.lock is already up to date"
+          fi

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "zedi"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "dirs 5.0.1",
  "serde",


### PR DESCRIPTION
## 概要

Release Please が `src-tauri/Cargo.toml` のバージョンをテキスト置換で更新する際、`src-tauri/Cargo.lock` は再生成されないため、`Cargo.toml` と `Cargo.lock` のバージョンが乖離する問題を修正する。リリース PR 作成後に `cargo generate-lockfile` を実行して `Cargo.lock` を更新する `update-cargo-lock` ジョブを追加した。

## 変更点

- `.github/workflows/release-please.yml` に `update-cargo-lock` ジョブを追加
  - `release-please` ジョブの outputs でリリース PR のブランチ名を公開
  - リリース PR が作成/更新された場合にのみ実行
  - リリース PR ブランチをチェックアウトし `cargo generate-lockfile` で `Cargo.lock` を再生成
  - 差分がある場合のみコミット・プッシュ

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. 次回 develop → main マージ後に Release Please がリリース PR を作成するのを待つ
2. リリース PR 上で `update-cargo-lock` ジョブが実行されることを確認
3. リリース PR に `chore: update Cargo.lock for release` コミットが追加され、`Cargo.lock` のバージョンが `Cargo.toml` と一致することを確認
4. リリース PR マージ後、sync-main-to-develop で正しい `Cargo.lock` が develop に還流されることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

N/A（CI ワークフロー変更のみ）

## 関連 Issue

Closes #579

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
