### PR TITLE
fix(api): address PR #585 review comments

### DIFF
--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776211200000,
       "tag": "0004_add_admin_audit_logs",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1776297600000,
+      "tag": "0005_add_user_status",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/src/__tests__/middleware/mcpAuth.test.ts
+++ b/server/api/src/__tests__/middleware/mcpAuth.test.ts
@@ -18,8 +18,26 @@ vi.mock("../../lib/mcpAuth.js", async (importOriginal) => {
 import { mcpReadRequired, mcpWriteRequired } from "../../middleware/mcpAuth.js";
 import { MCP_JWT_AUDIENCE, MCP_SCOPE_READ, MCP_SCOPE_WRITE } from "../../lib/mcpAuth.js";
 
-function createApp() {
+type MockStatusRow = { status: "active" | "suspended" | "deleted" };
+
+function createMockDb(statusRows: MockStatusRow[]) {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => statusRows,
+        }),
+      }),
+    }),
+  } as unknown as AppEnv["Variables"]["db"];
+}
+
+function createApp(statusRows: MockStatusRow[] = [{ status: "active" }]) {
   const app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("db", createMockDb(statusRows));
+    await next();
+  });
   app.get("/read", mcpReadRequired, (c) => c.json({ ok: true, userId: c.get("userId") }));
   app.get("/write", mcpWriteRequired, (c) => c.json({ ok: true, userId: c.get("userId") }));
   return app;
@@ -88,6 +106,19 @@ describe("mcpReadRequired", () => {
     });
     expect(res.status).toBe(200);
   });
