### PR TITLE
fix(editor): Delete duplicate page on opening existing one

### DIFF
--- a/src/components/editor/PageEditor/usePageDeletion.test.ts
+++ b/src/components/editor/PageEditor/usePageDeletion.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { usePageDeletion } from "./usePageDeletion";
+
+/**
+ * `usePageDeletion` の振る舞い、特に重複タイトル時の「開く」ボタンハンドラ
+ * (`handleOpenDuplicatePage`) をカバーするテスト。
+ *
+ * Tests for `usePageDeletion`, focused on the "Open" button handler
+ * (`handleOpenDuplicatePage`) used by the duplicate-title warning.
+ */
+
+const { mockNavigate, mockMutate, mockToast } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockMutate: vi.fn(),
+  mockToast: vi.fn(),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("@/hooks/usePageQueries", () => ({
+  useDeletePage: () => ({ mutate: mockMutate }),
+}));
+
+vi.mock("@zedi/ui", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+// 空ではないコンテンツを表す JSON / JSON representing non-empty Tiptap content.
+const NON_EMPTY_CONTENT = JSON.stringify({
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text: "hello" }] }],
+});
+
+// 空の Tiptap ドキュメント / Empty Tiptap document.
+const EMPTY_CONTENT = JSON.stringify({
+  type: "doc",
+  content: [{ type: "paragraph" }],
+});
+
+describe("usePageDeletion.handleOpenDuplicatePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("現在のページが未作成なら削除せず遷移する / navigates without deleting when currentPageId is null", () => {
+    const { result } = renderHook(() =>
+      usePageDeletion({
+        currentPageId: null,
+        title: "foo",
+        content: NON_EMPTY_CONTENT,
+        shouldBlockSave: true,
+      }),
+    );
+
+    act(() => result.current.handleOpenDuplicatePage("target-id"));
+
+    expect(mockMutate).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/page/target-id");
+    expect(result.current.deleteConfirmOpen).toBe(false);
+  });
+
+  it("コンテンツが空なら即削除して遷移する / deletes immediately and navigates when content is empty", () => {
+    const { result } = renderHook(() =>
+      usePageDeletion({
+        currentPageId: "dup-id",
+        title: "foo",
+        content: EMPTY_CONTENT,
+        shouldBlockSave: true,
+      }),
+    );
+
+    act(() => result.current.handleOpenDuplicatePage("target-id"));
+
+    expect(mockMutate).toHaveBeenCalledWith("dup-id");
+    expect(mockNavigate).toHaveBeenCalledWith("/page/target-id");
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "重複するタイトルのため、ページを削除しました",
+    });
+    expect(result.current.deleteConfirmOpen).toBe(false);
+  });
+
+  it("コンテンツがあれば確認ダイアログを開き、削除・遷移はまだ行わない / opens confirm dialog without deleting or navigating when content exists", () => {
+    const { result } = renderHook(() =>
+      usePageDeletion({
+        currentPageId: "dup-id",
+        title: "foo",
+        content: NON_EMPTY_CONTENT,
+        shouldBlockSave: true,
+      }),
+    );
+
+    act(() => result.current.handleOpenDuplicatePage("target-id"));
+
+    expect(mockMutate).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(result.current.deleteConfirmOpen).toBe(true);
+    expect(result.current.deleteReason).toBe("重複するタイトルのページ");
+  });
+
+  it("確認後は削除して既存ページへ遷移する / after confirm, deletes and navigates to the target page", () => {
+    const { result } = renderHook(() =>
+      usePageDeletion({
+        currentPageId: "dup-id",
+        title: "foo",
+        content: NON_EMPTY_CONTENT,
+        shouldBlockSave: true,
+      }),
+    );
+
+    act(() => result.current.handleOpenDuplicatePage("target-id"));
+    act(() => result.current.handleConfirmDelete());
+
+    expect(mockMutate).toHaveBeenCalledWith("dup-id");
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "重複するタイトルのページを削除しました",
+    });
+    expect(mockNavigate).toHaveBeenCalledWith("/page/target-id");
+    expect(result.current.deleteConfirmOpen).toBe(false);
+  });
+
+  it("キャンセルすると削除も遷移も行わない / cancel leaves page intact and does not navigate", () => {
+    const { result } = renderHook(() =>
+      usePageDeletion({
+        currentPageId: "dup-id",
+        title: "foo",
+        content: NON_EMPTY_CONTENT,
+        shouldBlockSave: true,
+      }),
+    );
+
+    act(() => result.current.handleOpenDuplicatePage("target-id"));
+    act(() => result.current.handleCancelDelete());
+
+    expect(mockMutate).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(result.current.deleteConfirmOpen).toBe(false);
+  });
+
+  it("キャンセル後に handleBack を使うと /home へ戻る / pendingNavTarget resets so handleBack goes back to /home", () => {
+    const { result } = renderHook(() =>
+      usePageDeletion({
+        currentPageId: "dup-id",
+        title: "foo",
+        content: NON_EMPTY_CONTENT,
+        shouldBlockSave: true,
+      }),
+    );
+
+    act(() => result.current.handleOpenDuplicatePage("target-id"));
+    act(() => result.current.handleCancelDelete());
+    act(() => result.current.handleBack());
+    // handleBack は hasContent のため確認ダイアログを開くだけ
+    act(() => result.current.handleConfirmDelete());
+
+    // 最終 navigate は /home であるべき
+    expect(mockNavigate).toHaveBeenLastCalledWith("/home");
+  });
+});

