### PR TITLE
fix(review): address remaining PR #585 comments

### DIFF
--- a/.github/workflows/terraform-cloudflare-prod.yml
+++ b/.github/workflows/terraform-cloudflare-prod.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
@@ -56,7 +56,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false

--- a/admin/src/pages/audit-logs/index.tsx
+++ b/admin/src/pages/audit-logs/index.tsx
@@ -5,6 +5,7 @@ import { AuditLogsContent, type AuditLogsFilters } from "./AuditLogsContent";
 
 const FILTER_DEBOUNCE_MS = 300;
 const PAGE_SIZE = 50;
+const INITIAL_FILTERS: AuditLogsFilters = {};
 
 /**
  * `datetime-local` の値 (`YYYY-MM-DDTHH:mm`) を API が受け付ける ISO 文字列に変換する。
@@ -28,8 +29,8 @@ export default function AuditLogs() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(0);
-  const [filters, setFilters] = useState<AuditLogsFilters>({});
-  const [appliedFilters, setAppliedFilters] = useState<AuditLogsFilters>({});
+  const [filters, setFilters] = useState<AuditLogsFilters>(INITIAL_FILTERS);
+  const [appliedFilters, setAppliedFilters] = useState<AuditLogsFilters>(INITIAL_FILTERS);
 
   const isMountedRef = useRef(true);
   const filterTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/admin/src/pages/users/useConfirmDialogs.ts
+++ b/admin/src/pages/users/useConfirmDialogs.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import type { UserAdmin, UserRole, UserImpact } from "@/api/admin";
 import { getUserImpact } from "@/api/admin";
 
@@ -38,6 +38,7 @@ export function useConfirmDialogs(
   const [roleChangeTarget, setRoleChangeTarget] = useState<RoleChangeTarget | null>(null);
   const [unsuspendTarget, setUnsuspendTarget] = useState<UserAdmin | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+  const deleteImpactRequestIdRef = useRef(0);
 
   const requestRoleChange = useCallback((user: UserAdmin, role: UserRole) => {
     if (user.role === role) return;
@@ -69,13 +70,23 @@ export function useConfirmDialogs(
   }, []);
 
   const requestDelete = useCallback((user: UserAdmin) => {
+    const requestId = deleteImpactRequestIdRef.current + 1;
+    deleteImpactRequestIdRef.current = requestId;
     setDeleteTarget({ user, impact: null, loadingImpact: true });
     getUserImpact(user.id)
       .then((impact) => {
-        setDeleteTarget((prev) => (prev ? { ...prev, impact, loadingImpact: false } : null));
+        setDeleteTarget((prev) =>
+          prev && prev.user.id === user.id && deleteImpactRequestIdRef.current === requestId
+            ? { ...prev, impact, loadingImpact: false }
+            : prev,
+        );
       })
       .catch(() => {
-        setDeleteTarget((prev) => (prev ? { ...prev, loadingImpact: false } : null));
+        setDeleteTarget((prev) =>
+          prev && prev.user.id === user.id && deleteImpactRequestIdRef.current === requestId
+            ? { ...prev, loadingImpact: false }
+            : prev,
+        );
       });
   }, []);
 
@@ -86,6 +97,7 @@ export function useConfirmDialogs(
   }, [deleteTarget, onDelete]);
 
   const cancelDelete = useCallback(() => {
+    deleteImpactRequestIdRef.current += 1;
     setDeleteTarget(null);
   }, []);
 

--- a/server/api/drizzle/0004_add_admin_audit_logs.sql
+++ b/server/api/drizzle/0004_add_admin_audit_logs.sql
@@ -31,3 +31,27 @@ CREATE INDEX IF NOT EXISTS "idx_admin_audit_logs_target_created"
 
 CREATE INDEX IF NOT EXISTS "idx_admin_audit_logs_action_created"
   ON "admin_audit_logs" ("action", "created_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "idx_admin_audit_logs_created_id"
+  ON "admin_audit_logs" ("created_at" DESC, "id" DESC);
+
+CREATE OR REPLACE FUNCTION "prevent_admin_audit_logs_mutation"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'admin_audit_logs is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "trg_admin_audit_logs_no_update" ON "admin_audit_logs";
+CREATE TRIGGER "trg_admin_audit_logs_no_update"
+BEFORE UPDATE ON "admin_audit_logs"
+FOR EACH ROW
+EXECUTE FUNCTION "prevent_admin_audit_logs_mutation"();
+
+DROP TRIGGER IF EXISTS "trg_admin_audit_logs_no_delete" ON "admin_audit_logs";
+CREATE TRIGGER "trg_admin_audit_logs_no_delete"
+BEFORE DELETE ON "admin_audit_logs"
+FOR EACH ROW
+EXECUTE FUNCTION "prevent_admin_audit_logs_mutation"();

--- a/server/api/drizzle/0004_add_admin_audit_logs.sql
+++ b/server/api/drizzle/0004_add_admin_audit_logs.sql
@@ -31,27 +31,3 @@ CREATE INDEX IF NOT EXISTS "idx_admin_audit_logs_target_created"
 
 CREATE INDEX IF NOT EXISTS "idx_admin_audit_logs_action_created"
   ON "admin_audit_logs" ("action", "created_at" DESC);
-
-CREATE INDEX IF NOT EXISTS "idx_admin_audit_logs_created_id"
-  ON "admin_audit_logs" ("created_at" DESC, "id" DESC);
-
-CREATE OR REPLACE FUNCTION "prevent_admin_audit_logs_mutation"()
-RETURNS trigger
-LANGUAGE plpgsql
-AS $$
-BEGIN
-  RAISE EXCEPTION 'admin_audit_logs is append-only';
-END;
-$$;
-
-DROP TRIGGER IF EXISTS "trg_admin_audit_logs_no_update" ON "admin_audit_logs";
-CREATE TRIGGER "trg_admin_audit_logs_no_update"
-BEFORE UPDATE ON "admin_audit_logs"
-FOR EACH ROW
-EXECUTE FUNCTION "prevent_admin_audit_logs_mutation"();
-
-DROP TRIGGER IF EXISTS "trg_admin_audit_logs_no_delete" ON "admin_audit_logs";
-CREATE TRIGGER "trg_admin_audit_logs_no_delete"
-BEFORE DELETE ON "admin_audit_logs"
-FOR EACH ROW
-EXECUTE FUNCTION "prevent_admin_audit_logs_mutation"();

--- a/server/api/drizzle/0006_audit_logs_append_only.sql
+++ b/server/api/drizzle/0006_audit_logs_append_only.sql
@@ -1,0 +1,26 @@
+-- Add deterministic ordering index and append-only triggers for admin_audit_logs.
+-- 監査ログの順序安定化用インデックスと追記専用トリガーを追加する。
+
+CREATE INDEX IF NOT EXISTS "idx_admin_audit_logs_created_id"
+  ON "admin_audit_logs" ("created_at" DESC, "id" DESC);
+
+CREATE OR REPLACE FUNCTION "prevent_admin_audit_logs_mutation"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'admin_audit_logs is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "trg_admin_audit_logs_no_update" ON "admin_audit_logs";
+CREATE TRIGGER "trg_admin_audit_logs_no_update"
+BEFORE UPDATE ON "admin_audit_logs"
+FOR EACH ROW
+EXECUTE FUNCTION "prevent_admin_audit_logs_mutation"();
+
+DROP TRIGGER IF EXISTS "trg_admin_audit_logs_no_delete" ON "admin_audit_logs";
+CREATE TRIGGER "trg_admin_audit_logs_no_delete"
+BEFORE DELETE ON "admin_audit_logs"
+FOR EACH ROW
+EXECUTE FUNCTION "prevent_admin_audit_logs_mutation"();

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1776297600000,
       "tag": "0005_add_user_status",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1776384000000,
+      "tag": "0006_audit_logs_append_only",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/src/__tests__/middleware/mcpAuth.test.ts
+++ b/server/api/src/__tests__/middleware/mcpAuth.test.ts
@@ -94,6 +94,19 @@ describe("mcpReadRequired", () => {
     expect(body.userId).toBe("user-42");
   });
 
+  it("accepts a lowercase bearer scheme", async () => {
+    mockVerifyMcpToken.mockResolvedValue({
+      sub: "user-42",
+      scope: [MCP_SCOPE_READ],
+      aud: MCP_JWT_AUDIENCE,
+      exp: 0,
+    });
+    const res = await createApp().request("/read", {
+      headers: { Authorization: "bearer t" },
+    });
+    expect(res.status).toBe(200);
+  });
+
   it("accepts a token that has only mcp:write (write implies read)", async () => {
     mockVerifyMcpToken.mockResolvedValue({
       sub: "user-42",

--- a/server/api/src/__tests__/middleware/mcpAuth.test.ts
+++ b/server/api/src/__tests__/middleware/mcpAuth.test.ts
@@ -107,6 +107,14 @@ describe("mcpReadRequired", () => {
     expect(res.status).toBe(200);
   });
 
+  it("returns 401 when Authorization has extra segments after the token", async () => {
+    const res = await createApp().request("/read", {
+      headers: { Authorization: "Bearer t extra" },
+    });
+    expect(res.status).toBe(401);
+    expect(mockVerifyMcpToken).not.toHaveBeenCalled();
+  });
+
   it("accepts a token that has only mcp:write (write implies read)", async () => {
     mockVerifyMcpToken.mockResolvedValue({
       sub: "user-42",

--- a/server/api/src/lib/userDelete.ts
+++ b/server/api/src/lib/userDelete.ts
@@ -78,7 +78,7 @@ export async function getUserImpact(db: Database, userId: string): Promise<UserI
  *
  * @param tx - Drizzle transaction client
  * @param userId - Target user ID
- * @returns Anonymized user row (for the API response) and before-snapshot
+ * @returns Anonymized user row (for the API response) and a redacted before-snapshot for audit logs
  */
 export async function anonymizeUser(
   tx: Database,
@@ -96,13 +96,12 @@ export async function anonymizeUser(
     createdAt: Date;
   };
   before: {
-    name: string;
-    email: string;
-    image: string | null;
     status: string;
+    piiRedacted: true;
   };
 }> {
-  // 変更前のスナップショットを取得 / Capture before-snapshot
+  // 変更前ステータスを取得する。監査ログには PII を残さない。
+  // Capture the pre-delete status only; audit logs must not retain recoverable PII.
   const [target] = await tx
     .select({
       id: users.id,
@@ -120,10 +119,8 @@ export async function anonymizeUser(
   }
 
   const before = {
-    name: target.name,
-    email: target.email,
-    image: target.image,
     status: target.status,
+    piiRedacted: true as const,
   };
 
   const now = new Date();

--- a/server/api/src/middleware/auth.ts
+++ b/server/api/src/middleware/auth.ts
@@ -50,14 +50,12 @@ export const authRequired = createMiddleware<AppEnv>(async (c, next) => {
   await next();
 });
 
-export /**
- *
+/**
+ * セッションがあればユーザー情報をコンテキストへ設定する任意認証ミドルウェア。
+ * Continues without failure when no valid session exists, but populates context when present.
  */
-const authOptional = createMiddleware<AppEnv>(async (c, next) => {
+export const authOptional = createMiddleware<AppEnv>(async (c, next) => {
   try {
-    /**
-     *
-     */
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
     if (session) {
       c.set("userId", session.user.id);

--- a/server/api/src/middleware/mcpAuth.ts
+++ b/server/api/src/middleware/mcpAuth.ts
@@ -23,10 +23,11 @@ import type { AppEnv } from "../types/index.js";
  * Verifies the Bearer token from request headers; throws HTTPException 401 on failure.
  */
 async function extractAndVerify(authHeader: string | undefined) {
-  const [scheme, token = ""] = authHeader?.trim().split(/\s+/, 2) ?? [];
-  if (scheme?.toLowerCase() !== "bearer" || !token) {
+  const parts = authHeader?.trim().split(/\s+/) ?? [];
+  if (parts.length !== 2 || parts[0]?.toLowerCase() !== "bearer" || !parts[1]) {
     throw new HTTPException(401, { message: "Bearer token required" });
   }
+  const token = parts[1];
   const payload = await verifyMcpToken(token);
   if (!payload) {
     throw new HTTPException(401, { message: "Invalid or expired token" });

--- a/server/api/src/middleware/mcpAuth.ts
+++ b/server/api/src/middleware/mcpAuth.ts
@@ -23,10 +23,10 @@ import type { AppEnv } from "../types/index.js";
  * Verifies the Bearer token from request headers; throws HTTPException 401 on failure.
  */
 async function extractAndVerify(authHeader: string | undefined) {
-  if (!authHeader?.startsWith("Bearer ")) {
+  const [scheme, token = ""] = authHeader?.trim().split(/\s+/, 2) ?? [];
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
     throw new HTTPException(401, { message: "Bearer token required" });
   }
-  const token = authHeader.slice(7).trim();
   const payload = await verifyMcpToken(token);
   if (!payload) {
     throw new HTTPException(401, { message: "Invalid or expired token" });

--- a/server/api/src/routes/admin/auditLogs.ts
+++ b/server/api/src/routes/admin/auditLogs.ts
@@ -120,7 +120,7 @@ app.get("/", async (c) => {
       and(eq(adminAuditLogs.targetType, "user"), eq(target.id, adminAuditLogs.targetId)),
     )
     .where(whereClause)
-    .orderBy(desc(adminAuditLogs.createdAt))
+    .orderBy(desc(adminAuditLogs.createdAt), desc(adminAuditLogs.id))
     .limit(limit)
     .offset(offset);
 

--- a/server/api/src/schema/auditLogs.ts
+++ b/server/api/src/schema/auditLogs.ts
@@ -32,14 +32,14 @@ export const adminAuditLogs = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [
-    index("idx_admin_audit_logs_created_id").on(table.createdAt, table.id),
-    index("idx_admin_audit_logs_actor_created").on(table.actorUserId, table.createdAt),
+    index("idx_admin_audit_logs_created_id").on(table.createdAt.desc(), table.id.desc()),
+    index("idx_admin_audit_logs_actor_created").on(table.actorUserId, table.createdAt.desc()),
     index("idx_admin_audit_logs_target_created").on(
       table.targetType,
       table.targetId,
-      table.createdAt,
+      table.createdAt.desc(),
     ),
-    index("idx_admin_audit_logs_action_created").on(table.action, table.createdAt),
+    index("idx_admin_audit_logs_action_created").on(table.action, table.createdAt.desc()),
   ],
 );
 

--- a/server/api/src/schema/auditLogs.ts
+++ b/server/api/src/schema/auditLogs.ts
@@ -32,6 +32,7 @@ export const adminAuditLogs = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [
+    index("idx_admin_audit_logs_created_id").on(table.createdAt, table.id),
     index("idx_admin_audit_logs_actor_created").on(table.actorUserId, table.createdAt),
     index("idx_admin_audit_logs_target_created").on(
       table.targetType,

--- a/server/api/src/schema/users.ts
+++ b/server/api/src/schema/users.ts
@@ -6,10 +6,11 @@ export type UserRole = "user" | "admin";
 /** User account status. 'suspended' blocks all API access. */
 export type UserStatus = "active" | "suspended" | "deleted";
 
-export /**
- *
+/**
+ * Better Auth user table with Zedi-specific role and status columns.
+ * Zedi 固有のロール・ステータス列を含む Better Auth のユーザーテーブル。
  */
-const users = pgTable(
+export const users = pgTable(
   "user",
   {
     id: text("id").primaryKey(),
@@ -41,18 +42,21 @@ const users = pgTable(
 );
 
 /**
- *
+ * User row type inferred from the `user` table.
+ * `user` テーブルから推論した行型。
  */
 export type User = typeof users.$inferSelect;
 /**
- *
+ * Insert payload type inferred from the `user` table.
+ * `user` テーブルから推論した挿入型。
  */
 export type NewUser = typeof users.$inferInsert;
 
-export /**
- *
+/**
+ * Better Auth session table.
+ * Better Auth のセッションテーブル。
  */
-const session = pgTable("session", {
+export const session = pgTable("session", {
   id: text("id").primaryKey(),
   userId: text("user_id")
     .notNull()
@@ -65,10 +69,11 @@ const session = pgTable("session", {
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
-export /**
- *
+/**
+ * Better Auth account table for linked OAuth identities.
+ * OAuth 連携アカウントを保持する Better Auth の account テーブル。
  */
-const account = pgTable("account", {
+export const account = pgTable("account", {
   id: text("id").primaryKey(),
   userId: text("user_id")
     .notNull()
@@ -86,10 +91,11 @@ const account = pgTable("account", {
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
-export /**
- *
+/**
+ * Better Auth verification table for one-time verification values.
+ * ワンタイム検証値を保持する Better Auth の verification テーブル。
  */
-const verification = pgTable("verification", {
+export const verification = pgTable("verification", {
   id: text("id").primaryKey(),
   identifier: text("identifier").notNull(),
   value: text("value").notNull(),

--- a/server/mcp/src/client/httpClient.ts
+++ b/server/mcp/src/client/httpClient.ts
@@ -29,11 +29,11 @@ import type {
 
 /** HttpZediClient のコンストラクタオプション / Options for HttpZediClient. */
 export interface HttpZediClientOptions {
-  /** Zedi API の baseUrl。末尾スラッシュは正規化される。 */
+  /** Zedi API の baseUrl。末尾スラッシュは正規化される。 Base URL for the Zedi API; trailing slashes are normalized. */
   baseUrl: string;
-  /** MCP JWT。`Authorization: Bearer ...` に付与される。 */
+  /** MCP JWT。`Authorization: Bearer ...` に付与される。 MCP JWT attached as `Authorization: Bearer ...`. */
   token: string;
-  /** テスト用 fetch 注入。省略時は globalThis.fetch を使用。 */
+  /** テスト用 fetch 注入。省略時は globalThis.fetch を使用。 Optional fetch implementation for tests; defaults to globalThis.fetch. */
   fetch?: typeof fetch;
 }
 

--- a/src/components/editor/extensions/MarkdownPasteExtension.test.ts
+++ b/src/components/editor/extensions/MarkdownPasteExtension.test.ts
@@ -137,6 +137,17 @@ describe("MarkdownPaste extension", () => {
     expect(mockEditor.commands.insertContent).toHaveBeenCalledWith(parsedDoc);
   });
 
+  it("returns false when insertContent rejects the parsed content", () => {
+    const parsedDoc = { type: "doc", content: [] };
+    const { handlePaste } = getHandlePaste({
+      parse: vi.fn(() => parsedDoc),
+      insertContent: vi.fn(() => false),
+    });
+
+    const event = createMockPasteEvent("# Hello");
+    expect(handlePaste(null, event, null)).toBe(false);
+  });
+
   it("returns false for plain text without markdown patterns", () => {
     const { handlePaste, mockEditor } = getHandlePaste();
 

--- a/src/components/editor/extensions/MarkdownPasteExtension.ts
+++ b/src/components/editor/extensions/MarkdownPasteExtension.ts
@@ -85,8 +85,7 @@ export const MarkdownPaste = Extension.create({
                     parsed as Parameters<typeof transformWikiLinksInContent>[0],
                   )
                 : parsed;
-              editor.commands.insertContent(content);
-              return true;
+              return editor.commands.insertContent(content);
             } catch {
               // パース失敗時は ProseMirror のデフォルトペースト処理にフォールバック
               // On parse failure, fall back to ProseMirror's default paste handling

--- a/src/components/editor/extensions/transformWikiLinksInContent.test.ts
+++ b/src/components/editor/extensions/transformWikiLinksInContent.test.ts
@@ -328,4 +328,32 @@ describe("transformWikiLinksInContent", () => {
 
     expect(doc).toEqual(snapshot);
   });
+
+  it("keeps wiki-link syntax literal inside inline code marks", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "[[Foo]]", marks: [{ type: "code" }] }],
+        },
+      ],
+    };
+
+    expect(transformWikiLinksInContent(doc)).toEqual(doc);
+  });
+
+  it("keeps wiki-link syntax literal inside code blocks", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          content: [{ type: "text", text: "[[Foo]]" }],
+        },
+      ],
+    };
+
+    expect(transformWikiLinksInContent(doc)).toEqual(doc);
+  });
 });

--- a/src/components/editor/extensions/transformWikiLinksInContent.ts
+++ b/src/components/editor/extensions/transformWikiLinksInContent.ts
@@ -141,6 +141,14 @@ function mergeMarks(existing: MarkJSON[] | undefined, extra: MarkJSON): MarkJSON
 }
 
 /**
+ * コードとして扱うノード種別かを返す。
+ * Returns whether the given parent node type should preserve literal code text.
+ */
+function isCodeContainerType(type: string): boolean {
+  return type === "codeBlock" || type === "code_block";
+}
+
+/**
  * 任意のノードを再帰的に変換する（テキストノードのみWikiリンク変換を適用）。
  * Recursively transform a node; wiki link extraction only applies to text nodes.
  */
@@ -157,7 +165,10 @@ function transformNode(node: NodeJSON): NodeJSON {
 
   const newContent: NodeJSON[] = [];
   for (const child of node.content) {
-    if (child.type === "text") {
+    const isLiteralCodeText =
+      child.type === "text" &&
+      (isCodeContainerType(node.type) || child.marks?.some((mark) => mark.type === "code"));
+    if (child.type === "text" && !isLiteralCodeText) {
       newContent.push(...splitTextNodeByWikiLinks(child));
     } else {
       newContent.push(transformNode(child));

--- a/src/components/settings/useSettingsSummaries.ts
+++ b/src/components/settings/useSettingsSummaries.ts
@@ -51,8 +51,11 @@ export function useSettingsSummaries(): Record<SettingsSectionId, string> {
       ? t("settings.summary.ai.ownKeyMode")
       : t("settings.summary.ai.serverMode");
     // api_server モードでは API キー不要のため常に設定済みとして扱う。
-    // In api_server mode no API key is required, so always treat as configured.
-    const effectivelyConfigured = !useOwnKey || ai.settings.isConfigured;
+    // In api_server mode no API key is required, except for claude-code which
+    // still depends on its own local configuration state.
+    const effectivelyConfigured =
+      ai.settings.isConfigured ||
+      (ai.settings.apiMode === "api_server" && ai.settings.provider !== "claude-code");
     const statusText = effectivelyConfigured
       ? t("settings.summary.ai.configured")
       : t("settings.summary.ai.notSet");

--- a/src/pages/McpAuthorize.tsx
+++ b/src/pages/McpAuthorize.tsx
@@ -94,7 +94,13 @@ const McpAuthorize: React.FC = () => {
         return;
       }
       const { code } = body as { code: string };
-      const target = new URL(redirectUri);
+      let target: URL;
+      try {
+        target = new URL(redirectUri);
+      } catch {
+        setError("Invalid redirect URI");
+        return;
+      }
       target.searchParams.set("code", code);
       target.searchParams.set("state", state);
       setDone(true);


### PR DESCRIPTION
## 概要

PR #585 に残っていた未対応レビュー指摘を、`develop` に安全に取り込むための follow-up PR です。監査ログの整合性、MCP 認証、エディタの paste 処理、管理画面の state 管理まわりを中心に、別ブランチで解消できる内容をまとめて修正しました。

## 変更点

- `admin/`
  - 監査ログページで初回表示時に不要な二重 fetch が走る問題を解消
  - ユーザー削除確認ダイアログの impact fetch race を request id で防止
- `server/api/`
  - `admin_audit_logs` に `created_at + id` index を追加し、一覧 API の並び順を安定化
  - 監査ログテーブルに DB レベルの append-only 制約を追加
  - ユーザー削除監査ログの before snapshot から recoverable PII を除去
  - MCP Bearer 認証を RFC 準拠の case-insensitive parsing に修正し、回帰テストを追加
  - `authOptional` と `users` schema 周辺の空 JSDoc を整理し、説明を補強
- `src/` / `server/mcp/`
  - Markdown paste で `insertContent` 失敗時に fallback paste を阻害しないよう修正
  - code block / inline code 内の `[[WikiLink]]` を literal のまま保持するよう修正し、回帰テストを追加
  - `claude-code` が誤って configured 表示されるケースを修正
  - `McpAuthorize` で不正な `redirect_uri` を defensive に処理
  - `HttpZediClientOptions` の exported field docs を JA/EN 併記に整理
- `CI`
  - production Terraform workflow の `actions/checkout` を immutable SHA に pin

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [x] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run lint`
2. `bun run test:run`
3. `bun run format:check` を実行し、既存の repo-wide formatting warnings がこのブランチ起因ではないことを確認する

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

なし（UI の見た目ではなく挙動の修正が中心）

## 関連 Issue

N/A（PR #585 のレビュー指摘 follow-up）

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit logs are now enforced append-only at the database level.
  * PII is redacted in audit-log snapshots for user privacy.
  * Wiki-links no longer transform within code blocks or inline code.

* **Bug Fixes**
  * Improved Bearer token parsing to handle case variations and reject malformed headers.
  * Enhanced user-deletion impact tracking to avoid race conditions.
  * Markdown paste now correctly returns actual command results.
  * Added validation for MCP authorization redirect URIs.

* **Improvements**
  * Deterministic audit-log ordering for consistent pagination.
  * Refined AI configuration status computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->