### PR TITLE
fix: enforce BETTER_AUTH_URL requirement in commitImage with fail-fast

### DIFF
--- a/server/api/src/__tests__/services/commitService.test.ts
+++ b/server/api/src/__tests__/services/commitService.test.ts
@@ -1,0 +1,151 @@
+/**
+ * commitService のテスト。
+ * BETTER_AUTH_URL 未設定時の fail-fast 挙動と、通常時の imageUrl 生成を検証する。
+ *
+ * Tests for commitService.
+ * Verifies fail-fast behavior when BETTER_AUTH_URL is unset, and imageUrl
+ * generation when the env is configured.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockS3Send, envMap } = vi.hoisted(() => ({
+  mockS3Send: vi.fn(),
+  envMap: {} as Record<string, string | undefined>,
+}));
+
+vi.mock("../../lib/env.js", () => ({
+  getEnv: (key: string) => {
+    const value = envMap[key];
+    if (!value) throw new Error(`Missing required env var: ${key}`);
+    return value;
+  },
+}));
+
+vi.mock("@aws-sdk/client-s3", () => {
+  class MockS3Client {
+    send = (...args: unknown[]) => mockS3Send(...args);
+  }
+  function MockPutObjectCommand() {
+    /* stub */
+  }
+  return {
+    S3Client: MockS3Client,
+    PutObjectCommand: MockPutObjectCommand,
+  };
+});
+
+vi.mock("../../services/subscriptionService.js", () => ({
+  getUserTier: vi.fn().mockResolvedValue("free"),
+}));
+
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII=";
+
+const TEST_USER_ID = "user-test-123";
+const DATA_URI = `data:image/png;base64,${TINY_PNG_BASE64}`;
+
+function setBaseEnv() {
+  envMap.STORAGE_ENDPOINT = "http://localhost:9000";
+  envMap.STORAGE_ACCESS_KEY = "test-key";
+  envMap.STORAGE_SECRET_KEY = "test-secret";
+  envMap.STORAGE_BUCKET_NAME = "test-bucket";
+  envMap.BETTER_AUTH_URL = "https://zedi.example.com";
+  process.env.STORAGE_BUCKET_NAME = "test-bucket";
+}
+
+function clearEnv() {
+  for (const key of Object.keys(envMap)) {
+    envMap[key] = undefined;
+  }
+  process.env.STORAGE_BUCKET_NAME = undefined;
+}
+
+async function importCommitService() {
+  // 動的 import にして、モック適用後の最新モジュールを取得する。
+  // Use dynamic import so the module picks up our mocks.
+  return await import("../../services/commitService.js");
+}
+
+function makeDbMock(tier: string, quotaBytes: number, usedBytes: number) {
+  // commitService は次の順番で DB を呼び出す:
+  // 1) getUserTier (モック済み、DB は使わない)
+  // 2) getStorageQuotaBytes: select().from().where().limit()
+  // 3) getStorageUsedBytes: select().from().where()
+  // 4) insert().values()
+  const chain = (final: unknown) =>
+    new Proxy(
+      {},
+      {
+        get(_, prop: string) {
+          if (prop === "then") {
+            return (resolve?: (v: unknown) => unknown) => Promise.resolve(final).then(resolve);
+          }
+          return () => chain(final);
+        },
+      },
+    );
+
+  let call = 0;
+  const db = new Proxy(
+    {},
+    {
+      get(_, prop: string) {
+        return () => {
+          if (prop === "select") {
+            call++;
+            if (call === 1) return chain([{ storageLimitBytes: quotaBytes }]);
+            if (call === 2) return chain([{ sum: String(usedBytes) }]);
+          }
+          if (prop === "insert") return chain([]);
+          return chain([]);
+        };
+      },
+    },
+  );
+  return db;
+}
+
+describe("commitImage — BETTER_AUTH_URL handling", () => {
+  beforeEach(() => {
+    clearEnv();
+    mockS3Send.mockReset();
+    mockS3Send.mockResolvedValue({});
+    vi.resetModules();
+  });
+
+  it("BETTER_AUTH_URL 未設定時は fail-fast で throw する / throws when BETTER_AUTH_URL is unset", async () => {
+    setBaseEnv();
+    envMap.BETTER_AUTH_URL = undefined;
+
+    const { commitImage } = await importCommitService();
+    const db = makeDbMock("free", 10 * 1024 * 1024, 0) as never;
+
+    await expect(commitImage(TEST_USER_ID, DATA_URI, undefined, db)).rejects.toThrow(
+      /Missing required env var: BETTER_AUTH_URL/,
+    );
+  });
+
+  it("BETTER_AUTH_URL が設定されていれば絶対 URL を返す / returns an absolute URL when BETTER_AUTH_URL is set", async () => {
+    setBaseEnv();
+
+    const { commitImage } = await importCommitService();
+    const db = makeDbMock("free", 10 * 1024 * 1024, 0) as never;
+
+    const { imageUrl } = await commitImage(TEST_USER_ID, DATA_URI, undefined, db);
+
+    expect(imageUrl).toMatch(/^https:\/\/zedi\.example\.com\/api\/thumbnail\/serve\/[0-9a-f-]+$/);
+  });
+
+  it("BETTER_AUTH_URL 末尾のスラッシュは除去される / trims trailing slash on BETTER_AUTH_URL", async () => {
+    setBaseEnv();
+    envMap.BETTER_AUTH_URL = "https://zedi.example.com/";
+
+    const { commitImage } = await importCommitService();
+    const db = makeDbMock("free", 10 * 1024 * 1024, 0) as never;
+
+    const { imageUrl } = await commitImage(TEST_USER_ID, DATA_URI, undefined, db);
+
+    expect(imageUrl.startsWith("https://zedi.example.com/api/thumbnail/serve/")).toBe(true);
+    expect(imageUrl.startsWith("https://zedi.example.com//")).toBe(false);
+  });
+});

