### PR TITLE
Implement MCP token revocation via Redis deny-list

### DIFF
--- a/server/api/src/__tests__/lib/mcpAuth.test.ts
+++ b/server/api/src/__tests__/lib/mcpAuth.test.ts
@@ -21,11 +21,13 @@ import {
   hasScope,
   storeMcpRevocation,
   getMcpRevocationTimestamp,
-  getMcpJwtExpiresInSeconds,
+  getMcpRevocationTtlSeconds,
+  McpRevocationLookupError,
   MCP_SCOPE_READ,
   MCP_SCOPE_WRITE,
   MCP_JWT_AUDIENCE,
   MCP_REVOKED_PREFIX,
+  MCP_JWT_EXP_DAYS_DEFAULT,
 } from "../../lib/mcpAuth.js";
 import { createHash } from "node:crypto";
 
@@ -243,7 +245,7 @@ describe("hasScope", () => {
 });
 
 describe("storeMcpRevocation / getMcpRevocationTimestamp", () => {
-  it("writes mcp:revoked:<userId> with current epoch seconds and JWT TTL", async () => {
+  it("writes mcp:revoked:<userId> with current epoch seconds and revocation TTL", async () => {
     const redis = createMockRedis();
     const before = Math.floor(Date.now() / 1000);
     const stored = await storeMcpRevocation(
@@ -260,8 +262,35 @@ describe("storeMcpRevocation / getMcpRevocationTimestamp", () => {
     if (!call) throw new Error("setex was not called");
     const [key, ttl, value] = call;
     expect(key).toBe(`${MCP_REVOKED_PREFIX}user-rev-1`);
-    expect(ttl).toBe(getMcpJwtExpiresInSeconds());
+    expect(ttl).toBe(getMcpRevocationTtlSeconds());
     expect(Number(value)).toBe(stored);
+  });
+
+  it("revocation TTL is never shorter than the default JWT lifetime even when MCP_JWT_EXP_DAYS is reduced", async () => {
+    // Simulate a later operator decision to shorten token lifetime. The deny-list
+    // entry must still outlive any token that was issued under the old (longer) setting.
+    // MCP_JWT_EXP_DAYS が短縮されても、旧設定で発行された長寿命トークンを覆えるよう TTL 下限を保証する。
+    const original = process.env.MCP_JWT_EXP_DAYS;
+    process.env.MCP_JWT_EXP_DAYS = "1";
+    try {
+      const ttl = getMcpRevocationTtlSeconds();
+      expect(ttl).toBe(MCP_JWT_EXP_DAYS_DEFAULT * 24 * 60 * 60);
+    } finally {
+      if (original === undefined) delete process.env.MCP_JWT_EXP_DAYS;
+      else process.env.MCP_JWT_EXP_DAYS = original;
+    }
+  });
+
+  it("revocation TTL grows with larger configured lifetimes", async () => {
+    const original = process.env.MCP_JWT_EXP_DAYS;
+    process.env.MCP_JWT_EXP_DAYS = "90";
+    try {
+      const ttl = getMcpRevocationTtlSeconds();
+      expect(ttl).toBe(90 * 24 * 60 * 60);
+    } finally {
+      if (original === undefined) delete process.env.MCP_JWT_EXP_DAYS;
+      else process.env.MCP_JWT_EXP_DAYS = original;
+    }
   });
 
   it("getMcpRevocationTimestamp returns null when no entry exists", async () => {
@@ -312,21 +341,38 @@ describe("verifyMcpToken deny-list round-trip", () => {
     expect(payload).toBeNull();
   });
 
-  it("accepts a token whose iat is at or after the stored revocation timestamp", async () => {
-    // revokedAt <= iat must still pass: the token was issued after (or exactly at) the revoke.
-    // revokedAt <= iat のトークンは、失効後に発行されたとみなして許可する。
+  it("rejects a token issued in the same second as the revocation (inclusive comparison)", async () => {
+    // Boundary case: a token with iat == revokedAt must be rejected to avoid a 1-second
+    // window where a pre-revoke token remains valid at second-precision.
+    // 秒精度の境界で、失効直前 (同一秒) に発行されたトークンが残らないよう iat == revokedAt は失効扱いとする。
     const redis = createMockRedis();
-    const { access_token } = await issueMcpToken("user-fresh-after-revoke", [MCP_SCOPE_READ]);
+    const { access_token } = await issueMcpToken("user-boundary", [MCP_SCOPE_READ]);
     const [, payloadB64] = access_token.split(".");
     if (!payloadB64) throw new Error("jwt has no payload segment");
     const iat = (
       JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8")) as { iat: number }
     ).iat;
-    await redis.setex(`${MCP_REVOKED_PREFIX}user-fresh-after-revoke`, 60, String(iat));
+    await redis.setex(`${MCP_REVOKED_PREFIX}user-boundary`, 60, String(iat));
+
+    const payload = await verifyMcpToken(access_token, redis as unknown as import("ioredis").Redis);
+    expect(payload).toBeNull();
+  });
+
+  it("accepts a token whose iat is strictly after the stored revocation timestamp", async () => {
+    // A token issued in a later second than the revoke remains valid.
+    // 失効後 (iat > revokedAt) に発行されたトークンは有効。
+    const redis = createMockRedis();
+    const { access_token } = await issueMcpToken("user-after-revoke", [MCP_SCOPE_READ]);
+    const [, payloadB64] = access_token.split(".");
+    if (!payloadB64) throw new Error("jwt has no payload segment");
+    const iat = (
+      JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8")) as { iat: number }
+    ).iat;
+    await redis.setex(`${MCP_REVOKED_PREFIX}user-after-revoke`, 60, String(iat - 1));
 
     const payload = await verifyMcpToken(access_token, redis as unknown as import("ioredis").Redis);
     expect(payload).not.toBeNull();
-    expect(payload?.sub).toBe("user-fresh-after-revoke");
+    expect(payload?.sub).toBe("user-after-revoke");
   });
 
   it("passes through verification when no revocation entry exists", async () => {
@@ -374,5 +420,27 @@ describe("verifyMcpToken deny-list round-trip", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("throws McpRevocationLookupError when the deny-list lookup fails (does not downgrade to 401)", async () => {
+    // Redis 障害を null (→401) にすり替えず、専用エラーで上位に伝播させることを確認する。
+    // Confirms Redis I/O errors during deny-list lookup propagate as McpRevocationLookupError
+    // rather than being silently converted into a null payload.
+    const { access_token } = await issueMcpToken("user-redis-outage", [MCP_SCOPE_READ]);
+    const brokenRedis = {
+      get: vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+    } as unknown as import("ioredis").Redis;
+
+    await expect(verifyMcpToken(access_token, brokenRedis)).rejects.toBeInstanceOf(
+      McpRevocationLookupError,
+    );
+  });
+
+  it("still returns null (401-bound) for structurally invalid tokens even when redis is provided", async () => {
+    // JWT 検証失敗は従来どおり null を返し、401 扱いにすること (503 に波及させない)。
+    // JWT validation failures still return null (→ 401), independent of deny-list behavior.
+    const redis = createMockRedis();
+    const payload = await verifyMcpToken("not-a-jwt", redis as unknown as import("ioredis").Redis);
+    expect(payload).toBeNull();
   });
 });

--- a/server/api/src/__tests__/lib/mcpAuth.test.ts
+++ b/server/api/src/__tests__/lib/mcpAuth.test.ts
@@ -19,9 +19,13 @@ import {
   issueMcpToken,
   verifyMcpToken,
   hasScope,
+  storeMcpRevocation,
+  getMcpRevocationTimestamp,
+  getMcpJwtExpiresInSeconds,
   MCP_SCOPE_READ,
   MCP_SCOPE_WRITE,
   MCP_JWT_AUDIENCE,
+  MCP_REVOKED_PREFIX,
 } from "../../lib/mcpAuth.js";
 import { createHash } from "node:crypto";
 
@@ -35,6 +39,11 @@ function createMockRedis() {
     setex: vi.fn(async (key: string, ttl: number, value: string) => {
       store.set(key, { value, expireAt: Date.now() + ttl * 1000 });
       return "OK" as const;
+    }),
+    get: vi.fn(async (key: string) => {
+      const entry = store.get(key);
+      if (!entry) return null;
+      return entry.value;
     }),
     getdel: vi.fn(async (key: string) => {
       const entry = store.get(key);
@@ -230,5 +239,140 @@ describe("hasScope", () => {
         MCP_SCOPE_WRITE,
       ),
     ).toBe(false);
+  });
+});
+
+describe("storeMcpRevocation / getMcpRevocationTimestamp", () => {
+  it("writes mcp:revoked:<userId> with current epoch seconds and JWT TTL", async () => {
+    const redis = createMockRedis();
+    const before = Math.floor(Date.now() / 1000);
+    const stored = await storeMcpRevocation(
+      redis as unknown as import("ioredis").Redis,
+      "user-rev-1",
+    );
+    const after = Math.floor(Date.now() / 1000);
+
+    expect(stored).toBeGreaterThanOrEqual(before);
+    expect(stored).toBeLessThanOrEqual(after);
+
+    expect(redis.setex).toHaveBeenCalledOnce();
+    const call = redis.setex.mock.calls[0];
+    if (!call) throw new Error("setex was not called");
+    const [key, ttl, value] = call;
+    expect(key).toBe(`${MCP_REVOKED_PREFIX}user-rev-1`);
+    expect(ttl).toBe(getMcpJwtExpiresInSeconds());
+    expect(Number(value)).toBe(stored);
+  });
+
+  it("getMcpRevocationTimestamp returns null when no entry exists", async () => {
+    const redis = createMockRedis();
+    const ts = await getMcpRevocationTimestamp(
+      redis as unknown as import("ioredis").Redis,
+      "user-absent",
+    );
+    expect(ts).toBeNull();
+  });
+
+  it("getMcpRevocationTimestamp returns null when stored value is not numeric", async () => {
+    const redis = createMockRedis();
+    await redis.setex(`${MCP_REVOKED_PREFIX}user-garbage`, 60, "not-a-number");
+    const ts = await getMcpRevocationTimestamp(
+      redis as unknown as import("ioredis").Redis,
+      "user-garbage",
+    );
+    expect(ts).toBeNull();
+  });
+
+  it("getMcpRevocationTimestamp returns the stored epoch value", async () => {
+    const redis = createMockRedis();
+    await redis.setex(`${MCP_REVOKED_PREFIX}user-set`, 60, "1700000000");
+    const ts = await getMcpRevocationTimestamp(
+      redis as unknown as import("ioredis").Redis,
+      "user-set",
+    );
+    expect(ts).toBe(1700000000);
+  });
+});
+
+describe("verifyMcpToken deny-list round-trip", () => {
+  it("rejects a token whose iat is earlier than the stored revocation timestamp", async () => {
+    // Issue a token, then simulate a revoke that happens 30s later by writing
+    // `mcp:revoked:<sub>` = iat + 30 directly (avoids fake-timer interplay with jose).
+    // 30 秒後の失効を模擬するため、iat+30 を Redis に直書きして round-trip を再現する。
+    const redis = createMockRedis();
+    const { access_token } = await issueMcpToken("user-revoked", [MCP_SCOPE_READ, MCP_SCOPE_WRITE]);
+    const [, payloadB64] = access_token.split(".");
+    if (!payloadB64) throw new Error("jwt has no payload segment");
+    const iat = (
+      JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8")) as { iat: number }
+    ).iat;
+    await redis.setex(`${MCP_REVOKED_PREFIX}user-revoked`, 60, String(iat + 30));
+
+    const payload = await verifyMcpToken(access_token, redis as unknown as import("ioredis").Redis);
+    expect(payload).toBeNull();
+  });
+
+  it("accepts a token whose iat is at or after the stored revocation timestamp", async () => {
+    // revokedAt <= iat must still pass: the token was issued after (or exactly at) the revoke.
+    // revokedAt <= iat のトークンは、失効後に発行されたとみなして許可する。
+    const redis = createMockRedis();
+    const { access_token } = await issueMcpToken("user-fresh-after-revoke", [MCP_SCOPE_READ]);
+    const [, payloadB64] = access_token.split(".");
+    if (!payloadB64) throw new Error("jwt has no payload segment");
+    const iat = (
+      JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8")) as { iat: number }
+    ).iat;
+    await redis.setex(`${MCP_REVOKED_PREFIX}user-fresh-after-revoke`, 60, String(iat));
+
+    const payload = await verifyMcpToken(access_token, redis as unknown as import("ioredis").Redis);
+    expect(payload).not.toBeNull();
+    expect(payload?.sub).toBe("user-fresh-after-revoke");
+  });
+
+  it("passes through verification when no revocation entry exists", async () => {
+    const redis = createMockRedis();
+    const { access_token } = await issueMcpToken("user-untouched", [MCP_SCOPE_READ]);
+    const payload = await verifyMcpToken(access_token, redis as unknown as import("ioredis").Redis);
+    expect(payload).not.toBeNull();
+    expect(payload?.sub).toBe("user-untouched");
+  });
+
+  it("ignores the deny-list when redis is not supplied (backwards-compatible)", async () => {
+    const redis = createMockRedis();
+    const { access_token } = await issueMcpToken("user-no-redis", [MCP_SCOPE_READ]);
+    const [, payloadB64] = access_token.split(".");
+    if (!payloadB64) throw new Error("jwt has no payload segment");
+    const iat = (
+      JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8")) as { iat: number }
+    ).iat;
+    await redis.setex(`${MCP_REVOKED_PREFIX}user-no-redis`, 60, String(iat + 60));
+
+    // Without redis, verification must not consult the deny-list.
+    // redis を渡さない場合は deny-list を参照しないこと。
+    const payload = await verifyMcpToken(access_token);
+    expect(payload).not.toBeNull();
+    expect(payload?.sub).toBe("user-no-redis");
+  });
+
+  it("end-to-end: issueMcpToken → storeMcpRevocation → verifyMcpToken returns null", async () => {
+    // Freeze time so iat == now, advance past revoke boundary, then revoke via the real helper.
+    // 時刻を固定して iat を決定後、時計を進めてから storeMcpRevocation を呼び round-trip を確認する。
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-04-01T00:00:00Z"));
+      const { access_token } = await issueMcpToken("user-e2e", [MCP_SCOPE_READ, MCP_SCOPE_WRITE]);
+
+      vi.setSystemTime(new Date("2026-04-01T00:00:30Z"));
+      const redis = createMockRedis();
+      await storeMcpRevocation(redis as unknown as import("ioredis").Redis, "user-e2e");
+
+      const payload = await verifyMcpToken(
+        access_token,
+        redis as unknown as import("ioredis").Redis,
+      );
+      expect(payload).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/server/api/src/__tests__/middleware/mcpAuth.test.ts
+++ b/server/api/src/__tests__/middleware/mcpAuth.test.ts
@@ -16,7 +16,12 @@ vi.mock("../../lib/mcpAuth.js", async (importOriginal) => {
 });
 
 import { mcpReadRequired, mcpWriteRequired } from "../../middleware/mcpAuth.js";
-import { MCP_JWT_AUDIENCE, MCP_SCOPE_READ, MCP_SCOPE_WRITE } from "../../lib/mcpAuth.js";
+import {
+  MCP_JWT_AUDIENCE,
+  MCP_SCOPE_READ,
+  MCP_SCOPE_WRITE,
+  McpRevocationLookupError,
+} from "../../lib/mcpAuth.js";
 
 type MockStatusRow = { status: "active" | "suspended" | "deleted" };
 
@@ -216,5 +221,21 @@ describe("redis deny-list wiring", () => {
     });
     expect(res.status).toBe(200);
     expect(mockVerifyMcpToken).toHaveBeenCalledWith("t", redisSentinel);
+  });
+
+  it("returns 503 (not 401) when the deny-list lookup itself fails", async () => {
+    // If Redis is unreachable, verifyMcpToken throws McpRevocationLookupError.
+    // The middleware must surface this as 503 so legitimate tokens are not
+    // misclassified as invalid during an infrastructure outage.
+    // Redis 障害時は 401 ではなく 503 を返し、正規トークンを誤認しないことを確認する。
+    mockVerifyMcpToken.mockRejectedValue(
+      new McpRevocationLookupError("redis offline", { cause: new Error("ECONNREFUSED") }),
+    );
+    const res = await createApp([{ status: "active" }]).request("/read", {
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(res.status).toBe(503);
+    const text = await res.text();
+    expect(text).toMatch(/deny-list unavailable/i);
   });
 });

--- a/server/api/src/__tests__/middleware/mcpAuth.test.ts
+++ b/server/api/src/__tests__/middleware/mcpAuth.test.ts
@@ -32,10 +32,14 @@ function createMockDb(statusRows: MockStatusRow[]) {
   } as unknown as AppEnv["Variables"]["db"];
 }
 
-function createApp(statusRows: MockStatusRow[] = [{ status: "active" }]) {
+function createApp(
+  statusRows: MockStatusRow[] = [{ status: "active" }],
+  redis?: AppEnv["Variables"]["redis"],
+) {
   const app = new Hono<AppEnv>();
   app.use("*", async (c, next) => {
     c.set("db", createMockDb(statusRows));
+    if (redis) c.set("redis", redis);
     await next();
   });
   app.get("/read", mcpReadRequired, (c) => c.json({ ok: true, userId: c.get("userId") }));
@@ -195,5 +199,22 @@ describe("mcpWriteRequired", () => {
       headers: { Authorization: "Bearer t" },
     });
     expect(res.status).toBe(401);
+  });
+});
+
+describe("redis deny-list wiring", () => {
+  it("passes redis from context to verifyMcpToken so the deny-list is consulted", async () => {
+    mockVerifyMcpToken.mockResolvedValue({
+      sub: "user-rev",
+      scope: [MCP_SCOPE_READ],
+      aud: MCP_JWT_AUDIENCE,
+      exp: 0,
+    });
+    const redisSentinel = { tag: "redis-sentinel" } as unknown as AppEnv["Variables"]["redis"];
+    const res = await createApp([{ status: "active" }], redisSentinel).request("/read", {
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(res.status).toBe(200);
+    expect(mockVerifyMcpToken).toHaveBeenCalledWith("t", redisSentinel);
   });
 });

--- a/server/api/src/__tests__/routes/mcp.test.ts
+++ b/server/api/src/__tests__/routes/mcp.test.ts
@@ -418,3 +418,34 @@ describe("POST /api/mcp/revoke", () => {
     expect(mockStoreMcpRevocation).toHaveBeenCalledWith(mockRedis, "user-revoke-42");
   });
 });
+
+describe("POST /api/mcp/revoke-session", () => {
+  it("returns 401 when no Better Auth session is present", async () => {
+    // デバイス紛失等のユーザー操作用エンドポイント。セッションなしは 401。
+    // Session-protected endpoint for UI-driven revocation; no session → 401.
+    vi.mocked(auth.api.getSession).mockResolvedValue(null);
+    const res = await createMcpApp(mockRedis, mockDb).request("/api/mcp/revoke-session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(401);
+    expect(mockStoreMcpRevocation).not.toHaveBeenCalled();
+  });
+
+  it("records the revocation in Redis when called with a valid user session", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      user: { ...mockSessionUser, id: "user-session-7" },
+    } as AuthSession);
+    const res = await createMcpApp(mockRedis, mockDb).request("/api/mcp/revoke-session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { revoked?: boolean };
+    expect(body.revoked).toBe(true);
+    expect(mockStoreMcpRevocation).toHaveBeenCalledOnce();
+    expect(mockStoreMcpRevocation).toHaveBeenCalledWith(mockRedis, "user-session-7");
+  });
+});

--- a/server/api/src/__tests__/routes/mcp.test.ts
+++ b/server/api/src/__tests__/routes/mcp.test.ts
@@ -61,6 +61,7 @@ const mockVerifyPKCE = vi.fn();
 const mockIsMcpRedirectUriAllowed = vi.fn();
 const mockIssueMcpToken = vi.fn();
 const mockStoreMcpCode = vi.fn();
+const mockStoreMcpRevocation = vi.fn();
 vi.mock("../../lib/mcpAuth.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../lib/mcpAuth.js")>();
   return {
@@ -70,6 +71,7 @@ vi.mock("../../lib/mcpAuth.js", async (importOriginal) => {
     isMcpRedirectUriAllowed: (...args: unknown[]) => mockIsMcpRedirectUriAllowed(...args),
     issueMcpToken: (...args: unknown[]) => mockIssueMcpToken(...args),
     storeMcpCode: (...args: unknown[]) => mockStoreMcpCode(...args),
+    storeMcpRevocation: (...args: unknown[]) => mockStoreMcpRevocation(...args),
   };
 });
 
@@ -123,7 +125,9 @@ beforeEach(() => {
   mockIsMcpRedirectUriAllowed.mockReset();
   mockIssueMcpToken.mockReset();
   mockStoreMcpCode.mockReset();
+  mockStoreMcpRevocation.mockReset();
   mockStoreMcpCode.mockResolvedValue(undefined);
+  mockStoreMcpRevocation.mockResolvedValue(1_700_000_000);
   mockIssueMcpToken.mockResolvedValue({
     access_token: "mock-mcp-jwt",
     expires_in: 30 * 24 * 3600,
@@ -394,16 +398,23 @@ describe("POST /api/mcp/revoke", () => {
       body: JSON.stringify({}),
     });
     expect(res.status).toBe(401);
+    expect(mockStoreMcpRevocation).not.toHaveBeenCalled();
   });
 
-  it("returns 200 ok when revoke is accepted (best-effort)", async () => {
+  it("records the revocation in Redis and returns 200", async () => {
     const res = await createMcpApp(mockRedis, mockDb).request("/api/mcp/revoke", {
       method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: "Bearer t" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer t",
+        "x-test-mcp-user-id": "user-revoke-42",
+      },
       body: JSON.stringify({}),
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { revoked?: boolean };
     expect(body.revoked).toBe(true);
+    expect(mockStoreMcpRevocation).toHaveBeenCalledOnce();
+    expect(mockStoreMcpRevocation).toHaveBeenCalledWith(mockRedis, "user-revoke-42");
   });
 });

--- a/server/api/src/lib/mcpAuth.ts
+++ b/server/api/src/lib/mcpAuth.ts
@@ -36,6 +36,12 @@ export const MCP_SCOPE_WRITE = "mcp:write";
 /** Redis key prefix (extAuth の `ext:code:` と分離) / Redis namespace distinct from ext codes. */
 const REDIS_CODE_PREFIX = "mcp:code:";
 
+/**
+ * Redis key prefix for per-user MCP token revocation timestamps.
+ * ユーザー単位の MCP トークン失効時刻を保存する Redis キー prefix。
+ */
+export const MCP_REVOKED_PREFIX = "mcp:revoked:";
+
 // ── PKCE ────────────────────────────────────────────────────────────────────
 
 /** base64url encode (no padding). */
@@ -174,6 +180,17 @@ export interface McpTokenPayload {
 }
 
 /**
+ * MCP JWT の有効期限 (秒) を環境変数から算出する。不正・未設定時はデフォルトにフォールバック。
+ * Returns MCP JWT expiration (seconds) from env, falling back to default for invalid/missing values.
+ */
+export function getMcpJwtExpiresInSeconds(): number {
+  const expDays = Number(getOptionalEnv("MCP_JWT_EXP_DAYS", String(MCP_JWT_EXP_DAYS_DEFAULT)));
+  const effectiveDays =
+    Number.isFinite(expDays) && expDays > 0 ? expDays : MCP_JWT_EXP_DAYS_DEFAULT;
+  return effectiveDays * 24 * 60 * 60;
+}
+
+/**
  * MCP 用 JWT を発行する。
  * Issues JWT for MCP server with requested scopes.
  *
@@ -187,9 +204,7 @@ export async function issueMcpToken(
 ): Promise<{ access_token: string; expires_in: number }> {
   const secret = getEnv("BETTER_AUTH_SECRET");
   const key = new TextEncoder().encode(secret);
-  const expDays = Number(getOptionalEnv("MCP_JWT_EXP_DAYS", String(MCP_JWT_EXP_DAYS_DEFAULT)));
-  const expiresIn =
-    (Number.isFinite(expDays) && expDays > 0 ? expDays : MCP_JWT_EXP_DAYS_DEFAULT) * 24 * 60 * 60;
+  const expiresIn = getMcpJwtExpiresInSeconds();
   const exp = Math.floor(Date.now() / 1000) + expiresIn;
 
   const jwt = await new SignJWT({ scope: scopes })
@@ -204,10 +219,44 @@ export async function issueMcpToken(
 }
 
 /**
- * Bearer トークンを検証し、ペイロードを返す。audience と最低 1 つの MCP スコープを要求する。
- * Verifies MCP Bearer token and returns payload; requires `zedi-mcp` audience and at least one mcp:* scope.
+ * 指定ユーザーの MCP トークンをすべて失効させるために、現在時刻 (UNIX 秒) を Redis に書き込む。
+ * TTL は最長の JWT 有効期限に合わせて自動消滅する。戻り値は記録した失効時刻 (UNIX 秒)。
+ *
+ * Records a per-user MCP revocation timestamp (epoch seconds) in Redis.
+ * TTL matches the longest possible JWT lifetime so the entry self-expires once no prior token can still be valid.
+ * Returns the stored revocation timestamp in epoch seconds.
  */
-export async function verifyMcpToken(token: string): Promise<McpTokenPayload | null> {
+export async function storeMcpRevocation(redis: Redis, userId: string): Promise<number> {
+  const now = Math.floor(Date.now() / 1000);
+  await redis.setex(`${MCP_REVOKED_PREFIX}${userId}`, getMcpJwtExpiresInSeconds(), String(now));
+  return now;
+}
+
+/**
+ * 指定ユーザーの MCP トークン失効時刻 (UNIX 秒) を取得する。未登録または不正値なら null。
+ * Returns the stored MCP revocation timestamp (epoch seconds) for a user, or null if none / malformed.
+ */
+export async function getMcpRevocationTimestamp(
+  redis: Redis,
+  userId: string,
+): Promise<number | null> {
+  const raw = await redis.get(`${MCP_REVOKED_PREFIX}${userId}`);
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Bearer トークンを検証し、ペイロードを返す。audience と最低 1 つの MCP スコープを要求する。
+ * `redis` を渡した場合は `mcp:revoked:<sub>` の失効時刻と `iat` を比較し、失効後に発行されたトークンのみ通す。
+ *
+ * Verifies MCP Bearer token and returns payload; requires `zedi-mcp` audience and at least one mcp:* scope.
+ * When `redis` is provided, consults the deny-list: rejects tokens whose `iat` is earlier than the stored revocation timestamp.
+ */
+export async function verifyMcpToken(
+  token: string,
+  redis?: Redis | null,
+): Promise<McpTokenPayload | null> {
   try {
     const secret = getEnv("BETTER_AUTH_SECRET");
     const key = new TextEncoder().encode(secret);
@@ -222,8 +271,16 @@ export async function verifyMcpToken(token: string): Promise<McpTokenPayload | n
     if (!hasAnyMcpScope) return null;
     const aud = payload.aud;
     const exp = payload.exp;
+    const iat = payload.iat;
     if (typeof aud !== "string") return null;
     if (typeof exp !== "number") return null;
+    if (typeof iat !== "number") return null;
+
+    if (redis) {
+      const revokedAt = await getMcpRevocationTimestamp(redis, sub);
+      if (revokedAt !== null && iat < revokedAt) return null;
+    }
+
     return { sub, scope, aud, exp };
   } catch {
     return null;

--- a/server/api/src/lib/mcpAuth.ts
+++ b/server/api/src/lib/mcpAuth.ts
@@ -219,16 +219,32 @@ export async function issueMcpToken(
 }
 
 /**
- * 指定ユーザーの MCP トークンをすべて失効させるために、現在時刻 (UNIX 秒) を Redis に書き込む。
- * TTL は最長の JWT 有効期限に合わせて自動消滅する。戻り値は記録した失効時刻 (UNIX 秒)。
+ * 失効レコードの TTL (秒)。現在の設定値とデフォルト値の大きい方を使う。
+ * `MCP_JWT_EXP_DAYS` を後から短縮しても、旧設定で発行済みの長寿命トークンが
+ * Redis の失効キー消滅後に再び有効化されないよう、デフォルト (最大想定) を下限とする。
  *
- * Records a per-user MCP revocation timestamp (epoch seconds) in Redis.
- * TTL matches the longest possible JWT lifetime so the entry self-expires once no prior token can still be valid.
+ * Returns the TTL (seconds) for revocation entries: the greater of the current
+ * configured JWT lifetime and the default. This prevents a later reduction of
+ * `MCP_JWT_EXP_DAYS` from prematurely expiring the deny-list entry and
+ * re-validating tokens issued under the previous (longer) configuration.
+ */
+export function getMcpRevocationTtlSeconds(): number {
+  return Math.max(getMcpJwtExpiresInSeconds(), MCP_JWT_EXP_DAYS_DEFAULT * 24 * 60 * 60);
+}
+
+/**
+ * 指定ユーザーの MCP トークンをすべて失効させるために、現在時刻 (UNIX 秒) を Redis に書き込む。
+ * TTL は現在設定とデフォルトの大きい方とし、設定変更で失効情報が先に消えるのを防ぐ。
+ * 戻り値は記録した失効時刻 (UNIX 秒)。
+ *
+ * Records a per-user MCP revocation timestamp (epoch seconds) in Redis with a TTL
+ * that is at least as long as the maximum expected JWT lifetime, so the entry
+ * cannot expire before every previously issued token does.
  * Returns the stored revocation timestamp in epoch seconds.
  */
 export async function storeMcpRevocation(redis: Redis, userId: string): Promise<number> {
   const now = Math.floor(Date.now() / 1000);
-  await redis.setex(`${MCP_REVOKED_PREFIX}${userId}`, getMcpJwtExpiresInSeconds(), String(now));
+  await redis.setex(`${MCP_REVOKED_PREFIX}${userId}`, getMcpRevocationTtlSeconds(), String(now));
   return now;
 }
 
@@ -247,16 +263,50 @@ export async function getMcpRevocationTimestamp(
 }
 
 /**
+ * Deny-list 参照で発生した Redis 障害を JWT 検証失敗と区別するためのエラー型。
+ * 呼び出し側 (ミドルウェア) はこれを捕捉し、401 ではなく 503 で応答する。
+ *
+ * Dedicated error type raised when the revocation deny-list lookup itself fails
+ * (e.g. Redis outage). Lets callers map infrastructure errors to 503 instead of
+ * silently returning 401 "invalid token" for legitimately signed tokens.
+ */
+export class McpRevocationLookupError extends Error {
+  /**
+   * 指定メッセージと `cause` で `McpRevocationLookupError` を生成する。
+   * Constructs a new `McpRevocationLookupError` with an optional `cause`.
+   *
+   * @param message - 人間可読なエラーメッセージ / Human-readable message.
+   * @param options - `cause` に元の例外を添付できる / Optional `cause` for the original error.
+   */
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "McpRevocationLookupError";
+  }
+}
+
+/**
  * Bearer トークンを検証し、ペイロードを返す。audience と最低 1 つの MCP スコープを要求する。
  * `redis` を渡した場合は `mcp:revoked:<sub>` の失効時刻と `iat` を比較し、失効後に発行されたトークンのみ通す。
+ * 比較は `iat <= revokedAt` を失効扱いとし、秒精度で同一秒に発行された境界トークンも安全側で拒否する。
+ *
+ * JWT 自体の検証失敗 (署名不一致・audience 相違・形式不正など) は `null` を返す。
+ * 一方、deny-list の Redis 参照に失敗した場合は `McpRevocationLookupError` を投げ、
+ * ミドルウェアで 503 にマップできるようにする (インフラ障害を 401 と誤認させない)。
  *
  * Verifies MCP Bearer token and returns payload; requires `zedi-mcp` audience and at least one mcp:* scope.
- * When `redis` is provided, consults the deny-list: rejects tokens whose `iat` is earlier than the stored revocation timestamp.
+ * When `redis` is provided, consults the deny-list: rejects tokens whose `iat` is at or before the stored
+ * revocation timestamp (inclusive, to cover boundary tokens at second-precision).
+ *
+ * JWT verification failures (bad signature, wrong audience, malformed payload, etc.) return `null`.
+ * Deny-list lookup failures throw `McpRevocationLookupError` so callers can surface a 503 rather than
+ * misclassifying an infrastructure outage as an authentication error.
  */
 export async function verifyMcpToken(
   token: string,
   redis?: Redis | null,
 ): Promise<McpTokenPayload | null> {
+  let verified: McpTokenPayload;
+  let iat: number;
   try {
     const secret = getEnv("BETTER_AUTH_SECRET");
     const key = new TextEncoder().encode(secret);
@@ -271,20 +321,35 @@ export async function verifyMcpToken(
     if (!hasAnyMcpScope) return null;
     const aud = payload.aud;
     const exp = payload.exp;
-    const iat = payload.iat;
+    const maybeIat = payload.iat;
     if (typeof aud !== "string") return null;
     if (typeof exp !== "number") return null;
-    if (typeof iat !== "number") return null;
-
-    if (redis) {
-      const revokedAt = await getMcpRevocationTimestamp(redis, sub);
-      if (revokedAt !== null && iat < revokedAt) return null;
-    }
-
-    return { sub, scope, aud, exp };
+    if (typeof maybeIat !== "number") return null;
+    iat = maybeIat;
+    verified = { sub, scope, aud, exp };
   } catch {
     return null;
   }
+
+  // Deny-list lookup runs outside the JWT try/catch so Redis-side I/O errors
+  // are NOT silently swallowed as "invalid token". The caller must distinguish
+  // an infrastructure outage (→ 503) from an auth failure (→ 401).
+  //
+  // deny-list 参照は JWT 検証とは別の try で扱い、Redis 障害を誤って 401 に
+  // すり替えないようにする。呼び出し側でインフラ障害 (503) と認証失敗 (401) を分離する。
+  if (redis) {
+    let revokedAt: number | null;
+    try {
+      revokedAt = await getMcpRevocationTimestamp(redis, verified.sub);
+    } catch (err) {
+      throw new McpRevocationLookupError("Failed to consult MCP revocation deny-list", {
+        cause: err,
+      });
+    }
+    if (revokedAt !== null && iat <= revokedAt) return null;
+  }
+
+  return verified;
 }
 
 /**

--- a/server/api/src/middleware/mcpAuth.ts
+++ b/server/api/src/middleware/mcpAuth.ts
@@ -14,7 +14,13 @@
 import { eq } from "drizzle-orm";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
-import { verifyMcpToken, MCP_SCOPE_READ, MCP_SCOPE_WRITE, hasScope } from "../lib/mcpAuth.js";
+import {
+  verifyMcpToken,
+  MCP_SCOPE_READ,
+  MCP_SCOPE_WRITE,
+  hasScope,
+  McpRevocationLookupError,
+} from "../lib/mcpAuth.js";
 import { users } from "../schema/users.js";
 import type { AppEnv } from "../types/index.js";
 
@@ -34,7 +40,18 @@ async function extractAndVerify(
     throw new HTTPException(401, { message: "Bearer token required" });
   }
   const token = parts[1];
-  const payload = await verifyMcpToken(token, redis);
+  let payload: Awaited<ReturnType<typeof verifyMcpToken>>;
+  try {
+    payload = await verifyMcpToken(token, redis);
+  } catch (err) {
+    if (err instanceof McpRevocationLookupError) {
+      // Redis 障害時はインフラ問題として 503 を返す。401 に潰すと正規トークンを誤って拒絶する。
+      // Redis outage must surface as 503, not 401, so legitimately signed tokens aren't misclassified.
+      console.error("[mcp] deny-list lookup failed", err);
+      throw new HTTPException(503, { message: "Token deny-list unavailable" });
+    }
+    throw err;
+  }
   if (!payload) {
     throw new HTTPException(401, { message: "Invalid or expired token" });
   }

--- a/server/api/src/middleware/mcpAuth.ts
+++ b/server/api/src/middleware/mcpAuth.ts
@@ -20,15 +20,21 @@ import type { AppEnv } from "../types/index.js";
 
 /**
  * Bearer トークンを検証し、ペイロードを返す。形式不正・検証失敗時は 401 を投げる。
+ * `redis` を渡した場合は deny-list を参照し、失効済みトークンを拒否する。
+ *
  * Verifies the Bearer token from request headers; throws HTTPException 401 on failure.
+ * When `redis` is provided, revoked tokens are rejected via the deny-list.
  */
-async function extractAndVerify(authHeader: string | undefined) {
+async function extractAndVerify(
+  authHeader: string | undefined,
+  redis: AppEnv["Variables"]["redis"] | undefined,
+) {
   const parts = authHeader?.trim().split(/\s+/) ?? [];
   if (parts.length !== 2 || parts[0]?.toLowerCase() !== "bearer" || !parts[1]) {
     throw new HTTPException(401, { message: "Bearer token required" });
   }
   const token = parts[1];
-  const payload = await verifyMcpToken(token);
+  const payload = await verifyMcpToken(token, redis);
   if (!payload) {
     throw new HTTPException(401, { message: "Invalid or expired token" });
   }
@@ -62,7 +68,7 @@ async function ensureActiveMcpUser(db: AppEnv["Variables"]["db"], userId: string
  * Auth middleware for read-only MCP routes; accepts `mcp:read` or `mcp:write` scope.
  */
 export const mcpReadRequired = createMiddleware<AppEnv>(async (c, next) => {
-  const payload = await extractAndVerify(c.req.header("Authorization"));
+  const payload = await extractAndVerify(c.req.header("Authorization"), c.get("redis"));
   if (!hasScope(payload, MCP_SCOPE_READ) && !hasScope(payload, MCP_SCOPE_WRITE)) {
     throw new HTTPException(403, { message: "mcp:read scope required" });
   }
@@ -76,7 +82,7 @@ export const mcpReadRequired = createMiddleware<AppEnv>(async (c, next) => {
  * Auth middleware for write MCP routes; requires `mcp:write` scope.
  */
 export const mcpWriteRequired = createMiddleware<AppEnv>(async (c, next) => {
-  const payload = await extractAndVerify(c.req.header("Authorization"));
+  const payload = await extractAndVerify(c.req.header("Authorization"), c.get("redis"));
   if (!hasScope(payload, MCP_SCOPE_WRITE)) {
     throw new HTTPException(403, { message: "mcp:write scope required" });
   }

--- a/server/api/src/routes/mcp.ts
+++ b/server/api/src/routes/mcp.ts
@@ -3,7 +3,8 @@
  *
  * - POST /authorize-code  Better Auth セッションで認証済みのユーザーがワンタイムコードを発行する
  * - POST /session         ワンタイムコード + PKCE verifier を JWT に交換する
- * - POST /revoke          MCP JWT を失効登録する (best-effort)
+ * - POST /revoke          MCP JWT (bearer) 経由で自分のトークンを失効させる
+ * - POST /revoke-session  ユーザーセッション (authRequired) 経由で自分の MCP トークンを失効させる
  * - POST /clip            MCP 権限で URL をクリップしてページを生成する (clipAndCreate ラッパ)
  *
  * MCP server routes: PKCE-based authorize/session, token revocation, and clip-and-create.
@@ -148,21 +149,43 @@ app.post("/session", async (c) => {
   });
 });
 
-// ── POST /revoke ────────────────────────────────────────────────────────────
-// 呼び出し元ユーザーの MCP JWT を失効させる。Redis に `mcp:revoked:<userId>` として
-// 失効時刻 (UNIX 秒) を TTL=最長 JWT 有効期限で保存し、以降の `verifyMcpToken` は
-// `iat < revokedAt` のトークンを拒否する。現行スコープ粒度では per-user で十分。
-//
-// Per-user MCP token revocation backed by a Redis deny-list. Subsequent `verifyMcpToken`
-// calls reject tokens whose `iat` predates the stored revocation timestamp.
-app.post("/revoke", mcpReadRequired, async (c) => {
-  const redis = c.get("redis");
+/**
+ * 共通: Redis に失効時刻を書き込むヘルパ。MCP bearer / ユーザーセッションの両経路から呼ぶ。
+ * Shared helper that writes a per-user revocation timestamp, used by both
+ * the MCP-bearer and session-protected revoke endpoints.
+ */
+async function recordMcpRevocation(
+  redis: AppEnv["Variables"]["redis"] | undefined,
+  userId: string,
+  source: "mcp" | "session",
+) {
   if (!redis) {
     throw new HTTPException(503, { message: "Redis unavailable" });
   }
-  const userId = c.get("userId");
   const revokedAt = await storeMcpRevocation(redis, userId);
-  console.log(`[mcp] revoke recorded for userId=${userId} revokedAt=${revokedAt}`);
+  console.log(`[mcp] revoke recorded via=${source} userId=${userId} revokedAt=${revokedAt}`);
+}
+
+// ── POST /revoke ────────────────────────────────────────────────────────────
+// 呼び出し元ユーザーの MCP JWT を失効させる。Redis に `mcp:revoked:<userId>` として
+// 失効時刻 (UNIX 秒) を保存し、以降の `verifyMcpToken` は `iat <= revokedAt` のトークンを拒否する。
+// 現行スコープ粒度では per-user で十分。
+//
+// Per-user MCP token revocation backed by a Redis deny-list. Subsequent `verifyMcpToken`
+// calls reject tokens whose `iat` is at or before the stored revocation timestamp.
+app.post("/revoke", mcpReadRequired, async (c) => {
+  await recordMcpRevocation(c.get("redis"), c.get("userId"), "mcp");
+  return c.json({ revoked: true });
+});
+
+// ── POST /revoke-session ────────────────────────────────────────────────────
+// ユーザー (Better Auth セッション) 経由で自分の MCP トークンをすべて失効させる。
+// 端末紛失や MCP トークン不明時のために、ブラウザから利用できる経路を提供する。
+//
+// Session-protected counterpart to POST /revoke. Lets users invalidate all their
+// MCP tokens from the web UI when the MCP token itself is unavailable (e.g. lost device).
+app.post("/revoke-session", authRequired, async (c) => {
+  await recordMcpRevocation(c.get("redis"), c.get("userId"), "session");
   return c.json({ revoked: true });
 });
 

--- a/server/api/src/routes/mcp.ts
+++ b/server/api/src/routes/mcp.ts
@@ -18,6 +18,7 @@ import {
   isMcpRedirectUriAllowed,
   issueMcpToken,
   storeMcpCode,
+  storeMcpRevocation,
   verifyPKCE,
   MCP_SCOPE_READ,
   MCP_SCOPE_WRITE,
@@ -148,15 +149,20 @@ app.post("/session", async (c) => {
 });
 
 // ── POST /revoke ────────────────────────────────────────────────────────────
-// MCP JWT の失効登録 (best-effort)。Stateless JWT のため、Redis にブラックリスト登録する程度の実装。
-// MVP では成功応答のみ返し、将来的にデナイリストを追加する。
+// 呼び出し元ユーザーの MCP JWT を失効させる。Redis に `mcp:revoked:<userId>` として
+// 失効時刻 (UNIX 秒) を TTL=最長 JWT 有効期限で保存し、以降の `verifyMcpToken` は
+// `iat < revokedAt` のトークンを拒否する。現行スコープ粒度では per-user で十分。
 //
-// Best-effort revoke for stateless JWTs (MVP returns success; deny-list to be added).
+// Per-user MCP token revocation backed by a Redis deny-list. Subsequent `verifyMcpToken`
+// calls reject tokens whose `iat` predates the stored revocation timestamp.
 app.post("/revoke", mcpReadRequired, async (c) => {
+  const redis = c.get("redis");
+  if (!redis) {
+    throw new HTTPException(503, { message: "Redis unavailable" });
+  }
   const userId = c.get("userId");
-  // TODO: Persist a per-user revocation timestamp in Redis so verifyMcpToken can check `iat < revokedAt`.
-  // TODO: ユーザー単位の失効時刻を Redis に保存し、検証時に iat と比較してブロックする。
-  console.log(`[mcp] revoke requested for userId=${userId}`);
+  const revokedAt = await storeMcpRevocation(redis, userId);
+  console.log(`[mcp] revoke recorded for userId=${userId} revokedAt=${revokedAt}`);
   return c.json({ revoked: true });
 });
 


### PR DESCRIPTION
## 概要

MCP JWT トークンの失効機能を実装しました。Redis を使用した deny-list 方式で、ユーザー単位のトークン失効時刻を記録し、検証時に `iat < revokedAt` のトークンを拒否します。

## 変更点

- **`mcpAuth.ts`**
  - `getMcpJwtExpiresInSeconds()` 関数を新規追加：JWT 有効期限を秒単位で計算
  - `storeMcpRevocation(redis, userId)` 関数を新規追加：ユーザーの失効時刻を Redis に記録（TTL は最長 JWT 有効期限）
  - `getMcpRevocationTimestamp(redis, userId)` 関数を新規追加：Redis から失効時刻を取得
  - `verifyMcpToken()` に `redis` オプショナルパラメータを追加：deny-list を参照して失効済みトークンを拒否
  - `MCP_REVOKED_PREFIX` 定数を新規追加：Redis キープレフィックス `mcp:revoked:`

- **`middleware/mcpAuth.ts`**
  - `extractAndVerify()` に `redis` パラメータを追加
  - `mcpReadRequired` と `mcpWriteRequired` ミドルウェアで Redis を `verifyMcpToken()` に渡すよう更新

- **`routes/mcp.ts`**
  - `POST /revoke` エンドポイントを実装：`storeMcpRevocation()` を呼び出して失効時刻を記録
  - Redis が利用不可の場合は 503 エラーを返す

- **テスト**
  - `mcpAuth.test.ts` に `storeMcpRevocation` と `getMcpRevocationTimestamp` のユニットテストを追加
  - `verifyMcpToken` の deny-list 動作を検証するテストを追加（失効前後のトークン、Redis なしの後方互換性など）
  - `middleware/mcpAuth.test.ts` に Redis 連携テストを追加
  - `routes/mcp.test.ts` に `/revoke` エンドポイントのテストを追加

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm test` で全テストスイートを実行
2. 特に以下のテストが新規追加されており、deny-list 機能を検証：
   - `storeMcpRevocation / getMcpRevocationTimestamp` テストスイート
   - `verifyMcpToken deny-list round-trip` テストスイート
   - `redis deny-list wiring` テストスイート
   - `POST /api/mcp/revoke` テストスイート

## チェックリスト

- [x] テストがすべてパスする
- [x] 必要に応じてドキュメントを更新した（コメント・ドキュメント文字列を追加）
- [x] 後方互換性を維持（`redis` パラメータはオプショナル）

## 実装の詳細

- **失効時刻の記録**：`storeMcpRevocation()` は現在の UNIX 秒を Redis に記録し、TTL を最長 JWT 有効期限に設定することで、古い失効エントリは自動削除される
- **トークン検証**：`verifyMcpToken()` は Redis が提

https://claude.ai/code/session_01X9S1oJQaEMCH4aBk2Zmn6J
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
