### PR TITLE
fix(editor): preserve [[ ]] brackets when promoting pasted wiki links

### DIFF
--- a/src/components/editor/extensions/MarkdownPasteExtension.test.ts
+++ b/src/components/editor/extensions/MarkdownPasteExtension.test.ts
@@ -245,7 +245,9 @@ describe("MarkdownPaste extension - wiki links", () => {
       }>;
     };
     const textNode = inserted.content[0].content[0];
-    expect(textNode.text).toBe("Foo");
+    // 括弧 `[[ ]]` を保持したまま wikiLink マークを付与する。
+    // Preserve the `[[ ]]` brackets while applying the wikiLink mark.
+    expect(textNode.text).toBe("[[Foo]]");
     expect(textNode.marks).toEqual([
       {
         type: "wikiLink",
@@ -268,7 +270,7 @@ describe("MarkdownPaste extension - wiki links", () => {
     const nodes = inserted.content[0].content;
     expect(nodes).toHaveLength(3);
     expect(nodes[0].text).toBe("see ");
-    expect(nodes[1].text).toBe("Foo");
+    expect(nodes[1].text).toBe("[[Foo]]");
     expect(nodes[1].marks).toBeDefined();
     expect(nodes[2].text).toBe(" today");
   });
@@ -289,7 +291,7 @@ describe("MarkdownPaste extension - wiki links", () => {
       }>;
     };
     const textNodes = inserted.content[0].content;
-    const wikiNode = textNodes.find((n) => n.text === "Ref");
+    const wikiNode = textNodes.find((n) => n.text === "[[Ref]]");
     expect(wikiNode).toBeDefined();
     expect(wikiNode?.marks?.[0]?.type).toBe("wikiLink");
   });

--- a/src/components/editor/extensions/WikiLinkExtension.test.ts
+++ b/src/components/editor/extensions/WikiLinkExtension.test.ts
@@ -7,33 +7,38 @@ import { WikiLink, WIKI_LINK_PASTE_REGEX } from "./WikiLinkExtension";
  */
 describe("WikiLinkExtension paste rule", () => {
   describe("WIKI_LINK_PASTE_REGEX", () => {
-    it("should match a basic [[Title]] pattern", () => {
+    // 正規表現はキャプチャグループを持たず、マッチ全体 `[[Title]]` を対象とする
+    // （Tiptap の `markPasteRule` に括弧ごとマークを付与させるため）。
+    // The regex has no capture group; the full `[[Title]]` match is the target
+    // so that Tiptap's `markPasteRule` applies the mark to the brackets as well.
+
+    it("should match a basic [[Title]] pattern (full bracket form)", () => {
       const text = "[[MyPage]]";
       const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
       expect(matches).toHaveLength(1);
-      expect(matches[0][1]).toBe("MyPage");
+      expect(matches[0][0]).toBe("[[MyPage]]");
     });
 
     it("should match multiple [[WikiLink]] patterns in text", () => {
       const text = "See [[PageA]] and [[PageB]] for details";
       const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
       expect(matches).toHaveLength(2);
-      expect(matches[0][1]).toBe("PageA");
-      expect(matches[1][1]).toBe("PageB");
+      expect(matches[0][0]).toBe("[[PageA]]");
+      expect(matches[1][0]).toBe("[[PageB]]");
     });
 
     it("should match titles with spaces", () => {
       const text = "[[My Page Title]]";
       const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
       expect(matches).toHaveLength(1);
-      expect(matches[0][1]).toBe("My Page Title");
+      expect(matches[0][0]).toBe("[[My Page Title]]");
     });
 
     it("should match titles with Japanese characters", () => {
       const text = "[[日本語ページ]]";
       const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
       expect(matches).toHaveLength(1);
-      expect(matches[0][1]).toBe("日本語ページ");
+      expect(matches[0][0]).toBe("[[日本語ページ]]");
     });
 
     it("should not match empty brackets [[]]", () => {
@@ -42,14 +47,15 @@ describe("WikiLinkExtension paste rule", () => {
       expect(matches).toHaveLength(0);
     });
 
-    it("should not match whitespace-only titles [[ ]]", () => {
+    it("should match whitespace-only titles [[ ]] (handler filters via getAttributes)", () => {
       const text = "[[ ]]";
       const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
-      // The regex matches but the title is whitespace-only; the paste rule
-      // handler trims and skips empty titles at the attribute level.
-      // Regex itself captures the content between brackets.
+      // 正規表現自体は空白のみのタイトルもマッチさせるが、`getAttributes` 側で
+      // トリム後に空だった場合は `false` を返してマーク適用を抑止する。
+      // The regex itself matches whitespace-only titles, but `getAttributes`
+      // returns `false` after trimming so no mark is applied.
       expect(matches).toHaveLength(1);
-      expect(matches[0][1].trim()).toBe("");
+      expect(matches[0][0]).toBe("[[ ]]");
     });
 
     it("should not match single brackets [Title]", () => {
@@ -58,14 +64,15 @@ describe("WikiLinkExtension paste rule", () => {
       expect(matches).toHaveLength(0);
     });
 
-    it("should not capture brackets inside title with [[[Title]]]", () => {
-      // The improved regex `[^\[\]]` excludes both `[` and `]` from capture,
-      // so `[[[Title]]]` correctly matches only `[[Title]]` with capture "Title".
-      // 改善した正規表現により、`[[[Title]]]` でも正しく "Title" だけをキャプチャする。
+    it("should not include extra outer brackets in a [[[Title]]] match", () => {
+      // `[^[\]]` が `[` と `]` の両方を除外するため、`[[[Title]]]` は
+      // 内側の `[[Title]]` のみにマッチする。
+      // Because `[^[\]]` excludes both `[` and `]`, `[[[Title]]]` matches only
+      // the inner `[[Title]]`.
       const text = "[[[Title]]]";
       const matches = [...text.matchAll(WIKI_LINK_PASTE_REGEX)];
       expect(matches).toHaveLength(1);
-      expect(matches[0][1]).toBe("Title");
+      expect(matches[0][0]).toBe("[[Title]]");
     });
   });
 

--- a/src/components/editor/extensions/WikiLinkExtension.ts
+++ b/src/components/editor/extensions/WikiLinkExtension.ts
@@ -3,12 +3,38 @@ import { Plugin, PluginKey } from "@tiptap/pm/state";
 
 /**
  * Regex to match completed WikiLink patterns `[[Title]]` in pasted text.
- * Captures the title (non-empty, no `[` or `]` characters) inside the brackets.
  *
  * 貼り付けテキスト中の完成済み WikiLink パターン `[[Title]]` にマッチする正規表現。
- * ブラケット内のタイトル（空でなく `[` や `]` を含まない）をキャプチャする。
+ *
+ * Tiptap の `markPasteRule` は「最後のキャプチャグループ」の範囲にのみマークを適用し、
+ * それ以外を削除する仕様のため、括弧 `[[ ]]` を保持するには全体を単一キャプチャに
+ * 含めてマッチ全長をマーク対象とする必要がある。ここでは敢えてキャプチャグループを
+ * 使わず、マッチ全体（`match[0]`）が `markPasteRule` の captureGroup として扱われる
+ * ようにする。タイトルは `extractWikiLinkTitle` で後付け抽出する。
+ *
+ * Tiptap's `markPasteRule` only applies the mark to the *last* capture group
+ * and deletes everything outside of it. To preserve the `[[ ]]` brackets, we
+ * intentionally omit capture groups so that `match[match.length - 1]` equals
+ * `match[0]` (the full match), keeping brackets intact. The title is extracted
+ * afterwards via `extractWikiLinkTitle`.
  */
-export const WIKI_LINK_PASTE_REGEX = /\[\[([^[\]]+)\]\]/g;
+export const WIKI_LINK_PASTE_REGEX = /\[\[[^[\]]+\]\]/g;
+
+/**
+ * Regex capturing the title portion of a WikiLink (non-global, for title extraction).
+ * 内部タイトル抽出用の正規表現（非グローバル）。
+ */
+const WIKI_LINK_TITLE_REGEX = /\[\[([^[\]]+)\]\]/;
+
+/**
+ * Extract the trimmed title from a `[[Title]]` literal, or `null` if empty.
+ * `[[Title]]` 形式の文字列からトリム済みタイトルを取り出す。空なら `null`。
+ */
+function extractWikiLinkTitle(fullMatch: string): string | null {
+  const m = fullMatch.match(WIKI_LINK_TITLE_REGEX);
+  const title = (m?.[1] ?? "").trim();
+  return title || null;
+}
 
 /**
  * Options for the WikiLink mark extension.
@@ -111,7 +137,9 @@ export const WikiLink = Mark.create<WikiLinkOptions>({
         find: WIKI_LINK_PASTE_REGEX,
         type: this.type,
         getAttributes: (match) => {
-          const title = (match[1] ?? "").trim();
+          // match[0] は `[[Title]]` 全体。ここからタイトルのみを取り出す。
+          // match[0] is the full `[[Title]]` literal; extract only the title.
+          const title = extractWikiLinkTitle(match[0] ?? "");
           if (!title) return false;
           return { title, exists: false, referenced: false };
         },

--- a/src/components/editor/extensions/transformWikiLinksInContent.test.ts
+++ b/src/components/editor/extensions/transformWikiLinksInContent.test.ts
@@ -57,7 +57,7 @@ describe("transformWikiLinksInContent", () => {
     expect(transformWikiLinksInContent(doc)).toEqual(doc);
   });
 
-  it("transforms a single wiki link into a text node with wikiLink mark", () => {
+  it("transforms a single wiki link into a text node with wikiLink mark (brackets preserved)", () => {
     const doc = {
       type: "doc",
       content: [
@@ -79,9 +79,11 @@ describe("transformWikiLinksInContent", () => {
     };
 
     expect(result.content[0].content).toHaveLength(1);
+    // 括弧 `[[ ]]` は表示テキストとして保持し、マークの attrs.title にはトリム済みタイトルを格納する。
+    // Brackets `[[ ]]` are preserved in the display text; the mark's `attrs.title` holds the trimmed title.
     expect(result.content[0].content[0]).toEqual({
       type: "text",
-      text: "Foo",
+      text: "[[Foo]]",
       marks: [
         {
           type: "wikiLink",
@@ -110,7 +112,7 @@ describe("transformWikiLinksInContent", () => {
       { type: "text", text: "before " },
       {
         type: "text",
-        text: "Foo",
+        text: "[[Foo]]",
         marks: [
           {
             type: "wikiLink",
@@ -138,11 +140,11 @@ describe("transformWikiLinksInContent", () => {
     };
 
     expect(result.content[0].content).toHaveLength(3);
-    expect(result.content[0].content[0].text).toBe("A");
+    expect(result.content[0].content[0].text).toBe("[[A]]");
     expect(result.content[0].content[0].marks).toHaveLength(1);
     expect(result.content[0].content[1].text).toBe(" and ");
     expect(result.content[0].content[1].marks).toBeUndefined();
-    expect(result.content[0].content[2].text).toBe("B");
+    expect(result.content[0].content[2].text).toBe("[[B]]");
     expect(result.content[0].content[2].marks).toHaveLength(1);
   });
 
@@ -167,7 +169,7 @@ describe("transformWikiLinksInContent", () => {
 
     expect(result.content[0].type).toBe("heading");
     expect(result.content[0].content).toHaveLength(2);
-    expect(result.content[0].content[1].text).toBe("Link");
+    expect(result.content[0].content[1].text).toBe("[[Link]]");
     expect(result.content[0].content[1].marks).toEqual([
       {
         type: "wikiLink",
@@ -206,7 +208,7 @@ describe("transformWikiLinksInContent", () => {
     const nodes = result.content[0].content;
     expect(nodes).toHaveLength(3);
     expect(nodes[0].marks).toEqual([{ type: "bold" }]);
-    expect(nodes[1].text).toBe("Link");
+    expect(nodes[1].text).toBe("[[Link]]");
     // 既存マーク + wikiLink マークを両方保持する
     // Preserve both the existing mark(s) and the wikiLink mark
     expect(nodes[1].marks).toEqual(
@@ -221,7 +223,7 @@ describe("transformWikiLinksInContent", () => {
     expect(nodes[2].marks).toEqual([{ type: "bold" }]);
   });
 
-  it("trims whitespace from wiki link title", () => {
+  it("trims whitespace from wiki link title but keeps brackets/inner text verbatim", () => {
     const doc = {
       type: "doc",
       content: [
@@ -242,7 +244,9 @@ describe("transformWikiLinksInContent", () => {
       }>;
     };
 
-    expect(result.content[0].content[0].text).toBe("Foo Bar");
+    // 表示テキストは原文ママ（括弧と内部空白を保持）/ Display text preserves brackets and inner whitespace verbatim.
+    expect(result.content[0].content[0].text).toBe("[[  Foo Bar  ]]");
+    // attrs.title はトリム後 / `attrs.title` stores the trimmed title.
     expect(result.content[0].content[0].marks?.[0]?.attrs).toEqual({
       title: "Foo Bar",
       exists: false,
@@ -303,7 +307,7 @@ describe("transformWikiLinksInContent", () => {
 
     const textNodes = result.content[0].content[0].content[0].content;
     expect(textNodes).toHaveLength(2);
-    expect(textNodes[1].text).toBe("Ref");
+    expect(textNodes[1].text).toBe("[[Ref]]");
     expect(textNodes[1].marks).toEqual([
       {
         type: "wikiLink",

--- a/src/components/editor/extensions/transformWikiLinksInContent.ts
+++ b/src/components/editor/extensions/transformWikiLinksInContent.ts
@@ -91,13 +91,19 @@ function splitTextNodeByWikiLinks(node: NodeJSON): NodeJSON[] {
       result.push(buildTextNode(text.slice(cursor, start), node.marks));
     }
 
-    // Wikiリンクマーク付きノードを追加
-    // Push the wiki-linked text node
+    // Wikiリンクマーク付きノードを追加する。
+    // 表示テキストは `[[ ... ]]` を含む原文（match[0]）をそのまま保持し、
+    // マークの `attrs.title` にはトリム済みタイトルを格納する。
+    // これにより、再シリアライズ時や Markdown 出力時にも記法が失われない。
+    //
+    // Push the wiki-linked text node. The displayed text keeps the original
+    // `[[ ... ]]` syntax (match[0]) so that re-serialisation / markdown output
+    // preserves the wiki link notation, while `attrs.title` holds the trimmed title.
     const wikiMark: MarkJSON = {
       type: "wikiLink",
       attrs: { title, exists: false, referenced: false },
     };
-    result.push(buildTextNode(title, mergeMarks(node.marks, wikiMark)));
+    result.push(buildTextNode(match[0], mergeMarks(node.marks, wikiMark)));
 
     cursor = end;
   }


### PR DESCRIPTION
Pasting markdown containing `[[Title]]` previously stripped the double
brackets, leaving only the title with a wikiLink mark. That caused
ambiguity with plain styled text and broke round-tripping to markdown.

Keep the literal `[[ ]]` in the displayed text and store the trimmed
title on `attrs.title`, matching the behavior already used by the
content-load path in `contentUtils.ts`.

- `transformWikiLinksInContent`: emit `match[0]` (with brackets) as the
  text node, `attrs.title` stays trimmed.
- `WikiLinkExtension.addPasteRules`: drop the capture group from
  `WIKI_LINK_PASTE_REGEX` so Tiptap's `markPasteRule` treats the full
  match as the mark range (otherwise it deletes everything outside the
  last capture group and strips the brackets). Title is extracted via a
  separate non-global regex.
- Tests updated to assert bracket-preserved output.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wiki-link syntax `[[...]]` is now preserved in editor display and paste operations, rather than showing only the title text.

* **Tests**
  * Updated wiki-link parsing and paste integration tests to verify bracket preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->