### PR TITLE
claude/fix-issue-596-foPbZ

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -5,6 +5,7 @@ import Login from "./pages/Login";
 import AiModels from "./pages/ai-models";
 import Users from "./pages/users";
 import AuditLogs from "./pages/audit-logs";
+import WikiHealth from "./pages/wiki-health";
 
 /**
  * Root component for the admin SPA: sets up routing and the admin auth guard.
@@ -29,6 +30,7 @@ function App() {
           <Route path="ai-models" element={<AiModels />} />
           <Route path="users" element={<Users />} />
           <Route path="audit-logs" element={<AuditLogs />} />
+          <Route path="wiki-health" element={<WikiHealth />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/admin/src/api/lint.ts
+++ b/admin/src/api/lint.ts
@@ -1,0 +1,89 @@
+import { adminFetch } from "./client";
+
+/**
+ * Lint ルール名の型。
+ * Lint rule name type.
+ */
+export type LintRule = "orphan" | "ghost_many" | "title_similar" | "conflict" | "broken_link";
+
+/**
+ * Lint 重要度の型。
+ * Lint severity type.
+ */
+export type LintSeverity = "info" | "warn" | "error";
+
+/**
+ * Lint の 1 件の検出結果。
+ * A single lint finding.
+ */
+export interface LintFindingItem {
+  id: string;
+  rule: LintRule;
+  severity: LintSeverity;
+  page_ids: string[];
+  detail: Record<string, unknown>;
+  created_at: string;
+  resolved_at?: string | null;
+}
+
+/**
+ * Lint 実行結果のサマリ（ルールごとの件数）。
+ * Lint run summary (count per rule).
+ */
+export interface LintRunSummaryItem {
+  rule: LintRule;
+  count: number;
+}
+
+async function getErrorMessage(res: Response, fallback: string): Promise<string> {
+  const err = await res.json().catch(() => ({ message: res.statusText }));
+  return (err as { message?: string }).message ?? fallback;
+}
+
+/**
+ * Lint を実行する。
+ * Triggers a lint run.
+ *
+ * @returns ルールごとのサマリと合計件数 / Summary per rule and total count
+ */
+export async function runLint(): Promise<{ summary: LintRunSummaryItem[]; total: number }> {
+  const res = await adminFetch("/api/lint/run", { method: "POST" });
+  if (!res.ok) {
+    throw new Error(await getErrorMessage(res, "Failed to run lint"));
+  }
+  return res.json();
+}
+
+/**
+ * 未解決の Lint findings を取得する。
+ * Fetches unresolved lint findings.
+ *
+ * @returns findings と合計件数 / Findings and total count
+ */
+export async function getLintFindings(): Promise<{
+  findings: LintFindingItem[];
+  total: number;
+}> {
+  const res = await adminFetch("/api/lint/findings");
+  if (!res.ok) {
+    throw new Error(await getErrorMessage(res, "Failed to fetch lint findings"));
+  }
+  return res.json();
+}
+
+/**
+ * Lint finding を解決済みにマークする。
+ * Marks a lint finding as resolved.
+ *
+ * @param id - Finding ID
+ * @returns 更新された finding / Updated finding
+ */
+export async function resolveLintFinding(id: string): Promise<{ finding: LintFindingItem }> {
+  const res = await adminFetch(`/api/lint/findings/${encodeURIComponent(id)}/resolve`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(await getErrorMessage(res, "Failed to resolve finding"));
+  }
+  return res.json();
+}

--- a/admin/src/pages/Layout.tsx
+++ b/admin/src/pages/Layout.tsx
@@ -1,5 +1,5 @@
 import { Outlet, Link, useLocation } from "react-router-dom";
