### PR TITLE
docs: Add MCP server environment configuration examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,25 @@ POLAR_PRO_YEARLY_PRODUCT_ID=YOUR_POLAR_YEARLY_PRODUCT_ID
 # Create a PAT at https://github.com/settings/tokens with repo scope.
 # GITHUB_PERSONAL_ACCESS_TOKEN=
 
+# Zedi MCP server (server/api, /api/mcp/authorize-code endpoint)
+# MCP 認証フローで受け入れる redirect_uri のカンマ区切り許可リスト。**必須**。
+# 未設定だと /api/mcp/authorize-code はすべての redirect_uri を拒否する。
+# Comma-separated allowlist of redirect URIs for the MCP authorization-code flow. **Required**.
+# When unset, /api/mcp/authorize-code refuses every redirect URI.
+#
+# - Loopback (CLI login flow): ホストの末尾を `:` で終えると任意ポートを許可する
+#   (e.g. `http://127.0.0.1:` matches any port on 127.0.0.1 — needed because the
+#   CLI binds an ephemeral local port for the PKCE callback).
+# - Web flow: full origin を指定する / specify the exact origin, e.g. `https://zedi-note.app`.
+# MCP_REDIRECT_URI_ALLOW=http://127.0.0.1:,https://zedi-note.app
+#
+# MCP JWT の有効期限 (日)。未設定時は 30 日。
+# MCP JWT lifetime in days. Defaults to 30 when unset.
+# MCP_JWT_EXP_DAYS=30
+#
+# NOTE: MCP JWT は `BETTER_AUTH_SECRET` を署名鍵として共有する (audience で分離)。
+# MCP JWTs are signed with `BETTER_AUTH_SECRET` (audience-scoped to `zedi-mcp`).
+
 # Docker Compose (docker-compose.dev.yml)
 # Override defaults for local dev; required in shared/production. Do not commit real secrets.
 # POSTGRES_USER=zedi

--- a/server/mcp/.env.example
+++ b/server/mcp/.env.example
@@ -1,0 +1,26 @@
+# Zedi MCP HTTP server (server/mcp/src/http.ts)
+#
+# `zedi-mcp-http` (Streamable HTTP transport) を Railway などの独立サービスとして
+# デプロイするときに使う環境変数。stdio transport (`zedi-mcp-stdio`) は通常 Claude Code 側の
+# MCP 設定から `ZEDI_API_URL` / `ZEDI_MCP_TOKEN` を受け取るため、このファイルは不要。
+#
+# Environment variables for the HTTP MCP service (`zedi-mcp-http`). This file only applies to
+# the remote HTTP deployment (e.g. Railway); the stdio transport reads `ZEDI_API_URL` /
+# `ZEDI_MCP_TOKEN` from the MCP client config instead.
+
+# バックエンド REST API のベース URL。**必須**。
+# Base URL of the Zedi REST API the HTTP MCP server proxies to. **Required**.
+#
+# Railway の内部ネットワーク経由なら `http://api.railway.internal:3000` など。
+# Production 例: https://api.zedi-note.app
+# Use Railway's private network URL (e.g. `http://api.railway.internal:3000`) in production,
+# or `http://localhost:3000` for local dev.
+ZEDI_API_URL=http://localhost:3000
+
+# HTTP 待ち受けポート。未設定時は 3100。
+# HTTP listen port. Defaults to 3100 when unset.
+# PORT=3100
+
+# HTTP 待ち受けホスト。未設定時は 0.0.0.0 (全インターフェース)。
+# HTTP bind host. Defaults to 0.0.0.0 (all interfaces) when unset.
+# MCP_HOST=0.0.0.0


### PR DESCRIPTION
## 概要

MCP (Model Context Protocol) サーバーの環境変数設定に関するドキュメントを追加します。HTTP トランスポート用の `.env.example` ファイルを新規作成し、メインの `.env.example` に MCP 認証フロー関連の設定項目を追加しました。

## 変更点

- `server/mcp/.env.example` を新規作成し、HTTP MCP サーバー (`zedi-mcp-http`) のデプロイ時に必要な環境変数を文書化
  - `ZEDI_API_URL`: バックエンド REST API のベース URL（必須）
  - `PORT`: HTTP 待ち受けポート（デフォルト: 3100）
  - `MCP_HOST`: HTTP バインドホスト（デフォルト: 0.0.0.0）
  - 日本語と英語の両言語で説明を記載

- `.env.example` に MCP サーバー認証フロー関連の設定項目を追加
  - `MCP_REDIRECT_URI_ALLOW`: MCP 認可コードフローで許可する redirect_uri のカンマ区切りリスト（必須）
    - ループバック（CLI ログインフロー）とウェブフロー両対応の例を記載
  - `MCP_JWT_EXP_DAYS`: MCP JWT の有効期限（デフォルト: 30 日）
  - JWT 署名鍵が `BETTER_AUTH_SECRET` を共有することを注記

## 変更の種類

- [x] 📝 ドキュメント (Documentation)

## テスト方法

N/A（設定ファイルのドキュメント追加のため、テストは不要）

## チェックリスト

- [x] 必要に応じてドキュメントを更新した

https://claude.ai/code/session_014ZohZFmY5V2oWcHzy1gRBT
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
