### PR TITLE
claude/zedi-karpathy-integration-7zeLT

### DIFF
--- a/server/api/drizzle/0007_add_sources_and_page_sources.sql
+++ b/server/api/drizzle/0007_add_sources_and_page_sources.sql
@@ -1,0 +1,57 @@
+-- Add `sources` and `page_sources` tables for the LLM Wiki ingest flow.
+-- LLM Wiki ingest フロー用の sources / page_sources テーブルを追加する。
+--
+-- sources: immutable raw material (URL / conversation) ingested into the wiki.
+-- page_sources: M:N junction between mutable pages and immutable sources.
+--
+-- See parent issue otomatty/zedi#594, sub-issue #595.
+
+CREATE TABLE "sources" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    "owner_id" text NOT NULL,
+    "kind" text DEFAULT 'url' NOT NULL,
+    "url" text,
+    "title" text,
+    "content_hash" text,
+    "excerpt" text,
+    "extracted_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "page_sources" (
+    "page_id" uuid NOT NULL,
+    "source_id" uuid NOT NULL,
+    "section_anchor" text DEFAULT '' NOT NULL,
+    "citation_text" text,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT "page_sources_page_id_source_id_section_anchor_pk"
+        PRIMARY KEY ("page_id", "source_id", "section_anchor")
+);
+--> statement-breakpoint
+ALTER TABLE "sources"
+    ADD CONSTRAINT "sources_owner_id_user_id_fk"
+    FOREIGN KEY ("owner_id") REFERENCES "user"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "page_sources"
+    ADD CONSTRAINT "page_sources_page_id_pages_id_fk"
+    FOREIGN KEY ("page_id") REFERENCES "pages"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "page_sources"
+    ADD CONSTRAINT "page_sources_source_id_sources_id_fk"
+    FOREIGN KEY ("source_id") REFERENCES "sources"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "idx_sources_owner_id" ON "sources" ("owner_id");
+--> statement-breakpoint
+CREATE INDEX "idx_sources_kind" ON "sources" ("kind");
+--> statement-breakpoint
+CREATE INDEX "idx_sources_owner_content_hash" ON "sources" ("owner_id", "content_hash");
+--> statement-breakpoint
+CREATE INDEX "idx_sources_owner_url" ON "sources" ("owner_id", "url");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_sources_owner_url_hash"
+    ON "sources" ("owner_id", "url", "content_hash")
+    WHERE "url" IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX "idx_page_sources_page_id" ON "page_sources" ("page_id");
+--> statement-breakpoint
+CREATE INDEX "idx_page_sources_source_id" ON "page_sources" ("source_id");

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776384000000,
       "tag": "0006_audit_logs_append_only",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1776470400000,
+      "tag": "0007_add_sources_and_page_sources",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/src/__tests__/routes/ingest.test.ts
+++ b/server/api/src/__tests__/routes/ingest.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for /api/ingest (otomatty/zedi#595).
+ * /api/ingest のテスト。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { extractTitleKeywords } from "../../routes/ingest.js";
+
+type AuthSession = Awaited<ReturnType<typeof import("../../auth.js").auth.api.getSession>>;
+
+vi.mock("../../db/client.js", () => ({
+  getDb: vi.fn(() => ({})),
+}));
+
+const mockSessionUser = {
+  id: "user-1",
+  email: "u@e.com",
+  name: "",
+  image: null as string | null,
+  emailVerified: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  role: null as string | null,
+  status: "active" as string | null,
+};
+
+vi.mock("../../auth.js", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+// Middleware DB lookup should find an active user.
+vi.mock("../../middleware/db.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../middleware/db.js")>("../../middleware/db.js");
+  return actual;
+});
+
+import { auth } from "../../auth.js";
+import { Hono } from "hono";
+import { errorHandler } from "../../middleware/errorHandler.js";
+import ingestRoutes from "../../routes/ingest.js";
+import type { AppEnv } from "../../types/index.js";
+
+function createIngestApp(dbMock: unknown) {
+  const app = new Hono<AppEnv>();
+  app.onError(errorHandler);
+  // Inject a pre-set db into the context for each request.
+  app.use("*", async (c, next) => {
+    c.set("db", dbMock as never);
+    await next();
+  });
+  app.route("/api/ingest", ingestRoutes);
+  return app;
+}
+
+describe("extractTitleKeywords", () => {
+  it("splits title by whitespace and keeps tokens of length >= 2", () => {
+    expect(extractTitleKeywords("ripgrep is fast")).toEqual(["ripgrep", "is", "fast"]);
+  });
+
+  it("drops the ' - site name' navigation suffix", () => {
+    expect(extractTitleKeywords("ripgrep とは - Example.com")).toEqual(["ripgrep", "とは"]);
+  });
+
+  it("handles Japanese fullwidth bars '｜'", () => {
+    expect(extractTitleKeywords("ripgrep 入門｜ブログ名")).toEqual(["ripgrep", "入門"]);
+  });
+
+  it("caps result at 5 tokens", () => {
+    // 2 文字以上のトークンが 5 件を超えた場合に 5 件に制限されることを確認する。
+    expect(extractTitleKeywords("ab cd ef gh ij kl mn op qr st uv")).toHaveLength(5);
+  });
+
+  it("returns empty array when nothing qualifies", () => {
+    expect(extractTitleKeywords("")).toEqual([]);
+    // Single-char tokens are filtered out
+    expect(extractTitleKeywords("a b c")).toEqual([]);
+  });
+});
+
+describe("POST /api/ingest/plan", () => {
+  // status lookup の 1 件目結果を返す最小モック
+  const activeUserDb = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [{ status: "active" }],
+        }),
+      }),
+    }),
+  };
+
+  beforeEach(() => {
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      user: mockSessionUser,
+    } as unknown as AuthSession);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 when session is missing", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue(null);
+    const app = createIngestApp(activeUserDb);
+    const res = await app.request("/api/ingest/plan", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://example.com/" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when url is missing", async () => {
+    const app = createIngestApp(activeUserDb);
+    const res = await app.request("/api/ingest/plan", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: "openai", model: "gpt-4o-mini" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toMatch(/url is required/i);
+  });
+
+  it("returns 400 when provider or model is missing", async () => {
+    const app = createIngestApp(activeUserDb);
+    const res = await app.request("/api/ingest/plan", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://example.com/" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toMatch(/provider and model/i);
+  });
+});