-import { Bot, Users, ScrollText } from "lucide-react";
+import { Bot, Users, ScrollText, HeartPulse } from "lucide-react";
 import {
   SidebarProvider,
   Sidebar,
@@ -19,6 +19,7 @@ const navLinks = [
   { to: "/ai-models", label: "AI モデル", icon: Bot },
   { to: "/users", label: "ユーザー管理", icon: Users },
   { to: "/audit-logs", label: "監査ログ", icon: ScrollText },
+  { to: "/wiki-health", label: "Wiki Health", icon: HeartPulse },
 ];
 
 /**

--- a/admin/src/pages/wiki-health/WikiHealthContent.tsx
+++ b/admin/src/pages/wiki-health/WikiHealthContent.tsx
@@ -1,0 +1,206 @@
+import {
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Badge,
+} from "@zedi/ui";
+import type { LintFindingItem, LintRule, LintRunSummaryItem } from "@/api/lint";
+import { formatDate } from "@/lib/dateUtils";
+
+/**
+ * ルール名を日本語・英語で表示する。
+ * Maps rule name to display label (Japanese / English).
+ */
+const RULE_LABELS: Record<LintRule, string> = {
+  orphan: "孤立ページ / Orphan",
+  ghost_many: "Ghost Link 過多 / Ghost Excess",
+  title_similar: "タイトル類似 / Title Similar",
+  conflict: "矛盾 / Conflict",
+  broken_link: "リンク切れ / Broken Link",
+};
+
+/**
+ * 重要度に対応する Badge バリアント。
+ * Badge variant per severity.
+ */
+function severityVariant(severity: string): "default" | "secondary" | "destructive" | "outline" {
+  switch (severity) {
+    case "error":
+      return "destructive";
+    case "warn":
+      return "secondary";
+    default:
+      return "outline";
+  }
+}
+
+/**
+ * detail オブジェクトからサマリ文字列を生成する。
+ * Creates a summary string from a detail object.
+ */
+function formatDetail(detail: Record<string, unknown>): string {
+  if (typeof detail.suggestion === "string") return detail.suggestion;
+  if (typeof detail.title === "string") return detail.title;
+  if (typeof detail.linkText === "string") {
+    const count = typeof detail.count === "number" ? detail.count : "?";
+    return `「${detail.linkText}」(${count} 件)`;
+  }
+  return JSON.stringify(detail);
+}
+
+/** UI selector sentinel for "すべて" (no filter). */
+const ANY_RULE = "__any__";
+
+interface WikiHealthContentProps {
+  findings: LintFindingItem[];
+  summary: LintRunSummaryItem[] | null;
+  loading: boolean;
+  running: boolean;
+  error: string | null;
+  ruleFilter: LintRule | undefined;
+  onRuleFilterChange: (rule: LintRule | undefined) => void;
+  onRunLint: () => void;
+  onResolve: (id: string) => void;
+}
+
+/**
+ * Wiki Health ダッシュボードのプレゼンテーション層。
+ * Presentational component for the Wiki Health dashboard.
+ */
+export function WikiHealthContent({
+  findings,
+  summary,
+  loading,
+  running,
+  error,
+  ruleFilter,
+  onRuleFilterChange,
+  onRunLint,
+  onResolve,
+}: WikiHealthContentProps) {
+  const filtered = ruleFilter ? findings.filter((f) => f.rule === ruleFilter) : findings;
+
+  const handleRuleChange = (value: string) => {
+    onRuleFilterChange(value === ANY_RULE ? undefined : (value as LintRule));
+  };
+
+  return (
+    <div>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <h1 className="text-lg font-semibold">Wiki Health ダッシュボード</h1>
+        <Button type="button" onClick={onRunLint} disabled={running || loading}>
+          {running ? "実行中..." : "Lint 実行"}
+        </Button>
+      </div>
+
+      {/* サマリ表示 / Summary display */}
+      {summary && (
+        <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
+          {summary.map((s) => (
+            <div key={s.rule} className="bg-muted/50 rounded border px-3 py-2">
+              <div className="text-muted-foreground text-xs">{RULE_LABELS[s.rule]}</div>
+              <div className="mt-1 text-xl font-bold">{s.count}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* フィルタ / Filter */}
+      <div className="mt-4">
+        <label
+          htmlFor="lint-filter-rule"
+          className="text-muted-foreground mb-1 block text-xs"
+          id="lint-filter-rule-label"
+        >
+          ルールで絞り込み
+        </label>
+        <Select value={ruleFilter ?? ANY_RULE} onValueChange={handleRuleChange}>
+          <SelectTrigger
+            id="lint-filter-rule"
+            aria-labelledby="lint-filter-rule-label"
+            className="w-60"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ANY_RULE}>すべて</SelectItem>
+            {(Object.keys(RULE_LABELS) as LintRule[]).map((r) => (
+              <SelectItem key={r} value={r}>
+                {RULE_LABELS[r]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {error && (
+        <div className="mt-2 rounded bg-red-900/30 px-3 py-2 text-sm text-red-200">{error}</div>
+      )}
+
+      {loading && findings.length === 0 ? (
+        <p className="text-muted-foreground mt-4">読み込み中...</p>
+      ) : filtered.length === 0 ? (
+        <p className="text-muted-foreground mt-4">
+          {findings.length === 0
+            ? "Lint findings はありません。「Lint 実行」をクリックしてください。"
+            : "該当する findings はありません。"}
+        </p>
+      ) : (
+        <div className="mt-4 overflow-x-auto">
+          <Table className="border-border min-w-[640px] rounded border">
+            <TableHeader>
+              <TableRow className="border-border bg-muted/50 hover:bg-transparent">
+                <TableHead className="px-3 py-2">ルール</TableHead>
+                <TableHead className="px-3 py-2">重要度</TableHead>
+                <TableHead className="px-3 py-2">詳細</TableHead>
+                <TableHead className="px-3 py-2">検出日時</TableHead>
+                <TableHead className="px-3 py-2">操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filtered.map((f) => (
+                <TableRow key={f.id} className="border-border align-top">
+                  <TableCell className="px-3 py-2">
+                    <Badge variant="outline">{RULE_LABELS[f.rule]}</Badge>
+                  </TableCell>
+                  <TableCell className="px-3 py-2">
+                    <Badge variant={severityVariant(f.severity)}>{f.severity}</Badge>
+                  </TableCell>
+                  <TableCell className="max-w-md px-3 py-2">
+                    <div className="text-sm">{formatDetail(f.detail)}</div>
+                    <div className="text-muted-foreground mt-1 text-xs">
+                      {f.page_ids.length} ページ関連
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground px-3 py-2 whitespace-nowrap">
+                    {formatDate(f.created_at)}
+                  </TableCell>
+                  <TableCell className="px-3 py-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onResolve(f.id)}
+                    >
+                      解決
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          <p className="text-muted-foreground mt-2 text-xs">合計 {filtered.length} 件</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin/src/pages/wiki-health/index.tsx
+++ b/admin/src/pages/wiki-health/index.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { LintFindingItem, LintRule, LintRunSummaryItem } from "@/api/lint";
+import { getLintFindings, runLint, resolveLintFinding } from "@/api/lint";
+import { WikiHealthContent } from "./WikiHealthContent";
+
+/**
+ * 管理画面の「Wiki Health」ページ。
+ * Lint を実行して結果を一覧表示する。
+ *
+ * Admin "Wiki Health" page.
+ * Runs lint and displays findings in a table.
+ */
+export default function WikiHealth() {
+  const [findings, setFindings] = useState<LintFindingItem[]>([]);
+  const [summary, setSummary] = useState<LintRunSummaryItem[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [ruleFilter, setRuleFilter] = useState<LintRule | undefined>(undefined);
+
+  const isMountedRef = useRef(true);
+
+  const loadFindings = useCallback(async () => {
+    if (isMountedRef.current) setLoading(true);
+    if (isMountedRef.current) setError(null);
+    try {
+      const result = await getLintFindings();
+      if (!isMountedRef.current) return;
+      setFindings(result.findings);
+    } catch (e) {
+      if (!isMountedRef.current) return;
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      if (isMountedRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    void loadFindings();
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, [loadFindings]);
+
+  const handleRunLint = useCallback(async () => {
+    if (isMountedRef.current) setRunning(true);
+    if (isMountedRef.current) setError(null);
+    try {
+      const result = await runLint();
+      if (!isMountedRef.current) return;
+      setSummary(result.summary);
+      // findings を再取得 / Reload findings
+      await loadFindings();
+    } catch (e) {
+      if (!isMountedRef.current) return;
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      if (isMountedRef.current) setRunning(false);
+    }
+  }, [loadFindings]);
+
+  const handleResolve = useCallback(
+    async (id: string) => {
+      try {
+        await resolveLintFinding(id);
+        if (!isMountedRef.current) return;
+        await loadFindings();
+      } catch (e) {
+        if (!isMountedRef.current) return;
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [loadFindings],
+  );
+
+  return (
+    <WikiHealthContent
+      findings={findings}
+      summary={summary}
+      loading={loading}
+      running={running}
+      error={error}
+      ruleFilter={ruleFilter}
+      onRuleFilterChange={setRuleFilter}
+      onRunLint={handleRunLint}
+      onResolve={handleResolve}
+    />
+  );
+}

--- a/server/api/drizzle/0008_add_lint_findings.sql
+++ b/server/api/drizzle/0008_add_lint_findings.sql
@@ -1,0 +1,28 @@
+-- Add `lint_findings` table for Wiki Lint engine results.
+-- Wiki Lint エンジンの検出結果を永続化する lint_findings テーブルを追加する。
+--
+-- Stores findings from batch or on-demand lint runs for
+-- orphan pages, ghost link excess, title similarity, conflicts, and broken links.
+--
+-- See parent issue otomatty/zedi#594, sub-issue #596.
+
+CREATE TABLE "lint_findings" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    "owner_id" text NOT NULL,
+    "rule" text NOT NULL,
+    "severity" text NOT NULL,
+    "page_ids" text[] NOT NULL,
+    "detail" jsonb,
+    "resolved_at" timestamp with time zone,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "lint_findings"
+    ADD CONSTRAINT "lint_findings_owner_id_user_id_fk"
+    FOREIGN KEY ("owner_id") REFERENCES "user"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "idx_lint_findings_owner_id" ON "lint_findings" ("owner_id");
+--> statement-breakpoint
+CREATE INDEX "idx_lint_findings_rule" ON "lint_findings" ("rule");
+--> statement-breakpoint
+CREATE INDEX "idx_lint_findings_owner_rule" ON "lint_findings" ("owner_id", "rule");

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1776470400000,
       "tag": "0007_add_sources_and_page_sources",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1776556800000,
+      "tag": "0008_add_lint_findings",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/src/app.ts
+++ b/server/api/src/app.ts
@@ -34,6 +34,7 @@ import thumbServeRoutes from "./routes/thumbnail/serve.js";
 import webhookPolarRoutes from "./routes/webhooks/polar.js";
 import checkoutRoutes from "./routes/checkout.js";
 import subscriptionManageRoutes from "./routes/subscriptionManage.js";
+import lintRoutes from "./routes/lint.js";
 
 /**
  * Creates and configures the Hono API app (routes, CORS, etc.).
@@ -110,6 +111,9 @@ export function createApp(): Hono<AppEnv> {
 
   // Ingest (LLM Wiki pattern, P1)
   app.route("/api/ingest", ingestRoutes);
+
+  // Lint (Wiki Health, P2)
+  app.route("/api/lint", lintRoutes);
 
   // Chrome Extension (OAuth + clip-and-create)
   app.route("/api/ext", extRoutes);

--- a/server/api/src/routes/lint.ts
+++ b/server/api/src/routes/lint.ts
@@ -1,0 +1,114 @@
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { authRequired } from "../middleware/auth.js";
+import {
+  runAllLintRules,
+  getUnresolvedFindings,
+  getFindingsForPage,
+  resolveFinding,
+} from "../services/lintEngine/index.js";
+import type { AppEnv } from "../types/index.js";
+
+const app = new Hono<AppEnv>();
+
+app.use("*", authRequired);
+
+/**
+ * POST /api/lint/run
+ * 全 Lint ルールを実行し、結果を保存して返す。
+ * Runs all lint rules, persists results, and returns them.
+ */
+app.post("/run", async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+
+  const results = await runAllLintRules(userId, db);
+
+  const summary = results.map((r) => ({
+    rule: r.rule,
+    count: r.findings.length,
+  }));
+
+  const totalFindings = results.reduce((sum, r) => sum + r.findings.length, 0);
+
+  return c.json({ summary, total: totalFindings });
+});
+
+/**
+ * GET /api/lint/findings
+ * 未解決の Lint findings を取得する。
+ * Fetches unresolved lint findings.
+ */
+app.get("/findings", async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+
+  const findings = await getUnresolvedFindings(userId, db);
+
+  return c.json({
+    findings: findings.map((f) => ({
+      id: f.id,
+      rule: f.rule,
+      severity: f.severity,
+      page_ids: f.pageIds,
+      detail: f.detail,
+      created_at: f.createdAt.toISOString(),
+    })),
+    total: findings.length,
+  });
+});
+
+/**
+ * GET /api/lint/findings/page/:pageId
+ * 指定ページに関連する未解決 Lint findings を取得する。
+ * Fetches unresolved lint findings related to a specific page.
+ */
+app.get("/findings/page/:pageId", async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+  const pageId = c.req.param("pageId");
+
+  const findings = await getFindingsForPage(userId, pageId, db);
+
+  return c.json({
+    findings: findings.map((f) => ({
+      id: f.id,
+      rule: f.rule,
+      severity: f.severity,
+      page_ids: f.pageIds,
+      detail: f.detail,
+      created_at: f.createdAt.toISOString(),
+    })),
+    total: findings.length,
+  });
+});
+
+/**
+ * POST /api/lint/findings/:id/resolve
+ * Lint finding を解決済みにマークする。
+ * Marks a lint finding as resolved.
+ */
+app.post("/findings/:id/resolve", async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+  const findingId = c.req.param("id");
+
+  const updated = await resolveFinding(findingId, userId, db);
+  if (!updated) {
+    throw new HTTPException(404, { message: "Finding not found" });
+  }
+
+  return c.json({
+    finding: {
+      id: updated.id,
+      rule: updated.rule,
+      severity: updated.severity,
+      page_ids: updated.pageIds,
+      detail: updated.detail,
+      resolved_at: updated.resolvedAt?.toISOString() ?? null,
+      created_at: updated.createdAt.toISOString(),
+    },
+  });
+});
+
+export default app;

--- a/server/api/src/schema/index.ts
+++ b/server/api/src/schema/index.ts
@@ -60,6 +60,13 @@ export {
 export { adminAuditLogs, type AdminAuditLog, type NewAdminAuditLog } from "./auditLogs.js";
 export { sources, type Source, type NewSource } from "./sources.js";
 export { pageSources, type PageSource, type NewPageSource } from "./pageSources.js";
+export {
+  lintFindings,
+  type LintFinding,
+  type NewLintFinding,
+  type LintRule,
+  type LintSeverity,
+} from "./lintFindings.js";
 
 export {
   usersRelations,
@@ -80,4 +87,5 @@ export {
   aiMonthlyUsageRelations,
   sourcesRelations,
   pageSourcesRelations,
+  lintFindingsRelations,
 } from "./relations.js";

--- a/server/api/src/schema/lintFindings.ts
+++ b/server/api/src/schema/lintFindings.ts
@@ -1,0 +1,51 @@
+import { pgTable, uuid, text, timestamp, jsonb, index } from "drizzle-orm/pg-core";
+import { users } from "./users.js";
+
+/**
+ * Lint ルール名の型。
+ * Lint rule name type.
+ */
+export type LintRule = "orphan" | "ghost_many" | "title_similar" | "conflict" | "broken_link";
+
+/**
+ * Lint 重要度の型。
+ * Lint severity type.
+ */
+export type LintSeverity = "info" | "warn" | "error";
+
+/**
+ * Wiki Lint 検出結果テーブル。
+ * バッチまたはオンデマンドで実行した Lint の結果を永続化する。
+ *
+ * Wiki Lint findings table.
+ * Persists results from batch or on-demand Lint runs.
+ */
+export const lintFindings = pgTable(
+  "lint_findings",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    ownerId: text("owner_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    rule: text("rule").notNull().$type<LintRule>(),
+    severity: text("severity").notNull().$type<LintSeverity>(),
+    pageIds: text("page_ids").array().notNull(),
+    detail: jsonb("detail").$type<Record<string, unknown>>(),
+    resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    index("idx_lint_findings_owner_id").on(table.ownerId),
+    index("idx_lint_findings_rule").on(table.rule),
+    index("idx_lint_findings_owner_rule").on(table.ownerId, table.rule),
+  ],
+);
+
+/**
+ *
+ */
+export type LintFinding = typeof lintFindings.$inferSelect;
+/**
+ *
+ */
+export type NewLintFinding = typeof lintFindings.$inferInsert;

--- a/server/api/src/schema/relations.ts
+++ b/server/api/src/schema/relations.ts
@@ -10,6 +10,7 @@ import { subscriptions } from "./subscriptions.js";
 import { aiUsageLogs, aiMonthlyUsage } from "./aiModels.js";
 import { sources } from "./sources.js";
 import { pageSources } from "./pageSources.js";
+import { lintFindings } from "./lintFindings.js";
 
 export /**
  *
@@ -258,5 +259,16 @@ export const pageSourcesRelations = relations(pageSources, ({ one }) => ({
   source: one(sources, {
     fields: [pageSources.sourceId],
     references: [sources.id],
+  }),
+}));
+
+/**
+ * `lint_findings` のリレーション定義。オーナーへの多対一。
+ * Relations for `lint_findings`: many-to-one to owner.
+ */
+export const lintFindingsRelations = relations(lintFindings, ({ one }) => ({
+  owner: one(users, {
+    fields: [lintFindings.ownerId],
+    references: [users.id],
   }),
 }));

--- a/server/api/src/services/lintEngine/index.ts
+++ b/server/api/src/services/lintEngine/index.ts
@@ -1,4 +1,4 @@
-import { eq, and, isNull } from "drizzle-orm";
+import { eq, and, isNull, sql } from "drizzle-orm";
 import { lintFindings } from "../../schema/lintFindings.js";
 import type { Database } from "../../types/index.js";
 import type { LintFindingCandidate, LintRuleResult } from "./types.js";
@@ -31,27 +31,27 @@ export async function runAllLintRules(ownerId: string, db: Database): Promise<Li
     runConflictRule(ownerId, db),
   ]);
 
-  // 既存の未解決 findings を削除して最新結果のみ保持
-  // Delete existing unresolved findings and keep only latest results
-  await db
-    .delete(lintFindings)
-    .where(and(eq(lintFindings.ownerId, ownerId), isNull(lintFindings.resolvedAt)));
-
-  // 全 findings を集約してバルクインサート
-  // Aggregate all findings and bulk insert
+  // トランザクション内で既存の未解決 findings を削除し、最新結果のみ保持
+  // Within a transaction: delete unresolved findings and insert new ones atomically
   const allFindings: LintFindingCandidate[] = results.flatMap((r) => r.findings);
 
-  if (allFindings.length > 0) {
-    await db.insert(lintFindings).values(
-      allFindings.map((f) => ({
-        ownerId,
-        rule: f.rule,
-        severity: f.severity,
-        pageIds: f.pageIds,
-        detail: f.detail,
-      })),
-    );
-  }
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(lintFindings)
+      .where(and(eq(lintFindings.ownerId, ownerId), isNull(lintFindings.resolvedAt)));
+
+    if (allFindings.length > 0) {
+      await tx.insert(lintFindings).values(
+        allFindings.map((f) => ({
+          ownerId,
+          rule: f.rule,
+          severity: f.severity,
+          pageIds: f.pageIds,
+          detail: f.detail,
+        })),
+      );
+    }
+  });
 
   return results;
 }
@@ -82,8 +82,17 @@ export async function getUnresolvedFindings(ownerId: string, db: Database) {
  * @returns 該当ページに関連する findings / Findings related to the page
  */
 export async function getFindingsForPage(ownerId: string, pageId: string, db: Database) {
-  const all = await getUnresolvedFindings(ownerId, db);
-  return all.filter((f) => f.pageIds.includes(pageId));
+  return db
+    .select()
+    .from(lintFindings)
+    .where(
+      and(
+        eq(lintFindings.ownerId, ownerId),
+        isNull(lintFindings.resolvedAt),
+        sql`${pageId} = ANY(${lintFindings.pageIds})`,
+      ),
+    )
+    .orderBy(lintFindings.createdAt);
 }
 
 /**

--- a/server/api/src/services/lintEngine/index.ts
+++ b/server/api/src/services/lintEngine/index.ts
@@ -1,0 +1,105 @@
+import { eq, and, isNull } from "drizzle-orm";
+import { lintFindings } from "../../schema/lintFindings.js";
+import type { Database } from "../../types/index.js";
+import type { LintFindingCandidate, LintRuleResult } from "./types.js";
+import { runOrphanRule } from "./rules/orphan.js";
+import { runGhostManyRule } from "./rules/ghostMany.js";
+import { runTitleSimilarRule } from "./rules/titleSimilar.js";
+import { runBrokenLinkRule } from "./rules/brokenLink.js";
+import { runConflictRule } from "./rules/conflict.js";
+
+export type { LintFindingCandidate, LintRuleResult } from "./types.js";
+
+/**
+ * 全 Lint ルールを実行し、結果を lint_findings テーブルに保存する。
+ * 実行前に未解決の findings をクリアし、最新の結果のみを保持する。
+ *
+ * Runs all lint rules and persists results to the lint_findings table.
+ * Clears unresolved findings before inserting new ones to keep only latest results.
+ *
+ * @param ownerId - 対象ユーザー ID / Target user ID
+ * @param db - データベース接続 / Database connection
+ * @returns 検出された全 findings / All detected findings
+ */
+export async function runAllLintRules(ownerId: string, db: Database): Promise<LintRuleResult[]> {
+  // 全ルールを並列実行 / Run all rules in parallel
+  const results = await Promise.all([
+    runOrphanRule(ownerId, db),
+    runGhostManyRule(ownerId, db),
+    runTitleSimilarRule(ownerId, db),
+    runBrokenLinkRule(ownerId, db),
+    runConflictRule(ownerId, db),
+  ]);
+
+  // 既存の未解決 findings を削除して最新結果のみ保持
+  // Delete existing unresolved findings and keep only latest results
+  await db
+    .delete(lintFindings)
+    .where(and(eq(lintFindings.ownerId, ownerId), isNull(lintFindings.resolvedAt)));
+
+  // 全 findings を集約してバルクインサート
+  // Aggregate all findings and bulk insert
+  const allFindings: LintFindingCandidate[] = results.flatMap((r) => r.findings);
+
+  if (allFindings.length > 0) {
+    await db.insert(lintFindings).values(
+      allFindings.map((f) => ({
+        ownerId,
+        rule: f.rule,
+        severity: f.severity,
+        pageIds: f.pageIds,
+        detail: f.detail,
+      })),
+    );
+  }
+
+  return results;
+}
+
+/**
+ * 指定ユーザーの未解決 Lint findings を取得する。
+ * Fetches unresolved lint findings for the specified user.
+ *
+ * @param ownerId - 対象ユーザー ID / Target user ID
+ * @param db - データベース接続 / Database connection
+ * @returns 未解決の findings / Unresolved findings
+ */
+export async function getUnresolvedFindings(ownerId: string, db: Database) {
+  return db
+    .select()
+    .from(lintFindings)
+    .where(and(eq(lintFindings.ownerId, ownerId), isNull(lintFindings.resolvedAt)))
+    .orderBy(lintFindings.createdAt);
+}
+
+/**
+ * 指定ページに関連する未解決 Lint findings を取得する。
+ * Fetches unresolved lint findings related to the specified page.
+ *
+ * @param ownerId - 対象ユーザー ID / Target user ID
+ * @param pageId - 対象ページ ID / Target page ID
+ * @param db - データベース接続 / Database connection
+ * @returns 該当ページに関連する findings / Findings related to the page
+ */
+export async function getFindingsForPage(ownerId: string, pageId: string, db: Database) {
+  const all = await getUnresolvedFindings(ownerId, db);
+  return all.filter((f) => f.pageIds.includes(pageId));
+}
+
+/**
+ * Finding を解決済みにマークする。
+ * Marks a finding as resolved.
+ *
+ * @param findingId - Finding ID
+ * @param ownerId - 対象ユーザー ID / Target user ID
+ * @param db - データベース接続 / Database connection
+ * @returns 更新された finding（見つからない場合は null） / Updated finding or null
+ */
+export async function resolveFinding(findingId: string, ownerId: string, db: Database) {
+  const [updated] = await db
+    .update(lintFindings)
+    .set({ resolvedAt: new Date() })
+    .where(and(eq(lintFindings.id, findingId), eq(lintFindings.ownerId, ownerId)))
+    .returning();
+  return updated ?? null;
+}

--- a/server/api/src/services/lintEngine/rules/brokenLink.ts
+++ b/server/api/src/services/lintEngine/rules/brokenLink.ts
@@ -1,0 +1,58 @@
+import { eq, and, sql } from "drizzle-orm";
+import { links } from "../../../schema/links.js";
+import { pages } from "../../../schema/pages.js";
+import type { Database } from "../../../types/index.js";
+import type { LintRuleResult } from "../types.js";
+
+/**
+ * リンク切れ検出ルール。
+ * 削除済みページを指すリンクを検出する。
+ *
+ * Broken link detection rule.
+ * Detects links pointing to deleted pages.
+ *
+ * @param ownerId - 対象ユーザー ID / Target user ID
+ * @param db - データベース接続 / Database connection
+ * @returns リンク切れの検出結果 / Broken link findings
+ */
+export async function runBrokenLinkRule(ownerId: string, db: Database): Promise<LintRuleResult> {
+  // source ページが存在し、target ページが削除済みのリンクを取得
+  // Find links where source page is active but target page is deleted
+  const sourcePage = pages;
+
+  const broken = await db
+    .select({
+      sourceId: links.sourceId,
+      targetId: links.targetId,
+      sourceTitle: sourcePage.title,
+    })
+    .from(links)
+    .innerJoin(sourcePage, eq(links.sourceId, sourcePage.id))
+    .where(
+      and(
+        eq(sourcePage.ownerId, ownerId),
+        eq(sourcePage.isDeleted, false),
+        sql`EXISTS (
+          SELECT 1 FROM pages AS target
+          WHERE target.id = ${links.targetId}
+          AND target.is_deleted = true
+        )`,
+      ),
+    );
+
+  return {
+    rule: "broken_link",
+    findings: broken.map((b) => ({
+      rule: "broken_link" as const,
+      severity: "error" as const,
+      pageIds: [b.sourceId, b.targetId],
+      detail: {
+        sourceTitle: b.sourceTitle ?? "(無題 / untitled)",
+        sourceId: b.sourceId,
+        targetId: b.targetId,
+        suggestion:
+          "リンク先が削除されています。リンクの修正を検討してください / Link target has been deleted. Consider fixing the link.",
+      },
+    })),
+  };
+}

--- a/server/api/src/services/lintEngine/rules/conflict.test.ts
+++ b/server/api/src/services/lintEngine/rules/conflict.test.ts
@@ -1,0 +1,61 @@
+/**
+ * conflict ルールの単体テスト（純粋関数 extractFacts のテスト）。
+ * Unit tests for the conflict rule (pure function extractFacts).
+ */
+import { describe, it, expect } from "vitest";
+import { extractFacts } from "./conflict.js";
+
+describe("extractFacts", () => {
+  it("空文字列からは何も抽出しない / extracts nothing from empty string", () => {
+    expect(extractFacts("")).toEqual([]);
+  });
+
+  it("日付パターンを抽出する / extracts date patterns", () => {
+    const text = "東京タワーは 1958年12月23日 に完工した。";
+    const facts = extractFacts(text);
+    expect(facts.length).toBeGreaterThanOrEqual(1);
+    expect(facts.some((f) => f.value.includes("1958"))).toBe(true);
+  });
+
+  it("スラッシュ区切りの日付を抽出する / extracts slash-separated dates", () => {
+    const text = "設立日は 2020/04/01 です。";
+    const facts = extractFacts(text);
+    expect(facts.length).toBeGreaterThanOrEqual(1);
+    expect(facts.some((f) => f.value.includes("2020"))).toBe(true);
+  });
+
+  it("ハイフン区切りの日付を抽出する / extracts hyphen-separated dates", () => {
+    const text = "開業は 2015-03-14 です。";
+    const facts = extractFacts(text);
+    expect(facts.length).toBeGreaterThanOrEqual(1);
+    expect(facts.some((f) => f.value.includes("2015"))).toBe(true);
+  });
+
+  it("数値+単位パターンを抽出する / extracts numeric patterns with units", () => {
+    const text = "富士山の標高は 3,776m である。";
+    const facts = extractFacts(text);
+    expect(facts.length).toBeGreaterThanOrEqual(1);
+    expect(facts.some((f) => f.value.includes("3,776m"))).toBe(true);
+  });
+
+  it("人口の数値を抽出する / extracts population numbers", () => {
+    const text = "東京都の人口は約 1,400万人 です。";
+    const facts = extractFacts(text);
+    expect(facts.length).toBeGreaterThanOrEqual(1);
+    expect(facts.some((f) => f.value.includes("万"))).toBe(true);
+  });
+
+  it("コンテキストが短すぎる場合はスキップする / skips when context is too short", () => {
+    const text = "3,776m";
+    const facts = extractFacts(text);
+    // コンテキスト（先行テキスト）がないためスキップされる
+    // Skipped because there is no preceding context
+    expect(facts).toEqual([]);
+  });
+
+  it("複数のファクトを同時に抽出する / extracts multiple facts", () => {
+    const text = "東京タワーの高さは 333m で、1958年12月23日 に完成した。";
+    const facts = extractFacts(text);
+    expect(facts.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/server/api/src/services/lintEngine/rules/conflict.ts
+++ b/server/api/src/services/lintEngine/rules/conflict.ts
@@ -1,0 +1,122 @@
+import { eq, and } from "drizzle-orm";
+import { pages } from "../../../schema/pages.js";
+import { pageContents } from "../../../schema/pageContents.js";
+import type { Database } from "../../../types/index.js";
+import type { LintRuleResult, LintFindingCandidate } from "../types.js";
+
+/**
+ * 数値・日付パターン抽出用の正規表現。
+ * Regex patterns for extracting numeric/date claims from content.
+ */
+const DATE_PATTERN = /(\d{4})[年/-](\d{1,2})[月/-](\d{1,2})[日]?/g;
+const NUMBER_PATTERN = /(\d[\d,.]+)\s*(km|m|kg|g|人|円|ドル|年|歳|万|億)/g;
+
+/**
+ * テキストからファクト（数値・日付の主張）を抽出する。
+ * Extracts factual claims (numbers, dates) from text content.
+ *
+ * @param text - 対象テキスト / Source text
+ * @returns 抽出されたファクト一覧 / Extracted facts
+ */
+export function extractFacts(text: string): Array<{ key: string; value: string }> {
+  const facts: Array<{ key: string; value: string }> = [];
+
+  // 日付ファクト / Date facts
+  let match: RegExpExecArray | null;
+  const dateRegex = new RegExp(DATE_PATTERN.source, "g");
+  while ((match = dateRegex.exec(text)) !== null) {
+    const context = text.substring(Math.max(0, match.index - 20), match.index).trim();
+    const contextKey = context.split(/\s+/).slice(-3).join(" ");
+    if (contextKey) {
+      facts.push({ key: contextKey, value: match[0] });
+    }
+  }
+
+  // 数値ファクト / Numeric facts
+  const numRegex = new RegExp(NUMBER_PATTERN.source, "g");
+  while ((match = numRegex.exec(text)) !== null) {
+    const context = text.substring(Math.max(0, match.index - 20), match.index).trim();
+    const contextKey = context.split(/\s+/).slice(-3).join(" ");
+    if (contextKey) {
+      facts.push({ key: contextKey, value: match[0] });
+    }
+  }
+
+  return facts;
+}
+
+/**
+ * 矛盾検出ルール。
+ * 同じコンテキストで異なる数値・日付が使用されている場合を検出する。
+ * （LLM 判定は将来的に追加。現在はパターンマッチで検出）
+ *
+ * Conflict detection rule.
+ * Detects inconsistent numeric/date claims across pages.
+ * (LLM-based detection to be added later. Currently uses pattern matching.)
+ *
+ * @param ownerId - 対象ユーザー ID / Target user ID
+ * @param db - データベース接続 / Database connection
+ * @returns 矛盾の検出結果 / Conflict findings
+ */
+export async function runConflictRule(ownerId: string, db: Database): Promise<LintRuleResult> {
+  const pagesWithContent = await db
+    .select({
+      id: pages.id,
+      title: pages.title,
+      contentText: pageContents.contentText,
+    })
+    .from(pages)
+    .innerJoin(pageContents, eq(pages.id, pageContents.pageId))
+    .where(and(eq(pages.ownerId, ownerId), eq(pages.isDeleted, false)));
+
+  // ファクトをキーで集約 / Group facts by key
+  const factMap = new Map<string, Array<{ pageId: string; title: string; value: string }>>();
+
+  for (const page of pagesWithContent) {
+    if (!page.contentText) continue;
+    const facts = extractFacts(page.contentText);
+    for (const fact of facts) {
+      const normalizedKey = fact.key.toLowerCase();
+      const existing = factMap.get(normalizedKey) ?? [];
+      if (!factMap.has(normalizedKey)) {
+        factMap.set(normalizedKey, existing);
+      }
+      existing.push({
+        pageId: page.id,
+        title: page.title ?? "(無題 / untitled)",
+        value: fact.value,
+      });
+    }
+  }
+
+  // 同一キーに異なる値がある場合を検出 / Detect differing values for same key
+  const findings: LintFindingCandidate[] = [];
+
+  for (const [key, entries] of factMap) {
+    if (entries.length < 2) continue;
+
+    const uniqueValues = new Set(entries.map((e) => e.value));
+    if (uniqueValues.size <= 1) continue;
+
+    const pageIds = [...new Set(entries.map((e) => e.pageId))];
+    if (pageIds.length < 2) continue;
+
+    findings.push({
+      rule: "conflict",
+      severity: "warn",
+      pageIds,
+      detail: {
+        factKey: key,
+        claims: entries.map((e) => ({
+          pageId: e.pageId,
+          title: e.title,
+          value: e.value,
+        })),
+        suggestion:
+          "同じ事柄に異なる値が記載されています。確認してください / Different values found for the same fact. Please verify.",
+      },
+    });
+  }
+
+  return { rule: "conflict", findings };
+}

--- a/server/api/src/services/lintEngine/rules/ghostMany.ts
+++ b/server/api/src/services/lintEngine/rules/ghostMany.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { ghostLinks } from "../../../schema/links.js";
 import { pages } from "../../../schema/pages.js";
 import type { Database } from "../../../types/index.js";
@@ -34,7 +34,7 @@ export async function runGhostManyRule(ownerId: string, db: Database): Promise<L
     })
     .from(ghostLinks)
     .innerJoin(pages, eq(ghostLinks.sourcePageId, pages.id))
-    .where(eq(pages.ownerId, ownerId))
+    .where(and(eq(pages.ownerId, ownerId), eq(pages.isDeleted, false)))
     .groupBy(ghostLinks.linkText)
     .having(sql`count(*) >= ${GHOST_LINK_THRESHOLD}`);
 

--- a/server/api/src/services/lintEngine/rules/ghostMany.ts
+++ b/server/api/src/services/lintEngine/rules/ghostMany.ts
@@ -1,0 +1,54 @@
+import { eq, sql } from "drizzle-orm";
+import { ghostLinks } from "../../../schema/links.js";
+import { pages } from "../../../schema/pages.js";
+import type { Database } from "../../../types/index.js";
+import type { LintRuleResult } from "../types.js";
+
+/**
+ * 同じリンクテキストのゴーストリンクが多数あるものを検出するための閾値。
+ * Threshold for detecting ghost links with the same link text appearing many times.
+ */
+const GHOST_LINK_THRESHOLD = 3;
+
+/**
+ * Ghost Link 過多検出ルール。
+ * 同じ link_text が N 件以上のソースページから参照されている場合、新規ページ候補として提示する。
+ *
+ * Ghost link excess detection rule.
+ * When the same link_text appears in N+ source pages, suggests creating a new page.
+ *
+ * @param ownerId - 対象ユーザー ID / Target user ID
+ * @param db - データベース接続 / Database connection
+ * @returns Ghost Link 過多の検出結果 / Ghost link excess findings
+ */
+export async function runGhostManyRule(ownerId: string, db: Database): Promise<LintRuleResult> {
+  // owner_id でフィルタするため、ghost_links → pages を JOIN して owner を制限
+  // Join ghost_links → pages to filter by owner_id
+  const rows = await db
+    .select({
+      linkText: ghostLinks.linkText,
+      count: sql<number>`count(*)::int`.as("cnt"),
+      sourcePageIds: sql<string[]>`array_agg(${ghostLinks.sourcePageId}::text)`.as(
+        "source_page_ids",
+      ),
+    })
+    .from(ghostLinks)
+    .innerJoin(pages, eq(ghostLinks.sourcePageId, pages.id))
+    .where(eq(pages.ownerId, ownerId))
+    .groupBy(ghostLinks.linkText)
+    .having(sql`count(*) >= ${GHOST_LINK_THRESHOLD}`);
+
+  return {
+    rule: "ghost_many",
+    findings: rows.map((r) => ({
+      rule: "ghost_many" as const,
+      severity: "warn" as const,
+      pageIds: r.sourcePageIds,
+      detail: {
+        linkText: r.linkText,
+        count: r.count,
+        suggestion: `「${r.linkText}」の新規ページ作成を検討してください / Consider creating a new page for "${r.linkText}"`,
+      },
+    })),
+  };
+}

--- a/server/api/src/services/lintEngine/rules/orphan.ts
+++ b/server/api/src/services/lintEngine/rules/orphan.ts
@@ -1,0 +1,45 @@
+import { eq, and, sql } from "drizzle-orm";
+import { pages } from "../../../schema/pages.js";
+import type { Database } from "../../../types/index.js";
+import type { LintRuleResult } from "../types.js";
+
+/**
+ * 孤立ページ検出ルール。
+ * 他のページからリンクされていない（backlinks = 0）ページを検出する。
+ *
+ * Orphan page detection rule.
+ * Detects pages with no incoming links (backlinks = 0).
+ *
+ * @param ownerId - 対象ユーザー ID / Target user ID
+ * @param db - データベース接続 / Database connection
+ * @returns 孤立ページの検出結果 / Orphan page findings
+ */
+export async function runOrphanRule(ownerId: string, db: Database): Promise<LintRuleResult> {
+  // backlinks を持たない（links.target_id に出現しない）ページを取得
+  // Get pages that do not appear as link targets (no backlinks)
+  const orphans = await db
+    .select({
+      id: pages.id,
+      title: pages.title,
+    })
+    .from(pages)
+    .where(
+      and(
+        eq(pages.ownerId, ownerId),
+        eq(pages.isDeleted, false),
+        sql`NOT EXISTS (
+          SELECT 1 FROM links WHERE links.target_id = ${pages.id}
+        )`,
+      ),
+    );
+
+  return {
+    rule: "orphan",
+    findings: orphans.map((p) => ({
+      rule: "orphan" as const,
+      severity: "info" as const,
+      pageIds: [p.id],
+      detail: { title: p.title ?? "(無題 / untitled)" },
+    })),
+  };
+}

--- a/server/api/src/services/lintEngine/rules/orphan.ts
+++ b/server/api/src/services/lintEngine/rules/orphan.ts
@@ -28,7 +28,10 @@ export async function runOrphanRule(ownerId: string, db: Database): Promise<Lint
         eq(pages.ownerId, ownerId),
         eq(pages.isDeleted, false),
         sql`NOT EXISTS (
-          SELECT 1 FROM links WHERE links.target_id = ${pages.id}
+          SELECT 1 FROM links
+          INNER JOIN pages AS src ON src.id = links.source_id
+          WHERE links.target_id = ${pages.id}
+          AND src.is_deleted = false
         )`,
       ),
     );

--- a/server/api/src/services/lintEngine/rules/titleSimilar.test.ts
+++ b/server/api/src/services/lintEngine/rules/titleSimilar.test.ts
@@ -1,0 +1,49 @@
+/**
+ * titleSimilar ルールの単体テスト（純粋関数 levenshtein のテスト）。
+ * Unit tests for the titleSimilar rule (pure function levenshtein).
+ */
+import { describe, it, expect } from "vitest";
+import { levenshtein } from "./titleSimilar.js";
+
+describe("levenshtein", () => {
+  it("同一文字列の距離は 0 / identical strings have distance 0", () => {
+    expect(levenshtein("hello", "hello")).toBe(0);
+  });
+
+  it("空文字列との距離は文字列長 / distance to empty string equals string length", () => {
+    expect(levenshtein("", "hello")).toBe(5);
+    expect(levenshtein("hello", "")).toBe(5);
+  });
+
+  it("両方空文字列の場合は 0 / both empty strings have distance 0", () => {
+    expect(levenshtein("", "")).toBe(0);
+  });
+
+  it("1 文字の置換 / single character substitution", () => {
+    expect(levenshtein("cat", "bat")).toBe(1);
+  });
+
+  it("1 文字の挿入 / single character insertion", () => {
+    expect(levenshtein("cat", "cats")).toBe(1);
+  });
+
+  it("1 文字の削除 / single character deletion", () => {
+    expect(levenshtein("cats", "cat")).toBe(1);
+  });
+
+  it("複数の編集操作 / multiple edit operations", () => {
+    expect(levenshtein("kitten", "sitting")).toBe(3);
+  });
+
+  it("日本語文字列 / Japanese strings", () => {
+    expect(levenshtein("東京都", "東京府")).toBe(1);
+  });
+
+  it("完全に異なる文字列 / completely different strings", () => {
+    expect(levenshtein("abc", "xyz")).toBe(3);
+  });
+
+  it("React と ReactJS の距離 / React vs ReactJS", () => {
+    expect(levenshtein("react", "reactjs")).toBe(2);
+  });
+});

--- a/server/api/src/services/lintEngine/rules/titleSimilar.ts
+++ b/server/api/src/services/lintEngine/rules/titleSimilar.ts
@@ -14,19 +14,21 @@ import type { LintRuleResult, LintFindingCandidate } from "../types.js";
 export function levenshtein(a: string, b: string): number {
   const m = a.length;
   const n = b.length;
-  const dp: number[][] = Array.from({ length: m + 1 }, () => Array<number>(n + 1).fill(0));
-
-  for (let i = 0; i <= m; i++) dp[i][0] = i;
-  for (let j = 0; j <= n; j++) dp[0][j] = j;
+  // prev と curr の 2 行だけで DP を回す（型安全かつ省メモリ）
+  // Use two rows for DP (type-safe and memory efficient)
+  let prev = Array.from({ length: n + 1 }, (_, j) => j);
+  let curr = new Array<number>(n + 1).fill(0);
 
   for (let i = 1; i <= m; i++) {
+    curr[0] = i;
     for (let j = 1; j <= n; j++) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost);
+      const cost = a.charAt(i - 1) === b.charAt(j - 1) ? 0 : 1;
+      curr[j] = Math.min((prev[j] ?? 0) + 1, (curr[j - 1] ?? 0) + 1, (prev[j - 1] ?? 0) + cost);
     }
+    [prev, curr] = [curr, prev];
   }
 
-  return dp[m][n];
+  return prev[n] ?? 0;
 }
 
 /**
@@ -57,9 +59,11 @@ export async function runTitleSimilarRule(ownerId: string, db: Database): Promis
   const seen = new Set<string>();
 
   for (let i = 0; i < titled.length; i++) {
+    const a = titled[i];
+    if (!a) continue;
     for (let j = i + 1; j < titled.length; j++) {
-      const a = titled[i];
       const b = titled[j];
+      if (!b) continue;
       const titleA = (a.title ?? "").trim().toLowerCase();
       const titleB = (b.title ?? "").trim().toLowerCase();
 

--- a/server/api/src/services/lintEngine/rules/titleSimilar.ts
+++ b/server/api/src/services/lintEngine/rules/titleSimilar.ts
@@ -1,0 +1,95 @@
+import { eq, and } from "drizzle-orm";
+import { pages } from "../../../schema/pages.js";
+import type { Database } from "../../../types/index.js";
+import type { LintRuleResult, LintFindingCandidate } from "../types.js";
+
+/**
+ * タイトル間の Levenshtein 距離を計算する。
+ * Computes Levenshtein distance between two strings.
+ *
+ * @param a - 文字列 A / String A
+ * @param b - 文字列 B / String B
+ * @returns 編集距離 / Edit distance
+ */
+export function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array<number>(n + 1).fill(0));
+
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost);
+    }
+  }
+
+  return dp[m][n];
+}
+
+/**
+ * 類似度の閾値。タイトル長の短い方に対する比率。
+ * Similarity threshold as a ratio of the shorter title length.
+ */
+const SIMILARITY_RATIO = 0.3;
+
+/**
+ * タイトル類似検出ルール。
+ * Levenshtein 距離で潜在的な重複タイトルを検出する。
+ *
+ * Title similarity detection rule.
+ * Uses Levenshtein distance to find potentially duplicate titles.
+ *
+ * @param ownerId - 対象ユーザー ID / Target user ID
+ * @param db - データベース接続 / Database connection
+ * @returns タイトル類似の検出結果 / Title similarity findings
+ */
+export async function runTitleSimilarRule(ownerId: string, db: Database): Promise<LintRuleResult> {
+  const allPages = await db
+    .select({ id: pages.id, title: pages.title })
+    .from(pages)
+    .where(and(eq(pages.ownerId, ownerId), eq(pages.isDeleted, false)));
+
+  const titled = allPages.filter((p) => p.title && p.title.trim().length > 0);
+  const findings: LintFindingCandidate[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < titled.length; i++) {
+    for (let j = i + 1; j < titled.length; j++) {
+      const a = titled[i];
+      const b = titled[j];
+      const titleA = (a.title ?? "").trim().toLowerCase();
+      const titleB = (b.title ?? "").trim().toLowerCase();
+
+      if (titleA === titleB) continue; // exact dup handled elsewhere
+
+      const minLen = Math.min(titleA.length, titleB.length);
+      if (minLen === 0) continue;
+
+      const dist = levenshtein(titleA, titleB);
+      const threshold = Math.max(1, Math.floor(minLen * SIMILARITY_RATIO));
+
+      if (dist <= threshold) {
+        const key = [a.id, b.id].sort().join(":");
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        findings.push({
+          rule: "title_similar",
+          severity: "info",
+          pageIds: [a.id, b.id],
+          detail: {
+            titleA: a.title,
+            titleB: b.title,
+            distance: dist,
+            suggestion: `タイトルが類似しています。統合を検討してください / Titles are similar. Consider merging.`,
+          },
+        });
+      }
+    }
+  }
+
+  return { rule: "title_similar", findings };
+}

--- a/server/api/src/services/lintEngine/types.ts
+++ b/server/api/src/services/lintEngine/types.ts
@@ -1,0 +1,34 @@
+import type { LintRule, LintSeverity } from "../../schema/lintFindings.js";
+
+/**
+ * 1 件の Lint 検出結果（DB 挿入前）。
+ * A single lint finding before DB insertion.
+ */
+export interface LintFindingCandidate {
+  rule: LintRule;
+  severity: LintSeverity;
+  pageIds: string[];
+  detail: Record<string, unknown>;
+}
+
+/**
+ * Lint ルールの実行結果。
+ * Result returned by each lint rule runner.
+ */
+export interface LintRuleResult {
+  rule: LintRule;
+  findings: LintFindingCandidate[];
+}
+
+/**
+ * ルール実行関数のシグネチャ。
+ * Signature of a lint rule runner function.
+ *
+ * @param ownerId - 対象ユーザー ID / Target user ID
+ * @param db - データベース接続 / Database connection
+ * @returns Lint 検出結果 / Lint findings
+ */
+export type LintRuleRunner = (
+  ownerId: string,
+  db: import("../../types/index.js").Database,
+) => Promise<LintRuleResult>;

--- a/src/components/editor/PageEditor/PageEditorContent.tsx
+++ b/src/components/editor/PageEditor/PageEditorContent.tsx
@@ -7,6 +7,7 @@ import type { CollaborationConfig } from "../TiptapEditor/types";
 import { SourceUrlBadge } from "../SourceUrlBadge";
 import { WikiGeneratorButton } from "../WikiGeneratorButton";
 import { LinkedPagesSection } from "@/components/page/LinkedPagesSection";
+import { LintSuggestions } from "@/components/page/LintSuggestions";
 import Container from "@/components/layout/Container";
 import { isContentNotEmpty } from "@/lib/contentUtils";
 import type { UseCollaborationReturn } from "@/lib/collaboration/types";
@@ -179,6 +180,9 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
         {showLinkedPages && currentPageId && (
           <LinkedPagesSection pageId={currentPageId} isSyncingLinks={isSyncingLinks} />
         )}
+
+        {/* Lint Suggestions */}
+        {currentPageId && <LintSuggestions pageId={currentPageId} />}
       </Container>
     </main>
   );

--- a/src/components/page/LintSuggestions.tsx
+++ b/src/components/page/LintSuggestions.tsx
@@ -1,0 +1,207 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  Info,
+  AlertCircle,
+  CheckCircle2,
+  Ghost,
+  Unlink,
+  FileQuestion,
+  FileText,
+  Zap,
+} from "lucide-react";
+import { Badge, Button, Skeleton } from "@zedi/ui";
+import type { ReactNode } from "react";
+
+/**
+ * Lint finding の型（API レスポンス）。
+ * Lint finding type from API response.
+ */
+interface LintFindingResponse {
+  id: string;
+  rule: string;
+  severity: string;
+  page_ids: string[];
+  detail: Record<string, unknown>;
+  created_at: string;
+}
+
+function getApiBaseUrl(): string {
+  const base = (import.meta.env.VITE_API_BASE_URL as string) ?? "";
+  return base.replace(/\/$/, "") || (typeof window !== "undefined" ? window.location.origin : "");
+}
+
+/**
+ * 指定ページに関連する Lint findings を取得する。
+ * Fetches lint findings related to a specific page.
+ */
+async function fetchPageFindings(pageId: string): Promise<LintFindingResponse[]> {
+  const baseUrl = getApiBaseUrl();
+  const res = await fetch(`${baseUrl}/api/lint/findings/page/${encodeURIComponent(pageId)}`, {
+    credentials: "include",
+  });
+  if (!res.ok) return [];
+  const data = (await res.json()) as { findings: LintFindingResponse[] };
+  return data.findings;
+}
+
+/**
+ * Lint finding を解決済みにマークする。
+ * Resolves a lint finding.
+ */
+async function resolveFinding(findingId: string): Promise<void> {
+  const baseUrl = getApiBaseUrl();
+  await fetch(`${baseUrl}/api/lint/findings/${encodeURIComponent(findingId)}/resolve`, {
+    method: "POST",
+    credentials: "include",
+  });
+}
+
+/**
+ * ルールごとのアイコンを返す。
+ * Returns an icon for the given rule.
+ */
+function ruleIcon(rule: string): ReactNode {
+  switch (rule) {
+    case "orphan":
+      return <FileQuestion className="h-4 w-4" />;
+    case "ghost_many":
+      return <Ghost className="h-4 w-4" />;
+    case "title_similar":
+      return <FileText className="h-4 w-4" />;
+    case "conflict":
+      return <Zap className="h-4 w-4" />;
+    case "broken_link":
+      return <Unlink className="h-4 w-4" />;
+    default:
+      return <Info className="h-4 w-4" />;
+  }
+}
+
+/**
+ * ルール名を日本語で表示する。
+ * Returns a Japanese label for the given rule.
+ */
+function ruleLabel(rule: string): string {
+  switch (rule) {
+    case "orphan":
+      return "孤立ページ";
+    case "ghost_many":
+      return "Ghost Link 過多";
+    case "title_similar":
+      return "タイトル類似";
+    case "conflict":
+      return "矛盾";
+    case "broken_link":
+      return "リンク切れ";
+    default:
+      return rule;
+  }
+}
+
+/**
+ * 重要度に応じたスタイルアイコンを返す。
+ * Returns a styled icon for the given severity.
+ */
+function severityIcon(severity: string): ReactNode {
+  switch (severity) {
+    case "error":
+      return <AlertCircle className="h-4 w-4 text-red-500" />;
+    case "warn":
+      return <AlertTriangle className="h-4 w-4 text-amber-500" />;
+    default:
+      return <Info className="text-muted-foreground h-4 w-4" />;
+  }
+}
+
+/**
+ * detail からサマリ文字列を生成する。
+ * Creates a summary string from the detail object.
+ */
+function formatDetail(detail: Record<string, unknown>): string {
+  if (typeof detail.suggestion === "string") return detail.suggestion;
+  if (typeof detail.title === "string") return detail.title;
+  if (typeof detail.linkText === "string") {
+    return `「${detail.linkText}」`;
+  }
+  if (typeof detail.titleA === "string" && typeof detail.titleB === "string") {
+    return `「${detail.titleA}」と「${detail.titleB}」が類似しています`;
+  }
+  return JSON.stringify(detail);
+}
+
+interface LintSuggestionsProps {
+  pageId: string;
+}
+
+/**
+ * ページ下部に表示する Lint Suggestions カード。
+ * LinkedPagesSection の近辺で使用する。
+ *
+ * Lint Suggestions card displayed near the bottom of the page.
+ * Used alongside LinkedPagesSection.
+ *
+ * @param pageId - 対象ページ ID / Target page ID
+ */
+export function LintSuggestions({ pageId }: LintSuggestionsProps) {
+  const queryClient = useQueryClient();
+
+  const { data: findings, isLoading } = useQuery({
+    queryKey: ["lintFindings", pageId],
+    queryFn: () => fetchPageFindings(pageId),
+    staleTime: 1000 * 60, // 1 minute
+  });
+
+  const resolveMutation = useMutation({
+    mutationFn: resolveFinding,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["lintFindings", pageId] });
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="mt-4 space-y-2">
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+    );
+  }
+
+  if (!findings || findings.length === 0) return null;
+
+  return (
+    <div className="mt-6 space-y-3 border-t pt-6">
+      <div className="text-muted-foreground flex items-center gap-2 text-sm font-medium">
+        <AlertTriangle className="h-4 w-4" />
+        <span>Suggestions ({findings.length})</span>
+      </div>
+      <div className="space-y-2">
+        {findings.map((f) => (
+          <div key={f.id} className="bg-muted/50 flex items-start gap-3 rounded-lg border p-3">
+            <div className="mt-0.5 shrink-0">{severityIcon(f.severity)}</div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                {ruleIcon(f.rule)}
+                <Badge variant="outline" className="text-xs">
+                  {ruleLabel(f.rule)}
+                </Badge>
+              </div>
+              <p className="text-muted-foreground mt-1 text-sm">{formatDetail(f.detail)}</p>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="shrink-0"
+              onClick={() => resolveMutation.mutate(f.id)}
+              disabled={resolveMutation.isPending}
+            >
+              <CheckCircle2 className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/page/LintSuggestions.tsx
+++ b/src/components/page/LintSuggestions.tsx
@@ -51,10 +51,14 @@ async function fetchPageFindings(pageId: string): Promise<LintFindingResponse[]>
  */
 async function resolveFinding(findingId: string): Promise<void> {
   const baseUrl = getApiBaseUrl();
-  await fetch(`${baseUrl}/api/lint/findings/${encodeURIComponent(findingId)}/resolve`, {
+  const res = await fetch(`${baseUrl}/api/lint/findings/${encodeURIComponent(findingId)}/resolve`, {
     method: "POST",
     credentials: "include",
   });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ message: res.statusText }));
+    throw new Error((body as { message?: string }).message ?? "Failed to resolve finding");
+  }
 }
 
 /**


### PR DESCRIPTION
Introduce a Lint engine with 5 rules (orphan page, ghost link excess,
title similarity, conflict detection, broken link) and a Wiki Health
dashboard in the admin panel. Results are persisted to a new
lint_findings table and surfaced as Suggestions cards on page detail.

- New schema: lint_findings with migration 0008
- New service: server/api/src/services/lintEngine/ (5 rule runners)
- New routes: POST /api/lint/run, GET /api/lint/findings, resolve
- New admin page: /wiki-health with run/filter/resolve UI
- New component: LintSuggestions near LinkedPagesSection
- Unit tests: levenshtein (10 cases), extractFacts (8 cases)

https://claude.ai/code/session_01UbTy9cpbA1ZvppiDycM2cH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