+
+  it("returns 403 when the MCP user is suspended", async () => {
+    mockVerifyMcpToken.mockResolvedValue({
+      sub: "user-42",
+      scope: [MCP_SCOPE_READ],
+      aud: MCP_JWT_AUDIENCE,
+      exp: 0,
+    });
+    const res = await createApp([{ status: "suspended" }]).request("/read", {
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(res.status).toBe(403);
+  });
 });
 
 describe("mcpWriteRequired", () => {
@@ -117,5 +148,31 @@ describe("mcpWriteRequired", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { userId: string };
     expect(body.userId).toBe("user-7");
+  });
+
+  it("returns 403 when the MCP user is deleted", async () => {
+    mockVerifyMcpToken.mockResolvedValue({
+      sub: "user-7",
+      scope: [MCP_SCOPE_WRITE],
+      aud: MCP_JWT_AUDIENCE,
+      exp: 0,
+    });
+    const res = await createApp([{ status: "deleted" }]).request("/write", {
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 when the MCP user no longer exists", async () => {
+    mockVerifyMcpToken.mockResolvedValue({
+      sub: "user-7",
+      scope: [MCP_SCOPE_WRITE],
+      aud: MCP_JWT_AUDIENCE,
+      exp: 0,
+    });
+    const res = await createApp([]).request("/write", {
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(res.status).toBe(401);
   });
 });

--- a/server/api/src/__tests__/routes/admin/index.test.ts
+++ b/server/api/src/__tests__/routes/admin/index.test.ts
@@ -29,8 +29,23 @@ const ADMIN_ROLE_RESULT = [{ role: "admin" }];
 const USER_ROLE_RESULT = [{ role: "user" }];
 
 import { createAdminTestApp, createMockUserRow, adminAuthHeaders } from "./setup.js";
+import { parseAdminUserStatusFilter } from "../../../routes/admin/index.js";
 
 // ── GET /api/admin/users ─────────────────────────────────────────────────────
+
+describe("parseAdminUserStatusFilter", () => {
+  it("returns a valid status filter unchanged", () => {
+    expect(parseAdminUserStatusFilter("active")).toBe("active");
+    expect(parseAdminUserStatusFilter("suspended")).toBe("suspended");
+    expect(parseAdminUserStatusFilter("deleted")).toBe("deleted");
+  });
+
+  it("falls back to null for missing or invalid values", () => {
+    expect(parseAdminUserStatusFilter(undefined)).toBeNull();
+    expect(parseAdminUserStatusFilter("")).toBeNull();
+    expect(parseAdminUserStatusFilter("archived")).toBeNull();
+  });
+});
 
 describe("GET /api/admin/users", () => {
   it("returns 200 with users and total", async () => {

--- a/server/api/src/__tests__/routes/admin/suspend.test.ts
+++ b/server/api/src/__tests__/routes/admin/suspend.test.ts
@@ -185,6 +185,23 @@ describe("POST /api/admin/users/:id/suspend", () => {
     expect(body.error).toContain("already suspended");
   });
 
+  it("returns 400 when user is already deleted", async () => {
+    const { app } = createAdminTestApp([
+      ADMIN_ROLE_RESULT,
+      [{ id: "user-target-001", status: "deleted", role: "user" }],
+    ]);
+
+    const res = await app.request("/api/admin/users/user-target-001/suspend", {
+      method: "POST",
+      headers: adminAuthHeaders(),
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toContain("deleted");
+  });
+
   it("returns 404 when user not found", async () => {
     const { app } = createAdminTestApp([
       ADMIN_ROLE_RESULT,

--- a/server/api/src/middleware/mcpAuth.ts
+++ b/server/api/src/middleware/mcpAuth.ts
@@ -11,9 +11,11 @@
  * Bearer JWT middleware for MCP routes. Sets `userId` on context after scope check.
  * `mcp:write` implicitly grants read permission.
  */
+import { eq } from "drizzle-orm";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import { verifyMcpToken, MCP_SCOPE_READ, MCP_SCOPE_WRITE, hasScope } from "../lib/mcpAuth.js";
+import { users } from "../schema/users.js";
 import type { AppEnv } from "../types/index.js";
 
 /**
@@ -33,6 +35,28 @@ async function extractAndVerify(authHeader: string | undefined) {
 }
 
 /**
+ * MCP トークンの主体ユーザーが有効なアカウント状態か確認する。
+ * Rejects suspended, deleted, or missing users before allowing MCP access.
+ */
+async function ensureActiveMcpUser(db: AppEnv["Variables"]["db"], userId: string): Promise<void> {
+  const [row] = await db
+    .select({ status: users.status })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!row) {
+    throw new HTTPException(401, { message: "Unauthorized" });
+  }
+  if (row.status === "suspended") {
+    throw new HTTPException(403, { message: "Account suspended" });
+  }
+  if (row.status !== "active") {
+    throw new HTTPException(403, { message: "Account is not active" });
+  }
+}
+
+/**
  * MCP 読み取り系操作のための認証ミドルウェア。`mcp:read` または `mcp:write` を要求する。
  * Auth middleware for read-only MCP routes; accepts `mcp:read` or `mcp:write` scope.
  */
@@ -41,6 +65,7 @@ export const mcpReadRequired = createMiddleware<AppEnv>(async (c, next) => {
   if (!hasScope(payload, MCP_SCOPE_READ) && !hasScope(payload, MCP_SCOPE_WRITE)) {
     throw new HTTPException(403, { message: "mcp:read scope required" });
   }
+  await ensureActiveMcpUser(c.get("db"), payload.sub);
   c.set("userId", payload.sub);
   await next();
 });
@@ -54,6 +79,7 @@ export const mcpWriteRequired = createMiddleware<AppEnv>(async (c, next) => {
   if (!hasScope(payload, MCP_SCOPE_WRITE)) {
     throw new HTTPException(403, { message: "mcp:write scope required" });
   }
+  await ensureActiveMcpUser(c.get("db"), payload.sub);
   c.set("userId", payload.sub);
   await next();
 });

--- a/server/api/src/routes/admin/index.ts
+++ b/server/api/src/routes/admin/index.ts
@@ -32,6 +32,17 @@ const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
 
 /**
+ * 管理画面のユーザーステータス絞り込み値を正規化する。
+ * Returns a valid user status filter, or null when the value is missing/invalid.
+ */
+export function parseAdminUserStatusFilter(value: string | undefined): UserStatus | null {
+  if (value === "active" || value === "suspended" || value === "deleted") {
+    return value;
+  }
+  return null;
+}
+
+/**
  * GET /api/admin/users — list users (paginated, optional email search, optional status filter).
  *
  * ユーザー一覧を取得する（ページネーション、メール検索、ステータスフィルタ対応）。
@@ -39,7 +50,7 @@ const MAX_LIMIT = 200;
 app.get("/users", async (c) => {
   const db = c.get("db");
   const search = c.req.query("search")?.trim();
-  const statusFilter = c.req.query("status")?.trim() as UserStatus | undefined;
+  const statusFilter = parseAdminUserStatusFilter(c.req.query("status")?.trim());
   const limitRaw = parseInt(c.req.query("limit") ?? String(DEFAULT_LIMIT), 10);
   const limit = Number.isFinite(limitRaw)
     ? Math.min(Math.max(1, limitRaw), MAX_LIMIT)
@@ -51,11 +62,12 @@ app.get("/users", async (c) => {
   if (search) {
     conditions.push(like(users.email, `%${search.replace(/[%_\\]/g, (ch) => `\\${ch}`)}%`));
   }
-  if (statusFilter && ["active", "suspended", "deleted"].includes(statusFilter)) {
+  if (statusFilter) {
     conditions.push(eq(users.status, statusFilter));
-  } else if (!statusFilter) {
-    // デフォルトでは削除済みユーザーを除外する
-    // Exclude deleted users by default when no status filter is specified
+  }
+  // デフォルトでは削除済みユーザーを除外する。無効な status 値でも同じ既定動作に戻す。
+  // Exclude deleted users by default, including when an invalid status filter is provided.
+  if (!statusFilter) {
     conditions.push(ne(users.status, "deleted"));
   }
 
@@ -238,6 +250,10 @@ app.post("/users/:id/suspend", async (c) => {
       return { notFound: true } as const;
     }
 
+    if (target.status === "deleted") {
+      return { alreadyDeleted: true } as const;
+    }
+
     if (target.status === "suspended") {
       return { alreadySuspended: true } as const;
     }
@@ -292,6 +308,10 @@ app.post("/users/:id/suspend", async (c) => {
 
   if ("alreadySuspended" in result) {
     return c.json({ error: "User is already suspended" }, 400);
+  }
+
+  if ("alreadyDeleted" in result) {
+    return c.json({ error: "Cannot suspend a deleted user" }, 400);
   }
 
   return c.json({ user: result.updated });


### PR DESCRIPTION
## 概要

PR #585 のレビューで見つかった API 側の不整合を修正しました。MCP 認証で suspended/deleted ユーザーを拒否し、admin のユーザーステータス処理で無効な絞り込み値や deleted ユーザーへの suspend を安全に扱います。

## 変更点

- `server/api/`
- MCP 認証ミドルウェアで、JWT 検証後にユーザーステータスを確認し、`suspended` / `deleted` / 不存在ユーザーを拒否
- `GET /api/admin/users` の `status` クエリを正規化し、無効な値でも deleted ユーザー除外の既定動作を維持
- `POST /api/admin/users/:id/suspend` で deleted ユーザーを拒否
- 上記の回帰を防ぐテストを追加
- Drizzle journal に `0005_add_user_status` を追加して migration の適用漏れを防止

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `cd server/api`
2. `bun run test:run src/__tests__/middleware/mcpAuth.test.ts src/__tests__/routes/admin/index.test.ts src/__tests__/routes/admin/suspend.test.ts`
3. ルートで `bun run lint -- server/api/src/middleware/mcpAuth.ts server/api/src/__tests__/middleware/mcpAuth.test.ts server/api/src/routes/admin/index.ts server/api/src/__tests__/routes/admin/index.test.ts server/api/src/__tests__/routes/admin/suspend.test.ts`

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

UI 変更なし。

## 関連 Issue

なし

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
