### PR TITLE
refactor: move AppLayout to route level with Outlet pattern

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Toaster as Sonner } from "@zedi/ui/components/sonner";
 import { TooltipProvider } from "@zedi/ui";
 import { ThemeProvider } from "next-themes";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route, Navigate, useParams } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate, Outlet, useParams } from "react-router-dom";
 import Landing from "./pages/Landing";
 import Home from "./pages/Home";
 import Notes from "./pages/Notes";
@@ -37,6 +37,7 @@ import { ProtectedRoute } from "./components/auth/ProtectedRoute";
 import { AIChatProvider } from "./contexts/AIChatContext";
 import { AIChatConversationsProvider } from "./hooks/useAIChatConversations";
 import { FilePreviewDialogHost } from "./components/note/FilePreviewDialogHost";
+import { AppLayout } from "./components/layout/AppLayout";
 
 const queryClient = new QueryClient();
 
@@ -47,6 +48,20 @@ const queryClient = new QueryClient();
 function LegacyAIChatConversationRedirect() {
   const { conversationId } = useParams<{ conversationId: string }>();
   return <Navigate to={`/ai/${conversationId}`} replace />;
+}
+
+/**
+ * Layout route that renders the shared `AppLayout` (header + sidebar + AI dock)
+ * around nested route elements via `<Outlet />`.
+ *
+ * ネストしたルート要素を共通 `AppLayout`（ヘッダー・サイドバー・AI ドック）でラップするレイアウトルート。
+ */
+function AppShellRoute() {
+  return (
+    <AppLayout>
+      <Outlet />
+    </AppLayout>
+  );
 }
 
 /**
@@ -68,7 +83,8 @@ const App = () => (
               <GlobalShortcutsProvider>
                 <GlobalSearchProvider>
                   <Routes>
-                    {/* Public routes */}
+                    {/* Public / chrome-less routes: LP, auth flows, invites, onboarding
+                        ヘッダー非表示ルート: LP / 認証 / 招待 / オンボーディング */}
                     <Route path="/" element={<Landing />} />
                     <Route path="/sign-in/*" element={<SignIn />} />
                     <Route path="/auth/callback" element={<AuthCallback />} />
