### PR TITLE
fix: prevent Infinity baseline in AI models cost calculation (#609)

### DIFF
--- a/server/api/scripts/inspect-ai-models-cost.lib.ts
+++ b/server/api/scripts/inspect-ai-models-cost.lib.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure helpers for scripts/inspect-ai-models-cost.ts.
+ *
+ * The script itself is a thin driver (DB access + formatting). Pure calculation
+ * logic lives here so it can be unit-tested without spinning up a DB client.
+ *
+ * scripts/inspect-ai-models-cost.ts 用の純粋関数ヘルパー。
+ * スクリプト本体は DB アクセスと表示を担当し、計算ロジックだけを
+ * 切り出すことで DB を起動せずに単体テストできるようにする。
+ */
+
+/**
+ * Calculate the multiplier baseline (= minimum positive `input_cost_units`).
+ *
+ * Returns `1` as a safe fallback when:
+ *   - the input is empty,
+ *   - every value is `<= 0` (so `filter((v) => v > 0)` yields `[]` and
+ *     `Math.min(...[])` returns `Infinity`, which previously poisoned all
+ *     downstream multipliers), or
+ *   - the computed minimum is not a finite positive number for any reason.
+ *
+ * マルチプライヤ表示用のベースライン（= 最小の正の `input_cost_units`）を計算する。
+ * 入力が空、すべて `<= 0`、または最小値が有限正数でない場合は
+ * 安全なフォールバック値として `1` を返し、以降の倍率計算が 0 や
+ * Infinity になるのを防ぐ (#609)。
+ *
+ * @param inputCostUnits - `ai_models.input_cost_units` values to inspect.
+ * @returns Minimum positive value, or `1` when no valid minimum exists.
+ */
+export function calculateBaseline(inputCostUnits: readonly number[]): number {
+  const positives = inputCostUnits.filter((v) => v > 0);
+  if (positives.length === 0) return 1;
+  const minInput = Math.min(...positives);
+  return Number.isFinite(minInput) && minInput > 0 ? minInput : 1;
+}

--- a/server/api/scripts/inspect-ai-models-cost.lib.ts
+++ b/server/api/scripts/inspect-ai-models-cost.lib.ts
@@ -14,22 +14,26 @@
  *
  * Returns `1` as a safe fallback when:
  *   - the input is empty,
- *   - every value is `<= 0` (so `filter((v) => v > 0)` yields `[]` and
- *     `Math.min(...[])` returns `Infinity`, which previously poisoned all
- *     downstream multipliers), or
+ *   - every value is `<= 0` (so there is no positive minimum to find), or
  *   - the computed minimum is not a finite positive number for any reason.
+ *
+ * Implemented as a single-pass `reduce` to avoid both the `Math.min(...[])
+ * === Infinity` edge case that motivated #609 and the `RangeError` risk of
+ * spreading a very large array into `Math.min`.
  *
  * マルチプライヤ表示用のベースライン（= 最小の正の `input_cost_units`）を計算する。
  * 入力が空、すべて `<= 0`、または最小値が有限正数でない場合は
  * 安全なフォールバック値として `1` を返し、以降の倍率計算が 0 や
- * Infinity になるのを防ぐ (#609)。
+ * Infinity になるのを防ぐ (#609)。`reduce` の 1 パスで求めることで、
+ * 巨大配列を `Math.min(...arr)` にスプレッドした際の `RangeError` も回避する。
  *
  * @param inputCostUnits - `ai_models.input_cost_units` values to inspect.
  * @returns Minimum positive value, or `1` when no valid minimum exists.
  */
 export function calculateBaseline(inputCostUnits: readonly number[]): number {
-  const positives = inputCostUnits.filter((v) => v > 0);
-  if (positives.length === 0) return 1;
-  const minInput = Math.min(...positives);
-  return Number.isFinite(minInput) && minInput > 0 ? minInput : 1;
+  const minInput = inputCostUnits.reduce(
+    (min, v) => (v > 0 && v < min ? v : min),
+    Number.POSITIVE_INFINITY,
+  );
+  return Number.isFinite(minInput) ? minInput : 1;
 }

--- a/server/api/scripts/inspect-ai-models-cost.test.ts
+++ b/server/api/scripts/inspect-ai-models-cost.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for `calculateBaseline` (scripts/inspect-ai-models-cost.lib.ts).
+ *
+ * Covers the regression from issue #609 where `Math.min(...[])` evaluates to
+ * `Infinity` and poisons every downstream multiplier with `0`.
+ *
+ * scripts/inspect-ai-models-cost.lib.ts の `calculateBaseline` を対象とした
+ * 単体テスト。`Math.min(...[])` が `Infinity` を返し、後続の倍率計算がすべて
+ * `0` になる #609 のリグレッションを検証する。
+ */
+import { describe, it, expect } from "vitest";
+import { calculateBaseline } from "./inspect-ai-models-cost.lib.js";
+
+describe("calculateBaseline (issue #609)", () => {
+  it("returns 1 when the array is empty (guards Math.min(...[]) === Infinity)", () => {
+    const baseline = calculateBaseline([]);
+    expect(baseline).toBe(1);
+    expect(Number.isFinite(baseline)).toBe(true);
+  });
+
+  it("returns 1 when every value is zero", () => {
+    expect(calculateBaseline([0, 0, 0])).toBe(1);
+  });
+
+  it("returns 1 when every value is non-positive (zero or negative)", () => {
+    // 負値は本来想定外だが、防御的に fallback する。
+    // Negative values are not expected but we still fall back defensively.
+    expect(calculateBaseline([0, -1, -5])).toBe(1);
+  });
+
+  it("returns the minimum positive value when at least one positive exists", () => {
+    expect(calculateBaseline([10, 5, 20])).toBe(5);
+  });
+
+  it("ignores zeros and negatives when picking the minimum positive", () => {
+    expect(calculateBaseline([0, 7, -3, 2, 9])).toBe(2);
+  });
+
+  it("returns 1 when the computed minimum is not finite (defensive)", () => {
+    // すべて非有限値の場合も fallback。Math.min(Infinity) === Infinity のため
+    // `Number.isFinite` チェックで弾く必要がある。
+    // Even if a caller somehow passes non-finite values we must not propagate them.
+    expect(calculateBaseline([Number.POSITIVE_INFINITY])).toBe(1);
+  });
+
+  it("downstream multiplier calculation does not collapse to 0 when input is empty", () => {
+    // Regression guard: 以前は baseline=Infinity になり、倍率が Math.round(x / Infinity) = 0 になっていた。
+    // Previously baseline was Infinity, so `Math.round(x / baseline)` yielded 0 for every row.
+    const baseline = calculateBaseline([]);
+    const sampleInput = 42;
+    const multiplier = Math.round(sampleInput / baseline);
+    expect(multiplier).toBe(42);
+    expect(multiplier).not.toBe(0);
+  });
+});

--- a/server/api/scripts/inspect-ai-models-cost.ts
+++ b/server/api/scripts/inspect-ai-models-cost.ts
@@ -9,6 +9,7 @@ import { resolve } from "path";
 import { eq, asc } from "drizzle-orm";
 import { getDb } from "../src/db/client.js";
 import { aiModels } from "../src/schema/index.js";
+import { calculateBaseline } from "./inspect-ai-models-cost.lib.js";
 
 function loadEnvFromRoot() {
   const root = resolve(process.cwd(), "..", "..");
@@ -55,8 +56,9 @@ async function main() {
   );
   console.log("-".repeat(95));
 
-  const minInput = Math.min(...rows.map((r) => r.inputCostUnits).filter((v) => v > 0));
-  const baseline = minInput > 0 ? minInput : 1;
+  // baseline が Infinity になる問題 (#609) を避けるため、計算は `calculateBaseline` に委譲する。
+  // Delegate to `calculateBaseline` to avoid the `Infinity` baseline edge case (#609).
+  const baseline = calculateBaseline(rows.map((r) => r.inputCostUnits));
 
   for (const r of rows) {
     const mult = r.inputCostUnits > 0 ? Math.round(r.inputCostUnits / baseline) : 1;

--- a/server/api/vitest.config.ts
+++ b/server/api/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}", "scripts/**/*.{test,spec}.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## 概要

AI モデルコスト検査スクリプトで、入力配列が空またはすべて非正値の場合に `Math.min(...[])` が `Infinity` を返し、後続の倍率計算がすべて 0 になる問題を修正しました。

## 変更点

- **`inspect-ai-models-cost.lib.ts`** (新規): 純粋関数 `calculateBaseline` を抽出
  - 最小の正値を計算し、入力が空または有効な正値がない場合は安全なフォールバック値 `1` を返す
  - `Math.min(...[])` の `Infinity` 問題を防御的に処理

- **`inspect-ai-models-cost.ts`**: `calculateBaseline` を使用するよう修正
  - インライン計算を削除し、新しいヘルパー関数に委譲

- **`inspect-ai-models-cost.test.ts`** (新規): 包括的な単体テスト
  - 空配列、すべてゼロ、負値、非有限値などのエッジケースをカバー
  - リグレッション防止: 倍率計算が 0 に崩壊しないことを検証

- **`vitest.config.ts`**: テスト検出範囲を `scripts/` ディレクトリに拡張

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm run test` を実行して新しい単体テストがすべてパスすることを確認
2. スクリプトを実行: `node server/api/scripts/inspect-ai-models-cost.ts`
3. 空のモデルリストまたはすべてゼロコストのモデルでも倍率が正常に計算されることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 関連 Issue (#609) に対応

## 関連 Issue

Closes #609

https://claude.ai/code/session_01E6rWspG4wdKdMunE6RKpbm
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
