### PR TITLE
fix: address PR #585 review comments

### DIFF
--- a/admin/src/components/ConfirmActionDialog.test.tsx
+++ b/admin/src/components/ConfirmActionDialog.test.tsx
@@ -5,87 +5,103 @@ import userEvent from "@testing-library/user-event";
 import { ConfirmActionDialog } from "./ConfirmActionDialog";
 
 // AlertDialog のモック / Mock AlertDialog components from @zedi/ui
-vi.mock("@zedi/ui", () => ({
-  AlertDialog: ({
-    open,
-    onOpenChange,
-    children,
-  }: {
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-    children: React.ReactNode;
-  }) =>
-    open ? (
-      <div data-testid="alert-dialog" data-open={open}>
+vi.mock("@zedi/ui", () => {
+  const AlertDialogContext = React.createContext<{ onOpenChange: (open: boolean) => void } | null>(
+    null,
+  );
+
+  return {
+    AlertDialog: ({
+      open,
+      onOpenChange,
+      children,
+    }: {
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+      children: React.ReactNode;
+    }) =>
+      open ? (
+        <AlertDialogContext.Provider value={{ onOpenChange }}>
+          <div data-testid="alert-dialog" data-open={open}>
+            {children}
+            <button type="button" data-testid="backdrop" onClick={() => onOpenChange(false)}>
+              backdrop
+            </button>
+          </div>
+        </AlertDialogContext.Provider>
+      ) : null,
+    AlertDialogContent: ({
+      children,
+      ...props
+    }: {
+      children: React.ReactNode;
+      className?: string;
+    }) => (
+      <div data-testid="alert-dialog-content" {...props}>
         {children}
-        <button type="button" data-testid="backdrop" onClick={() => onOpenChange(false)}>
-          backdrop
-        </button>
       </div>
-    ) : null,
-  AlertDialogContent: ({
-    children,
-    ...props
-  }: {
-    children: React.ReactNode;
-    className?: string;
-  }) => (
-    <div data-testid="alert-dialog-content" {...props}>
-      {children}
-    </div>
-  ),
-  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="alert-dialog-header">{children}</div>
-  ),
-  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="alert-dialog-footer">{children}</div>
-  ),
-  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => (
-    <h2 data-testid="alert-dialog-title">{children}</h2>
-  ),
-  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
-    <p data-testid="alert-dialog-description">{children}</p>
-  ),
-  AlertDialogCancel: ({
-    children,
-    disabled,
-    ...props
-  }: {
-    children: React.ReactNode;
-    disabled?: boolean;
-  }) => (
-    <button type="button" data-testid="cancel-button" disabled={disabled} {...props}>
-      {children}
-    </button>
-  ),
-  AlertDialogAction: ({
-    children,
-    onClick,
-    disabled,
-    className,
-    ...props
-  }: {
-    children: React.ReactNode;
-    onClick?: (e: React.MouseEvent) => void;
-    disabled?: boolean;
-    className?: string;
-  }) => (
-    <button
-      type="button"
-      data-testid="confirm-button"
-      disabled={disabled}
-      className={className}
-      onClick={onClick}
-      {...props}
-    >
-      {children}
-    </button>
-  ),
-  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
-  Label: ({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) => (
-    <label htmlFor={htmlFor}>{children}</label>
-  ),
-}));
+    ),
+    AlertDialogHeader: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="alert-dialog-header">{children}</div>
+    ),
+    AlertDialogFooter: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="alert-dialog-footer">{children}</div>
+    ),
+    AlertDialogTitle: ({ children }: { children: React.ReactNode }) => (
+      <h2 data-testid="alert-dialog-title">{children}</h2>
+    ),
+    AlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
+      <p data-testid="alert-dialog-description">{children}</p>
+    ),
+    AlertDialogCancel: ({
+      children,
+      disabled,
+      ...props
+    }: {
+      children: React.ReactNode;
+      disabled?: boolean;
+    }) => (
+      <button type="button" data-testid="cancel-button" disabled={disabled} {...props}>
+        {children}
+      </button>
+    ),
+    AlertDialogAction: ({
+      children,
+      onClick,
+      disabled,
+      className,
+      ...props
+    }: {
+      children: React.ReactNode;
+      onClick?: (e: React.MouseEvent) => void;
+      disabled?: boolean;
+      className?: string;
+    }) => {
+      const dialog = React.useContext(AlertDialogContext);
+      return (
+        <button
+          type="button"
+          data-testid="confirm-button"
+          disabled={disabled}
+          className={className}
+          onClick={(e) => {
+            onClick?.(e);
+            if (!e.defaultPrevented) {
+              dialog?.onOpenChange(false);
+            }
+          }}
+          {...props}
+        >
+          {children}
+        </button>
+      );
+    },
+    Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+    Label: ({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) => (
+      <label htmlFor={htmlFor}>{children}</label>
+    ),
+  };
+});
 
 vi.mock("@zedi/ui/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
@@ -123,6 +139,15 @@ describe("ConfirmActionDialog", () => {
 
     await userEvent.click(screen.getByTestId("confirm-button"));
     expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("有効な確認クリックでダイアログを閉じる / closes dialog after enabled confirm click", async () => {
+    const onOpenChange = vi.fn();
+    render(<ConfirmActionDialog {...defaultProps} onOpenChange={onOpenChange} />);
+
+    await userEvent.click(screen.getByTestId("confirm-button"));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it("キャンセルボタンのデフォルトラベルは「キャンセル」/ cancel button shows default label", () => {

--- a/admin/src/components/ConfirmActionDialog.tsx
+++ b/admin/src/components/ConfirmActionDialog.tsx
@@ -145,7 +145,6 @@ export function ConfirmActionDialog({
                 e.preventDefault();
                 return;
               }
-              e.preventDefault();
               handleConfirm();
             }}
           >

--- a/server/api/src/__tests__/routes/admin/auditLogs.test.ts
+++ b/server/api/src/__tests__/routes/admin/auditLogs.test.ts
@@ -165,6 +165,19 @@ describe("GET /api/admin/audit-logs", () => {
     expect(body.error).toMatch(/to|date/i);
   });
 
+  it("returns 400 when 'from' is later than 'to'", async () => {
+    const { app } = createAdminTestApp([ADMIN_ROLE_RESULT]);
+
+    const res = await app.request(
+      "/api/admin/audit-logs?from=2026-12-31T23:59:59Z&to=2026-01-01T00:00:00Z",
+      { headers: adminAuthHeaders() },
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toMatch(/from|to|earlier/i);
+  });
+
   it("accepts filter query params without error", async () => {
     const { app } = createAdminTestApp([ADMIN_ROLE_RESULT, [], [{ count: 0 }]]);
 

--- a/server/api/src/__tests__/routes/admin/delete.test.ts
+++ b/server/api/src/__tests__/routes/admin/delete.test.ts
@@ -270,7 +270,7 @@ describe("GET /api/admin/users/:id/impact", () => {
       [{ id: "user-target-001" }], // user exists
       [{ count: 5 }], // notesCount
       [{ count: 2 }], // sessionsCount
-      [{ status: "active" }], // subscription
+      [{ count: 1 }], // active subscription count
       [{ createdAt: new Date("2026-04-01T12:00:00Z") }], // lastAiUsage
     ]);
 
@@ -280,11 +280,16 @@ describe("GET /api/admin/users/:id/impact", () => {
     });
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as Record<string, unknown>;
-    expect(body).toHaveProperty("notesCount");
-    expect(body).toHaveProperty("sessionsCount");
-    expect(body).toHaveProperty("activeSubscription");
-    expect(body).toHaveProperty("lastAiUsageAt");
+    const body = (await res.json()) as {
+      notesCount: number;
+      sessionsCount: number;
+      activeSubscription: boolean;
+      lastAiUsageAt: string | null;
+    };
+    expect(body.notesCount).toBe(5);
+    expect(body.sessionsCount).toBe(2);
+    expect(body.activeSubscription).toBe(true);
+    expect(body.lastAiUsageAt).toBe("2026-04-01T12:00:00.000Z");
   });
 
   it("returns 404 when user not found", async () => {

--- a/server/api/src/__tests__/routes/admin/suspend.test.ts
+++ b/server/api/src/__tests__/routes/admin/suspend.test.ts
@@ -202,6 +202,20 @@ describe("POST /api/admin/users/:id/suspend", () => {
     expect(body.error).toContain("deleted");
   });
 
+  it("returns 400 for malformed JSON instead of suspending the user", async () => {
+    const { app } = createAdminTestApp([ADMIN_ROLE_RESULT]);
+
+    const res = await app.request("/api/admin/users/user-target-001/suspend", {
+      method: "POST",
+      headers: adminAuthHeaders(),
+      body: '{"reason":',
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toContain("invalid JSON");
+  });
+
   it("returns 404 when user not found", async () => {
     const { app } = createAdminTestApp([
       ADMIN_ROLE_RESULT,

--- a/server/api/src/lib/userDelete.ts
+++ b/server/api/src/lib/userDelete.ts
@@ -49,10 +49,9 @@ export async function getUserImpact(db: Database, userId: string): Promise<UserI
       .from(session)
       .where(eq(session.userId, userId)),
     db
-      .select({ status: subscriptions.status })
+      .select({ count: sql<number>`cast(count(*) as integer)` })
       .from(subscriptions)
-      .where(eq(subscriptions.userId, userId))
-      .limit(1),
+      .where(and(eq(subscriptions.userId, userId), eq(subscriptions.status, "active"))),
     db
       .select({ createdAt: aiUsageLogs.createdAt })
       .from(aiUsageLogs)
@@ -64,7 +63,7 @@ export async function getUserImpact(db: Database, userId: string): Promise<UserI
   return {
     notesCount: notesResult[0]?.count ?? 0,
     sessionsCount: sessionsResult[0]?.count ?? 0,
-    activeSubscription: subResult[0]?.status === "active",
+    activeSubscription: (subResult[0]?.count ?? 0) > 0,
     lastAiUsageAt: aiResult[0]?.createdAt?.toISOString() ?? null,
   };
 }

--- a/server/api/src/routes/admin/auditLogs.ts
+++ b/server/api/src/routes/admin/auditLogs.ts
@@ -60,6 +60,14 @@ function parseDate(raw: string | undefined): { date: Date | null; invalid: boole
  * - `targetId`: 対象 ID で絞り込む
  * - `from`, `to`: ISO 8601 日時で期間絞り込み（createdAt）
  * - `limit`, `offset`: ページング（limit は最大 200）
+ *
+ * Query parameters:
+ * - `actorUserId`: filter by actor user ID
+ * - `action`: filter by action (e.g. `user.role.update`)
+ * - `targetType`: filter by target type (e.g. `user`)
+ * - `targetId`: filter by target ID
+ * - `from`, `to`: ISO 8601 datetime range on `createdAt`
+ * - `limit`, `offset`: pagination (`limit` max 200)
  */
 app.get("/", async (c) => {
   const db = c.get("db");
@@ -76,6 +84,9 @@ app.get("/", async (c) => {
   const to = parseDate(c.req.query("to"));
   if (to.invalid) {
     return c.json({ error: "invalid 'to' date (ISO 8601 required)" }, 400);
+  }
+  if (from.date && to.date && from.date > to.date) {
+    return c.json({ error: "'from' must be earlier than or equal to 'to'" }, 400);
   }
 
   const limit = clampLimit(c.req.query("limit"));

--- a/server/api/src/routes/admin/index.ts
+++ b/server/api/src/routes/admin/index.ts
@@ -226,14 +226,20 @@ app.post("/users/:id/suspend", async (c) => {
     return c.json({ error: "Cannot suspend yourself" }, 400);
   }
 
-  let body: { reason?: string };
-  try {
-    body = await c.req.json<{ reason?: string }>();
-  } catch {
-    body = {};
+  const rawBody = await c.req.text();
+  let reason: string | null = null;
+  if (rawBody.trim().length > 0) {
+    let body: { reason?: unknown } | null;
+    try {
+      body = JSON.parse(rawBody) as { reason?: unknown } | null;
+    } catch {
+      return c.json({ error: "invalid JSON body" }, 400);
+    }
+    reason =
+      body && typeof body === "object" && !Array.isArray(body) && typeof body.reason === "string"
+        ? body.reason.trim() || null
+        : null;
   }
-
-  const reason = typeof body.reason === "string" ? body.reason.trim() || null : null;
 
   const result = await db.transaction(async (tx) => {
     const [target] = await tx

--- a/src/components/editor/extensions/transformWikiLinksInContent.test.ts
+++ b/src/components/editor/extensions/transformWikiLinksInContent.test.ts
@@ -356,4 +356,19 @@ describe("transformWikiLinksInContent", () => {
 
     expect(transformWikiLinksInContent(doc)).toEqual(doc);
   });
+
+  it("keeps wiki-link syntax literal inside executable code blocks", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "executableCodeBlock",
+          attrs: { language: "bash" },
+          content: [{ type: "text", text: "echo [[Foo]]" }],
+        },
+      ],
+    };
+
+    expect(transformWikiLinksInContent(doc)).toEqual(doc);
+  });
 });

--- a/src/components/editor/extensions/transformWikiLinksInContent.ts
+++ b/src/components/editor/extensions/transformWikiLinksInContent.ts
@@ -145,7 +145,7 @@ function mergeMarks(existing: MarkJSON[] | undefined, extra: MarkJSON): MarkJSON
  * Returns whether the given parent node type should preserve literal code text.
  */
 function isCodeContainerType(type: string): boolean {
-  return type === "codeBlock" || type === "code_block";
+  return type === "codeBlock" || type === "code_block" || type === "executableCodeBlock";
 }
 
 /**


### PR DESCRIPTION
## 概要

PR #585 の未反映レビューコメントに対応するため、管理 API の入力検証・監査ログ API のバリデーション・確認ダイアログの close 挙動・Wiki リンク変換のコードブロック判定を追加で修正しました。
主に develop 上で未公開だった 1 コミットを、新しい作業ブランチに切り出して develop 向けに取り込み直すための PR です。

## 変更点

- `server/api/`
  - `POST /api/admin/users/:id/suspend` で malformed JSON を `400` として拒否するよう修正
  - `GET /api/admin/audit-logs` に日英併記コメントと `from > to` の明示バリデーションを追加
  - ユーザー削除影響表示の `activeSubscription` 判定を active 件数ベースに変更
  - 管連の回帰テストを追加・更新
- `admin/`
  - `ConfirmActionDialog` が有効時に Radix の auto-close を妨げないよう修正
  - close 動作を確認するテストモックと回帰テストを追加
- `src/`
  - `transformWikiLinksInContent` で `executableCodeBlock` をコードコンテナとして扱うよう修正
  - 実行可能コードブロック内では Wiki link を変換しない回帰テストを追加

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run lint`
2. `bun run test:run`
3. `bunx vitest run src/components/ConfirmActionDialog.test.tsx` と `bunx vitest run src/components/editor/extensions/transformWikiLinksInContent.test.ts`、および `server/api` の対象 admin route テストを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

補足: `bun run format:check` はこのブランチの変更箇所以外を含むリポジトリ全体の既存フォーマット崩れにより失敗しました。今回の変更ファイル自体は pre-commit の Prettier を通過しています。

## スクリーンショット（UI 変更がある場合）

UI の見た目変更はほぼなく、確認ダイアログの close 挙動修正が中心のため、必要に応じて動画または操作キャプチャを追加します。

## 関連 Issue

Related to #585

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
