### PR TITLE
fix(editor): parse wiki links and markdown on paste

### DIFF
--- a/src/components/editor/extensions/MarkdownPasteExtension.test.ts
+++ b/src/components/editor/extensions/MarkdownPasteExtension.test.ts
@@ -188,3 +188,120 @@ describe("MarkdownPaste extension", () => {
     expect(mockEditor.markdown?.parse).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Wikiリンクペーストの統合テスト / Wiki link paste integration tests
+// ---------------------------------------------------------------------------
+
+describe("MarkdownPaste extension - wiki links", () => {
+  /**
+   * editor.markdown.parse がテキストをそのまま段落として返すモック。
+   * Mock `parse` that echoes the text back as a single paragraph.
+   */
+  function createEchoParse() {
+    return vi.fn((text: string) => ({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text }],
+        },
+      ],
+    }));
+  }
+
+  it("intercepts paste of a bare wiki link like [[Foo]]", () => {
+    const { handlePaste, mockEditor } = getHandlePaste({ parse: createEchoParse() });
+
+    const event = createMockPasteEvent("[[Foo]]");
+    expect(handlePaste(null, event, null)).toBe(true);
+    expect(mockEditor.commands.insertContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies wikiLink mark to pasted [[Title]] text", () => {
+    const { handlePaste, mockEditor } = getHandlePaste({ parse: createEchoParse() });
+
+    const event = createMockPasteEvent("[[Foo]]");
+    handlePaste(null, event, null);
+
+    const inserted = mockEditor.commands.insertContent.mock.calls[0]?.[0] as {
+      content: Array<{
+        content: Array<{
+          type: string;
+          text: string;
+          marks?: Array<{ type: string; attrs: Record<string, unknown> }>;
+        }>;
+      }>;
+    };
+    const textNode = inserted.content[0].content[0];
+    expect(textNode.text).toBe("Foo");
+    expect(textNode.marks).toEqual([
+      {
+        type: "wikiLink",
+        attrs: { title: "Foo", exists: false, referenced: false },
+      },
+    ]);
+  });
+
+  it("handles wiki links mixed with surrounding text", () => {
+    const { handlePaste, mockEditor } = getHandlePaste({ parse: createEchoParse() });
+
+    const event = createMockPasteEvent("see [[Foo]] today");
+    expect(handlePaste(null, event, null)).toBe(true);
+
+    const inserted = mockEditor.commands.insertContent.mock.calls[0]?.[0] as {
+      content: Array<{
+        content: Array<{ type: string; text: string; marks?: unknown[] }>;
+      }>;
+    };
+    const nodes = inserted.content[0].content;
+    expect(nodes).toHaveLength(3);
+    expect(nodes[0].text).toBe("see ");
+    expect(nodes[1].text).toBe("Foo");
+    expect(nodes[1].marks).toBeDefined();
+    expect(nodes[2].text).toBe(" today");
+  });
+
+  it("applies wiki link transformation even when markdown patterns co-exist", () => {
+    const { handlePaste, mockEditor } = getHandlePaste({ parse: createEchoParse() });
+
+    const event = createMockPasteEvent("# Heading with [[Ref]]");
+    expect(handlePaste(null, event, null)).toBe(true);
+
+    const inserted = mockEditor.commands.insertContent.mock.calls[0]?.[0] as {
+      content: Array<{
+        content: Array<{
+          type: string;
+          text: string;
+          marks?: Array<{ type: string }>;
+        }>;
+      }>;
+    };
+    const textNodes = inserted.content[0].content;
+    const wikiNode = textNodes.find((n) => n.text === "Ref");
+    expect(wikiNode).toBeDefined();
+    expect(wikiNode?.marks?.[0]?.type).toBe("wikiLink");
+  });
+
+  it("does not intercept text with empty-bracket pattern only", () => {
+    const { handlePaste, mockEditor } = getHandlePaste({ parse: createEchoParse() });
+
+    const event = createMockPasteEvent("empty [[]] brackets");
+    // `[[]]` は Wikiリンクとも Markdown ともみなされないため、デフォルト処理に委ねる。
+    // `[[]]` matches neither wiki link nor markdown patterns, so fall through.
+    expect(handlePaste(null, event, null)).toBe(false);
+    expect(mockEditor.commands.insertContent).not.toHaveBeenCalled();
+  });
+
+  it("skips transformation when markdown.parse throws (falls back)", () => {
+    const { handlePaste, mockEditor } = getHandlePaste({
+      parse: vi.fn(() => {
+        throw new Error("parse error");
+      }),
+    });
+
+    const event = createMockPasteEvent("[[Foo]]");
+    expect(handlePaste(null, event, null)).toBe(false);
+    expect(mockEditor.commands.insertContent).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/editor/extensions/MarkdownPasteExtension.ts
+++ b/src/components/editor/extensions/MarkdownPasteExtension.ts
@@ -1,5 +1,9 @@
 import { Extension } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
+import {
+  containsWikiLinkPattern,
+  transformWikiLinksInContent,
+} from "./transformWikiLinksInContent";
 
 /**
  * ProseMirror プラグインキー（拡張再初期化時の再生成を避けるためトップレベルで定義）。
@@ -60,13 +64,28 @@ export const MarkdownPaste = Extension.create({
             if (!editor.isEditable) return false;
 
             const text = event.clipboardData?.getData("text/plain");
-            if (!text || !looksLikeMarkdown(text)) return false;
+            if (!text) return false;
+
+            // マークダウン記法または Wikiリンク記法のいずれかが含まれる場合のみ介入する。
+            // Intercept only when markdown patterns OR wiki link syntax are detected.
+            const hasMarkdown = looksLikeMarkdown(text);
+            const hasWikiLink = containsWikiLinkPattern(text);
+            if (!hasMarkdown && !hasWikiLink) return false;
 
             if (!editor.markdown) return false;
 
             try {
               const parsed = editor.markdown.parse(text);
-              editor.commands.insertContent(parsed);
+              // Wikiリンクは @tiptap/markdown がプレーンテキストとしてパースするため、
+              // 後処理で `wikiLink` マークを付与する。
+              // `@tiptap/markdown` leaves `[[...]]` as plain text, so post-process
+              // the parsed JSON to apply the `wikiLink` mark.
+              const content = hasWikiLink
+                ? transformWikiLinksInContent(
+                    parsed as Parameters<typeof transformWikiLinksInContent>[0],
+                  )
+                : parsed;
+              editor.commands.insertContent(content);
               return true;
             } catch {
               // パース失敗時は ProseMirror のデフォルトペースト処理にフォールバック

--- a/src/components/editor/extensions/transformWikiLinksInContent.test.ts
+++ b/src/components/editor/extensions/transformWikiLinksInContent.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from "vitest";
+import {
+  WIKI_LINK_TEXT_REGEX,
+  containsWikiLinkPattern,
+  transformWikiLinksInContent,
+} from "./transformWikiLinksInContent";
+
+describe("containsWikiLinkPattern", () => {
+  it("returns true for text containing a wiki link", () => {
+    expect(containsWikiLinkPattern("see [[Foo]] for details")).toBe(true);
+  });
+
+  it("returns true for text that is a single wiki link", () => {
+    expect(containsWikiLinkPattern("[[Foo]]")).toBe(true);
+  });
+
+  it("returns false for text without wiki links", () => {
+    expect(containsWikiLinkPattern("just plain text")).toBe(false);
+  });
+
+  it("returns false for empty bracket pair", () => {
+    expect(containsWikiLinkPattern("[[]] is empty")).toBe(false);
+  });
+
+  it("returns false for single brackets (markdown link syntax)", () => {
+    expect(containsWikiLinkPattern("[label](url)")).toBe(false);
+  });
+
+  it("returns false when brackets contain bracket characters", () => {
+    expect(containsWikiLinkPattern("[[foo[bar]]]")).toBe(false);
+  });
+});
+
+describe("WIKI_LINK_TEXT_REGEX", () => {
+  it("matches multiple wiki links in a string", () => {
+    const text = "[[A]] and [[B]] and [[C]]";
+    const matches = [...text.matchAll(WIKI_LINK_TEXT_REGEX)];
+    expect(matches).toHaveLength(3);
+    expect(matches[0][1]).toBe("A");
+    expect(matches[1][1]).toBe("B");
+    expect(matches[2][1]).toBe("C");
+  });
+});
+
+describe("transformWikiLinksInContent", () => {
+  it("returns content unchanged when no wiki links exist", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "plain text" }],
+        },
+      ],
+    };
+
+    expect(transformWikiLinksInContent(doc)).toEqual(doc);
+  });
+
+  it("transforms a single wiki link into a text node with wikiLink mark", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "[[Foo]]" }],
+        },
+      ],
+    };
+
+    const result = transformWikiLinksInContent(doc) as {
+      content: Array<{
+        content: Array<{
+          type: string;
+          text: string;
+          marks?: Array<{ type: string; attrs: Record<string, unknown> }>;
+        }>;
+      }>;
+    };
+
+    expect(result.content[0].content).toHaveLength(1);
+    expect(result.content[0].content[0]).toEqual({
+      type: "text",
+      text: "Foo",
+      marks: [
+        {
+          type: "wikiLink",
+          attrs: { title: "Foo", exists: false, referenced: false },
+        },
+      ],
+    });
+  });
+
+  it("splits a text node containing a wiki link surrounded by text", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "before [[Foo]] after" }],
+        },
+      ],
+    };
+
+    const result = transformWikiLinksInContent(doc) as {
+      content: Array<{ content: Array<{ type: string; text: string; marks?: unknown[] }> }>;
+    };
+
+    expect(result.content[0].content).toEqual([
+      { type: "text", text: "before " },
+      {
+        type: "text",
+        text: "Foo",
+        marks: [
+          {
+            type: "wikiLink",
+            attrs: { title: "Foo", exists: false, referenced: false },
+          },
+        ],
+      },
+      { type: "text", text: " after" },
+    ]);
+  });
+
+  it("handles multiple wiki links in one text node", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "[[A]] and [[B]]" }],
+        },
+      ],
+    };
+
+    const result = transformWikiLinksInContent(doc) as {
+      content: Array<{ content: Array<{ type: string; text: string; marks?: unknown[] }> }>;
+    };
+
+    expect(result.content[0].content).toHaveLength(3);
+    expect(result.content[0].content[0].text).toBe("A");
+    expect(result.content[0].content[0].marks).toHaveLength(1);
+    expect(result.content[0].content[1].text).toBe(" and ");
+    expect(result.content[0].content[1].marks).toBeUndefined();
+    expect(result.content[0].content[2].text).toBe("B");
+    expect(result.content[0].content[2].marks).toHaveLength(1);
+  });
+
+  it("transforms wiki links nested inside headings", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Title with [[Link]]" }],
+        },
+      ],
+    };
+
+    const result = transformWikiLinksInContent(doc) as {
+      content: Array<{
+        type: string;
+        content: Array<{ type: string; text: string; marks?: unknown[] }>;
+      }>;
+    };
+
+    expect(result.content[0].type).toBe("heading");
+    expect(result.content[0].content).toHaveLength(2);
+    expect(result.content[0].content[1].text).toBe("Link");
+    expect(result.content[0].content[1].marks).toEqual([
+      {
+        type: "wikiLink",
+        attrs: { title: "Link", exists: false, referenced: false },
+      },
+    ]);
+  });
+
+  it("preserves existing marks on the surrounding plain text parts", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "bold [[Link]] bold",
+              marks: [{ type: "bold" }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = transformWikiLinksInContent(doc) as {
+      content: Array<{
+        content: Array<{
+          type: string;
+          text: string;
+          marks?: Array<{ type: string; attrs?: Record<string, unknown> }>;
+        }>;
+      }>;
+    };
+
+    const nodes = result.content[0].content;
+    expect(nodes).toHaveLength(3);
+    expect(nodes[0].marks).toEqual([{ type: "bold" }]);
+    expect(nodes[1].text).toBe("Link");
+    // 既存マーク + wikiLink マークを両方保持する
+    // Preserve both the existing mark(s) and the wikiLink mark
+    expect(nodes[1].marks).toEqual(
+      expect.arrayContaining([
+        { type: "bold" },
+        {
+          type: "wikiLink",
+          attrs: { title: "Link", exists: false, referenced: false },
+        },
+      ]),
+    );
+    expect(nodes[2].marks).toEqual([{ type: "bold" }]);
+  });
+
+  it("trims whitespace from wiki link title", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "[[  Foo Bar  ]]" }],
+        },
+      ],
+    };
+
+    const result = transformWikiLinksInContent(doc) as {
+      content: Array<{
+        content: Array<{
+          type: string;
+          text: string;
+          marks?: Array<{ type: string; attrs: Record<string, unknown> }>;
+        }>;
+      }>;
+    };
+
+    expect(result.content[0].content[0].text).toBe("Foo Bar");
+    expect(result.content[0].content[0].marks?.[0]?.attrs).toEqual({
+      title: "Foo Bar",
+      exists: false,
+      referenced: false,
+    });
+  });
+
+  it("skips wiki links with empty titles (after trim)", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "[[   ]]" }],
+        },
+      ],
+    };
+
+    const result = transformWikiLinksInContent(doc);
+    expect(result).toEqual(doc);
+  });
+
+  it("returns input unchanged when content is undefined", () => {
+    const doc = { type: "doc" };
+    expect(transformWikiLinksInContent(doc)).toEqual(doc);
+  });
+
+  it("handles deeply nested structures (lists)", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "item [[Ref]]" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = transformWikiLinksInContent(doc) as {
+      content: Array<{
+        content: Array<{
+          content: Array<{
+            content: Array<{ type: string; text: string; marks?: unknown[] }>;
+          }>;
+        }>;
+      }>;
+    };
+
+    const textNodes = result.content[0].content[0].content[0].content;
+    expect(textNodes).toHaveLength(2);
+    expect(textNodes[1].text).toBe("Ref");
+    expect(textNodes[1].marks).toEqual([
+      {
+        type: "wikiLink",
+        attrs: { title: "Ref", exists: false, referenced: false },
+      },
+    ]);
+  });
+
+  it("does not mutate the input object", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "[[Foo]]" }],
+        },
+      ],
+    };
+    const snapshot = JSON.parse(JSON.stringify(doc));
+
+    transformWikiLinksInContent(doc);
+
+    expect(doc).toEqual(snapshot);
+  });
+});

--- a/src/components/editor/extensions/transformWikiLinksInContent.ts
+++ b/src/components/editor/extensions/transformWikiLinksInContent.ts
@@ -1,0 +1,186 @@
+/**
+ * 貼り付けテキスト内の `[[Title]]` 形式のWikiリンク記法を検出・変換するユーティリティ。
+ * Utilities to detect and transform `[[Title]]` wiki link syntax inside pasted content.
+ *
+ * `@tiptap/markdown` はWikiリンク記法を解さずプレーンテキストとしてパースするため、
+ * パース後の ProseMirror JSON を後処理して `wikiLink` マークを付与する必要がある。
+ *
+ * Since `@tiptap/markdown` treats `[[...]]` as plain text, we post-process the parsed
+ * ProseMirror JSON and apply the `wikiLink` mark so the final inserted content renders
+ * as proper wiki links.
+ */
+
+/**
+ * テキスト中のWikiリンクにマッチする正規表現（グローバルフラグ）。
+ * Regex matching wiki links inside text (global flag).
+ *
+ * `g` フラグ付きの共有インスタンスは `lastIndex` を持つため、使用時は毎回
+ * `matchAll` で列挙するか、新しい `RegExp` を作成して副作用を避けること。
+ */
+export const WIKI_LINK_TEXT_REGEX = /\[\[([^[\]]+)\]\]/g;
+
+/**
+ * 単一マッチ用（lastIndex の副作用なし）。
+ * Single-match variant without `g` flag (no `lastIndex` side effects).
+ */
+const WIKI_LINK_TEXT_TEST_REGEX = /\[\[([^[\]]+)\]\]/;
+
+/**
+ * 与えられた文字列にWikiリンクパターンが1つ以上含まれるか判定する。
+ * Returns whether the given text contains at least one wiki link pattern.
+ *
+ * @param text - 判定対象のテキスト / Text to check
+ * @returns Wikiリンクが含まれていれば true / true if at least one wiki link exists
+ */
+export function containsWikiLinkPattern(text: string): boolean {
+  return WIKI_LINK_TEXT_TEST_REGEX.test(text);
+}
+
+/**
+ * ProseMirror のマーク定義（最小限の構造）。
+ * Minimal shape of a ProseMirror mark definition.
+ */
+interface MarkJSON {
+  type: string;
+  attrs?: Record<string, unknown>;
+}
+
+/**
+ * ProseMirror のノード定義（最小限の構造）。
+ * Minimal shape of a ProseMirror node.
+ */
+interface NodeJSON {
+  type: string;
+  text?: string;
+  attrs?: Record<string, unknown>;
+  marks?: MarkJSON[];
+  content?: NodeJSON[];
+}
+
+/**
+ * 単一のテキストノードを、Wikiリンクマーク付きに分割変換する。
+ * Split a text node into segments, applying the wikiLink mark to the matches.
+ *
+ * @param node - 変換対象のテキストノード / The text node to transform
+ * @returns 分割後のノード配列（変換不要なら長さ1の配列）/ Resulting nodes (length 1 if unchanged)
+ */
+function splitTextNodeByWikiLinks(node: NodeJSON): NodeJSON[] {
+  const text = node.text ?? "";
+  if (!text || !containsWikiLinkPattern(text)) {
+    return [node];
+  }
+
+  const result: NodeJSON[] = [];
+  let cursor = 0;
+
+  for (const match of text.matchAll(WIKI_LINK_TEXT_REGEX)) {
+    const raw = match[1] ?? "";
+    const title = raw.trim();
+    const start = match.index ?? 0;
+    const end = start + match[0].length;
+
+    // 空タイトルは変換せずスキップ（プレーンテキストのまま残す）
+    // Empty titles are skipped; the literal `[[   ]]` stays as plain text
+    if (!title) {
+      continue;
+    }
+
+    // マッチ前のプレーン部分を追加
+    // Push the plain prefix before the match (if any)
+    if (start > cursor) {
+      result.push(buildTextNode(text.slice(cursor, start), node.marks));
+    }
+
+    // Wikiリンクマーク付きノードを追加
+    // Push the wiki-linked text node
+    const wikiMark: MarkJSON = {
+      type: "wikiLink",
+      attrs: { title, exists: false, referenced: false },
+    };
+    result.push(buildTextNode(title, mergeMarks(node.marks, wikiMark)));
+
+    cursor = end;
+  }
+
+  // 末尾のプレーン部分
+  // Trailing plain tail (if any)
+  if (cursor < text.length) {
+    result.push(buildTextNode(text.slice(cursor), node.marks));
+  }
+
+  // マッチはしたが全て空タイトルだった場合は元のノードを維持
+  // If all matches had empty titles, keep the original node
+  if (result.length === 0) {
+    return [node];
+  }
+
+  return result;
+}
+
+/**
+ * テキストノードを生成する（任意でマーク配列をコピーして付与）。
+ * Build a text node, optionally copying a marks array.
+ */
+function buildTextNode(text: string, marks?: MarkJSON[]): NodeJSON {
+  const node: NodeJSON = { type: "text", text };
+  if (marks && marks.length > 0) {
+    node.marks = marks.map((mark) => ({ ...mark }));
+  }
+  return node;
+}
+
+/**
+ * 既存マーク配列と新規マークをマージして新しい配列を返す。
+ * Merge an existing marks array with a new mark, returning a new array.
+ */
+function mergeMarks(existing: MarkJSON[] | undefined, extra: MarkJSON): MarkJSON[] {
+  if (!existing || existing.length === 0) {
+    return [extra];
+  }
+  return [...existing, extra];
+}
+
+/**
+ * 任意のノードを再帰的に変換する（テキストノードのみWikiリンク変換を適用）。
+ * Recursively transform a node; wiki link extraction only applies to text nodes.
+ */
+function transformNode(node: NodeJSON): NodeJSON {
+  if (node.type === "text") {
+    // テキストノードはここでは単独では分割できない（親の content 配列で差し替える必要あり）
+    // Text node splitting is handled by the parent via transformChildren.
+    return node;
+  }
+
+  if (!node.content || node.content.length === 0) {
+    return node;
+  }
+
+  const newContent: NodeJSON[] = [];
+  for (const child of node.content) {
+    if (child.type === "text") {
+      newContent.push(...splitTextNodeByWikiLinks(child));
+    } else {
+      newContent.push(transformNode(child));
+    }
+  }
+
+  return { ...node, content: newContent };
+}
+
+/**
+ * ProseMirror JSON ドキュメント内のテキストノードに含まれる `[[Title]]` パターンを
+ * 走査し、`wikiLink` マーク付きのテキストノードに変換して返す。
+ *
+ * Walk a ProseMirror JSON document, replacing `[[Title]]` patterns inside text nodes
+ * with text nodes carrying the `wikiLink` mark. Input is never mutated.
+ *
+ * @param content - `editor.markdown.parse()` 等で得たドキュメントJSON
+ *                  The document JSON returned by e.g. `editor.markdown.parse()`
+ * @returns 変換後のドキュメントJSON（入力は不変）/ Transformed document JSON (input untouched)
+ */
+export function transformWikiLinksInContent<T extends NodeJSON>(content: T): T {
+  // 入力を不変に保つためディープクローン
+  // Deep-clone to keep the input immutable
+  const cloned = JSON.parse(JSON.stringify(content)) as T;
+  return transformNode(cloned) as T;
+}


### PR DESCRIPTION
ペースト時に [[Title]] 形式のWikiリンクと、Wikiリンクを含む
マークダウンテキストが自動変換されるよう修正。

- `transformWikiLinksInContent` ヘルパーを追加し、パース済み
  ProseMirror JSON のテキストノードから `[[Title]]` パターンを
  抽出して `wikiLink` マーク付きノードに分割する
- `useMarkdownPasteHandler` で Wikiリンクパターンも検知し、
  Markdown パース後にヘルパーで後処理する

Wikiリンクのみのテキスト（例: `[[Foo]]`）や、マークダウンと
Wikiリンクが混在するテキスト（例: `# Title [[Ref]]`）も
正しく変換される。TDD（helper 18件 + handler 追加6件）で実装。

https://claude.ai/code/session_01KE3zw9j7gtqRCgzB28R2DW
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for wiki-link syntax (`[[Title]]`) in the editor. When pasting content with wiki links, they are now recognized and converted to proper wiki-link elements within the document.

* **Tests**
  * Added comprehensive test coverage for wiki-link detection and transformation utilities.
  * Added test coverage for wiki-link handling during paste operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->