--- a/src/components/editor/PageEditor/usePageDeletion.ts
+++ b/src/components/editor/PageEditor/usePageDeletion.ts
@@ -19,6 +19,16 @@ interface UsePageDeletionReturn {
   handleBack: () => void;
   handleConfirmDelete: () => void;
   handleCancelDelete: () => void;
+  /**
+   * 重複警告の「開く」ボタン押下時のハンドラ。
+   * 現在編集中のページ（重複側）を削除してから既存ページへ遷移する。
+   * コンテンツがある場合は確認ダイアログを表示する。
+   *
+   * Handler for the "Open" button on the duplicate-title warning.
+   * Deletes the currently editing (duplicate) page before navigating to the existing one.
+   * Shows a confirmation dialog when the page has content.
+   */
+  handleOpenDuplicatePage: (targetPageId: string) => void;
 }
 
 /**
@@ -37,6 +47,9 @@ export function usePageDeletion({
 
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [deleteReason, setDeleteReason] = useState<string>("");
+  // 確認ダイアログ確定後の遷移先。デフォルトは /home。
+  // Navigation target to use after the confirmation dialog resolves. Defaults to /home.
+  const [pendingNavTarget, setPendingNavTarget] = useState<string>("/home");
 
   const handleDelete = useCallback(() => {
     if (currentPageId) {
@@ -75,6 +88,8 @@ export function usePageDeletion({
         } else {
           setDeleteReason("タイトルが未入力のページ");
         }
+        // 戻る経由なので遷移先はホーム
+        setPendingNavTarget("/home");
         setDeleteConfirmOpen(true);
         return;
       }
@@ -102,12 +117,48 @@ export function usePageDeletion({
       });
     }
     setDeleteConfirmOpen(false);
-    navigate("/home");
-  }, [currentPageId, deletePageMutation, deleteReason, navigate, toast]);
+    navigate(pendingNavTarget);
+    // 次回に備えてデフォルトに戻す / reset to default for next invocation
+    setPendingNavTarget("/home");
+  }, [currentPageId, deletePageMutation, deleteReason, navigate, pendingNavTarget, toast]);
 
   const handleCancelDelete = useCallback(() => {
     setDeleteConfirmOpen(false);
+    setPendingNavTarget("/home");
   }, []);
+
+  const handleOpenDuplicatePage = useCallback(
+    (targetPageId: string) => {
+      const targetPath = `/page/${targetPageId}`;
+
+      // 現在のページがまだ作成されていない場合は削除不要でそのまま遷移
+      // No current page persisted yet — just navigate.
+      if (!currentPageId) {
+        navigate(targetPath);
+        return;
+      }
+
+      const hasContent = isContentNotEmpty(content);
+
+      // コンテンツがある場合は確認ダイアログを表示
+      // Ask for confirmation when the duplicate page has content.
+      if (hasContent) {
+        setDeleteReason("重複するタイトルのページ");
+        setPendingNavTarget(targetPath);
+        setDeleteConfirmOpen(true);
+        return;
+      }
+
+      // コンテンツがない場合はそのまま削除して遷移
+      // Otherwise delete immediately and navigate to the existing page.
+      deletePageMutation.mutate(currentPageId);
+      toast({
+        title: "重複するタイトルのため、ページを削除しました",
+      });
+      navigate(targetPath);
+    },
+    [currentPageId, content, deletePageMutation, navigate, toast],
+  );
 
   return {
     deleteConfirmOpen,
@@ -117,5 +168,6 @@ export function usePageDeletion({
     handleBack,
     handleConfirmDelete,
     handleCancelDelete,
+    handleOpenDuplicatePage,
   };
 }

--- a/src/components/editor/PageEditor/usePageEditor.ts
+++ b/src/components/editor/PageEditor/usePageEditor.ts
@@ -66,7 +66,6 @@ export function usePageEditor() {
     title: state.title,
     content: state.content,
     enableAutoTitle: state.isNewPage,
-    duplicatePage: state.duplicatePage ?? null,
     setTitle: state.setTitle,
     setContent: state.setContent,
     setContentError: state.setContentError,
@@ -109,7 +108,11 @@ export function usePageEditor() {
       onExportMarkdown: state.handleExportMarkdown,
       onCopyMarkdown: state.handleCopyMarkdown,
       onGenerateWiki: handlers.handleGenerateWiki,
-      onOpenDuplicatePage: handlers.handleOpenDuplicatePage,
+      onOpenDuplicatePage: () => {
+        if (state.duplicatePage) {
+          state.handleOpenDuplicatePage(state.duplicatePage.id);
+        }
+      },
       onCancelWiki: state.cancelWiki,
       onContentChange: handlers.handleContentChange,
       onContentError: handlers.handleContentError,

--- a/src/components/editor/PageEditor/usePageEditorHandlers.ts
+++ b/src/components/editor/PageEditor/usePageEditorHandlers.ts
@@ -2,14 +2,12 @@ import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import type { ContentError } from "../TiptapEditor/useContentSanitizer";
 import { generateAutoTitle } from "@/lib/contentUtils";
-import type { Page } from "@/types/page";
 
 interface UsePageEditorHandlersOptions {
   title: string;
   content: string;
   /** true のときだけオートタイトル（コンテンツ先頭行からの自動生成）を有効にする */
   enableAutoTitle: boolean;