--- a/server/api/src/__tests__/services/commitService.test.ts
+++ b/server/api/src/__tests__/services/commitService.test.ts
@@ -125,6 +125,22 @@ describe("commitImage — BETTER_AUTH_URL handling", () => {
     );
   });
 
+  it("BETTER_AUTH_URL 未設定時は S3 アップロード前に throw する / rejects before any S3 PUT when BETTER_AUTH_URL is unset", async () => {
+    setBaseEnv();
+    envMap.BETTER_AUTH_URL = undefined;
+
+    const { commitImage } = await importCommitService();
+    const db = makeDbMock("free", 10 * 1024 * 1024, 0) as never;
+
+    await expect(commitImage(TEST_USER_ID, DATA_URI, undefined, db)).rejects.toThrow(
+      /Missing required env var: BETTER_AUTH_URL/,
+    );
+
+    // オーファンオブジェクトを生まないために、S3 への PUT が一切発生していないこと。
+    // Verify we never hit S3 — otherwise a missing env leaves orphan objects.
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+
   it("BETTER_AUTH_URL が設定されていれば絶対 URL を返す / returns an absolute URL when BETTER_AUTH_URL is set", async () => {
     setBaseEnv();
 

--- a/server/api/src/services/commitService.ts
+++ b/server/api/src/services/commitService.ts
@@ -71,23 +71,41 @@ async function fetchImageAsBuffer(
   return { buffer, mimeType, ext };
 }
 
+/**
+ *
+ */
 export async function commitImage(
   userId: string,
   sourceUrl: string,
   fallbackUrl: string | undefined,
   db: Database,
 ): Promise<{ imageUrl: string }> {
+  /**
+   *
+   */
   let buffer: Buffer;
+  /**
+   *
+   */
   let mimeType: string;
+  /**
+   *
+   */
   let ext: string;
 
   try {
+    /**
+     *
+     */
     const result = await fetchImageAsBuffer(sourceUrl);
     buffer = result.buffer;
     mimeType = result.mimeType;
     ext = result.ext;
   } catch (err) {
     if (fallbackUrl && fallbackUrl !== sourceUrl) {
+      /**
+       *
+       */
       const fallback = await fetchImageAsBuffer(fallbackUrl);
       buffer = fallback.buffer;
       mimeType = fallback.mimeType;
@@ -97,17 +115,38 @@ export async function commitImage(
     }
   }
 
+  /**
+   *
+   */
   const sizeBytes = buffer.length;
+  /**
+   *
+   */
   const tier = await getUserTier(userId, db);
+  /**
+   *
+   */
   const quotaBytes = await getStorageQuotaBytes(tier, db);
+  /**
+   *
+   */
   const usedBytes = await getStorageUsedBytes(userId, db);
 
   if (usedBytes + sizeBytes > quotaBytes) {
     throw new Error("STORAGE_QUOTA_EXCEEDED");
   }
 
+  /**
+   *
+   */
   const objectId = crypto.randomUUID();
+  /**
+   *
+   */
   const s3Key = `users/${userId}/thumbnails/${objectId}.${ext}`;
+  /**
+   *
+   */
   const bucketName = process.env.STORAGE_BUCKET_NAME;
 
   await s3.send(
@@ -127,6 +166,12 @@ export async function commitImage(
   });
 
   // バケット非公開のため、API 経由でプロキシストリーミングする URL を返す
-  const baseUrl = process.env.BETTER_AUTH_URL?.replace(/\/$/, "") ?? "";
+  // Return a proxy-streaming URL served via this API because the bucket is private.
+  // BETTER_AUTH_URL は必須。未設定なら fail-fast し、不正な相対 URL を返さない。
+  // BETTER_AUTH_URL is required; fail fast on missing value instead of returning a broken relative URL.
+  /**
+   *
+   */
+  const baseUrl = getEnv("BETTER_AUTH_URL").replace(/\/$/, "");
   return { imageUrl: `${baseUrl}/api/thumbnail/serve/${objectId}` };
 }

--- a/server/api/src/services/commitService.ts
+++ b/server/api/src/services/commitService.ts
@@ -72,7 +72,20 @@ async function fetchImageAsBuffer(
 }
 
 /**
+ * サムネイル画像を取得して S3 に保存し、プロキシ配信用の URL を返す。
+ * Fetches a thumbnail image, persists it to S3, and returns a proxy-serving URL.
  *
+ * バケットは非公開のため、`/api/thumbnail/serve/:id` 経由でストリーミング配信する。
+ * The bucket is private, so the returned URL streams via `/api/thumbnail/serve/:id`.
+ *
+ * 必須環境変数 `BETTER_AUTH_URL` は、副作用（S3 アップロード・DB 挿入）より前に
+ * 検証する。未設定なら即座に throw し、オーファンなオブジェクトや行を残さない。
+ * The required env var `BETTER_AUTH_URL` is validated before any side effects
+ * (S3 upload, DB insert); if missing, we throw immediately so no orphan object
+ * or row is persisted.
+ *
+ * @throws `STORAGE_QUOTA_EXCEEDED` when the user's tier quota is exhausted.
+ * @throws `Missing required env var: BETTER_AUTH_URL` when the env var is unset.
  */
 export async function commitImage(
   userId: string,
@@ -80,32 +93,22 @@ export async function commitImage(
   fallbackUrl: string | undefined,
   db: Database,
 ): Promise<{ imageUrl: string }> {
-  /**
-   *
-   */
+  // BETTER_AUTH_URL は必須。S3 アップロードや DB 挿入より前に検証して fail-fast する。
+  // Validate BETTER_AUTH_URL before any side effects so a missing env var cannot
+  // leave orphan storage objects or DB rows.
+  const baseUrl = getEnv("BETTER_AUTH_URL").replace(/\/$/, "");
+
   let buffer: Buffer;
-  /**
-   *
-   */
   let mimeType: string;
-  /**
-   *
-   */
   let ext: string;
 
   try {
-    /**
-     *
-     */
     const result = await fetchImageAsBuffer(sourceUrl);
     buffer = result.buffer;
     mimeType = result.mimeType;
     ext = result.ext;
   } catch (err) {
     if (fallbackUrl && fallbackUrl !== sourceUrl) {
-      /**
-       *
-       */
       const fallback = await fetchImageAsBuffer(fallbackUrl);
       buffer = fallback.buffer;
       mimeType = fallback.mimeType;
@@ -115,38 +118,17 @@ export async function commitImage(
     }
   }
 
-  /**
-   *
-   */
   const sizeBytes = buffer.length;
-  /**
-   *
-   */
   const tier = await getUserTier(userId, db);
-  /**
-   *
-   */
   const quotaBytes = await getStorageQuotaBytes(tier, db);
-  /**
-   *
-   */
   const usedBytes = await getStorageUsedBytes(userId, db);
 
   if (usedBytes + sizeBytes > quotaBytes) {
     throw new Error("STORAGE_QUOTA_EXCEEDED");
   }
 
-  /**
-   *
-   */
   const objectId = crypto.randomUUID();
-  /**
-   *
-   */
   const s3Key = `users/${userId}/thumbnails/${objectId}.${ext}`;
-  /**
-   *
-   */
   const bucketName = process.env.STORAGE_BUCKET_NAME;
 
   await s3.send(
@@ -165,13 +147,5 @@ export async function commitImage(
     sizeBytes,
   });
 
-  // バケット非公開のため、API 経由でプロキシストリーミングする URL を返す
-  // Return a proxy-streaming URL served via this API because the bucket is private.
-  // BETTER_AUTH_URL は必須。未設定なら fail-fast し、不正な相対 URL を返さない。
-  // BETTER_AUTH_URL is required; fail fast on missing value instead of returning a broken relative URL.
-  /**
-   *
-   */
-  const baseUrl = getEnv("BETTER_AUTH_URL").replace(/\/$/, "");
   return { imageUrl: `${baseUrl}/api/thumbnail/serve/${objectId}` };
 }


### PR DESCRIPTION
## 概要

`commitImage` 関数で `BETTER_AUTH_URL` 環境変数の設定を必須化し、未設定時に fail-fast で例外を発生させるように改善しました。また、この変更を検証する包括的なテストスイートを追加しました。

## 変更点

- `commitService.ts`: `process.env.BETTER_AUTH_URL?.replace(/\/$/, "") ?? ""` から `getEnv("BETTER_AUTH_URL").replace(/\/$/, "")` に変更し、未設定時に明示的にエラーを発生させるように改善
- `commitService.test.ts`: 新規追加。以下の3つのテストケースで `BETTER_AUTH_URL` の処理を検証
  - `BETTER_AUTH_URL` 未設定時に例外がスローされることを確認
  - `BETTER_AUTH_URL` が設定されている場合に正しい絶対 URL が返されることを確認
  - `BETTER_AUTH_URL` の末尾スラッシュが正しく除去されることを確認

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm test` または `vitest` を実行して、新しく追加された `commitService.test.ts` のテストがすべてパスすることを確認
2. 既存のテストスイートがすべてパスすることを確認

## チェックリスト

- [x] テストがすべてパスする（新規テストスイート追加）
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

## 補足

この変更により、`BETTER_AUTH_URL` が未設定の場合に不正な相対 URL（`/api/thumbnail/serve/...`）が返されるバグを防ぎます。環境変数の設定漏れを早期に検出できるようになります。

https://claude.ai/code/session_012a5r8jkLYqrRewrHS8Jtg5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