--- a/server/api/src/__tests__/services/ingestPlanner.test.ts
+++ b/server/api/src/__tests__/services/ingestPlanner.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for the ingest planner service (otomatty/zedi#595).
+ * Ingest プランナー（P1, LLM Wiki ingest）のユニットテスト。
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildIngestPlannerPrompt,
+  createIngestLlmDriver,
+  extractJsonFromResponse,
+  IngestPlanParseError,
+  parseIngestPlanResponse,
+  planIngest,
+  type CallProviderAdapter,
+  type CandidatePage,
+  type IngestArticleSummary,
+} from "../../services/ingestPlanner.js";
+
+const sampleArticle: IngestArticleSummary = {
+  title: "Ripgrep: 高速な検索ツール",
+  url: "https://example.com/rg",
+  excerpt: "ripgrep は ag / ack の後継となる高速検索ツール。",
+};
+
+const sampleCandidates: CandidatePage[] = [
+  {
+    id: "11111111-1111-1111-1111-111111111111",
+    title: "ripgrep",
+    excerpt: "ripgrep は Rust 製の検索ツール。",
+  },
+  {
+    id: "22222222-2222-2222-2222-222222222222",
+    title: "grep",
+    excerpt: "Unix の伝統的なテキスト検索ツール。",
+  },
+];
+
+const candidate0Id = "11111111-1111-1111-1111-111111111111";
+
+describe("extractJsonFromResponse", () => {
+  it("returns the original string when no fence is present", () => {
+    expect(extractJsonFromResponse(`{"a":1}`)).toBe(`{"a":1}`);
+  });
+
+  it("strips ```json fences", () => {
+    const raw = '```json\n{"a":1}\n```';
+    expect(extractJsonFromResponse(raw)).toBe(`{"a":1}`);
+  });
+
+  it("strips plain ``` fences", () => {
+    const raw = '```\n{"a":1}\n```';
+    expect(extractJsonFromResponse(raw)).toBe(`{"a":1}`);
+  });
+
+  it("falls back to first { .. last } when there is surrounding prose", () => {
+    const raw = `Here is the plan:\n{"a":1, "b":2}\nThanks!`;
+    expect(extractJsonFromResponse(raw)).toBe(`{"a":1, "b":2}`);
+  });
+});
+
+describe("parseIngestPlanResponse", () => {
+  const validIds = new Set(sampleCandidates.map((c) => c.id));
+
+  it("parses a valid merge plan with conflicts", () => {
+    const raw = JSON.stringify({
+      action: "merge",
+      reason: "既存 ripgrep ページを拡張する",
+      targetPageId: candidate0Id,
+      summary: "ripgrep の新しい利用例を追記",
+      conflicts: [
+        { claim: "Rust 製", existing: "Go 製", note: "言語記述の齟齬" },
+        { claim: "", existing: "invalid", note: "should be dropped" },
+      ],
+    });
+    const plan = parseIngestPlanResponse(raw, { validCandidateIds: validIds });
+    expect(plan.action).toBe("merge");
+    expect(plan.targetPageId).toBe(candidate0Id);
+    expect(plan.summary).toBe("ripgrep の新しい利用例を追記");
+    expect(plan.conflicts).toHaveLength(1);
+    expect(plan.conflicts?.[0]?.note).toBe("言語記述の齟齬");
+  });
+
+  it("parses a valid create plan", () => {
+    const raw = JSON.stringify({
+      action: "create",
+      reason: "候補に一致するページがない",
+      title: "fd-find",
+    });
+    const plan = parseIngestPlanResponse(raw, { validCandidateIds: validIds });
+    expect(plan.action).toBe("create");
+    expect(plan.title).toBe("fd-find");
+    expect(plan.targetPageId).toBeUndefined();
+  });
+
+  it("parses a valid skip plan", () => {
+    const raw = JSON.stringify({
+      action: "skip",
+      reason: "新規情報なし",
+    });
+    const plan = parseIngestPlanResponse(raw);
+    expect(plan.action).toBe("skip");
+    expect(plan.reason).toBe("新規情報なし");
+  });
+
+  it("throws on invalid JSON", () => {
+    expect(() => parseIngestPlanResponse(`not json`)).toThrow(IngestPlanParseError);
+  });
+
+  it("throws on non-object payload", () => {
+    expect(() => parseIngestPlanResponse(`[1,2,3]`)).toThrow(IngestPlanParseError);
+  });
+
+  it("throws on unknown action", () => {
+    const raw = JSON.stringify({ action: "purge", reason: "x" });
+    expect(() => parseIngestPlanResponse(raw)).toThrow(/Invalid action/);
+  });
+
+  it("throws when reason is missing or empty", () => {
+    const raw = JSON.stringify({ action: "skip", reason: "   " });
+    expect(() => parseIngestPlanResponse(raw)).toThrow(/"reason" is required/);
+  });
+
+  it("throws when merge has no targetPageId", () => {
+    const raw = JSON.stringify({ action: "merge", reason: "merge" });
+    expect(() => parseIngestPlanResponse(raw, { validCandidateIds: validIds })).toThrow(
+      /"targetPageId" is required/,
+    );
+  });
+
+  it("throws when targetPageId is not in the candidate set (hallucination guard)", () => {
+    const raw = JSON.stringify({
+      action: "merge",
+      reason: "merge",
+      targetPageId: "99999999-9999-9999-9999-999999999999",
+    });
+    expect(() => parseIngestPlanResponse(raw, { validCandidateIds: validIds })).toThrow(
+      /hallucinated/,
+    );
+  });
+
+  it("accepts targetPageId when no validCandidateIds set is provided (no guard)", () => {
+    const raw = JSON.stringify({
+      action: "merge",
+      reason: "merge",
+      targetPageId: "free-form-id",
+    });
+    const plan = parseIngestPlanResponse(raw);
+    expect(plan.targetPageId).toBe("free-form-id");
+  });
+
+  it("throws when create has no title", () => {
+    const raw = JSON.stringify({ action: "create", reason: "create" });
+    expect(() => parseIngestPlanResponse(raw)).toThrow(/"title" is required/);
+  });
+
+  it("tolerates extra unknown fields", () => {
+    const raw = JSON.stringify({
+      action: "skip",
+      reason: "noise",
+      irrelevant: { foo: "bar" },
+    });
+    const plan = parseIngestPlanResponse(raw);
+    expect(plan.action).toBe("skip");
+  });
+
+  it("drops conflicts when not an array", () => {
+    const raw = JSON.stringify({
+      action: "skip",
+      reason: "noise",
+      conflicts: "nope",
+    });
+    const plan = parseIngestPlanResponse(raw);
+    expect(plan.conflicts).toBeUndefined();
+  });
+
+  it("strips fenced JSON responses", () => {
+    const raw = '```json\n{"action":"skip","reason":"ok"}\n```';
+    const plan = parseIngestPlanResponse(raw);
+    expect(plan.action).toBe("skip");
+  });
+});
+
+describe("buildIngestPlannerPrompt", () => {
+  it("includes article title, url, and candidates", () => {
+    const messages = buildIngestPlannerPrompt({
+      article: sampleArticle,
+      candidates: sampleCandidates,
+    });
+    const [systemMsg, userMsg] = messages;
+    expect(messages).toHaveLength(2);
+    expect(systemMsg?.role).toBe("system");
+    expect(userMsg?.role).toBe("user");
+    expect(userMsg?.content).toContain(sampleArticle.title);
+    expect(userMsg?.content).toContain(sampleArticle.url);
+    expect(userMsg?.content).toContain(candidate0Id);
+    expect(userMsg?.content).toContain("22222222-2222-2222-2222-222222222222");
+  });
+
+  it("renders '(no candidates)' when candidates is empty", () => {
+    const messages = buildIngestPlannerPrompt({
+      article: sampleArticle,
+      candidates: [],
+    });
+    expect(messages[1]?.content).toContain("(no candidates)");
+  });
+
+  it("includes userSchema block when provided and non-empty", () => {
+    const messages = buildIngestPlannerPrompt({
+      article: sampleArticle,
+      candidates: sampleCandidates,
+      userSchema: "Cite sources at the end of each paragraph.",
+    });
+    expect(messages[0]?.content).toContain("User-defined wiki schema");
+    expect(messages[0]?.content).toContain("Cite sources at the end of each paragraph.");
+  });
+
+  it("omits userSchema block when string is whitespace", () => {
+    const messages = buildIngestPlannerPrompt({
+      article: sampleArticle,
+      candidates: sampleCandidates,
+      userSchema: "   \n   ",
+    });
+    expect(messages[0]?.content).not.toContain("User-defined wiki schema");
+  });
+
+  it("truncates very long excerpts to avoid prompt blow-up", () => {
+    const hugeExcerpt = "A".repeat(10_000);
+    const messages = buildIngestPlannerPrompt({
+      article: { ...sampleArticle, excerpt: hugeExcerpt },
+      candidates: [],
+    });
+    const userMsg = messages[1];
+    expect(userMsg?.content).toContain("…");
+    expect(userMsg?.content.length ?? 0).toBeLessThan(hugeExcerpt.length);
+  });
+});
+
+describe("planIngest (orchestration)", () => {
+  it("calls the LLM driver with the built prompt and parses the response", async () => {
+    const fakeResponse = JSON.stringify({
+      action: "merge",
+      reason: "既存 ripgrep を拡張",
+      targetPageId: candidate0Id,
+    });
+    const plan = await planIngest({
+      article: sampleArticle,
+      candidates: sampleCandidates,
+      llm: async (messages) => {
+        // The orchestrator passes through to buildIngestPlannerPrompt
+        expect(messages[0]?.role).toBe("system");
+        expect(messages[1]?.content).toContain(sampleArticle.title);
+        return fakeResponse;
+      },
+    });
+    expect(plan.action).toBe("merge");
+    expect(plan.targetPageId).toBe(candidate0Id);
+  });
+
+  it("propagates parse errors as IngestPlanParseError", async () => {
+    await expect(
+      planIngest({
+        article: sampleArticle,
+        candidates: sampleCandidates,
+        llm: async () => "not json at all",
+      }),
+    ).rejects.toBeInstanceOf(IngestPlanParseError);
+  });
+
+  it("guards against hallucinated targetPageId via the candidate set", async () => {
+    await expect(
+      planIngest({
+        article: sampleArticle,
+        candidates: sampleCandidates,
+        llm: async () =>
+          JSON.stringify({
+            action: "merge",
+            reason: "x",
+            targetPageId: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+          }),
+      }),
+    ).rejects.toThrow(/hallucinated/);
+  });
+});
+
+describe("createIngestLlmDriver", () => {
+  it("wraps a callProvider-compatible adapter into a driver", async () => {
+    let capturedProvider = "";
+    let capturedModel = "";
+    let capturedKey = "";
+    const adapter: CallProviderAdapter = async (provider, apiKey, model, _messages) => {
+      capturedProvider = provider;
+      capturedModel = model;
+      capturedKey = apiKey;
+      return { content: `[${provider}] ok` };
+    };
+    const driver = createIngestLlmDriver(adapter, {
+      provider: "openai",
+      model: "gpt-x",
+      apiKey: "sk-TEST",
+    });
+    const out = await driver([{ role: "user", content: "hi" }]);
+    expect(out).toBe("[openai] ok");
+    expect(capturedProvider).toBe("openai");
+    expect(capturedModel).toBe("gpt-x");
+    expect(capturedKey).toBe("sk-TEST");
+  });
+});

--- a/server/api/src/app.ts
+++ b/server/api/src/app.ts
@@ -17,6 +17,7 @@ import noteRoutes from "./routes/notes/index.js";
 import searchRoutes from "./routes/search.js";
 import mediaRoutes from "./routes/media.js";
 import clipRoutes from "./routes/clip.js";
+import ingestRoutes from "./routes/ingest.js";
 import extRoutes from "./routes/ext.js";
 import mcpRoutes from "./routes/mcp.js";
 import inviteRoutes from "./routes/invite.js";