@@ -76,12 +92,6 @@ const App = () => (
                     <Route path="/auth/extension-callback" element={<ExtensionAuthCallback />} />
                     <Route path="/mcp/authorize" element={<McpAuthorize />} />
                     <Route path="/invite" element={<InvitePage />} />
-                    <Route path="/note/:noteId" element={<NoteView />} />
-                    <Route path="/note/:noteId/settings" element={<NoteSettings />} />
-                    <Route path="/note/:noteId/members" element={<NoteMembers />} />
-                    <Route path="/note/:noteId/page/:pageId" element={<NotePageView />} />
-
-                    {/* Protected routes - require authentication */}
                     <Route
                       path="/onboarding"
                       element={
@@ -90,36 +100,47 @@ const App = () => (
                         </ProtectedRoute>
                       }
                     />
-                    {/* Home and PageEditor: available without login (local-only mode) */}
-                    <Route path="/home" element={<Home />} />
-                    <Route path="/ai/history" element={<AIChatHistory />} />
-                    <Route path="/ai/:conversationId" element={<AIChatDetail />} />
-                    <Route path="/ai" element={<AIChatLanding />} />
-                    <Route
-                      path="/ai-chat/history"
-                      element={<Navigate to="/ai/history" replace />}
-                    />
-                    <Route
-                      path="/ai-chat/:conversationId"
-                      element={<LegacyAIChatConversationRedirect />}
-                    />
-                    <Route path="/search" element={<SearchResults />} />
-                    <Route path="/notes/discover" element={<NotesDiscover />} />
-                    <Route path="/notes" element={<Notes />} />
-                    <Route path="/page/:id" element={<PageEditorPage />} />
-                    <Route path="/settings" element={<Settings />} />
-                    <Route path="/wiki-schema" element={<WikiSchemaPage />} />
-                    <Route path="/index" element={<IndexPage />} />
-                    <Route path="/pricing" element={<Pricing />} />
-                    <Route
-                      path="/subscription"
-                      element={
-                        <ProtectedRoute>
-                          <SubscriptionManagement />
-                        </ProtectedRoute>
-                      }
-                    />
-                    <Route path="/donate" element={<Donate />} />
+
+                    {/* App shell routes: wrapped with the shared AppLayout
+                        so every page gets the common Header + UnifiedMenu.
+                        共通 AppLayout（ヘッダー + UnifiedMenu + サイドバー）でラップ。 */}
+                    <Route element={<AppShellRoute />}>
+                      {/* Home and PageEditor: available without login (local-only mode) */}
+                      <Route path="/home" element={<Home />} />
+                      <Route path="/ai/history" element={<AIChatHistory />} />
+                      <Route path="/ai/:conversationId" element={<AIChatDetail />} />
+                      <Route path="/ai" element={<AIChatLanding />} />
+                      <Route
+                        path="/ai-chat/history"
+                        element={<Navigate to="/ai/history" replace />}
+                      />
+                      <Route
+                        path="/ai-chat/:conversationId"
+                        element={<LegacyAIChatConversationRedirect />}
+                      />
+                      <Route path="/search" element={<SearchResults />} />
+                      <Route path="/notes/discover" element={<NotesDiscover />} />
+                      <Route path="/notes" element={<Notes />} />
+                      <Route path="/page/:id" element={<PageEditorPage />} />
+                      <Route path="/settings" element={<Settings />} />
+                      <Route path="/wiki-schema" element={<WikiSchemaPage />} />
+                      <Route path="/index" element={<IndexPage />} />
+                      <Route path="/pricing" element={<Pricing />} />
+                      <Route
+                        path="/subscription"
+                        element={
+                          <ProtectedRoute>
+                            <SubscriptionManagement />
+                          </ProtectedRoute>
+                        }
+                      />
+                      <Route path="/donate" element={<Donate />} />
+                      <Route path="/note/:noteId" element={<NoteView />} />
+                      <Route path="/note/:noteId/settings" element={<NoteSettings />} />
+                      <Route path="/note/:noteId/members" element={<NoteMembers />} />
+                      <Route path="/note/:noteId/page/:pageId" element={<NotePageView />} />
+                    </Route>
+
                     {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                     <Route path="*" element={<NotFound />} />
                   </Routes>

--- a/src/components/editor/PageEditor/PageEditorHeader.tsx
+++ b/src/components/editor/PageEditor/PageEditorHeader.tsx
@@ -9,15 +9,12 @@ import {
   DropdownMenuTrigger,
 } from "@zedi/ui";
 import Container from "@/components/layout/Container";
-import { HeaderSearchBar } from "@/components/layout/Header/HeaderSearchBar";
-import { useGlobalSearchContextOptional } from "@/contexts/GlobalSearchContext";
 import { useTranslation } from "react-i18next";
 import { formatTimeAgo } from "@/lib/dateUtils";
 import { ConnectionIndicator } from "../ConnectionIndicator";
 import { UserAvatars } from "../UserAvatars";
 import type { ConnectionStatus } from "@/lib/collaboration/types";
 import type { UserPresence } from "@/lib/collaboration/types";
-import { AIChatButton } from "@/components/layout/Header/AIChatButton";
 
 interface PageEditorHeaderProps {
   lastSaved: number | null;
@@ -37,8 +34,12 @@ interface PageEditorHeaderProps {
 }
 
 /**
- * Header component for PageEditor
- * Contains search bar, action buttons, and dropdown menu
+ * Page-specific toolbar for PageEditor. Shown below the common `Header`
+ * (which already provides search / AI chat / UnifiedMenu), so this toolbar
+ * only contains editor-specific actions (back, collaboration status, more menu).
+ *
+ * PageEditor のページ固有ツールバー。検索・AI チャット・ユーザーメニューは
+ * 共通 `Header` 側で提供されるため、ここではエディタ固有の操作（戻る・コラボ・その他メニュー）のみ。
  */
 export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
   lastSaved,
@@ -50,24 +51,13 @@ export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
   collaboration,
 }) => {
   const { t } = useTranslation();
-  const searchContext = useGlobalSearchContextOptional();
-  const hasSearchContext = searchContext != null;
 
   return (
-    <header className="border-border bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 border-b backdrop-blur">
-      <Container className="flex h-16 items-center gap-4">
+    <div className="border-border/60 bg-background/80 supports-[backdrop-filter]:bg-background/60 border-b backdrop-blur">
+      <Container className="flex h-12 items-center justify-between gap-4">
         <Button variant="ghost" size="icon" onClick={onBack} className="shrink-0">
           <ArrowLeft className="h-5 w-5" />
         </Button>
-
-        {/* Center: Search bar */}
-        {hasSearchContext ? (
-          <div className="flex max-w-xl min-w-0 flex-1 justify-center">
-            <HeaderSearchBar />
-          </div>
-        ) : (
-          <div className="min-w-0 flex-1" aria-hidden="true" />
-        )}
 
         <div className="flex items-center gap-2">
           {/* リアルタイムコラボ: 接続状態・オンラインユーザー */}
@@ -82,7 +72,6 @@ export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
               <UserAvatars users={collaboration.onlineUsers} className="shrink-0" />
             </>
           )}
-          <AIChatButton />
           {lastSaved && (
             <span className="text-muted-foreground hidden text-xs sm:inline">
               {formatTimeAgo(lastSaved)}に保存
@@ -122,6 +111,6 @@ export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
           </DropdownMenu>
         </div>
       </Container>
-    </header>
+    </div>
   );
 };

--- a/src/components/editor/PageEditor/PageEditorLayout.tsx
+++ b/src/components/editor/PageEditor/PageEditorLayout.tsx
@@ -117,7 +117,7 @@ export const PageEditorLayout: React.FC<PageEditorLayoutProps> = (props) => {
   const ydoc = collaboration?.ydoc ?? null;
 
   return (
-    <div className="bg-background flex min-h-screen flex-col">
+    <div className="bg-background flex min-h-0 flex-1 flex-col overflow-hidden">
       <PageEditorHeader
         lastSaved={displayLastSaved}
         onBack={onBack}

--- a/src/components/editor/PageEditor/PageEditorLayout.tsx
+++ b/src/components/editor/PageEditor/PageEditorLayout.tsx
@@ -117,7 +117,7 @@ export const PageEditorLayout: React.FC<PageEditorLayoutProps> = (props) => {
   const ydoc = collaboration?.ydoc ?? null;
 
   return (
-    <div className="bg-background flex min-h-0 flex-1 flex-col overflow-hidden">
+    <main className="bg-background flex min-h-0 flex-1 flex-col overflow-hidden">
       <PageEditorHeader
         lastSaved={displayLastSaved}
         onBack={onBack}
@@ -186,6 +186,6 @@ export const PageEditorLayout: React.FC<PageEditorLayoutProps> = (props) => {
           onRestored={handleRestored}
         />
       )}
-    </div>
+    </main>
   );
 };

--- a/src/components/editor/PageEditorView.tsx
+++ b/src/components/editor/PageEditorView.tsx
@@ -4,7 +4,7 @@ import { usePageEditor } from "./PageEditor/usePageEditor";
 import { PageEditorLayout } from "./PageEditor/PageEditorLayout";
 
 const LoadingSpinner = () => (
-  <div className="bg-background flex min-h-screen items-center justify-center">
+  <div className="bg-background flex min-h-0 flex-1 items-center justify-center">
     <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
   </div>
 );

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { ArrowLeft } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Button, cn } from "@zedi/ui";
+import Container from "@/components/layout/Container";
+
+/**
+ * PageHeader の Props。
+ * Props for the PageHeader component.
+ */
+export interface PageHeaderProps {
+  /** タイトル。文字列またはノード。 / Title text or node. */
+  title?: React.ReactNode;
+  /** タイトル横の小さな注釈やバッジ等。 / Slot shown next to the title (e.g. badges). */
+  titleAdornment?: React.ReactNode;
+  /** 戻るリンク先（相対パス）。指定時は戻るボタンを表示。 / Path for the back link; renders a back button. */
+  backTo?: string;
+  /** 戻るボタンの aria-label。 / aria-label for the back button. */
+  backLabel?: string;
+  /** 右側のアクション領域。 / Right-aligned action slot. */
+  actions?: React.ReactNode;
+  /** タイトル下に追加する要素（サブテキスト、タブなど）。 / Extra content rendered below the title row. */
+  children?: React.ReactNode;
+  /** 追加の className。 / Extra className. */
+  className?: string;
+}
+
+/**
+ * ページ固有のサブヘッダー（共通 `Header` の下に配置するツールバー）。
+ * 戻るボタン・タイトル・アクションを横並びで表示する。
+ *
+ * Page-specific sub-header placed below the global `Header`.
+ * Provides an inline row with back button, title, and action slot.
+ */
+export const PageHeader: React.FC<PageHeaderProps> = ({
+  title,
+  titleAdornment,
+  backTo,
+  backLabel = "Back",
+  actions,
+  children,
+  className,
+}) => {
+  return (
+    <div className={cn("border-border/60 border-b", className)}>
+      <Container className="flex min-h-14 flex-wrap items-center justify-between gap-3 py-2">
+        <div className="flex min-w-0 items-center gap-3">
+          {backTo && (
+            <Button asChild variant="ghost" size="icon" className="shrink-0">
+              <Link to={backTo} aria-label={backLabel}>
+                <ArrowLeft className="h-5 w-5" aria-hidden />
+              </Link>
+            </Button>
+          )}
+          {title != null && (
+            <div className="flex min-w-0 items-center gap-2">
+              {typeof title === "string" ? (
+                <h1 className="truncate text-lg font-semibold sm:text-xl">{title}</h1>
+              ) : (
+                title
+              )}
+              {titleAdornment}
+            </div>
+          )}
+        </div>
+        {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+      </Container>
+      {children && (
+        <Container className="pb-3">
+          <div className="min-w-0">{children}</div>
+        </Container>
+      )}
+    </div>
+  );
+};
+
+export default PageHeader;

--- a/src/components/note/NotesLayout.tsx
+++ b/src/components/note/NotesLayout.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { AppLayout } from "@/components/layout/AppLayout";
 import Container from "@/components/layout/Container";
 import { useAuth } from "@/hooks/useAuth";
 import { useTranslation } from "react-i18next";
@@ -11,8 +10,10 @@ interface NotesLayoutProps {
 }
 
 /**
- * Layout for `/notes` routes: App shell + tab navigation (my notes / discover).
- * `/notes` 系のタブ付きレイアウト（マイノート / 発見）。
+ * Tabbed layout for `/notes` routes (my notes / discover).
+ * The shared `AppLayout`（ヘッダー・サイドバー・AI ドック）はルートレベルで適用されるため、ここではタブ＋本文のみを描画する。
+ *
+ * `/notes` 系のタブ付きレイアウト（マイノート / 発見）。共通 `AppLayout` は親ルートで適用される。
  */
 export const NotesLayout: React.FC<NotesLayoutProps> = ({ children }) => {
   const { t } = useTranslation();
@@ -31,37 +32,35 @@ export const NotesLayout: React.FC<NotesLayoutProps> = ({ children }) => {
   };
 
   return (
-    <AppLayout>
-      <main className="min-h-0 flex-1 overflow-y-auto py-6">
-        <Container>
-          <div className="border-border mb-6 flex border-b">
-            <Link
-              to="/notes"
-              onClick={handleMyNotesClick}
-              className={cn(
-                "-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors",
-                isMyNotes
-                  ? "border-primary text-foreground"
-                  : "text-muted-foreground hover:text-foreground border-transparent",
-              )}
-            >
-              {t("notes.tabMyNotes")}
-            </Link>
-            <Link
-              to="/notes/discover"
-              className={cn(
-                "-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors",
-                isDiscover
-                  ? "border-primary text-foreground"
-                  : "text-muted-foreground hover:text-foreground border-transparent",
-              )}
-            >
-              {t("notes.tabDiscover")}
-            </Link>
-          </div>
-          {children}
-        </Container>
-      </main>
-    </AppLayout>
+    <main className="min-h-0 flex-1 overflow-y-auto py-6">
+      <Container>
+        <div className="border-border mb-6 flex border-b">
+          <Link
+            to="/notes"
+            onClick={handleMyNotesClick}
+            className={cn(
+              "-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors",
+              isMyNotes
+                ? "border-primary text-foreground"
+                : "text-muted-foreground hover:text-foreground border-transparent",
+            )}
+          >
+            {t("notes.tabMyNotes")}
+          </Link>
+          <Link
+            to="/notes/discover"
+            className={cn(
+              "-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors",
+              isDiscover
+                ? "border-primary text-foreground"
+                : "text-muted-foreground hover:text-foreground border-transparent",
+            )}
+          >
+            {t("notes.tabDiscover")}
+          </Link>
+        </div>
+        {children}
+      </Container>
+    </main>
   );
 };

--- a/src/pages/AIChatDetail.tsx
+++ b/src/pages/AIChatDetail.tsx
@@ -139,7 +139,7 @@ export default function AIChatDetail() {
     <>
       {/* Fill SidebarInset (already below header). flex-1 + min-h-0 prevents page-level scroll.
           SidebarInset 内を埋める（ヘッダー下の高さは親が保証）。メッセージのみスクロール。 */}
-      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col">
+      <main className="flex min-h-0 w-full min-w-0 flex-1 flex-col">
         <div className="border-border shrink-0 border-b px-4 py-2">
           <AIChatViewTabs activeTab={activeViewTab} onTabChange={setActiveViewTab} />
         </div>
@@ -184,7 +184,7 @@ export default function AIChatDetail() {
             />
           </Container>
         </div>
-      </div>
+      </main>
       <PromoteToWikiDialog
         open={promote.open}
         onClose={promote.close}

--- a/src/pages/AIChatDetail.tsx
+++ b/src/pages/AIChatDetail.tsx
@@ -1,6 +1,5 @@
 import { Suspense, lazy, useCallback, useMemo, useState } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { AppLayout } from "@/components/layout/AppLayout";
 import Container from "@/components/layout/Container";
 import { AIChatMessages } from "@/components/ai-chat/AIChatMessages";
 import { AIChatInput } from "@/components/ai-chat/AIChatInput";
@@ -137,7 +136,7 @@ export default function AIChatDetail() {
   );
 
   return (
-    <AppLayout>
+    <>
       {/* Fill SidebarInset (already below header). flex-1 + min-h-0 prevents page-level scroll.
           SidebarInset 内を埋める（ヘッダー下の高さは親が保証）。メッセージのみスクロール。 */}
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col">
@@ -193,6 +192,6 @@ export default function AIChatDetail() {
         existingTitles={existingPageTitles}
         conversationId={conversationId}
       />
-    </AppLayout>
+    </>
   );
 }

--- a/src/pages/AIChatHistory.tsx
+++ b/src/pages/AIChatHistory.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { AppLayout } from "@/components/layout/AppLayout";
 import Container from "@/components/layout/Container";
 import { ContentWithAIChat } from "@/components/ai-chat/ContentWithAIChat";
 import { AIChatConversationListRow } from "@/components/ai-chat/AIChatConversationListRow";
@@ -35,51 +34,49 @@ export default function AIChatHistory() {
   );
 
   return (
-    <AppLayout>
-      <ContentWithAIChat>
-        <main className="min-h-0 flex-1 overflow-y-auto py-6">
-          <Container>
-            <h1 className="text-foreground text-2xl font-semibold tracking-tight">
-              {t("aiChat.history.pageTitle", "AI chat history")}
-            </h1>
-            <p className="text-muted-foreground mt-1 text-sm">
-              {t(
-                "aiChat.history.pageDescription",
-                "Open a conversation in the AI panel or delete it from this list.",
-              )}
-            </p>
-            <div className="mt-6 flex max-w-2xl flex-col gap-2">
-              {sorted.length === 0 ? (
-                <p className="text-muted-foreground text-sm">
-                  {t("aiChat.history.empty", "No conversations yet")}
-                </p>
-              ) : (
-                sorted.map((conv) => {
-                  const titleLabel =
-                    conv.title.trim().length > 0
-                      ? conv.title
-                      : t("nav.sidebarUntitledChat", "New chat");
-                  const dateLabel = formatDistanceToNow(new Date(conv.updatedAt), {
-                    addSuffix: true,
-                    locale: dateLocale,
-                  });
-                  return (
-                    <AIChatConversationListRow
-                      key={conv.id}
-                      conversation={conv}
-                      variant="page"
-                      isActive={activeConversationId === conv.id}
-                      onOpen={() => handleOpen(conv.id)}
-                      dateLabel={dateLabel}
-                      titleLabel={titleLabel}
-                    />
-                  );
-                })
-              )}
-            </div>
-          </Container>
-        </main>
-      </ContentWithAIChat>
-    </AppLayout>
+    <ContentWithAIChat>
+      <main className="min-h-0 flex-1 overflow-y-auto py-6">
+        <Container>
+          <h1 className="text-foreground text-2xl font-semibold tracking-tight">
+            {t("aiChat.history.pageTitle", "AI chat history")}
+          </h1>
+          <p className="text-muted-foreground mt-1 text-sm">
+            {t(
+              "aiChat.history.pageDescription",
+              "Open a conversation in the AI panel or delete it from this list.",
+            )}
+          </p>
+          <div className="mt-6 flex max-w-2xl flex-col gap-2">
+            {sorted.length === 0 ? (
+              <p className="text-muted-foreground text-sm">
+                {t("aiChat.history.empty", "No conversations yet")}
+              </p>
+            ) : (
+              sorted.map((conv) => {
+                const titleLabel =
+                  conv.title.trim().length > 0
+                    ? conv.title
+                    : t("nav.sidebarUntitledChat", "New chat");
+                const dateLabel = formatDistanceToNow(new Date(conv.updatedAt), {
+                  addSuffix: true,
+                  locale: dateLocale,
+                });
+                return (
+                  <AIChatConversationListRow
+                    key={conv.id}
+                    conversation={conv}
+                    variant="page"
+                    isActive={activeConversationId === conv.id}
+                    onOpen={() => handleOpen(conv.id)}
+                    dateLabel={dateLabel}
+                    titleLabel={titleLabel}
+                  />
+                );
+              })
+            )}
+          </div>
+        </Container>
+      </main>
+    </ContentWithAIChat>
   );
 }

--- a/src/pages/AIChatLanding.tsx
+++ b/src/pages/AIChatLanding.tsx
@@ -4,7 +4,6 @@ import { useNavigate, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { formatDistanceToNow } from "date-fns";
 import { enUS, ja } from "date-fns/locale";
-import { AppLayout } from "@/components/layout/AppLayout";
 import Container from "@/components/layout/Container";
 import { AIChatInput } from "@/components/ai-chat/AIChatInput";
 import { AIChatConversationListRow } from "@/components/ai-chat/AIChatConversationListRow";
@@ -67,7 +66,7 @@ export default function AIChatLanding() {
   const handleStopStreaming = useCallback(() => {}, []);
 
   return (
-    <AppLayout>
+    <>
       {/* Fill main below header (parent shell uses h-svh + overflow-hidden). / ヘッダー下のメイン領域を埋める */}
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
         {/* Input: vertically centered in the flex-1 region above history / 履歴より上の領域で縦中央 */}
@@ -132,6 +131,6 @@ export default function AIChatLanding() {
           </Container>
         </div>
       </div>
-    </AppLayout>
+    </>
   );
 }

--- a/src/pages/AIChatLanding.tsx
+++ b/src/pages/AIChatLanding.tsx
@@ -66,71 +66,69 @@ export default function AIChatLanding() {
   const handleStopStreaming = useCallback(() => {}, []);
 
   return (
-    <>
-      {/* Fill main below header (parent shell uses h-svh + overflow-hidden). / ヘッダー下のメイン領域を埋める */}
-      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
-        {/* Input: vertically centered in the flex-1 region above history / 履歴より上の領域で縦中央 */}
-        <div className="bg-background flex min-h-0 flex-1 flex-col justify-center px-4 py-4">
-          <Container className="mx-auto w-full max-w-2xl">
-            <AIChatInput
-              onSendMessage={handleSendMessage}
-              onStopStreaming={handleStopStreaming}
-              placeholderOverride={t("aiChat.landing.placeholder")}
-              formClassName="p-3"
-              editorClassName="min-h-[120px] max-h-[min(40vh,280px)] text-base"
-              emptyOverlayClassName="text-base"
-            />
-          </Container>
-        </div>
-
-        {/* Recent chats (scrollable, capped height so the input area keeps vertical balance) / 履歴は高さ制限付きでスクロール */}
-        <div className="scrollbar-none bg-background max-h-[min(42vh,320px)] min-h-0 shrink-0 overflow-y-auto">
-          <Container className="mx-auto max-w-2xl pb-8">
-            <div className="mb-3 flex items-center justify-between">
-              <h2 className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
-                {t("aiChat.landing.recentChats")}
-              </h2>
-              {conversations.length > 0 && (
-                <Link
-                  to={AI_CHAT_HISTORY_PATH}
-                  className="text-primary hover:text-primary/80 text-xs transition-colors"
-                >
-                  {t("aiChat.landing.viewAll")}
-                </Link>
-              )}
-            </div>
-
-            {recentChats.length === 0 ? (
-              <p className="text-muted-foreground text-sm">{t("aiChat.landing.noRecentChats")}</p>
-            ) : (
-              <div className="flex max-w-2xl flex-col gap-2">
-                {recentChats.map((conv) => {
-                  const titleLabel =
-                    conv.title.trim().length > 0
-                      ? conv.title
-                      : t("nav.sidebarUntitledChat", "New chat");
-                  const dateLabel = formatDistanceToNow(new Date(conv.updatedAt), {
-                    addSuffix: true,
-                    locale: dateLocale,
-                  });
-                  return (
-                    <AIChatConversationListRow
-                      key={conv.id}
-                      conversation={conv}
-                      variant="page"
-                      borderless
-                      isActive={activeConversationId === conv.id}
-                      onOpen={() => navigate(aiChatConversationPath(conv.id))}
-                      dateLabel={dateLabel}
-                      titleLabel={titleLabel}
-                    />
-                  );
-                })}
-              </div>
-            )}
-          </Container>
-        </div>
+    // Fill main below header (parent shell uses h-svh + overflow-hidden). / ヘッダー下のメイン領域を埋める
+    <main className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
+      {/* Input: vertically centered in the flex-1 region above history / 履歴より上の領域で縦中央 */}
+      <div className="bg-background flex min-h-0 flex-1 flex-col justify-center px-4 py-4">
+        <Container className="mx-auto w-full max-w-2xl">
+          <AIChatInput
+            onSendMessage={handleSendMessage}
+            onStopStreaming={handleStopStreaming}
+            placeholderOverride={t("aiChat.landing.placeholder")}
+            formClassName="p-3"
+            editorClassName="min-h-[120px] max-h-[min(40vh,280px)] text-base"
+            emptyOverlayClassName="text-base"
+          />
+        </Container>
       </div>
-    </>
+
+      {/* Recent chats (scrollable, capped height so the input area keeps vertical balance) / 履歴は高さ制限付きでスクロール */}
+      <div className="scrollbar-none bg-background max-h-[min(42vh,320px)] min-h-0 shrink-0 overflow-y-auto">
+        <Container className="mx-auto max-w-2xl pb-8">
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
+              {t("aiChat.landing.recentChats")}
+            </h2>
+            {conversations.length > 0 && (
+              <Link
+                to={AI_CHAT_HISTORY_PATH}
+                className="text-primary hover:text-primary/80 text-xs transition-colors"
+              >
+                {t("aiChat.landing.viewAll")}
+              </Link>
+            )}
+          </div>
+
+          {recentChats.length === 0 ? (
+            <p className="text-muted-foreground text-sm">{t("aiChat.landing.noRecentChats")}</p>
+          ) : (
+            <div className="flex max-w-2xl flex-col gap-2">
+              {recentChats.map((conv) => {
+                const titleLabel =
+                  conv.title.trim().length > 0
+                    ? conv.title
+                    : t("nav.sidebarUntitledChat", "New chat");
+                const dateLabel = formatDistanceToNow(new Date(conv.updatedAt), {
+                  addSuffix: true,
+                  locale: dateLocale,
+                });
+                return (
+                  <AIChatConversationListRow
+                    key={conv.id}
+                    conversation={conv}
+                    variant="page"
+                    borderless
+                    isActive={activeConversationId === conv.id}
+                    onOpen={() => navigate(aiChatConversationPath(conv.id))}
+                    dateLabel={dateLabel}
+                    titleLabel={titleLabel}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </Container>
+      </div>
+    </main>
   );
 }

--- a/src/pages/Donate.tsx
+++ b/src/pages/Donate.tsx
@@ -1,10 +1,9 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { ArrowLeft, Coffee, Heart, Sparkles, ExternalLink } from "lucide-react";
-import { Button } from "@zedi/ui";
+import { Coffee, Heart, Sparkles, ExternalLink } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@zedi/ui";
 import Container from "@/components/layout/Container";
+import { PageHeader } from "@/components/layout/PageHeader";
 
 interface DonationOptionProps {
   icon: React.ReactNode;
@@ -56,21 +55,11 @@ const Donate: React.FC = () => {
   };
 
   return (
-    <div className="bg-background min-h-screen">
-      {/* Header */}
-      <header className="border-border bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 border-b backdrop-blur">
-        <Container className="flex h-16 items-center gap-4">
-          <Link to="/home">
-            <Button variant="ghost" size="icon">
-              <ArrowLeft className="h-5 w-5" />
-            </Button>
-          </Link>
-          <h1 className="text-xl font-semibold">{t("nav.support")}</h1>
-        </Container>
-      </header>
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PageHeader title={t("nav.support")} backTo="/home" backLabel={t("common.back")} />
 
       {/* Content */}
-      <main className="py-8">
+      <main className="min-h-0 flex-1 overflow-y-auto py-8">
         <Container>
           <div className="mx-auto max-w-2xl">
             {/* Hero Section */}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect } from "react";
 import { Navigate, useLocation, useNavigate, useSearchParams } from "react-router-dom";
-import { AppLayout } from "@/components/layout/AppLayout";
 import Container from "@/components/layout/Container";
 import PageGrid from "@/components/page/PageGrid";
 import FloatingActionButton from "@/components/layout/FloatingActionButton";
@@ -61,37 +60,35 @@ const Home: React.FC = () => {
   }
 
   return (
-    <AppLayout>
-      <div className="flex min-h-0 flex-1 flex-col">
-        <QuickTour run={isTourRunning} onComplete={completeTour} />
+    <div className="flex min-h-0 flex-1 flex-col">
+      <QuickTour run={isTourRunning} onComplete={completeTour} />
 
-        <ContentWithAIChat
-          floatingAction={
-            <>
-              <div className="mr-4 mb-4">
-                {validClipUrl ? (
-                  <FloatingActionButton
-                    initialClipUrl={validClipUrl}
-                    onClipDialogClosedWithInitialUrl={handleClipDialogClosedWithInitialUrl}
-                  />
-                ) : (
-                  <FloatingActionButton />
-                )}
-              </div>
-              <HomePageCount />
-            </>
-          }
-        >
-          <main className="min-h-0 flex-1 overflow-y-auto py-6">
-            <Container>
-              <div data-tour-id="tour-home-page-grid" className="min-h-[200px]">
-                <PageGrid isSeeding={isSeeding} />
-              </div>
-            </Container>
-          </main>
-        </ContentWithAIChat>
-      </div>
-    </AppLayout>
+      <ContentWithAIChat
+        floatingAction={
+          <>
+            <div className="mr-4 mb-4">
+              {validClipUrl ? (
+                <FloatingActionButton
+                  initialClipUrl={validClipUrl}
+                  onClipDialogClosedWithInitialUrl={handleClipDialogClosedWithInitialUrl}
+                />
+              ) : (
+                <FloatingActionButton />
+              )}
+            </div>
+            <HomePageCount />
+          </>
+        }
+      >
+        <main className="min-h-0 flex-1 overflow-y-auto py-6">
+          <Container>
+            <div data-tour-id="tour-home-page-grid" className="min-h-[200px]">
+              <PageGrid isSeeding={isSeeding} />
+            </div>
+          </Container>
+        </main>
+      </ContentWithAIChat>
+    </div>
   );
 };
 

--- a/src/pages/IndexPage.tsx
+++ b/src/pages/IndexPage.tsx
@@ -13,9 +13,10 @@
  */
 import React, { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { ArrowLeft, Loader2, RefreshCw } from "lucide-react";
+import { Loader2, RefreshCw } from "lucide-react";
 import { Button, useToast } from "@zedi/ui";
 import Container from "@/components/layout/Container";
+import { PageHeader } from "@/components/layout/PageHeader";
 
 /**
  * Read-only response from GET /api/activity/index.
@@ -143,17 +144,12 @@ const IndexPage: React.FC = () => {
   const busy = loading || rebuilding;
 
   return (
-    <div className="bg-background min-h-screen">
-      <header className="border-border bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 border-b backdrop-blur">
-        <Container className="flex h-16 items-center justify-between gap-4">
-          <div className="flex min-w-0 items-center gap-4">
-            <Button asChild variant="ghost" size="icon">
-              <Link to="/home" aria-label="Back to home">
-                <ArrowLeft className="h-5 w-5" aria-hidden />
-              </Link>
-            </Button>
-            <h1 className="truncate text-xl font-semibold">Wiki Index / カテゴリ目次</h1>
-          </div>
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PageHeader
+        title="Wiki Index / カテゴリ目次"
+        backTo="/home"
+        backLabel="Back to home"
+        actions={
           <Button onClick={() => void rebuild()} disabled={busy} size="sm">
             {rebuilding ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -162,10 +158,10 @@ const IndexPage: React.FC = () => {
             )}
             再構築 / Rebuild
           </Button>
-        </Container>
-      </header>
+        }
+      />
 
-      <main className="py-6">
+      <main className="min-h-0 flex-1 overflow-y-auto py-6">
         <Container>
           <div className="mx-auto max-w-2xl space-y-6">
             <p className="text-muted-foreground text-sm">

--- a/src/pages/NoteMembers/NoteMembersLoadingOrDenied.tsx
+++ b/src/pages/NoteMembers/NoteMembersLoadingOrDenied.tsx
@@ -1,16 +1,15 @@
 import React from "react";
-import { AppLayout } from "@/components/layout/AppLayout";
 import Container from "@/components/layout/Container";
 
 /**
- *
+ * Loading/denied state shell for NoteMembers.
+ * Outer `AppLayout` is applied at the route level; here we render only the main area.
+ * NoteMembers の読み込み中／権限なし表示のシェル。AppLayout は親ルートで適用される。
  */
 export function NoteMembersLoadingOrDenied({ children }: { children: React.ReactNode }) {
   return (
-    <AppLayout>
-      <main className="min-h-0 flex-1 overflow-y-auto py-10">
-        <Container>{children}</Container>
-      </main>
-    </AppLayout>
+    <main className="min-h-0 flex-1 overflow-y-auto py-10">
+      <Container>{children}</Container>
+    </main>
   );
 }

--- a/src/pages/NoteMembers/index.tsx
+++ b/src/pages/NoteMembers/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import { AppLayout } from "@/components/layout/AppLayout";
 import Container from "@/components/layout/Container";
 import { Button, useToast } from "@zedi/ui";
 import {
@@ -124,43 +123,41 @@ const NoteMembers: React.FC = () => {
   }
 
   return (
-    <AppLayout>
-      <main className="min-h-0 flex-1 overflow-y-auto py-8">
-        <Container>
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0">
-              <h1 className="truncate text-xl font-semibold">{t("notes.members")}</h1>
-              <p className="text-muted-foreground mt-1 truncate text-sm">
-                {note.title || t("notes.untitledNote")}
-              </p>
-            </div>
-            <Button asChild variant="outline" size="sm">
-              <Link to={`/note/${note.id}`}>{t("notes.backToNote")}</Link>
-            </Button>
-          </div>
-
-          {!canManageMembers ? (
-            <p className="text-muted-foreground mt-6 text-sm">
-              {t("notes.noPermissionToManageMembers")}
+    <main className="min-h-0 flex-1 overflow-y-auto py-8">
+      <Container>
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="truncate text-xl font-semibold">{t("notes.members")}</h1>
+            <p className="text-muted-foreground mt-1 truncate text-sm">
+              {note.title || t("notes.untitledNote")}
             </p>
-          ) : (
-            <NoteMembersManageSection
-              members={members}
-              isMembersLoading={isMembersLoading}
-              memberEmail={memberEmail}
-              setMemberEmail={setMemberEmail}
-              memberRole={memberRole}
-              setMemberRole={setMemberRole}
-              roleOptions={memberRoleOptions}
-              onAddMember={handleAddMember}
-              onUpdateRole={handleUpdateMemberRole}
-              onRemoveMember={handleRemoveMember}
-              onResendInvitation={handleResendInvitation}
-            />
-          )}
-        </Container>
-      </main>
-    </AppLayout>
+          </div>
+          <Button asChild variant="outline" size="sm">
+            <Link to={`/note/${note.id}`}>{t("notes.backToNote")}</Link>
+          </Button>
+        </div>
+
+        {!canManageMembers ? (
+          <p className="text-muted-foreground mt-6 text-sm">
+            {t("notes.noPermissionToManageMembers")}
+          </p>
+        ) : (
+          <NoteMembersManageSection
+            members={members}
+            isMembersLoading={isMembersLoading}
+            memberEmail={memberEmail}
+            setMemberEmail={setMemberEmail}
+            memberRole={memberRole}
+            setMemberRole={setMemberRole}
+            roleOptions={memberRoleOptions}
+            onAddMember={handleAddMember}
+            onUpdateRole={handleUpdateMemberRole}
+            onRemoveMember={handleRemoveMember}
+            onResendInvitation={handleResendInvitation}
+          />
+        )}
+      </Container>
+    </main>
   );
 };
 

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -172,7 +172,7 @@ const NotePageView: React.FC = () => {
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className="border-border/60 shrink-0 border-b">
         <Container className="flex h-10 items-center justify-between">
           <Button variant="ghost" size="icon" onClick={handleBack}>
@@ -210,7 +210,7 @@ const NotePageView: React.FC = () => {
           )}
         </NoteWorkspaceProvider>
       </div>
-    </div>
+    </main>
   );
 };
 

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
-import { AppLayout } from "@/components/layout/AppLayout";
 import Container from "@/components/layout/Container";
 import { PageEditorContent } from "@/components/editor/PageEditor/PageEditorContent";
 import { Button } from "@zedi/ui";
@@ -153,71 +152,65 @@ const NotePageView: React.FC = () => {
   const isNotFound = !note || !access?.canView || !page;
   if (isLoading) {
     return (
-      <AppLayout>
-        <main className="min-h-0 flex-1 overflow-y-auto py-10">
-          <Container>
-            <p className="text-muted-foreground text-sm">読み込み中...</p>
-          </Container>
-        </main>
-      </AppLayout>
+      <main className="min-h-0 flex-1 overflow-y-auto py-10">
+        <Container>
+          <p className="text-muted-foreground text-sm">読み込み中...</p>
+        </Container>
+      </main>
     );
   }
   if (isNotFound) {
     return (
-      <AppLayout>
-        <main className="min-h-0 flex-1 overflow-y-auto py-10">
-          <Container>
-            <p className="text-muted-foreground text-sm">
-              ページが見つからないか、閲覧権限がありません。
-            </p>
-          </Container>
-        </main>
-      </AppLayout>
+      <main className="min-h-0 flex-1 overflow-y-auto py-10">
+        <Container>
+          <p className="text-muted-foreground text-sm">
+            ページが見つからないか、閲覧権限がありません。
+          </p>
+        </Container>
+      </main>
     );
   }
 
   return (
-    <AppLayout>
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="border-border/60 shrink-0 border-b">
-          <Container className="flex h-10 items-center justify-between">
-            <Button variant="ghost" size="icon" onClick={handleBack}>
-              <ArrowLeft className="h-4 w-4" />
-            </Button>
-            {!canEdit && <span className="text-muted-foreground text-xs">閲覧専用</span>}
-          </Container>
-        </div>
-
-        <div className="min-h-0 flex-1 overflow-hidden">
-          <NoteWorkspaceProvider key={note.id} noteId={note.id}>
-            {canEdit ? (
-              <NotePageEditorEditable
-                key={page.id}
-                noteId={note.id}
-                page={page}
-                collaboration={collaboration}
-                isCollaborationEnabled={isCollaborationEnabled}
-              />
-            ) : (
-              <PageEditorContent
-                content={page?.content ?? ""}
-                title={page.title}
-                sourceUrl={page.sourceUrl}
-                currentPageId={page.id}
-                pageId={page.id}
-                isNewPage={false}
-                isWikiGenerating={false}
-                isReadOnly={true}
-                showLinkedPages={false}
-                showToolbar={false}
-                onContentChange={() => undefined}
-                onContentError={() => undefined}
-              />
-            )}
-          </NoteWorkspaceProvider>
-        </div>
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="border-border/60 shrink-0 border-b">
+        <Container className="flex h-10 items-center justify-between">
+          <Button variant="ghost" size="icon" onClick={handleBack}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          {!canEdit && <span className="text-muted-foreground text-xs">閲覧専用</span>}
+        </Container>
       </div>
-    </AppLayout>
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <NoteWorkspaceProvider key={note.id} noteId={note.id}>
+          {canEdit ? (
+            <NotePageEditorEditable
+              key={page.id}
+              noteId={note.id}
+              page={page}
+              collaboration={collaboration}
+              isCollaborationEnabled={isCollaborationEnabled}
+            />
+          ) : (
+            <PageEditorContent
+              content={page?.content ?? ""}
+              title={page.title}
+              sourceUrl={page.sourceUrl}
+              currentPageId={page.id}
+              pageId={page.id}
+              isNewPage={false}
+              isWikiGenerating={false}
+              isReadOnly={true}
+              showLinkedPages={false}
+              showToolbar={false}
+              onContentChange={() => undefined}
+              onContentError={() => undefined}
+            />
+          )}
+        </NoteWorkspaceProvider>
+      </div>
+    </div>
   );
 };
 

--- a/src/pages/NoteSettings/index.tsx
+++ b/src/pages/NoteSettings/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { AppLayout } from "@/components/layout/AppLayout";
 import Container from "@/components/layout/Container";
 import { NoteVisibilityBadge } from "@/components/note/NoteVisibilityBadge";
 import { Button, useToast } from "@zedi/ui";
@@ -92,81 +91,75 @@ const NoteSettings: React.FC = () => {
 
   if (isNoteLoading) {
     return (
-      <AppLayout>
-        <main className="min-h-0 flex-1 overflow-y-auto py-10">
-          <Container>
-            <p className="text-muted-foreground text-sm">{t("common.loading")}</p>
-          </Container>
-        </main>
-      </AppLayout>
+      <main className="min-h-0 flex-1 overflow-y-auto py-10">
+        <Container>
+          <p className="text-muted-foreground text-sm">{t("common.loading")}</p>
+        </Container>
+      </main>
     );
   }
 
   if (!note || !access?.canView) {
     return (
-      <AppLayout>
-        <main className="min-h-0 flex-1 overflow-y-auto py-10">
-          <Container>
-            <p className="text-muted-foreground text-sm">{t("notes.noteNotFoundOrNoAccess")}</p>
-          </Container>
-        </main>
-      </AppLayout>
+      <main className="min-h-0 flex-1 overflow-y-auto py-10">
+        <Container>
+          <p className="text-muted-foreground text-sm">{t("notes.noteNotFoundOrNoAccess")}</p>
+        </Container>
+      </main>
     );
   }
 
   return (
-    <AppLayout>
-      <main className="min-h-0 flex-1 overflow-y-auto py-8">
-        <Container>
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0">
-              <div className="flex items-center gap-2">
-                <h1 className="truncate text-xl font-semibold">{t("notes.noteSettings")}</h1>
-                <NoteVisibilityBadge visibility={visibility} />
-              </div>
-              <p className="text-muted-foreground mt-1 truncate text-sm">
-                {note.title || t("notes.untitledNote")}
-              </p>
+    <main className="min-h-0 flex-1 overflow-y-auto py-8">
+      <Container>
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <h1 className="truncate text-xl font-semibold">{t("notes.noteSettings")}</h1>
+              <NoteVisibilityBadge visibility={visibility} />
             </div>
-            <Button asChild variant="outline" size="sm">
-              <Link to={`/note/${note.id}`}>{t("notes.backToNote")}</Link>
-            </Button>
+            <p className="text-muted-foreground mt-1 truncate text-sm">
+              {note.title || t("notes.untitledNote")}
+            </p>
           </div>
+          <Button asChild variant="outline" size="sm">
+            <Link to={`/note/${note.id}`}>{t("notes.backToNote")}</Link>
+          </Button>
+        </div>
 
-          {!canManage ? (
-            <p className="text-muted-foreground mt-6 text-sm">{t("notes.noPermissionToEdit")}</p>
-          ) : (
-            <>
-              <NoteSettingsShareSection noteUrl={noteUrl} onCopyLink={handleCopyLink} />
-              <NoteSettingsVisibilitySection
-                title={title}
-                setTitle={setTitle}
-                visibility={visibility}
-                setVisibility={setVisibility}
-                editPermission={editPermission}
-                setEditPermission={setEditPermission}
-                onSaveNote={handleSaveNote}
-                isSaving={isSaving}
-              />
-              <NoteSettingsDeleteSection
-                isDeleteDialogOpen={isDeleteDialogOpen}
-                onOpenChange={setIsDeleteDialogOpen}
-                onConfirmDelete={handleDeleteNote}
-                isDeleting={deleteNoteMutation.isPending}
-                noteTitle={note.title || t("notes.untitledNote")}
-              />
+        {!canManage ? (
+          <p className="text-muted-foreground mt-6 text-sm">{t("notes.noPermissionToEdit")}</p>
+        ) : (
+          <>
+            <NoteSettingsShareSection noteUrl={noteUrl} onCopyLink={handleCopyLink} />
+            <NoteSettingsVisibilitySection
+              title={title}
+              setTitle={setTitle}
+              visibility={visibility}
+              setVisibility={setVisibility}
+              editPermission={editPermission}
+              setEditPermission={setEditPermission}
+              onSaveNote={handleSaveNote}
+              isSaving={isSaving}
+            />
+            <NoteSettingsDeleteSection
+              isDeleteDialogOpen={isDeleteDialogOpen}
+              onOpenChange={setIsDeleteDialogOpen}
+              onConfirmDelete={handleDeleteNote}
+              isDeleting={deleteNoteMutation.isPending}
+              noteTitle={note.title || t("notes.untitledNote")}
+            />
 
-              <PublicAnyLoggedInSaveAlertDialog
-                open={isPublicAnyLoggedInSaveConfirmOpen}
-                onOpenChange={setIsPublicAnyLoggedInSaveConfirmOpen}
-                onConfirm={handleConfirmPublicAnyLoggedInSave}
-                isSaving={isSaving}
-              />
-            </>
-          )}
-        </Container>
-      </main>
-    </AppLayout>
+            <PublicAnyLoggedInSaveAlertDialog
+              open={isPublicAnyLoggedInSaveConfirmOpen}
+              onOpenChange={setIsPublicAnyLoggedInSaveConfirmOpen}
+              onConfirm={handleConfirmPublicAnyLoggedInSave}
+              isSaving={isSaving}
+            />
+          </>
+        )}
+      </Container>
+    </main>
   );
 };
 

--- a/src/pages/NoteView/NoteViewLoadingOrDenied.tsx
+++ b/src/pages/NoteView/NoteViewLoadingOrDenied.tsx
@@ -1,16 +1,15 @@
 import React from "react";
-import { AppLayout } from "@/components/layout/AppLayout";
 import Container from "@/components/layout/Container";
 
 /**
- *
+ * Loading/denied state shell for NoteView.
+ * Outer `AppLayout`（ヘッダー・サイドバー）はルートレベルで適用されるため、ここではメイン領域のみを描画する。
+ * NoteView の読み込み中／権限なし表示のシェル。AppLayout は親ルートで適用される。
  */
 export function NoteViewLoadingOrDenied({ children }: { children: React.ReactNode }) {
   return (
-    <AppLayout>
-      <main className="min-h-0 flex-1 overflow-y-auto py-10">
-        <Container>{children}</Container>
-      </main>
-    </AppLayout>
+    <main className="min-h-0 flex-1 overflow-y-auto py-10">
+      <Container>{children}</Container>
+    </main>
   );
 }

--- a/src/pages/NoteView/index.tsx
+++ b/src/pages/NoteView/index.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
-import { AppLayout } from "@/components/layout/AppLayout";
 import Container from "@/components/layout/Container";
 import { NoteVisibilityBadge } from "@/components/note/NoteVisibilityBadge";
 import { Badge, useToast } from "@zedi/ui";
@@ -128,51 +127,49 @@ const NoteView: React.FC = () => {
   }
 
   return (
-    <AppLayout>
-      <main className="min-h-0 flex-1 overflow-y-auto py-6">
-        <Container>
-          <div className="flex flex-wrap items-start justify-between gap-4">
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
-                <h1 className="truncate text-xl font-semibold">
-                  {note.title || t("notes.untitledNote")}
-                </h1>
-                <NoteVisibilityBadge visibility={note.visibility} />
-                {note.isOfficial && <Badge variant="secondary">{t("notes.officialBadge")}</Badge>}
-              </div>
-              <p className="text-muted-foreground mt-1 text-sm">
-                {t("notes.pagesCount", { count: notePages.length })}
-              </p>
+    <main className="min-h-0 flex-1 overflow-y-auto py-6">
+      <Container>
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="truncate text-xl font-semibold">
+                {note.title || t("notes.untitledNote")}
+              </h1>
+              <NoteVisibilityBadge visibility={note.visibility} />
+              {note.isOfficial && <Badge variant="secondary">{t("notes.officialBadge")}</Badge>}
             </div>
-            <NoteViewHeaderActions
-              noteId={note.id}
-              canManageMembers={canManageMembers}
-              isSignedIn={isSignedIn}
-              canView={Boolean(access?.canView)}
-              canShowAddPage={canShowAddPage}
-              isAddPageOpen={isAddPageOpen}
-              setIsAddPageOpen={setIsAddPageOpen}
-              newPageTitle={newPageTitle}
-              setNewPageTitle={setNewPageTitle}
-              pageFilter={pageFilter}
-              setPageFilter={setPageFilter}
-              filteredPages={filteredPages}
-              canEdit={canEdit}
-              onAddByTitle={handleAddNewPageByTitle}
-              onAddByPageId={handleAddPage}
-              addPagePending={addPageMutation.isPending}
-            />
+            <p className="text-muted-foreground mt-1 text-sm">
+              {t("notes.pagesCount", { count: notePages.length })}
+            </p>
           </div>
-          <NoteViewMainContent
+          <NoteViewHeaderActions
             noteId={note.id}
-            notePages={notePages}
-            isPagesLoading={isPagesLoading}
-            canDeletePage={canDeletePage}
-            onRemovePage={handleRemovePage}
+            canManageMembers={canManageMembers}
+            isSignedIn={isSignedIn}
+            canView={Boolean(access?.canView)}
+            canShowAddPage={canShowAddPage}
+            isAddPageOpen={isAddPageOpen}
+            setIsAddPageOpen={setIsAddPageOpen}
+            newPageTitle={newPageTitle}
+            setNewPageTitle={setNewPageTitle}
+            pageFilter={pageFilter}
+            setPageFilter={setPageFilter}
+            filteredPages={filteredPages}
+            canEdit={canEdit}
+            onAddByTitle={handleAddNewPageByTitle}
+            onAddByPageId={handleAddPage}
+            addPagePending={addPageMutation.isPending}
           />
-        </Container>
-      </main>
-    </AppLayout>
+        </div>
+        <NoteViewMainContent
+          noteId={note.id}
+          notePages={notePages}
+          isPagesLoading={isPagesLoading}
+          canDeletePage={canDeletePage}
+          onRemovePage={handleRemovePage}
+        />
+      </Container>
+    </main>
   );
 };
 

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { ArrowLeft, Check, Sparkles, Zap } from "lucide-react";
+import { Check, Sparkles, Zap } from "lucide-react";
 import { Button } from "@zedi/ui";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@zedi/ui";
 import { Badge } from "@zedi/ui";
 import { Progress } from "@zedi/ui";
 import Container from "@/components/layout/Container";
+import { PageHeader } from "@/components/layout/PageHeader";
 import { cn } from "@zedi/ui";
 import { useSubscription } from "@/hooks/useSubscription";
 import { useAuth } from "@/hooks/useAuth";
@@ -391,19 +392,10 @@ const Pricing: React.FC = () => {
   };
 
   return (
-    <div className="bg-background min-h-screen">
-      <header className="border-border bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 border-b backdrop-blur">
-        <Container className="flex h-16 items-center gap-4">
-          <Link to="/home">
-            <Button variant="ghost" size="icon">
-              <ArrowLeft className="h-5 w-5" />
-            </Button>
-          </Link>
-          <h1 className="text-xl font-semibold">{t("pricing.pageTitle")}</h1>
-        </Container>
-      </header>
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PageHeader title={t("pricing.pageTitle")} backTo="/home" backLabel={t("common.back")} />
 
-      <main className="py-8">
+      <main className="min-h-0 flex-1 overflow-y-auto py-8">
         <Container>
           <CurrentPlanStatus isSignedIn={isSignedIn} isProUser={isProUser} usage={usage} />
 

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useEffect } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import { AppLayout } from "@/components/layout/AppLayout";
 import Container from "@/components/layout/Container";
 import { SearchResultCard } from "@/components/search/SearchResultCard";
 import type { SearchResultCardItem } from "@/components/search/SearchResultCard";
@@ -112,56 +111,54 @@ export default function SearchResults() {
     item.noteId ? `shared-${item.noteId}-${item.pageId}` : `personal-${item.pageId}`;
 
   return (
-    <AppLayout>
-      <main className="min-h-0 flex-1 overflow-y-auto py-6">
-        <Container>
-          <div className="mb-6">
-            {searchQuery ? (
-              <h1 className="text-lg font-medium">
-                「{searchQuery}」の検索結果
-                {!isLoading && (
-                  <span className="text-muted-foreground ml-2 text-sm font-normal">
-                    {results.length}件
-                  </span>
-                )}
-              </h1>
-            ) : (
-              <h1 className="text-muted-foreground text-lg font-medium">
-                検索キーワードを入力してください
-              </h1>
-            )}
+    <main className="min-h-0 flex-1 overflow-y-auto py-6">
+      <Container>
+        <div className="mb-6">
+          {searchQuery ? (
+            <h1 className="text-lg font-medium">
+              「{searchQuery}」の検索結果
+              {!isLoading && (
+                <span className="text-muted-foreground ml-2 text-sm font-normal">
+                  {results.length}件
+                </span>
+              )}
+            </h1>
+          ) : (
+            <h1 className="text-muted-foreground text-lg font-medium">
+              検索キーワードを入力してください
+            </h1>
+          )}
+        </div>
+
+        {isLoading && searchQuery.length >= 3 && <SearchResultsLoadingSkeleton />}
+
+        {searchQuery.length > 0 && searchQuery.length < 3 && (
+          <SearchResultsEmptyState description="3文字以上入力してください" />
+        )}
+
+        {!isLoading && searchQuery.length >= 3 && results.length === 0 && (
+          <SearchResultsEmptyState
+            title="検索結果が見つかりません"
+            description="別のキーワードで検索してみてください"
+          />
+        )}
+
+        {!isLoading && results.length > 0 && (
+          <div className="max-w-3xl space-y-3">
+            {results.map((item) => (
+              <SearchResultCard
+                key={resultKey(item)}
+                item={item}
+                onClick={() => handleResultClick(item)}
+              />
+            ))}
           </div>
+        )}
 
-          {isLoading && searchQuery.length >= 3 && <SearchResultsLoadingSkeleton />}
-
-          {searchQuery.length > 0 && searchQuery.length < 3 && (
-            <SearchResultsEmptyState description="3文字以上入力してください" />
-          )}
-
-          {!isLoading && searchQuery.length >= 3 && results.length === 0 && (
-            <SearchResultsEmptyState
-              title="検索結果が見つかりません"
-              description="別のキーワードで検索してみてください"
-            />
-          )}
-
-          {!isLoading && results.length > 0 && (
-            <div className="max-w-3xl space-y-3">
-              {results.map((item) => (
-                <SearchResultCard
-                  key={resultKey(item)}
-                  item={item}
-                  onClick={() => handleResultClick(item)}
-                />
-              ))}
-            </div>
-          )}
-
-          {!searchQuery && (
-            <SearchResultsEmptyState description="ヘッダーの検索バーからキーワードを入力してください" />
-          )}
-        </Container>
-      </main>
-    </AppLayout>
+        {!searchQuery && (
+          <SearchResultsEmptyState description="ヘッダーの検索バーからキーワードを入力してください" />
+        )}
+      </Container>
+    </main>
   );
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import { useSearchParams } from "react-router-dom";
-import { ArrowLeft } from "lucide-react";
-import { Button } from "@zedi/ui";
-import { Link } from "react-router-dom";
 import Container from "@/components/layout/Container";
+import { PageHeader } from "@/components/layout/PageHeader";
 import { useTranslation } from "react-i18next";
 import { SettingsSection } from "@/components/settings/SettingsSection";
 import { SettingsHeaderNav } from "@/components/settings/SettingsHeaderNav";
@@ -45,22 +43,15 @@ const Settings: React.FC = () => {
   };
 
   return (
-    <div className="bg-background min-h-screen">
-      <header className="border-border bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 border-b backdrop-blur">
-        <Container className="flex h-16 items-center justify-between gap-4">
-          <div className="flex min-w-0 items-center gap-4">
-            <Button asChild variant="ghost" size="icon">
-              <Link to={backTo} aria-label={t("common.back")}>
-                <ArrowLeft className="h-5 w-5" aria-hidden />
-              </Link>
-            </Button>
-            <h1 className="truncate text-xl font-semibold">{t("settings.title")}</h1>
-          </div>
-          <SettingsHeaderNav value={currentSection} onChange={setSection} />
-        </Container>
-      </header>
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PageHeader
+        title={t("settings.title")}
+        backTo={backTo}
+        backLabel={t("common.back")}
+        actions={<SettingsHeaderNav value={currentSection} onChange={setSection} />}
+      />
 
-      <main className="py-6">
+      <main className="min-h-0 flex-1 overflow-y-auto py-6">
         <Container>
           <div className="mx-auto max-w-2xl space-y-6">
             <div>

--- a/src/pages/SubscriptionManagement.tsx
+++ b/src/pages/SubscriptionManagement.tsx
@@ -1,15 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import {
-  ArrowLeft,
-  ExternalLink,
-  Loader2,
-  Zap,
-  Calendar,
-  CreditCard,
-  RefreshCw,
-} from "lucide-react";
+import { ExternalLink, Loader2, Zap, Calendar, CreditCard, RefreshCw } from "lucide-react";
 import { Button } from "@zedi/ui";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@zedi/ui";
 import { Badge } from "@zedi/ui";
@@ -26,6 +18,7 @@ import {
   AlertDialogTrigger,
 } from "@zedi/ui";
 import Container from "@/components/layout/Container";
+import { PageHeader } from "@/components/layout/PageHeader";
 import { cn } from "@zedi/ui";
 import { useAuth } from "@/hooks/useAuth";
 import { toast } from "@zedi/ui/components/sonner";
@@ -153,19 +146,14 @@ const SubscriptionManagement: React.FC = () => {
   })();
 
   return (
-    <div className="bg-background min-h-screen">
-      <header className="border-border bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 border-b backdrop-blur">
-        <Container className="flex h-16 items-center gap-4">
-          <Link to="/pricing">
-            <Button variant="ghost" size="icon">
-              <ArrowLeft className="h-5 w-5" />
-            </Button>
-          </Link>
-          <h1 className="text-xl font-semibold">{t("pricing.subscription.title")}</h1>
-        </Container>
-      </header>
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PageHeader
+        title={t("pricing.subscription.title")}
+        backTo="/pricing"
+        backLabel={t("common.back")}
+      />
 
-      <main className="py-8">
+      <main className="min-h-0 flex-1 overflow-y-auto py-8">
         <Container className="max-w-2xl">
           {loading ? (
             <div className="flex justify-center py-16">

--- a/src/pages/WikiSchemaPage.tsx
+++ b/src/pages/WikiSchemaPage.tsx
@@ -3,10 +3,10 @@
  * ユーザー定義の Wiki スキーマ（「憲法」）を編集するページ。
  */
 import React, { useState, useCallback, useEffect } from "react";
-import { ArrowLeft, Save, Loader2 } from "lucide-react";
+import { Save, Loader2 } from "lucide-react";
 import { Button, useToast } from "@zedi/ui";
-import { Link } from "react-router-dom";
 import Container from "@/components/layout/Container";
+import { PageHeader } from "@/components/layout/PageHeader";
 import { useTranslation } from "react-i18next";
 import { useWikiSchema } from "@/hooks/useWikiSchema";
 
@@ -54,17 +54,12 @@ const WikiSchemaPage: React.FC = () => {
   }, [title, content, updateSchema, toast, t]);
 
   return (
-    <div className="bg-background min-h-screen">
-      <header className="border-border bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 border-b backdrop-blur">
-        <Container className="flex h-16 items-center justify-between gap-4">
-          <div className="flex min-w-0 items-center gap-4">
-            <Button asChild variant="ghost" size="icon">
-              <Link to="/settings" aria-label={t("common.back")}>
-                <ArrowLeft className="h-5 w-5" aria-hidden />
-              </Link>
-            </Button>
-            <h1 className="truncate text-xl font-semibold">{t("wikiSchema.title")}</h1>
-          </div>
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PageHeader
+        title={t("wikiSchema.title")}
+        backTo="/settings"
+        backLabel={t("common.back")}
+        actions={
           <Button onClick={handleSave} disabled={!isDirty || isUpdating} size="sm">
             {isUpdating ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -73,10 +68,10 @@ const WikiSchemaPage: React.FC = () => {
             )}
             {t("wikiSchema.save")}
           </Button>
-        </Container>
-      </header>
+        }
+      />
 
-      <main className="py-6">
+      <main className="min-h-0 flex-1 overflow-y-auto py-6">
         <Container>
           <div className="mx-auto max-w-2xl space-y-6">
             {isLoading ? (


### PR DESCRIPTION
## 概要

ルートレベルでの `AppLayout` の適用を実装し、ページコンポーネントから `AppLayout` のラッピングを削除しました。React Router の `Outlet` パターンを使用して、共通のヘッダー・サイドバー・AI ドックを一度だけレンダリングするようにリファクタリングしました。

## 変更点

- **App.tsx**: 新しい `AppShellRoute` コンポーネントを追加し、`AppLayout` でネストされたルートをラップ。ルート構造を再編成して、保護されたルートと公開ルートを分離
- **ページコンポーネント**: 以下のファイルから `AppLayout` インポートと使用を削除:
  - `NoteSettings/index.tsx`
  - `NotePageView.tsx`
  - `SearchResults.tsx`
  - `AIChatHistory.tsx`
  - `NoteView/index.tsx`
  - `NoteMembers/index.tsx`
  - `Home.tsx`
  - `AIChatDetail.tsx`
  - `AIChatLanding.tsx`
  - `NotesLayout.tsx`
  - `NoteViewLoadingOrDenied.tsx`
  - `NoteMembersLoadingOrDenied.tsx`

- **新規コンポーネント**: `PageHeader.tsx` を追加。ページ固有のサブヘッダー（戻るボタン・タイトル・アクション）を提供
- **既存コンポーネント更新**:
  - `SubscriptionManagement.tsx`: `PageHeader` を使用するように更新
  - `Settings.tsx`: `PageHeader` を使用するように更新
  - `WikiSchemaPage.tsx`: `PageHeader` を使用するように更新
  - `IndexPage.tsx`: `PageHeader` を使用するように更新
  - `Donate.tsx`: `PageHeader` を使用するように更新
  - `Pricing.tsx`: `PageHeader` を使用するように更新
  - `PageEditorHeader.tsx`: 検索バーと AI チャットボタンの参照を削除（共通 `Header` で提供）

## 変更の種類

- [x] 🎨 スタイル/リファクタリング (Style/Refactor)

## テスト方法

1. アプリケーションを起動し、保護されたルート（`/home`, `/notes`, `/note/:id` など）にアクセスしてヘッダー・サイドバー・AI ドックが正常に表示されることを確認
2. 公開ルート（`/`, `/sign-in`, `/pricing` など）にアクセスして、これらのルートでは `AppLayout` が適用されていないことを確認
3. ページ遷移時にヘッダーやサイドバーが不要に再レンダリングされていないことを確認
4. `PageHeader` を使用するページ（設定、Wiki スキーマ、価格設定など）で戻るボタンとタイトルが正常に表示されることを確認

## チェックリスト

- [x] 既存の機能が保持されている
- [x] ルート構造が正しく再編成されている
- [x] `Outlet` パターンが正しく実装されている
- [x] ページコンポーネントから不要な `AppLayout` ラッピングが削除されている

https://claude.ai/code/session_017mtZFN18yVY27qnDNUcuSF
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