-  duplicatePage: Page | null;
   setTitle: (title: string) => void;
   setContent: (content: string) => void;
   setContentError: (error: ContentError | null) => void;
@@ -27,7 +25,6 @@ export function usePageEditorHandlers(options: UsePageEditorHandlersOptions) {
     title,
     content,
     enableAutoTitle,
-    duplicatePage,
     setTitle,
     setContent,
     setContentError,
@@ -73,12 +70,6 @@ export function usePageEditorHandlers(options: UsePageEditorHandlersOptions) {
     [setContentError],
   );
 
-  const handleOpenDuplicatePage = useCallback(() => {
-    if (duplicatePage) {
-      navigate(`/page/${duplicatePage.id}`);
-    }
-  }, [duplicatePage, navigate]);
-
   const handleGenerateWiki = useCallback(() => {
     generateWiki(title);
   }, [generateWiki, title]);
@@ -94,7 +85,6 @@ export function usePageEditorHandlers(options: UsePageEditorHandlersOptions) {
     handleContentChange,
     handleTitleChange,
     handleContentError,
-    handleOpenDuplicatePage,
     handleGenerateWiki,
     handleGoToAISettings,
   };

--- a/src/components/editor/PageEditor/usePageEditorStateAndSync.ts
+++ b/src/components/editor/PageEditor/usePageEditorStateAndSync.ts
@@ -136,6 +136,7 @@ export function usePageEditorStateAndSync() {
     handleBack,
     handleConfirmDelete,
     handleCancelDelete,
+    handleOpenDuplicatePage,
     handleExportMarkdown,
     handleCopyMarkdown,
   } = usePageEditorDeletionAndNav(currentPageId, title, content, sourceUrl, shouldBlockSave);
@@ -219,6 +220,7 @@ export function usePageEditorStateAndSync() {
       handleBack,
       handleConfirmDelete,
       handleCancelDelete,
+      handleOpenDuplicatePage,
       setTitle,
       setContent,
       setContentError,

--- a/src/components/editor/PageEditor/usePageEditorStateAndSyncReturnSlices.ts
+++ b/src/components/editor/PageEditor/usePageEditorStateAndSyncReturnSlices.ts
@@ -70,6 +70,7 @@ export interface PageEditorActionsReturnSlice {
   handleBack: () => void;
   handleConfirmDelete: () => void;
   handleCancelDelete: () => void;
+  handleOpenDuplicatePage: (targetPageId: string) => void;
   setTitle: (t: string) => void;
   setContent: (c: string) => void;
   setContentError: (e: string | null) => void;


### PR DESCRIPTION
## Changes

- **Added `handleOpenDuplicatePage` to `usePageDeletion`**: New handler for the duplicate-title warning's "Open" button that deletes the current (duplicate) page before navigating to the existing one
- **Smart deletion logic**: 
  - If current page is not yet persisted (`currentPageId` is null), just navigate
  - If page has no content, delete immediately and show toast
  - If page has content, show confirmation dialog first
- **Configurable navigation target**: Uses `pendingNavTarget` state to navigate to the duplicate page after deletion, or `/home` when using handleBack
- **Comprehensive test coverage**: Added 161 lines of tests covering all scenarios (unsaved page, empty content, confirmation flows, cancellation)
- **Refactored `usePageEditorHandlers`**: Removed duplicate page navigation logic that is now handled by the new deletion hook

## Related Issues

Addresses duplicate title warning flow by automatically cleaning up the duplicate page when the user chooses to open the existing one.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