@@ -106,6 +107,9 @@ export function createApp(): Hono<AppEnv> {
 
   // Clip
   app.route("/api/clip", clipRoutes);
+
+  // Ingest (LLM Wiki pattern, P1)
+  app.route("/api/ingest", ingestRoutes);
 
   // Chrome Extension (OAuth + clip-and-create)
   app.route("/api/ext", extRoutes);

--- a/server/api/src/lib/articleExtractor.ts
+++ b/server/api/src/lib/articleExtractor.ts
@@ -21,6 +21,8 @@ import { common, createLowlight } from "lowlight";
 import { createHash } from "node:crypto";
 import { ClipFetchBlockedError, fetchClipHtmlWithRedirects } from "./clipServerFetch.js";
 
+export { ClipFetchBlockedError };
+
 const lowlight = createLowlight(common);
 
 /**
@@ -187,7 +189,9 @@ export async function extractArticleFromUrl(input: ExtractArticleInput): Promise
       ({ html, finalUrl } = await fetchClipHtmlWithRedirects(url, controller));
     } catch (err) {
       if (err instanceof ClipFetchBlockedError) {
-        throw new Error("URL not allowed");
+        // Preserve the original error type so callers can differentiate
+        // policy-blocked URLs from other fetch failures.
+        throw err;
       }
       throw err;
     }

--- a/server/api/src/lib/articleExtractor.ts
+++ b/server/api/src/lib/articleExtractor.ts
@@ -1,0 +1,251 @@
+/**
+ * Reusable URL → HTML → Readability → Tiptap JSON extraction pipeline.
+ *
+ * Extracted from `clipAndCreate.ts` so that the new Ingest flow (P1 of the
+ * Karpathy "LLM Wiki" pattern, sub-issue #595) can run the same extraction
+ * without persisting a page.
+ *
+ * clipAndCreate から切り出した、URL → Tiptap JSON までの純粋な抽出パイプライン。
+ * Ingest プランナー（otomatty/zedi#595）が Page を保存せずに同じ抽出を行うために共有する。
+ */
+import { Mutex } from "async-mutex";
+import { JSDOM } from "jsdom";
+import { Readability } from "@mozilla/readability";
+import { generateJSON } from "@tiptap/html";
+import { getSchema } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import Link from "@tiptap/extension-link";
+import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
+import Image from "@tiptap/extension-image";
+import { common, createLowlight } from "lowlight";
+import { createHash } from "node:crypto";
+import { ClipFetchBlockedError, fetchClipHtmlWithRedirects } from "./clipServerFetch.js";
+
+const lowlight = createLowlight(common);
+
+/**
+ * Serializes globalThis.document mutation so concurrent extractor calls do not race.
+ * 同時実行時に globalThis.document が取り合いにならないよう直列化する。
+ */
+const extractorDocMutex = new Mutex();
+
+/**
+ * Tiptap 拡張（サーバー側の正規化に使う）。
+ * Tiptap extensions used for server-side normalization.
+ */
+export const articleExtractorExtensions = [
+  StarterKit.configure({
+    heading: { levels: [1, 2, 3] },
+    codeBlock: false,
+  }),
+  Link.configure({ openOnClick: false }),
+  CodeBlockLowlight.configure({ lowlight, defaultLanguage: null }),
+  Image,
+];
+
+/**
+ * Tiptap スキーマを構築する。主に Y.Doc 化のために呼び出される。
+ * Builds the Tiptap schema; mainly used by downstream Y.Doc conversion.
+ */
+export function buildArticleSchema() {
+  return getSchema(articleExtractorExtensions);
+}
+
+/**
+ * Tiptap JSON のノード。
+ * A Tiptap JSON node.
+ */
+export interface TiptapNode {
+  type: string;
+  attrs?: Record<string, unknown>;
+  content?: TiptapNode[];
+  text?: string;
+  marks?: Array<{ type: string; attrs?: Record<string, unknown> }>;
+}
+
+/**
+ * 抽出結果。
+ * Extraction result shared by clipAndCreate and the ingest flow.
+ *
+ * @property finalUrl - リダイレクト後の最終 URL。Final URL after redirects.
+ * @property title - 抽出したタイトル。Extracted title (fallback: "Untitled").
+ * @property thumbnailUrl - OGP 由来のサムネイル URL（あれば）。OGP thumbnail URL if any.
+ * @property tiptapJson - Tiptap 用 JSON ドキュメント。Tiptap JSON document.
+ * @property contentText - 本文の先頭プレビュー（最大 length 文字）。Plain-text excerpt.
+ * @property contentHash - 本文の SHA-256（dedup 用）。Content hash for dedup.
+ */
+export interface ExtractedArticle {
+  finalUrl: string;
+  title: string;
+  thumbnailUrl: string | null;
+  tiptapJson: TiptapNode;
+  contentText: string;
+  contentHash: string;
+}
+
+/**
+ * 本文抽出で使うフェッチタイムアウト既定値（ミリ秒）。
+ * Default fetch timeout for article extraction, in milliseconds.
+ */
+export const ARTICLE_FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * ExtractArticle の入力。
+ * Input for {@link extractArticleFromUrl}.
+ *
+ * @property url - 抽出対象の URL（http/https のみ）。Target URL (http/https only).
+ * @property timeoutMs - フェッチのタイムアウト。Fetch timeout.
+ * @property previewLength - contentText のプレビュー長。Length of content preview in characters.
+ */
+export interface ExtractArticleInput {
+  url: string;
+  timeoutMs?: number;
+  previewLength?: number;
+}
+
+/**
+ * `<meta property="og:image">` を抽出する。
+ * Extracts `<meta property="og:image">` from the document.
+ */
+function extractOgImage(doc: Document): string | null {
+  const meta =
+    doc.querySelector('meta[property="og:image"]') || doc.querySelector('meta[name="og:image"]');
+  return meta?.getAttribute("content") || null;
+}
+
+/**
+ * 相対 URL を絶対 URL に解決する。http/https 以外は null。
+ * Resolves a relative URL to absolute. Returns null for non-http(s) schemes.
+ */
+function resolveUrl(base: string, relative: string | null): string | null {
+  if (!relative) return null;
+  try {
+    const resolved = new URL(relative, base);
+    if (resolved.protocol !== "http:" && resolved.protocol !== "https:") return null;
+    return resolved.href;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * script / iframe 等の不要タグを除去する。
+ * Strips script / iframe / form / etc. from the provided HTML fragment.
+ */
+function cleanupHtml(html: string, doc: Document): string {
+  const div = doc.createElement("div");
+  div.innerHTML = html;
+
+  const unwanted = ["script", "style", "noscript", "iframe", "object", "embed", "form"];
+  for (const sel of unwanted) {
+    div.querySelectorAll(sel).forEach((el) => {
+      el.remove();
+    });
+  }
+  return div.innerHTML.trim();
+}
+
+/**
+ * Tiptap JSON からテキストを抽出して空白圧縮する。
+ * Walks a Tiptap JSON tree and joins the inline text content.
+ */
+export function extractTextFromTiptap(node: TiptapNode | null): string {
+  if (!node) return "";
+  if (typeof node.text === "string") return node.text;
+  if (!Array.isArray(node.content)) return "";
+  return node.content
+    .map((child) => extractTextFromTiptap(child))
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * URL から記事を抽出して Tiptap JSON / プレビュー / コンテンツハッシュを返す。
+ * Fetches a URL and extracts a Tiptap JSON document plus preview and content hash.
+ *
+ * Page の作成はここでは行わない（DB 書き込みなし）。ingest プランナーと
+ * clipAndCreate の両方から再利用される。
+ * This helper is pure with respect to the database; it performs fetching and
+ * parsing only.
+ *
+ * @param input - 抽出入力。Extraction input.
+ * @returns 抽出された Tiptap JSON ドキュメントとメタデータ。Parsed article.
+ * @throws URL が許可されない、fetch 失敗、Readability 抽出失敗時。
+ * Throws when URL is disallowed, fetch fails, or Readability cannot parse.
+ */
+export async function extractArticleFromUrl(input: ExtractArticleInput): Promise<ExtractedArticle> {
+  const { url, timeoutMs = ARTICLE_FETCH_TIMEOUT_MS, previewLength = 200 } = input;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let html: string;
+  let finalUrl: string;
+  try {
+    try {
+      ({ html, finalUrl } = await fetchClipHtmlWithRedirects(url, controller));
+    } catch (err) {
+      if (err instanceof ClipFetchBlockedError) {
+        throw new Error("URL not allowed");
+      }
+      throw err;
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const dom = new JSDOM(html, { url: finalUrl });
+  const document = dom.window.document;
+
+  const reader = new Readability(document.cloneNode(true) as Document);
+  const article = reader.parse();
+  if (!article) {
+    throw new Error("Failed to extract article content");
+  }
+
+  const ogImage = extractOgImage(document);
+  const thumbnailUrl = resolveUrl(finalUrl, ogImage);
+
+  const cleanContent = cleanupHtml(article.content ?? "", document);
+
+  const mainJson = await extractorDocMutex.runExclusive(async () => {
+    const prevDocument = (globalThis as { document?: Document }).document;
+    (globalThis as { document?: Document }).document = document;
+    try {
+      return generateJSON(cleanContent, articleExtractorExtensions) as TiptapNode;
+    } finally {
+      (globalThis as { document?: Document }).document = prevDocument;
+    }
+  });
+
+  const baseContent = Array.isArray(mainJson.content) ? mainJson.content : [];
+  const imageNode: TiptapNode | null = thumbnailUrl
+    ? {
+        type: "image",
+        attrs: {
+          src: thumbnailUrl,
+          alt: article.title ?? "OGP thumbnail",
+        },
+      }
+    : null;
+  const tiptapJson: TiptapNode = {
+    type: "doc",
+    content: imageNode ? [imageNode, ...baseContent] : baseContent,
+  };
+
+  const rawText = extractTextFromTiptap(tiptapJson);
+  const contentText = rawText.slice(0, previewLength);
+  const title = article.title || "Untitled";
+
+  const contentHash = createHash("sha256").update(rawText).digest("hex");
+
+  return {
+    finalUrl,
+    title,
+    thumbnailUrl,
+    tiptapJson,
+    contentText,
+    contentHash,
+  };
+}

--- a/server/api/src/lib/clipAndCreate.ts
+++ b/server/api/src/lib/clipAndCreate.ts
@@ -2,83 +2,20 @@
  * clip-and-create: URL → fetch → Readability → Tiptap JSON → Y.Doc → DB
  *
  * Server-side web clipping pipeline for Chrome extension.
+ * Chrome 拡張向けのサーバー側 Web クリッピングパイプライン。
+ *
+ * Since sub-issue otomatty/zedi#595 (Karpathy "LLM Wiki" ingest flow), the
+ * URL → Tiptap JSON extraction is delegated to {@link extractArticleFromUrl}
+ * so the ingest planner can reuse the same pipeline without DB writes.
  */
-import { Mutex } from "async-mutex";
-import { JSDOM } from "jsdom";
-import { Readability } from "@mozilla/readability";
-import { generateJSON } from "@tiptap/html";
-import { getSchema } from "@tiptap/core";
-import StarterKit from "@tiptap/starter-kit";
-import Link from "@tiptap/extension-link";
-import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
-import Image from "@tiptap/extension-image";
-import { common, createLowlight } from "lowlight";
 import * as Y from "yjs";
 import { prosemirrorJSONToYDoc } from "@tiptap/y-tiptap";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import { pages, pageContents } from "../schema/index.js";
 import type * as schema from "../schema/index.js";
-import { ClipFetchBlockedError, fetchClipHtmlWithRedirects } from "./clipServerFetch.js";
+import { buildArticleSchema, extractArticleFromUrl } from "./articleExtractor.js";
 
-const lowlight = createLowlight(common);
 const YDOC_FRAGMENT = "default";
-/** Serializes globalThis.document mutation so concurrent clipAndCreate calls do not race. */
-const clipDocMutex = new Mutex();
-
-const extensions = [
-  StarterKit.configure({
-    heading: { levels: [1, 2, 3] },
-    codeBlock: false,
-  }),
-  Link.configure({ openOnClick: false }),
-  CodeBlockLowlight.configure({ lowlight, defaultLanguage: null }),
-  Image,
-];
-
-function buildSchema() {
-  return getSchema(extensions);
-}
-
-function extractOgImage(doc: Document): string | null {
-  const meta =
-    doc.querySelector('meta[property="og:image"]') || doc.querySelector('meta[name="og:image"]');
-  return meta?.getAttribute("content") || null;
-}
-
-function resolveUrl(base: string, relative: string | null): string | null {
-  if (!relative) return null;
-  try {
-    const resolved = new URL(relative, base);
-    if (resolved.protocol !== "http:" && resolved.protocol !== "https:") return null;
-    return resolved.href;
-  } catch {
-    return null;
-  }
-}
-
-function cleanupHtml(html: string, doc: Document): string {
-  const div = doc.createElement("div");
-  div.innerHTML = html;
-
-  const unwanted = ["script", "style", "noscript", "iframe", "object", "embed", "form"];
-  for (const sel of unwanted) {
-    div.querySelectorAll(sel).forEach((el) => {
-      el.remove();
-    });
-  }
-  return div.innerHTML.trim();
-}
-
-function extractTextFromTiptap(node: { text?: string; content?: unknown[] } | null): string {
-  if (!node) return "";
-  if (typeof node.text === "string") return node.text;
-  if (!Array.isArray(node.content)) return "";
-  return node.content
-    .map((child: unknown) => extractTextFromTiptap(child as { text?: string; content?: unknown[] }))
-    .join(" ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
 
 /**
  * クリップ作成結果。作成されたページの ID・タイトル・サムネイル URL。
@@ -119,81 +56,22 @@ export interface ClipAndCreateInput {
 export async function clipAndCreate(input: ClipAndCreateInput): Promise<ClipAndCreateResult> {
   const { url, userId, db } = input;
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 15_000);
-  let html: string;
-  let finalUrl: string;
+  const article = await extractArticleFromUrl({ url });
 
-  try {
-    try {
-      ({ html, finalUrl } = await fetchClipHtmlWithRedirects(url, controller));
-    } catch (err) {
-      if (err instanceof ClipFetchBlockedError) {
-        throw new Error("URL not allowed");
-      }
-      throw err;
-    }
-  } finally {
-    clearTimeout(timeout);
-  }
-  const dom = new JSDOM(html, { url: finalUrl });
-  const document = dom.window.document;
-
-  const reader = new Readability(document.cloneNode(true) as Document);
-  const article = reader.parse();
-
-  if (!article) {
-    throw new Error("Failed to extract article content");
-  }
-
-  const ogImage = extractOgImage(document);
-  const thumbnailUrl = resolveUrl(finalUrl, ogImage);
-
-  const cleanContent = cleanupHtml(article.content ?? "", document);
-
-  const mainJson = await clipDocMutex.runExclusive(async () => {
-    const prevDocument = (globalThis as { document?: Document }).document;
-    (globalThis as { document?: Document }).document = document;
-    try {
-      return generateJSON(cleanContent, extensions) as {
-        type: string;
-        content?: Array<{ type: string; attrs?: Record<string, unknown> }>;
-      };
-    } finally {
-      (globalThis as { document?: Document }).document = prevDocument;
-    }
-  });
-
-  const baseContent = mainJson.content ?? [];
-  const imageNode = thumbnailUrl
-    ? {
-        type: "image",
-        attrs: {
-          src: thumbnailUrl,
-          alt: (article.title ?? "OGP thumbnail") as string,
-        },
-      }
-    : null;
-  const tiptapJson = {
-    type: "doc",
-    content: imageNode ? [imageNode, ...baseContent] : baseContent,
-  };
-  const schema = buildSchema();
-  const ydoc = prosemirrorJSONToYDoc(schema, tiptapJson, YDOC_FRAGMENT);
+  const tiptapSchema = buildArticleSchema();
+  const ydoc = prosemirrorJSONToYDoc(tiptapSchema, article.tiptapJson, YDOC_FRAGMENT);
   const ydocState = Y.encodeStateAsUpdate(ydoc);
   const ydocBase64 = Buffer.from(ydocState).toString("base64");
-  const contentText = extractTextFromTiptap(tiptapJson).slice(0, 200);
-  const title = article.title || "Untitled";
 
   const result = await db.transaction(async (tx) => {
     const [page] = await tx
       .insert(pages)
       .values({
         ownerId: userId,
-        title,
-        contentPreview: contentText || null,
-        sourceUrl: finalUrl,
-        thumbnailUrl: thumbnailUrl ?? null,
+        title: article.title,
+        contentPreview: article.contentText || null,
+        sourceUrl: article.finalUrl,
+        thumbnailUrl: article.thumbnailUrl ?? null,
       })
       .returning({ id: pages.id });
 
@@ -203,10 +81,10 @@ export async function clipAndCreate(input: ClipAndCreateInput): Promise<ClipAndC
       pageId: page.id,
       ydocState: Buffer.from(ydocBase64, "base64"),
       version: 1,
-      contentText: contentText || null,
+      contentText: article.contentText || null,
     });
 
-    return { page, title, thumbnailUrl };
+    return { page, title: article.title, thumbnailUrl: article.thumbnailUrl };
   });
 
   return {

--- a/server/api/src/routes/ingest.ts
+++ b/server/api/src/routes/ingest.ts
@@ -98,7 +98,7 @@ async function fetchCandidates(params: {
     content_preview: string | null;
     content_text: string | null;
   }>(sql`
-    SELECT p.id, p.title, p.content_preview, pc.content_text
+    SELECT p.id, p.title, p.content_preview, LEFT(pc.content_text, 400) AS content_text
     FROM pages p
     LEFT JOIN page_contents pc ON pc.page_id = p.id
     WHERE p.is_deleted = false

--- a/server/api/src/routes/ingest.ts
+++ b/server/api/src/routes/ingest.ts
@@ -17,6 +17,13 @@ import { authRequired } from "../middleware/auth.js";
 import { rateLimit } from "../middleware/rateLimit.js";
 import { extractArticleFromUrl } from "../lib/articleExtractor.js";
 import { callProvider, getProviderApiKeyName } from "../services/aiProviders.js";
+import { getUserTier } from "../services/subscriptionService.js";
+import {
+  checkUsage,
+  validateModelAccess,
+  calculateCost,
+  recordUsage,
+} from "../services/usageService.js";
 import {
   createIngestLlmDriver,
   planIngest,
@@ -126,17 +133,38 @@ app.post("/plan", authRequired, rateLimit(), async (c) => {
     throw new HTTPException(400, { message: "Invalid JSON body" });
   }
 
-  const url = body.url?.trim();
-  if (!url) {
+  // --- Input validation (runtime type checks) ---
+  if (typeof body.url !== "string" || !body.url.trim()) {
     throw new HTTPException(400, { message: "url is required" });
   }
-  const provider = body.provider;
-  const model = body.model?.trim();
-  if (!provider || !model) {
+  const url = body.url.trim();
+
+  if (typeof body.provider !== "string" || typeof body.model !== "string" || !body.model.trim()) {
     throw new HTTPException(400, { message: "provider and model are required" });
   }
+  const supportedProviders: AIProviderType[] = ["openai", "anthropic", "google"];
+  if (!supportedProviders.includes(body.provider as AIProviderType)) {
+    throw new HTTPException(400, { message: `unsupported provider: ${body.provider}` });
+  }
+  const provider = body.provider as AIProviderType;
+  const model = body.model.trim();
 
-  const candidateLimit = Math.min(Math.max(body.candidateLimit ?? 5, 1), 10);
+  const rawLimit = Number(body.candidateLimit ?? 5);
+  const candidateLimit = Number.isFinite(rawLimit) ? Math.min(Math.max(rawLimit, 1), 10) : 5;
+
+  // --- Model access & usage enforcement (mirrors /api/ai/chat) ---
+  const tier = await getUserTier(userId, db);
+  const modelInfo = await validateModelAccess(model, tier, db);
+  const usageCheck = await checkUsage(userId, tier, db);
+  if (!usageCheck.allowed) {
+    throw new HTTPException(429, { message: "Monthly budget exceeded" });
+  }
+
+  const apiKeyName = getProviderApiKeyName(provider);
+  const apiKey = process.env[apiKeyName];
+  if (!apiKey) {
+    throw new HTTPException(503, { message: `API key not configured: ${apiKeyName}` });
+  }
 
   let article;
   try {
@@ -151,13 +179,11 @@ app.post("/plan", authRequired, rateLimit(), async (c) => {
   const keywords = extractTitleKeywords(article.title);
   const candidates = await fetchCandidates({ db, userId, keywords, limit: candidateLimit });
 
-  const apiKeyName = getProviderApiKeyName(provider);
-  const apiKey = process.env[apiKeyName];
-  if (!apiKey) {
-    throw new HTTPException(503, { message: `API key not configured: ${apiKeyName}` });
-  }
-
-  const llm = createIngestLlmDriver(callProvider, { provider, model, apiKey });
+  const llm = createIngestLlmDriver(callProvider, {
+    provider: modelInfo.provider as AIProviderType,
+    model: modelInfo.apiModelId,
+    apiKey,
+  });
 
   try {
     const plan = await planIngest({
@@ -171,6 +197,24 @@ app.post("/plan", authRequired, rateLimit(), async (c) => {
       candidates,
       llm,
     });
+
+    // --- Usage recording (approximate token estimation, same approach as streaming in chat) ---
+    const inputTokens = Math.ceil(article.contentText.length / 4);
+    const outputTokens = Math.ceil((plan.reason?.length ?? 0) / 4) + 50;
+    const costUnits = calculateCost(
+      { inputTokens, outputTokens },
+      modelInfo.inputCostUnits,
+      modelInfo.outputCostUnits,
+    );
+    await recordUsage(
+      userId,
+      model,
+      "ingest_plan",
+      { inputTokens, outputTokens },
+      costUnits,
+      "system",
+      db,
+    );
 
     return c.json({
       plan,

--- a/server/api/src/routes/ingest.ts
+++ b/server/api/src/routes/ingest.ts
@@ -26,7 +26,8 @@ import {
 } from "../services/usageService.js";
 import {
   createIngestLlmDriver,
-  planIngest,
+  buildIngestPlannerPrompt,
+  parseIngestPlanResponse,
   IngestPlanParseError,
   type CandidatePage,
 } from "../services/ingestPlanner.js";
@@ -185,47 +186,45 @@ app.post("/plan", authRequired, rateLimit(), async (c) => {
     apiKey,
   });
 
+  // Build prompt in the route so we can measure ALL message content for
+  // accurate token estimation (system prompt + article + candidates).
+  const articleSummary = {
+    title: article.title,
+    url: article.finalUrl,
+    excerpt: article.contentText,
+  };
+  const messages = buildIngestPlannerPrompt({ article: articleSummary, candidates });
+
+  let rawResponse: string;
   try {
-    const plan = await planIngest({
-      article: {
-        title: article.title,
-        url: article.finalUrl,
-        // contentText は extractArticleFromUrl で previewLength=4000 に制限済。
-        // Planner 側でさらに truncate(4000) されるため二重の上限になる。
-        excerpt: article.contentText,
-      },
-      candidates,
-      llm,
-    });
+    rawResponse = await llm(messages);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "LLM call failed";
+    throw new HTTPException(502, { message: msg });
+  }
 
-    // --- Usage recording (approximate token estimation, same approach as streaming in chat) ---
-    const inputTokens = Math.ceil(article.contentText.length / 4);
-    const outputTokens = Math.ceil((plan.reason?.length ?? 0) / 4) + 50;
-    const costUnits = calculateCost(
-      { inputTokens, outputTokens },
-      modelInfo.inputCostUnits,
-      modelInfo.outputCostUnits,
-    );
-    await recordUsage(
-      userId,
-      model,
-      "ingest_plan",
-      { inputTokens, outputTokens },
-      costUnits,
-      "system",
-      db,
-    );
+  // --- Usage recording (sum ALL message content, matching chat.ts:66-68) ---
+  const inputTokens = Math.ceil(messages.reduce((sum, m) => sum + m.content.length, 0) / 4);
+  const outputTokens = Math.ceil(rawResponse.length / 4);
+  const costUnits = calculateCost(
+    { inputTokens, outputTokens },
+    modelInfo.inputCostUnits,
+    modelInfo.outputCostUnits,
+  );
+  await recordUsage(
+    userId,
+    model,
+    "ingest_plan",
+    { inputTokens, outputTokens },
+    costUnits,
+    "system",
+    db,
+  );
 
-    return c.json({
-      plan,
-      source: {
-        url: article.finalUrl,
-        title: article.title,
-        thumbnailUrl: article.thumbnailUrl,
-        contentHash: article.contentHash,
-      },
-      candidates,
-    });
+  let plan;
+  try {
+    const validCandidateIds = new Set(candidates.map((c) => c.id));
+    plan = parseIngestPlanResponse(rawResponse, { validCandidateIds });
   } catch (err) {
     if (err instanceof IngestPlanParseError) {
       throw new HTTPException(502, {
@@ -234,6 +233,17 @@ app.post("/plan", authRequired, rateLimit(), async (c) => {
     }
     throw err;
   }
+
+  return c.json({
+    plan,
+    source: {
+      url: article.finalUrl,
+      title: article.title,
+      thumbnailUrl: article.thumbnailUrl,
+      contentHash: article.contentHash,
+    },
+    candidates,
+  });
 });
 
 export default app;

--- a/server/api/src/routes/ingest.ts
+++ b/server/api/src/routes/ingest.ts
@@ -1,0 +1,195 @@
+/**
+ * /api/ingest — LLM Wiki ingest flow (P1, otomatty/zedi#595).
+ *
+ * POST /api/ingest/plan — dry-run: given a URL, propose how the article should
+ * be merged / created / skipped in the user's existing Wiki. Does NOT write
+ * to the database. The corresponding apply endpoint is tracked as a follow-up
+ * and will reuse the plan shape returned here.
+ *
+ * LLM Wiki の ingest フロー。プラン生成までの dry-run エンドポイント。
+ * DB への書き込みは行わず、プレビュー用のプラン JSON を返す。
+ * apply（実適用）エンドポイントは後続 PR で追加する。
+ */
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { sql } from "drizzle-orm";
+import { authRequired } from "../middleware/auth.js";
+import { rateLimit } from "../middleware/rateLimit.js";
+import { extractArticleFromUrl } from "../lib/articleExtractor.js";
+import { callProvider, getProviderApiKeyName } from "../services/aiProviders.js";
+import {
+  createIngestLlmDriver,
+  planIngest,
+  IngestPlanParseError,
+  type CandidatePage,
+} from "../services/ingestPlanner.js";
+import type { AppEnv, AIProviderType } from "../types/index.js";
+
+const app = new Hono<AppEnv>();
+
+/**
+ * リクエストボディ。
+ * Request body for POST /api/ingest/plan.
+ */
+interface IngestPlanRequestBody {
+  url?: string;
+  provider?: AIProviderType;
+  model?: string;
+  /** 候補検索で取得する最大ページ数（既定 5、上限 10）。Max candidate pages (default 5, max 10). */
+  candidateLimit?: number;
+}
+
+/**
+ * タイトルから検索キーワードを抽出する（素朴な空白分割 + ノイズ除去）。
+ * Pulls keyword tokens from the article title for a coarse candidate search.
+ *
+ * タイトル末尾のナビゲーション片（" - サイト名"、"｜ブログ名"、"| Site" 等）を
+ * 簡易的に取り除き、空白で分割して 2 文字以上のトークンのみを返す。
+ * 日本語全角バー「｜」は前後の空白なしで使われることが多いため、whitespace を
+ * 要求しないセパレータパターンも併用する。
+ *
+ * @param title - 抽出対象のタイトル。Title from which to extract keywords.
+ * @returns キーワード配列（最大 5 件）。Array of up to 5 keyword tokens.
+ */
+export function extractTitleKeywords(title: string): string[] {
+  // 「タイトル - サイト名」「タイトル｜ブログ名」形式のサイト名を落とす（素朴）
+  const separators = /(\s+[-–—|]\s+)|([｜])/u;
+  const primary = title.split(separators)[0] ?? title;
+  return primary
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length >= 2)
+    .slice(0, 5);
+}
+
+/**
+ * LIKE で使う特殊文字をエスケープする。
+ * Escapes LIKE wildcards so user input cannot widen the match.
+ */
+function escapeLike(input: string): string {
+  return input.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
+/**
+ * ユーザーの既存ページから候補を取得する。
+ * Fetches candidate pages from the user's existing wiki.
+ *
+ * @param params - userId・db・キーワード・最大件数。Params bag.
+ * @returns 候補ページ配列。Candidate array.
+ */
+async function fetchCandidates(params: {
+  db: AppEnv["Variables"]["db"];
+  userId: string;
+  keywords: string[];
+  limit: number;
+}): Promise<CandidatePage[]> {
+  const { db, userId, keywords, limit } = params;
+  if (keywords.length === 0) return [];
+
+  const patterns = keywords.map((k) => `%${escapeLike(k)}%`);
+
+  // 動的 OR を drizzle の sql テンプレで組む。タイトル一致を優先する。
+  const orClauses = patterns.map((p) => sql`p.title ILIKE ${p} OR pc.content_text ILIKE ${p}`);
+  const orExpr = orClauses.reduce((acc, cur, i) => (i === 0 ? cur : sql`${acc} OR ${cur}`));
+
+  const rows = await db.execute<{
+    id: string;
+    title: string | null;
+    content_preview: string | null;
+    content_text: string | null;
+  }>(sql`
+    SELECT p.id, p.title, p.content_preview, pc.content_text
+    FROM pages p
+    LEFT JOIN page_contents pc ON pc.page_id = p.id
+    WHERE p.is_deleted = false
+      AND p.owner_id = ${userId}
+      AND (${orExpr})
+    ORDER BY p.updated_at DESC
+    LIMIT ${limit}
+  `);
+
+  return rows.rows.map((r) => ({
+    id: r.id,
+    title: r.title ?? "Untitled",
+    excerpt: (r.content_preview || r.content_text || "").slice(0, 400),
+  }));
+}
+
+app.post("/plan", authRequired, rateLimit(), async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+
+  let body: IngestPlanRequestBody;
+  try {
+    body = await c.req.json<IngestPlanRequestBody>();
+  } catch {
+    throw new HTTPException(400, { message: "Invalid JSON body" });
+  }
+
+  const url = body.url?.trim();
+  if (!url) {
+    throw new HTTPException(400, { message: "url is required" });
+  }
+  const provider = body.provider;
+  const model = body.model?.trim();
+  if (!provider || !model) {
+    throw new HTTPException(400, { message: "provider and model are required" });
+  }
+
+  const candidateLimit = Math.min(Math.max(body.candidateLimit ?? 5, 1), 10);
+
+  let article;
+  try {
+    // プランナーが参照する excerpt を広めに取るため previewLength を拡張する。
+    article = await extractArticleFromUrl({ url, previewLength: 4000 });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "extraction failed";
+    // URL not allowed / extraction failed は 400 として伝える
+    throw new HTTPException(400, { message: msg });
+  }
+
+  const keywords = extractTitleKeywords(article.title);
+  const candidates = await fetchCandidates({ db, userId, keywords, limit: candidateLimit });
+
+  const apiKeyName = getProviderApiKeyName(provider);
+  const apiKey = process.env[apiKeyName];
+  if (!apiKey) {
+    throw new HTTPException(503, { message: `API key not configured: ${apiKeyName}` });
+  }
+
+  const llm = createIngestLlmDriver(callProvider, { provider, model, apiKey });
+
+  try {
+    const plan = await planIngest({
+      article: {
+        title: article.title,
+        url: article.finalUrl,
+        // contentText は extractArticleFromUrl で previewLength=4000 に制限済。
+        // Planner 側でさらに truncate(4000) されるため二重の上限になる。
+        excerpt: article.contentText,
+      },
+      candidates,
+      llm,
+    });
+
+    return c.json({
+      plan,
+      source: {
+        url: article.finalUrl,
+        title: article.title,
+        thumbnailUrl: article.thumbnailUrl,
+        contentHash: article.contentHash,
+      },
+      candidates,
+    });
+  } catch (err) {
+    if (err instanceof IngestPlanParseError) {
+      throw new HTTPException(502, {
+        message: `LLM returned an invalid plan: ${err.message}`,
+      });
+    }
+    throw err;
+  }
+});
+
+export default app;

--- a/server/api/src/schema/index.ts
+++ b/server/api/src/schema/index.ts
@@ -58,6 +58,8 @@ export {
   type NewThumbnailObject,
 } from "./thumbnails.js";
 export { adminAuditLogs, type AdminAuditLog, type NewAdminAuditLog } from "./auditLogs.js";
+export { sources, type Source, type NewSource } from "./sources.js";
+export { pageSources, type PageSource, type NewPageSource } from "./pageSources.js";
 
 export {
   usersRelations,
@@ -76,4 +78,6 @@ export {
   subscriptionsRelations,
   aiUsageLogsRelations,
   aiMonthlyUsageRelations,
+  sourcesRelations,
+  pageSourcesRelations,
 } from "./relations.js";

--- a/server/api/src/schema/pageSources.ts
+++ b/server/api/src/schema/pageSources.ts
@@ -1,0 +1,57 @@
+/**
+ * Link table between `pages` (mutable wiki entries) and `sources` (immutable
+ * raw material). One source can inform many pages, and one page can cite many
+ * sources — hence a many-to-many relation.
+ *
+ * ページ（可変の Wiki）と ソース（不変の素材）の多対多関連。
+ * 1 つのソースが複数ページに影響しうるし、1 ページが複数ソースを引用する。
+ *
+ * @see https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+ */
+import { pgTable, uuid, text, timestamp, primaryKey, index } from "drizzle-orm/pg-core";
+import { pages } from "./pages.js";
+import { sources } from "./sources.js";
+
+/**
+ * ページ ↔ ソースの紐付け。section_anchor で「このソースはページ内のどこに
+ * 反映されたか」を記録できる（未使用時は空文字で主キー衝突を防ぐ）。
+ * Page ↔ source junction. `sectionAnchor` records which part of the page a
+ * source informs; empty string when unknown.
+ *
+ * @property pageId - 対象ページ ID。Page ID.
+ * @property sourceId - 対象ソース ID。Source ID.
+ * @property sectionAnchor - ページ内アンカー（見出しスラッグ等。空文字可）。Section anchor (empty string allowed).
+ * @property citationText - 実際に引用した抜粋テキスト。Excerpt cited from the source.
+ * @property createdAt - リンク作成時刻。Linked at.
+ */
+export const pageSources = pgTable(
+  "page_sources",
+  {
+    pageId: uuid("page_id")
+      .notNull()
+      .references(() => pages.id, { onDelete: "cascade" }),
+    sourceId: uuid("source_id")
+      .notNull()
+      .references(() => sources.id, { onDelete: "cascade" }),
+    sectionAnchor: text("section_anchor").notNull().default(""),
+    citationText: text("citation_text"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.pageId, table.sourceId, table.sectionAnchor] }),
+    index("idx_page_sources_page_id").on(table.pageId),
+    index("idx_page_sources_source_id").on(table.sourceId),
+  ],
+);
+
+/**
+ * page_sources テーブルの SELECT 型。
+ * Select type for the page_sources table.
+ */
+export type PageSource = typeof pageSources.$inferSelect;
+
+/**
+ * page_sources テーブルの INSERT 型。
+ * Insert type for the page_sources table.
+ */
+export type NewPageSource = typeof pageSources.$inferInsert;

--- a/server/api/src/schema/relations.ts
+++ b/server/api/src/schema/relations.ts
@@ -8,6 +8,8 @@ import { pageSnapshots } from "./pageSnapshots.js";
 import { media } from "./media.js";
 import { subscriptions } from "./subscriptions.js";
 import { aiUsageLogs, aiMonthlyUsage } from "./aiModels.js";
+import { sources } from "./sources.js";
+import { pageSources } from "./pageSources.js";
 
 export /**
  *
@@ -229,5 +231,32 @@ const aiMonthlyUsageRelations = relations(aiMonthlyUsage, ({ one }) => ({
   user: one(users, {
     fields: [aiMonthlyUsage.userId],
     references: [users.id],
+  }),
+}));
+
+/**
+ * `sources` のリレーション定義。オーナー・ページ引用。
+ * Relations for `sources`: owner and citations from pages.
+ */
+export const sourcesRelations = relations(sources, ({ one, many }) => ({
+  owner: one(users, {
+    fields: [sources.ownerId],
+    references: [users.id],
+  }),
+  citations: many(pageSources),
+}));
+
+/**
+ * `page_sources` のリレーション定義。ページとソースを両端に持つ。
+ * Relations for `page_sources`: page and source endpoints.
+ */
+export const pageSourcesRelations = relations(pageSources, ({ one }) => ({
+  page: one(pages, {
+    fields: [pageSources.pageId],
+    references: [pages.id],
+  }),
+  source: one(sources, {
+    fields: [pageSources.sourceId],
+    references: [sources.id],
   }),
 }));

--- a/server/api/src/schema/sources.ts
+++ b/server/api/src/schema/sources.ts
@@ -1,0 +1,75 @@
+/**
+ * Raw sources for the LLM Wiki pattern.
+ *
+ * A `source` is an immutable record of an external artifact (URL, conversation,
+ * etc.) ingested into the user's Wiki. Unlike a `page`, a source is never
+ * rewritten by the AI — it preserves the original provenance so that pages can
+ * trace back to where their claims came from.
+ *
+ * LLM Wiki パターンの不変ソース層。
+ * URL / 会話などクリップ済みの元資料を保持する。ページ（pages）は AI により
+ * 書き換わるが、sources は不変で出典トレースに使う。
+ *
+ * @see https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+ */
+import { pgTable, uuid, text, timestamp, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { users } from "./users.js";
+
+/**
+ * 外部から取り込んだ素材（URL / 会話 等）。不変・AI による書き換え対象外。
+ * External material ingested from URL or conversation. Immutable.
+ *
+ * @property id - ソースの一意 ID。Unique ID.
+ * @property ownerId - 所有ユーザー ID。Owner user ID.
+ * @property kind - ソース種別。"url" | "conversation"（将来拡張可能）。Source kind.
+ * @property url - 取得元 URL（kind="url" のとき）。Source URL (when kind="url").
+ * @property title - ソースのタイトル（OGP / Readability 抽出）。Source title.
+ * @property contentHash - 本文の SHA-256 等。重複検出用。Content hash for dedup.
+ * @property excerpt - 先頭の要約プレビュー（重い本文を別カラムに分けず軽量化）。Short excerpt.
+ * @property extractedAt - 抽出を行った時刻。When extraction happened.
+ * @property createdAt - レコード作成時刻。Row created at.
+ */
+export const sources = pgTable(
+  "sources",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    ownerId: text("owner_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    kind: text("kind").notNull().default("url"),
+    url: text("url"),
+    title: text("title"),
+    contentHash: text("content_hash"),
+    excerpt: text("excerpt"),
+    extractedAt: timestamp("extracted_at", { withTimezone: true }).defaultNow().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    index("idx_sources_owner_id").on(table.ownerId),
+    index("idx_sources_kind").on(table.kind),
+    // content_hash lookup for dedup（同 hash のソースがあれば再利用する）
+    // Index for content-hash dedup lookups.
+    index("idx_sources_owner_content_hash").on(table.ownerId, table.contentHash),
+    // URL lookup（ユーザーごとに同 URL が複数回クリップされうるので non-unique）
+    // URL lookup (non-unique; same URL may be clipped multiple times).
+    index("idx_sources_owner_url").on(table.ownerId, table.url),
+    // URL が存在するときのみ (owner, url, hash) を一意とする部分ユニーク制約
+    // Partial unique index: only when url is not null.
+    uniqueIndex("uq_sources_owner_url_hash")
+      .on(table.ownerId, table.url, table.contentHash)
+      .where(sql`${table.url} IS NOT NULL`),
+  ],
+);
+
+/**
+ * sources テーブルの SELECT 型。
+ * Select type for the sources table.
+ */
+export type Source = typeof sources.$inferSelect;
+
+/**
+ * sources テーブルの INSERT 型。
+ * Insert type for the sources table.
+ */
+export type NewSource = typeof sources.$inferInsert;

--- a/server/api/src/services/ingestPlanner.ts
+++ b/server/api/src/services/ingestPlanner.ts
@@ -1,0 +1,399 @@
+/**
+ * Ingest Planner — LLM Wiki pattern, P1 (otomatty/zedi#595).
+ *
+ * Decides how a newly-extracted article should be merged into the user's
+ * existing Wiki. Produces an {@link IngestPlan} JSON with one of three
+ * actions:
+ *
+ * - `"merge"`  — append / integrate the article into an existing page
+ * - `"create"` — create a fresh page from the article
+ * - `"skip"`   — the article has no novel information worth storing
+ *
+ * ユーザーの既存 Wiki に対してクリップした記事をどう統合するかを LLM に
+ * 判断させるプランナー。merge / create / skip のいずれかを JSON で返す。
+ *
+ * この段階では DB への書き込みは行わない（dry-run）。受け入れ操作は
+ * 後続 PR の apply エンドポイントで実装する。
+ *
+ * @see https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+ */
+import type { AIMessage, AIProviderType } from "../types/index.js";
+
+/**
+ * Ingest プランが取れるアクション。
+ * Possible actions an ingest plan can propose.
+ */
+export type IngestAction = "merge" | "create" | "skip";
+
+/**
+ * 既存ページの候補。プランナーがマージ先を選ぶための最小情報。
+ * Minimal shape of an existing wiki page passed to the planner as a candidate.
+ *
+ * @property id - 候補ページの UUID。Candidate page UUID.
+ * @property title - ページタイトル。Page title.
+ * @property excerpt - ページの先頭プレビュー（最大数百文字）。Short preview of the page body.
+ */
+export interface CandidatePage {
+  id: string;
+  title: string;
+  excerpt: string;
+}
+
+/**
+ * 抽出済み記事のうち、プランナーに渡す最小限の情報。
+ * The subset of an extracted article passed to the planner.
+ *
+ * @property title - 記事タイトル。Article title.
+ * @property url - ソース URL。Source URL.
+ * @property excerpt - 記事のプレーンテキスト先頭（最大数千文字）。Article plain-text excerpt.
+ */
+export interface IngestArticleSummary {
+  title: string;
+  url: string;
+  excerpt: string;
+}
+
+/**
+ * マージ時に記録する矛盾情報。
+ * A conflict recorded while merging the article into an existing page.
+ *
+ * @property claim - ソース側の主張。The claim from the new source.
+ * @property existing - 既存ページ側の記述。The claim in the existing page.
+ * @property note - 説明（任意）。Optional human-readable note.
+ */
+export interface IngestConflict {
+  claim: string;
+  existing: string;
+  note?: string;
+}
+
+/**
+ * LLM が返す ingest プラン。
+ * Plan returned by the LLM. The payload is validated by {@link parseIngestPlanResponse}.
+ *
+ * @property action - 実行アクション。Action to perform.
+ * @property reason - 判断理由（ユーザー向けに必ず入れる）。Human-readable rationale.
+ * @property targetPageId - merge 時のマージ先ページ ID。Target page id when action="merge".
+ * @property title - create 時の新規タイトル。New page title when action="create".
+ * @property summary - ユーザー向けの 1 行要約（採用 UI に表示）。1-line summary for UI.
+ * @property conflicts - 検出した矛盾（任意）。Detected conflicts (optional).
+ */
+export interface IngestPlan {
+  action: IngestAction;
+  reason: string;
+  targetPageId?: string;
+  title?: string;
+  summary?: string;
+  conflicts?: IngestConflict[];
+}
+
+/**
+ * プロンプト組み立てに渡す入力。
+ * Input for {@link buildIngestPlannerPrompt}.
+ *
+ * @property article - 抽出済み記事の要約。Article summary.
+ * @property candidates - 既存ページ候補（search でヒットした上位 N 件）。Candidate pages.
+ * @property userSchema - ユーザー定義スキーマ（P3 で実装。現状は未設定時は undefined）。Optional user-defined wiki schema.
+ */
+export interface BuildIngestPlannerPromptInput {
+  article: IngestArticleSummary;
+  candidates: CandidatePage[];
+  userSchema?: string;
+}
+
+const SYSTEM_PROMPT_JA_EN = `
+You are the ingest planner for a personal AI-maintained knowledge wiki.
+あなたはパーソナル AI 知識 Wiki の ingest プランナーです。
+
+Given one newly-extracted ARTICLE and up to N CANDIDATE existing pages,
+decide one of:
+  - "merge":  the article extends a specific candidate page; return targetPageId
+  - "create": no candidate is a good fit; return a concise new page title
+  - "skip":   the article has no novel or valuable information
+
+Rules / ルール:
+  1. Prefer "merge" when a candidate page clearly covers the same entity.
+  2. Prefer "create" when the article introduces a distinct entity not covered.
+  3. Use "skip" sparingly — only when the article is noise or exact duplicate.
+  4. Always return a concise "reason" in the user's language.
+  5. If you detect a factual contradiction with an existing page, record it
+     under "conflicts" with "claim" (from the new article) and "existing"
+     (from the candidate page).
+  6. Respond with STRICT JSON only — no markdown, no prose outside JSON.
+
+Response JSON schema / レスポンス JSON スキーマ:
+{
+  "action": "merge" | "create" | "skip",
+  "reason": string,
+  "targetPageId": string (only when action="merge"),
+  "title":        string (only when action="create"),
+  "summary":      string (one-line user-facing summary; optional),
+  "conflicts": [ { "claim": string, "existing": string, "note"?: string } ]
+}
+`.trim();
+
+/**
+ * 記事・候補・（任意の）ユーザースキーマから LLM メッセージ列を組み立てる。
+ * Builds the LLM message list from article + candidates + optional user schema.
+ *
+ * @param input - プロンプトの入力。Prompt input.
+ * @returns LLM へ渡す `AIMessage[]`。Messages array ready for `callProvider`.
+ */
+export function buildIngestPlannerPrompt(input: BuildIngestPlannerPromptInput): AIMessage[] {
+  const { article, candidates, userSchema } = input;
+
+  const systemParts = [SYSTEM_PROMPT_JA_EN];
+  if (userSchema && userSchema.trim().length > 0) {
+    systemParts.push(
+      `User-defined wiki schema (apply when choosing titles and sections):\n${userSchema.trim()}`,
+    );
+  }
+
+  const candidatesBlock =
+    candidates.length === 0
+      ? "(no candidates)"
+      : candidates
+          .map(
+            (c, i) =>
+              `[${i + 1}] id=${c.id}\n    title: ${c.title}\n    excerpt: ${truncate(c.excerpt, 400)}`,
+          )
+          .join("\n\n");
+
+  const userMessage = [
+    `## ARTICLE`,
+    `title: ${article.title}`,
+    `url:   ${article.url}`,
+    `excerpt:`,
+    truncate(article.excerpt, 4000),
+    ``,
+    `## CANDIDATES`,
+    candidatesBlock,
+    ``,
+    `Produce the ingest plan as strict JSON per the schema above.`,
+  ].join("\n");
+
+  return [
+    { role: "system", content: systemParts.join("\n\n") },
+    { role: "user", content: userMessage },
+  ];
+}
+
+/**
+ * 文字列を指定長に切り詰める（UTF-8 安全な単純実装）。
+ * Truncates a string to at most `max` characters. Adds an ellipsis when cut.
+ */
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max).trimEnd() + "…";
+}
+
+/**
+ * LLM レスポンステキストから JSON を抽出する。Markdown ``` で囲まれていても剥がす。
+ * Extracts the JSON object out of an LLM response, tolerating ```json fences.
+ */
+export function extractJsonFromResponse(raw: string): string {
+  const trimmed = raw.trim();
+  const fenceMatch = /^```(?:json)?\s*([\s\S]*?)```$/i.exec(trimmed);
+  if (fenceMatch && fenceMatch[1]) {
+    return fenceMatch[1].trim();
+  }
+  // Fall back: find first "{" and last "}".
+  const first = trimmed.indexOf("{");
+  const last = trimmed.lastIndexOf("}");
+  if (first !== -1 && last !== -1 && last > first) {
+    return trimmed.slice(first, last + 1);
+  }
+  return trimmed;
+}
+
+/**
+ * パース / バリデーション失敗時のエラー。
+ * Thrown when the LLM response cannot be validated into an {@link IngestPlan}.
+ */
+export class IngestPlanParseError extends Error {
+  /**
+   * @param message - エラーメッセージ。Error message.
+   */
+  constructor(message: string) {
+    super(message);
+    this.name = "IngestPlanParseError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseConflicts(value: unknown): IngestConflict[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return undefined;
+  const out: IngestConflict[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    const claim = asNonEmptyString(entry.claim);
+    const existing = asNonEmptyString(entry.existing);
+    if (!claim || !existing) continue;
+    const note = asNonEmptyString(entry.note);
+    out.push(note ? { claim, existing, note } : { claim, existing });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * LLM の生応答を厳格にパース・バリデーションして {@link IngestPlan} を返す。
+ * Strictly validates an LLM raw response and returns a typed {@link IngestPlan}.
+ *
+ * @param raw - LLM の生テキスト応答。Raw LLM text response.
+ * @param options - 候補ページ ID の集合（merge 時の整合性チェック用）。Set of candidate IDs.
+ * @returns 検証済みプラン。Validated ingest plan.
+ * @throws {@link IngestPlanParseError} when JSON is malformed or fields are invalid.
+ */
+export function parseIngestPlanResponse(
+  raw: string,
+  options: { validCandidateIds?: ReadonlySet<string> } = {},
+): IngestPlan {
+  const jsonText = extractJsonFromResponse(raw);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new IngestPlanParseError(`Invalid JSON in LLM response: ${reason}`);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new IngestPlanParseError("Plan must be a JSON object");
+  }
+
+  const actionRaw = parsed.action;
+  if (actionRaw !== "merge" && actionRaw !== "create" && actionRaw !== "skip") {
+    throw new IngestPlanParseError(`Invalid action: ${JSON.stringify(actionRaw)}`);
+  }
+  const action = actionRaw as IngestAction;
+
+  const reason = asNonEmptyString(parsed.reason);
+  if (!reason) {
+    throw new IngestPlanParseError(`"reason" is required`);
+  }
+
+  const plan: IngestPlan = { action, reason };
+
+  const summary = asNonEmptyString(parsed.summary);
+  if (summary) plan.summary = summary;
+
+  const conflicts = parseConflicts(parsed.conflicts);
+  if (conflicts) plan.conflicts = conflicts;
+
+  if (action === "merge") {
+    const targetPageId = asNonEmptyString(parsed.targetPageId);
+    if (!targetPageId) {
+      throw new IngestPlanParseError(`"targetPageId" is required when action="merge"`);
+    }
+    if (options.validCandidateIds && !options.validCandidateIds.has(targetPageId)) {
+      throw new IngestPlanParseError(
+        `targetPageId ${targetPageId} is not in candidate list — LLM hallucinated a page ID`,
+      );
+    }
+    plan.targetPageId = targetPageId;
+  }
+
+  if (action === "create") {
+    const title = asNonEmptyString(parsed.title);
+    if (!title) {
+      throw new IngestPlanParseError(`"title" is required when action="create"`);
+    }
+    plan.title = title;
+  }
+
+  return plan;
+}
+
+/**
+ * LLM ドライバの型。provider / model / apiKey を束ねたコールバック。
+ * LLM driver interface — a callback that wraps provider / model / apiKey.
+ *
+ * Kept as an interface (not a hard dependency on `callProvider`) so tests can
+ * inject a deterministic fake without network I/O.
+ */
+export interface IngestLlmDriver {
+  /**
+   * AIMessage[] を受け取って生テキスト応答を返す。
+   * Takes an AIMessage array and returns a raw text response.
+   */
+  (messages: AIMessage[]): Promise<string>;
+}
+
+/**
+ * `planIngest` 入力。
+ * Input for {@link planIngest}.
+ *
+ * @property article - 抽出済み記事。Extracted article summary.
+ * @property candidates - 既存ページ候補。Existing page candidates.
+ * @property llm - LLM ドライバ。LLM driver callback.
+ * @property userSchema - ユーザー定義スキーマ（任意）。Optional user-defined schema.
+ */
+export interface PlanIngestInput {
+  article: IngestArticleSummary;
+  candidates: CandidatePage[];
+  llm: IngestLlmDriver;
+  userSchema?: string;
+}
+
+/**
+ * プラン生成のオーケストレーション。プロンプト組み立て → LLM 呼び出し → パースを行う。
+ * End-to-end orchestration: build prompt → call LLM → parse response.
+ *
+ * @param input - 入力。Input.
+ * @returns 検証済みプラン。Validated {@link IngestPlan}.
+ * @throws {@link IngestPlanParseError} when the LLM response is malformed.
+ */
+export async function planIngest(input: PlanIngestInput): Promise<IngestPlan> {
+  const messages = buildIngestPlannerPrompt({
+    article: input.article,
+    candidates: input.candidates,
+    userSchema: input.userSchema,
+  });
+  const raw = await input.llm(messages);
+  const validCandidateIds = new Set(input.candidates.map((c) => c.id));
+  return parseIngestPlanResponse(raw, { validCandidateIds });
+}
+
+/**
+ * `callProvider` 互換の関数をラップして {@link IngestLlmDriver} を作る薄いヘルパー。
+ * Adapter wrapping a provider-call function into an {@link IngestLlmDriver}.
+ *
+ * `callProvider` のインポートをテストに持ち込まずに済むよう、関数を注入する形に
+ * している。プロダクションコードからは route 層で {@link callProvider} を注入する。
+ */
+export interface CallProviderAdapter {
+  (
+    provider: AIProviderType,
+    apiKey: string,
+    model: string,
+    messages: AIMessage[],
+  ): Promise<{ content: string }>;
+}
+
+/**
+ * Provider 設定から `IngestLlmDriver` を作成する。
+ * Creates an {@link IngestLlmDriver} bound to a specific provider/model/key.
+ *
+ * @param adapter - `callProvider` 互換の関数。A function with the same shape as `callProvider`.
+ * @param config - プロバイダ・モデル・API キー。Provider / model / api key.
+ * @returns LLM ドライバ関数。LLM driver.
+ */
+export function createIngestLlmDriver(
+  adapter: CallProviderAdapter,
+  config: { provider: AIProviderType; model: string; apiKey: string },
+): IngestLlmDriver {
+  return async (messages) => {
+    const result = await adapter(config.provider, config.apiKey, config.model, messages);
+    return result.content;
+  };
+}

--- a/server/api/src/services/ingestPlanner.ts
+++ b/server/api/src/services/ingestPlanner.ts
@@ -179,12 +179,14 @@ export function buildIngestPlannerPrompt(input: BuildIngestPlannerPromptInput): 
 }
 
 /**
- * 文字列を指定長に切り詰める（UTF-8 安全な単純実装）。
- * Truncates a string to at most `max` characters. Adds an ellipsis when cut.
+ * 文字列を指定長に切り詰める（Unicode コードポイント単位でサロゲートペアを壊さない）。
+ * Truncates a string to at most `max` Unicode code points.
+ * Uses `Array.from` so surrogate pairs (emoji etc.) are never split.
  */
 function truncate(text: string, max: number): string {
-  if (text.length <= max) return text;
-  return text.slice(0, max).trimEnd() + "…";
+  const chars = Array.from(text);
+  if (chars.length <= max) return text;
+  return chars.slice(0, max).join("").trimEnd() + "…";
 }
 
 /**


### PR DESCRIPTION
Introduces the P1 foundation for the Karpathy "LLM Wiki" pattern
tracked in #594. This PR lays the data-model and dry-run prediction
path without any DB writes; the apply endpoint and diff-preview UI
remain as follow-ups on #595.

What this adds
- `sources` / `page_sources` tables + migration so the immutable raw
  layer can be separated from the mutable Wiki pages.
- `articleExtractor` lib: extract the URL → Readability → Tiptap JSON
  pipeline out of `clipAndCreate` so both clipping and ingest can
  share the same extraction without persisting a page.
- `ingestPlanner` service: builds an LLM prompt from an extracted
  article plus candidate existing pages and returns a strictly-
  validated `IngestPlan { action: "merge" | "create" | "skip", ... }`.
  Guards against hallucinated `targetPageId` values.
- `POST /api/ingest/plan` route (auth + rate-limited): dry-run that
  runs extraction, candidate search, and planning, and returns the
  plan JSON. No mutation.

Testing
- 27 unit tests for ingestPlanner (parse / prompt build / orchestration /
  provider adapter), 8 tests for the ingest route and keyword
  extractor. Full `bun run test:run` passes (412/412). Lint and
  Prettier clean.

Refs: otomatty/zedi#594 (Epic), otomatty/zedi#595 (P1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added URL content ingestion workflow with automatic article extraction and parsing.
  * Introduced AI-powered suggestion engine to recommend merging content with existing pages or creating new entries.
  * Enabled smart deduplication and citation tracking for ingested materials.
  * New `/api/ingest/plan` endpoint for previewing ingest decisions without committing changes.

* **Tests**
  * Added comprehensive test coverage for ingest routes and planning service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->