### PR TITLE
Fix storage-first deletion order in media and thumbnail delete endpoints

### DIFF
--- a/server/api/src/__tests__/routes/media.test.ts
+++ b/server/api/src/__tests__/routes/media.test.ts
@@ -384,3 +384,103 @@ describe("GET /api/media/:id — proxy stream (no redirect to storage)", () => {
     expect(body.error).toBe("Failed to retrieve object");
   });
 });
+
+describe("DELETE /api/media/:id — storage-first deletion order", () => {
+  const s3Key = `users/${TEST_USER_ID}/media/${MEDIA_ID}/photo.png`;
+  const mediaRow = {
+    id: MEDIA_ID,
+    ownerId: TEST_USER_ID,
+    s3Key,
+    fileName: "photo.png",
+    contentType: "image/png",
+    fileSize: null as number | null,
+    pageId: null as string | null,
+    createdAt: new Date(),
+  };
+
+  it("deletes storage object before DB row when both succeed", async () => {
+    mockS3Send.mockResolvedValueOnce({});
+    const { db } = createMockDb([[mediaRow], []]);
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/media", mediaRoutes);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockS3Send).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps DB row and returns 502 when storage deletion fails with unexpected error", async () => {
+    mockS3Send.mockRejectedValueOnce(new Error("network down"));
+    const { db, chains } = createMockDb([[mediaRow]]);
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/media", mediaRoutes);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(502);
+    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  it("proceeds to delete DB row when storage reports NoSuchKey (idempotent)", async () => {
+    mockS3Send.mockRejectedValueOnce({
+      name: "NoSuchKey",
+      $metadata: { httpStatusCode: 404 },
+    });
+    const { db, chains } = createMockDb([[mediaRow], []]);
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/media", mediaRoutes);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(200);
+    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
+    expect(deleteCalls).toHaveLength(1);
+  });
+
+  it("returns 403 when media belongs to another user (no storage call)", async () => {
+    const app = createMediaApp([[{ ...mediaRow, ownerId: ATTACKER_ID }]]);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(403);
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when media row is missing (no storage call)", async () => {
+    const app = createMediaApp([[]]);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(404);
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+});

--- a/server/api/src/__tests__/routes/media.test.ts
+++ b/server/api/src/__tests__/routes/media.test.ts
@@ -460,6 +460,29 @@ describe("DELETE /api/media/:id — storage-first deletion order", () => {
     expect(deleteCalls).toHaveLength(1);
   });
 
+  it("keeps DB row and returns 502 for NoSuchBucket 404 (config failure, not idempotent)", async () => {
+    mockS3Send.mockRejectedValueOnce({
+      name: "NoSuchBucket",
+      $metadata: { httpStatusCode: 404 },
+    });
+    const { db, chains } = createMockDb([[mediaRow]]);
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/media", mediaRoutes);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(502);
+    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
+    expect(deleteCalls).toHaveLength(0);
+  });
+
   it("returns 403 when media belongs to another user (no storage call)", async () => {
     const app = createMediaApp([[{ ...mediaRow, ownerId: ATTACKER_ID }]]);
 

--- a/server/api/src/__tests__/routes/thumbnail/serve.test.ts
+++ b/server/api/src/__tests__/routes/thumbnail/serve.test.ts
@@ -125,6 +125,23 @@ describe("DELETE /api/thumbnail/serve/:id — storage-first deletion order", () 
     expect(deleteCalls).toHaveLength(1);
   });
 
+  it("keeps DB row and returns 502 for NoSuchBucket 404 (config failure, not idempotent)", async () => {
+    mockS3Send.mockRejectedValueOnce({
+      name: "NoSuchBucket",
+      $metadata: { httpStatusCode: 404 },
+    });
+    const { app, chains } = createServeApp([[thumbRow]]);
+
+    const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(502);
+    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
+    expect(deleteCalls).toHaveLength(0);
+  });
+
   it("returns 404 when DB row is missing or belongs to another user (no storage call)", async () => {
     const { app } = createServeApp([[]]);
 

--- a/server/api/src/__tests__/routes/thumbnail/serve.test.ts
+++ b/server/api/src/__tests__/routes/thumbnail/serve.test.ts
@@ -1,0 +1,150 @@
+/**
+ * DELETE /api/thumbnail/serve/:id のストレージ→DB 削除順序テスト。
+ * Tests for storage-first deletion ordering in DELETE /api/thumbnail/serve/:id.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Context, Next } from "hono";
+import type { AppEnv } from "../../../types/index.js";
+
+const { mockS3Send } = vi.hoisted(() => ({
+  mockS3Send: vi.fn(),
+}));
+
+vi.mock("../../../middleware/auth.js", () => ({
+  authRequired: async (c: Context<AppEnv>, next: Next) => {
+    const userId = c.req.header("x-test-user-id");
+    if (!userId) return c.json({ message: "Unauthorized" }, 401);
+    c.set("userId", userId);
+    await next();
+  },
+}));
+
+vi.mock("../../../lib/env.js", () => ({
+  getEnv: (key: string) => {
+    const envMap: Record<string, string> = {
+      STORAGE_ENDPOINT: "http://localhost:9000",
+      STORAGE_ACCESS_KEY: "test-key",
+      STORAGE_SECRET_KEY: "test-secret",
+      STORAGE_BUCKET_NAME: "test-bucket",
+    };
+    return envMap[key] ?? "";
+  },
+}));
+
+vi.mock("@aws-sdk/client-s3", () => {
+  class MockS3Client {
+    send = (...args: unknown[]) => mockS3Send(...args);
+  }
+  function MockGetObjectCommand() {
+    /* stub */
+  }
+  function MockDeleteObjectCommand() {
+    /* stub */
+  }
+  return {
+    S3Client: MockS3Client,
+    GetObjectCommand: MockGetObjectCommand,
+    DeleteObjectCommand: MockDeleteObjectCommand,
+  };
+});
+
+import { Hono } from "hono";
+import serveRoutes from "../../../routes/thumbnail/serve.js";
+import { createMockDb } from "../../createMockDb.js";
+
+const TEST_USER_ID = "user-test-123";
+const ATTACKER_ID = "attacker-456";
+const OBJECT_ID = "thumb-uuid-001";
+
+function createServeApp(dbResults: unknown[]) {
+  const mockDb = createMockDb(dbResults);
+  const app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("db", mockDb.db as unknown as AppEnv["Variables"]["db"]);
+    await next();
+  });
+  app.route("/api/thumbnail/serve", serveRoutes);
+  return { app, chains: mockDb.chains };
+}
+
+beforeEach(() => {
+  mockS3Send.mockReset();
+});
+
+describe("DELETE /api/thumbnail/serve/:id — storage-first deletion order", () => {
+  const s3Key = `thumbnails/${TEST_USER_ID}/${OBJECT_ID}.jpg`;
+  const thumbRow = {
+    id: OBJECT_ID,
+    userId: TEST_USER_ID,
+    s3Key,
+    sizeBytes: 1024,
+    createdAt: new Date(),
+  };
+
+  it("deletes storage object before DB row when both succeed", async () => {
+    mockS3Send.mockResolvedValueOnce({});
+    const { app } = createServeApp([[thumbRow], []]);
+
+    const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockS3Send).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps DB row and returns 502 when storage deletion fails with unexpected error", async () => {
+    mockS3Send.mockRejectedValueOnce(new Error("network down"));
+    const { app, chains } = createServeApp([[thumbRow]]);
+
+    const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(502);
+    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  it("proceeds to delete DB row when storage reports NoSuchKey (idempotent)", async () => {
+    mockS3Send.mockRejectedValueOnce({
+      name: "NoSuchKey",
+      $metadata: { httpStatusCode: 404 },
+    });
+    const { app, chains } = createServeApp([[thumbRow], []]);
+
+    const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(200);
+    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
+    expect(deleteCalls).toHaveLength(1);
+  });
+
+  it("returns 404 when DB row is missing or belongs to another user (no storage call)", async () => {
+    const { app } = createServeApp([[]]);
+
+    const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": ATTACKER_ID },
+    });
+
+    expect(res.status).toBe(404);
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 without auth header", async () => {
+    const { app } = createServeApp([[thumbRow]]);
+
+    const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(401);
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+});

--- a/server/api/src/routes/media.ts
+++ b/server/api/src/routes/media.ts
@@ -240,8 +240,11 @@ app.delete("/:id", authRequired, async (c) => {
     throw new HTTPException(403, { message: "You can only delete your own media" });
   }
 
-  await db.delete(media).where(eq(media.id, mediaId));
-
+  // ストレージ→DB の順で削除する。ストレージ側が失敗した場合に DB レコードだけ消えて
+  // オブジェクトが孤児化するのを防ぐため。NoSuchKey 等の冪等エラーは DB 削除まで進める。
+  //
+  // Delete storage object before the DB row so a storage failure cannot leave an
+  // orphaned object behind. Idempotent errors (NoSuchKey) still advance to DB delete.
   try {
     await s3.send(
       new DeleteObjectCommand({
@@ -250,9 +253,17 @@ app.delete("/:id", authRequired, async (c) => {
       }),
     );
   } catch (err) {
-    console.error("[media] S3 DeleteObject failed:", err);
-    throw new HTTPException(502, { message: "Failed to delete object from storage" });
+    const meta = (err as { name?: string; $metadata?: { httpStatusCode?: number } } | undefined)
+      ?.$metadata;
+    const code = meta?.httpStatusCode;
+    const name = (err as { name?: string }).name;
+    if (name !== "NoSuchKey" && code !== 404) {
+      console.error("[media] S3 DeleteObject failed:", err);
+      throw new HTTPException(502, { message: "Failed to delete object from storage" });
+    }
   }
+
+  await db.delete(media).where(eq(media.id, mediaId));
 
   return c.json({ success: true });
 });

--- a/server/api/src/routes/media.ts
+++ b/server/api/src/routes/media.ts
@@ -253,11 +253,13 @@ app.delete("/:id", authRequired, async (c) => {
       }),
     );
   } catch (err) {
-    const meta = (err as { name?: string; $metadata?: { httpStatusCode?: number } } | undefined)
-      ?.$metadata;
-    const code = meta?.httpStatusCode;
-    const name = (err as { name?: string }).name;
-    if (name !== "NoSuchKey" && code !== 404) {
+    // NoSuchKey のみを冪等として扱う。NoSuchBucket 等、別の 404 応答は
+    // 本当の設定不整合なので 502 に倒して DB を残す。
+    //
+    // Only treat an explicit NoSuchKey as idempotent; other 404-class errors
+    // (e.g. NoSuchBucket) indicate real config failures — surface 502 and keep the DB row.
+    const s3Err = err as { name?: string } | null;
+    if (s3Err?.name !== "NoSuchKey") {
       console.error("[media] S3 DeleteObject failed:", err);
       throw new HTTPException(502, { message: "Failed to delete object from storage" });
     }

--- a/server/api/src/routes/thumbnail/serve.ts
+++ b/server/api/src/routes/thumbnail/serve.ts
@@ -99,8 +99,11 @@ app.delete("/:id", authRequired, async (c) => {
     return c.json({ error: "Not found" }, 404);
   }
 
-  await db.delete(thumbnailObjects).where(eq(thumbnailObjects.id, objectId));
-
+  // ストレージ→DB の順で削除する。ストレージ側が失敗した場合に DB レコードだけ消えて
+  // オブジェクトが孤児化するのを防ぐため。NoSuchKey 等の冪等エラーは DB 削除まで進める。
+  //
+  // Delete storage object before the DB row so a storage failure cannot leave an
+  // orphaned object behind. Idempotent errors (NoSuchKey) still advance to DB delete.
   try {
     await s3.send(
       new DeleteObjectCommand({
@@ -109,9 +112,17 @@ app.delete("/:id", authRequired, async (c) => {
       }),
     );
   } catch (err) {
-    console.error("[thumbnail/serve] S3 DeleteObject failed:", err);
-    return c.json({ error: "Failed to delete object from storage" }, 502);
+    const meta = (err as { name?: string; $metadata?: { httpStatusCode?: number } } | undefined)
+      ?.$metadata;
+    const code = meta?.httpStatusCode;
+    const name = (err as { name?: string }).name;
+    if (name !== "NoSuchKey" && code !== 404) {
+      console.error("[thumbnail/serve] S3 DeleteObject failed:", err);
+      return c.json({ error: "Failed to delete object from storage" }, 502);
+    }
   }
+
+  await db.delete(thumbnailObjects).where(eq(thumbnailObjects.id, objectId));
 
   return c.json({ success: true });
 });

--- a/server/api/src/routes/thumbnail/serve.ts
+++ b/server/api/src/routes/thumbnail/serve.ts
@@ -112,11 +112,13 @@ app.delete("/:id", authRequired, async (c) => {
       }),
     );
   } catch (err) {
-    const meta = (err as { name?: string; $metadata?: { httpStatusCode?: number } } | undefined)
-      ?.$metadata;
-    const code = meta?.httpStatusCode;
-    const name = (err as { name?: string }).name;
-    if (name !== "NoSuchKey" && code !== 404) {
+    // NoSuchKey のみを冪等として扱う。NoSuchBucket 等、別の 404 応答は
+    // 本当の設定不整合なので 502 に倒して DB を残す。
+    //
+    // Only treat an explicit NoSuchKey as idempotent; other 404-class errors
+    // (e.g. NoSuchBucket) indicate real config failures — surface 502 and keep the DB row.
+    const s3Err = err as { name?: string } | null;
+    if (s3Err?.name !== "NoSuchKey") {
       console.error("[thumbnail/serve] S3 DeleteObject failed:", err);
       return c.json({ error: "Failed to delete object from storage" }, 502);
     }


### PR DESCRIPTION
## 概要

メディアとサムネイル削除エンドポイントで、ストレージ削除失敗時にDBレコードだけが削除されて孤児オブジェクトが発生するリスクを修正しました。ストレージ削除を先に実行し、NoSuchKey等の冪等エラーは許容する実装に変更しました。

## 変更点

- **`DELETE /api/media/:id`**: ストレージ削除をDB削除の前に実行。予期しないエラーで502を返す場合はDB削除をスキップ。NoSuchKey (404) は冪等エラーとして許容し、DB削除に進む
- **`DELETE /api/thumbnail/serve/:id`**: 同様にストレージ削除を先に実行。エラーハンドリングロジックを統一
- **テスト追加**: 両エンドポイントで以下のシナリオをカバー
  - ストレージとDB削除が両方成功する場合
  - ストレージ削除が予期しないエラーで失敗した場合（DB削除をスキップ、502を返す）
  - ストレージがNoSuchKeyを返す場合（DB削除に進む、200を返す）
  - 認可チェック失敗時にストレージ呼び出しをスキップ

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm test` で新規テストスイートが実行される
2. 既存テストがすべてパスすることを確認
3. 新規テスト: `DELETE /api/media/:id — storage-first deletion order` と `DELETE /api/thumbnail/serve/:id — storage-first deletion order` で5つのシナリオをカバー

## チェックリスト

- [x] テストがすべてパスする
- [x] 新規テストで削除順序と例外処理をカバー
- [x] コミットメッセージが Conventional Commits に従っている

https://claude.ai/code/session_017TuXbN1zsGZoCFrr2mvxMa
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
