### PR TITLE
feat: Add GET /api/pages endpoint with pagination and scope filtering

### DIFF
--- a/server/api/src/__tests__/routes/pages.test.ts
+++ b/server/api/src/__tests__/routes/pages.test.ts
@@ -178,6 +178,19 @@ describe("GET /api/pages", () => {
     // Even with out-of-range params, the endpoint clamps to safe defaults and returns 200.
     expect(res.status).toBe(200);
   });
+
+  it("falls back to defaults when limit/offset are non-numeric", async () => {
+    const app = createPagesApp([{ rows: [] }]);
+
+    // `Number("abc")` だと NaN が SQL に渡って失敗するため、`parseInt + || default` でガードしている。
+    // Guards against `NaN` reaching SQL when params can't be parsed as integers.
+    const res = await app.request("/api/pages?limit=abc&offset=xyz", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+  });
 });
 
 describe("PUT /api/pages/:id/content", () => {

--- a/server/api/src/__tests__/routes/pages.test.ts
+++ b/server/api/src/__tests__/routes/pages.test.ts
@@ -92,6 +92,94 @@ describe("GET /api/pages/:id/content", () => {
   });
 });
 
+describe("GET /api/pages", () => {
+  it("returns 200 with paginated own pages by default", async () => {
+    const updatedAt = new Date("2026-01-01T00:00:00Z").toISOString();
+    const { app, chains } = createPagesAppWithChains([
+      {
+        rows: [
+          { id: "page-a", title: "A", content_preview: null, updated_at: updatedAt },
+          { id: "page-b", title: "B", content_preview: "preview", updated_at: updatedAt },
+        ],
+      },
+    ]);
+
+    const res = await app.request("/api/pages?limit=2&offset=0", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { pages: Array<Record<string, unknown>> };
+    expect(body.pages).toHaveLength(2);
+    expect(body.pages[0]).toMatchObject({ id: "page-a", title: "A" });
+    expect(body.pages[1]).toMatchObject({ id: "page-b", title: "B" });
+    // 単一の execute 呼び出しで完結する。
+    // The endpoint resolves with a single execute() call.
+    expect(chains.filter((c) => c.startMethod === "execute")).toHaveLength(1);
+  });
+
+  it("returns 200 with empty array when caller has no pages", async () => {
+    const app = createPagesApp([{ rows: [] }]);
+
+    const res = await app.request("/api/pages", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { pages: unknown[] };
+    expect(body.pages).toEqual([]);
+  });
+
+  it("returns 200 with shared pages when scope=shared", async () => {
+    const updatedAt = new Date("2026-02-01T00:00:00Z").toISOString();
+    const app = createPagesApp([
+      {
+        rows: [
+          {
+            id: "page-shared",
+            title: "Shared",
+            content_preview: null,
+            updated_at: updatedAt,
+          },
+        ],
+      },
+    ]);
+
+    const res = await app.request("/api/pages?scope=shared", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { pages: Array<Record<string, unknown>> };
+    expect(body.pages).toHaveLength(1);
+    expect(body.pages[0]).toMatchObject({ id: "page-shared" });
+  });
+
+  it("returns 401 without auth header", async () => {
+    const app = createPagesApp([{ rows: [] }]);
+
+    const res = await app.request("/api/pages", { method: "GET" });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("clamps limit/offset to safe ranges", async () => {
+    const app = createPagesApp([{ rows: [] }]);
+
+    const res = await app.request("/api/pages?limit=999&offset=-5", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    // 不正な値でも 200 を返し、内部で clamp する。
+    // Even with out-of-range params, the endpoint clamps to safe defaults and returns 200.
+    expect(res.status).toBe(200);
+  });
+});
+
 describe("PUT /api/pages/:id/content", () => {
   it("creates page_contents when expected_version is 0 and no row exists (aligns with GET version 0)", async () => {
     const ydocB64 = Buffer.from("hello").toString("base64");

--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -70,21 +70,30 @@ app.get("/", authRequired, async (c) => {
   const scope = c.req.query("scope") === "shared" ? "shared" : "own";
 
   // アクセス制御だけを変数化して SELECT 文の重複を避ける。
-  // `shared` は大規模データセットでもプランナーが効きやすい EXISTS + JOIN を採用する。
+  // `shared` は `services/pageAccessService.ts` と同じ正規の認可モデルを採用:
+  //   - notes が未削除であること
+  //   - note_members.status = 'accepted' (招待を受諾済み) であること
+  //   - note_members / note_pages が未削除であること
+  // 大規模データセットでもプランナーが効きやすい EXISTS + JOIN を使う。
   // Vary only the access predicate to avoid duplicating the SELECT.
-  // `shared` uses EXISTS + JOIN, which scales better than IN (SELECT ...) on large datasets.
+  // `shared` mirrors the canonical authorization model from `services/pageAccessService.ts`:
+  //   the linked note must be active, the membership must be accepted, and the join rows
+  //   must not be soft-deleted. EXISTS + JOIN keeps the planner happy on large datasets.
   const accessFilter =
     scope === "shared"
       ? sql`(
           p.owner_id = ${userId}
           OR EXISTS (
             SELECT 1 FROM note_pages np
+            JOIN notes n ON n.id = np.note_id
             JOIN note_members nm ON nm.note_id = np.note_id
             JOIN "user" u ON u.email = nm.member_email
             WHERE np.page_id = p.id
               AND u.id = ${userId}
+              AND nm.status = 'accepted'
               AND nm.is_deleted = false
               AND np.is_deleted = false
+              AND n.is_deleted = false
           )
         )`
       : sql`p.owner_id = ${userId}`;

--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -63,41 +63,41 @@ app.get("/", authRequired, async (c) => {
   const userId = c.get("userId");
   const db = c.get("db");
 
-  const limit = Math.min(Math.max(Number(c.req.query("limit") || 20), 1), 100);
-  const offset = Math.max(Number(c.req.query("offset") || 0), 0);
+  // クエリパラメータは整数として明示的にパースする。`Number("abc")` だと NaN が SQL に渡るため。
+  // Parse query params as integers — `Number("abc")` would propagate NaN into SQL.
+  const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "20", 10) || 20, 1), 100);
+  const offset = Math.max(parseInt(c.req.query("offset") ?? "0", 10) || 0, 0);
   const scope = c.req.query("scope") === "shared" ? "shared" : "own";
 
-  const result =
+  // アクセス制御だけを変数化して SELECT 文の重複を避ける。
+  // `shared` は大規模データセットでもプランナーが効きやすい EXISTS + JOIN を採用する。
+  // Vary only the access predicate to avoid duplicating the SELECT.
+  // `shared` uses EXISTS + JOIN, which scales better than IN (SELECT ...) on large datasets.
+  const accessFilter =
     scope === "shared"
-      ? await db.execute(sql`
-          SELECT p.id, p.title, p.content_preview, p.updated_at
-          FROM pages p
-          WHERE p.is_deleted = false
-            AND (
-              p.owner_id = ${userId}
-              OR p.id IN (
-                SELECT np.page_id FROM note_pages np
-                JOIN note_members nm ON nm.note_id = np.note_id
-                WHERE nm.member_email IN (
-                  SELECT email FROM "user" WHERE id = ${userId}
-                )
-                AND nm.is_deleted = false
-                AND np.is_deleted = false
-              )
-            )
-          ORDER BY p.updated_at DESC
-          LIMIT ${limit}
-          OFFSET ${offset}
-        `)
-      : await db.execute(sql`
-          SELECT p.id, p.title, p.content_preview, p.updated_at
-          FROM pages p
-          WHERE p.is_deleted = false
-            AND p.owner_id = ${userId}
-          ORDER BY p.updated_at DESC
-          LIMIT ${limit}
-          OFFSET ${offset}
-        `);
+      ? sql`(
+          p.owner_id = ${userId}
+          OR EXISTS (
+            SELECT 1 FROM note_pages np
+            JOIN note_members nm ON nm.note_id = np.note_id
+            JOIN "user" u ON u.email = nm.member_email
+            WHERE np.page_id = p.id
+              AND u.id = ${userId}
+              AND nm.is_deleted = false
+              AND np.is_deleted = false
+          )
+        )`
+      : sql`p.owner_id = ${userId}`;
+
+  const result = await db.execute(sql`
+    SELECT p.id, p.title, p.content_preview, p.updated_at
+    FROM pages p
+    WHERE p.is_deleted = false
+      AND ${accessFilter}
+    ORDER BY p.updated_at DESC
+    LIMIT ${limit}
+    OFFSET ${offset}
+  `);
 
   return c.json({ pages: result.rows });
 });

--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -1,6 +1,8 @@
 /**
  * /api/pages — ページ CRUD + コンテンツ管理
  *
+ * GET    /api/pages                — 自分 (own) のページ一覧、または共有 (shared) を含めた一覧をページネーション取得
+ *        — List the caller's pages (own, or own + shared via notes) with limit/offset pagination.
  * GET    /api/pages/:id/content — Y.Doc コンテンツ取得（`page_contents` 行が未作成の空ページは 200 + 空 ydoc）
  *        — Retrieve Y.Doc content (200 + empty `ydoc_state` when no `page_contents` row).
  * PUT    /api/pages/:id/content — Y.Doc コンテンツ更新 (楽観的ロック) / Update with optimistic locking
@@ -52,6 +54,53 @@ async function applyPagesMetadataUpdate(
   set.updatedAt = new Date();
   await db.update(pages).set(set).where(eq(pages.id, pageId));
 }
+
+// ── GET /pages ──────────────────────────────────────────────────────────────
+// `scope=shared` の場合、`/api/search` と同じ認可ロジック (own + 受諾済みノートメンバー) を流用する。
+// When `scope=shared`, reuses the same authorization model as `/api/search`
+// (own pages + pages attached to notes the caller is a member of).
+app.get("/", authRequired, async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+
+  const limit = Math.min(Math.max(Number(c.req.query("limit") || 20), 1), 100);
+  const offset = Math.max(Number(c.req.query("offset") || 0), 0);
+  const scope = c.req.query("scope") === "shared" ? "shared" : "own";
+
+  const result =
+    scope === "shared"
+      ? await db.execute(sql`
+          SELECT p.id, p.title, p.content_preview, p.updated_at
+          FROM pages p
+          WHERE p.is_deleted = false
+            AND (
+              p.owner_id = ${userId}
+              OR p.id IN (
+                SELECT np.page_id FROM note_pages np
+                JOIN note_members nm ON nm.note_id = np.note_id
+                WHERE nm.member_email IN (
+                  SELECT email FROM "user" WHERE id = ${userId}
+                )
+                AND nm.is_deleted = false
+                AND np.is_deleted = false
+              )
+            )
+          ORDER BY p.updated_at DESC
+          LIMIT ${limit}
+          OFFSET ${offset}
+        `)
+      : await db.execute(sql`
+          SELECT p.id, p.title, p.content_preview, p.updated_at
+          FROM pages p
+          WHERE p.is_deleted = false
+            AND p.owner_id = ${userId}
+          ORDER BY p.updated_at DESC
+          LIMIT ${limit}
+          OFFSET ${offset}
+        `);
+
+  return c.json({ pages: result.rows });
+});
 
 // ── GET /pages/:id/content ──────────────────────────────────────────────────
 app.get("/:id/content", authRequired, async (c) => {

--- a/server/mcp/src/__tests__/client/httpClient.test.ts
+++ b/server/mcp/src/__tests__/client/httpClient.test.ts
@@ -59,6 +59,38 @@ describe("HttpZediClient request shaping", () => {
     expect(headers.get("Authorization")).toBe(`Bearer ${TOKEN}`);
   });
 
+  it("listPages GETs /api/pages with limit/offset/scope and unwraps pages array", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse(200, {
+        pages: [
+          {
+            id: "p1",
+            title: "Hello",
+            content_preview: null,
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      }),
+    );
+    const list = await client.listPages({ limit: 10, offset: 5, scope: "shared" });
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe("p1");
+    const url = callArgs(fetchMock as unknown as Mock)[0] as string;
+    expect(url).toContain(`${BASE}/api/pages?`);
+    expect(url).toContain("limit=10");
+    expect(url).toContain("offset=5");
+    expect(url).toContain("scope=shared");
+  });
+
+  it("listPages defaults to own scope and limit=20/offset=0", async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, { pages: [] }));
+    await client.listPages();
+    const url = callArgs(fetchMock as unknown as Mock)[0] as string;
+    expect(url).toContain("limit=20");
+    expect(url).toContain("offset=0");
+    expect(url).toContain("scope=own");
+  });
+
   it("createPage sends POST with JSON body to /api/pages", async () => {
     const expected = {
       id: "p1",

--- a/server/mcp/src/__tests__/server.test.ts
+++ b/server/mcp/src/__tests__/server.test.ts
@@ -19,6 +19,7 @@ import { ZediApiError } from "../client/errors.js";
 function createMockClient(): ZediClient {
   return {
     getCurrentUser: vi.fn(),
+    listPages: vi.fn(),
     getPageContent: vi.fn(),
     createPage: vi.fn(),
     updatePageContent: vi.fn(),
@@ -79,6 +80,30 @@ describe("createMcpServer", () => {
     expect(content[0]?.type).toBe("text");
     const parsed = JSON.parse(content[0]?.text ?? "");
     expect(parsed.id).toBe("user-1");
+  });
+
+  it("zedi_list_pages forwards limit/offset/scope to client.listPages", async () => {
+    vi.mocked(mockClient.listPages).mockResolvedValue([
+      {
+        id: "p1",
+        title: "Hello",
+        content_preview: null,
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ]);
+    const result = await mcpClient.callTool({
+      name: "zedi_list_pages",
+      arguments: { limit: 5, offset: 0, scope: "shared" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockClient.listPages).toHaveBeenCalledWith({
+      limit: 5,
+      offset: 0,
+      scope: "shared",
+    });
+    const content = result.content as Array<{ type: string; text?: string }>;
+    const parsed = JSON.parse(content[0]?.text ?? "");
+    expect(parsed[0].id).toBe("p1");
   });
 
   it("zedi_create_page forwards arguments to client.createPage", async () => {

--- a/server/mcp/src/client/ZediClient.ts
+++ b/server/mcp/src/client/ZediClient.ts
@@ -43,6 +43,25 @@ export interface PageRow {
   is_deleted: boolean;
 }
 
+/** ページ一覧アイテム / Page list item returned by `GET /api/pages`. */
+export interface PageListItem {
+  id: string;
+  title: string | null;
+  content_preview: string | null;
+  updated_at: string;
+}
+
+/** `listPages` の入力 / Input for {@link ZediClient.listPages}. */
+export interface ListPagesParams {
+  /** 上限件数 (1-100, デフォルト 20) / Page size (1-100, default 20). */
+  limit?: number;
+  /** 取得開始位置 (>= 0, デフォルト 0) / Result offset (>= 0, default 0). */
+  offset?: number;
+  /** スコープ。"own" は自分のページのみ、"shared" は共有ノート経由で参加しているページも含む。
+   *  Scope: "own" lists only own pages; "shared" also includes pages from notes the caller is a member of. */
+  scope?: "own" | "shared";
+}
+
 /** ページ本文 (Y.Doc) / Page Y.Doc content. */
 export interface PageContent {
   ydoc_state: string;
@@ -157,6 +176,11 @@ export interface ZediClient {
   getCurrentUser(): Promise<CurrentUser>;
 
   // Pages
+  /**
+   * 自分のページ (own) または共有を含むページ (shared) を更新日時降順で一覧する。
+   * List the caller's pages — own only or own + shared via notes — ordered by `updated_at DESC`.
+   */
+  listPages(params?: ListPagesParams): Promise<PageListItem[]>;
   /** ページ本文 (Y.Doc) を取得する。Get page Y.Doc content. */
   getPageContent(pageId: string): Promise<PageContent>;
   /** 新規ページを作成する。Create a new page. */

--- a/server/mcp/src/client/httpClient.ts
+++ b/server/mcp/src/client/httpClient.ts
@@ -15,6 +15,8 @@ import type {
   CreatePageInput,
   PageRow,
   PageContent,
+  PageListItem,
+  ListPagesParams,
   UpdatePageContentInput,
   CreateNoteInput,
   UpdateNoteInput,
@@ -131,6 +133,17 @@ export class HttpZediClient implements ZediClient {
   }
 
   // ── Pages ────────────────────────────────────────────────────────────────
+
+  /** {@inheritDoc ZediClient.listPages} */
+  async listPages(params: ListPagesParams = {}): Promise<PageListItem[]> {
+    const { limit = 20, offset = 0, scope = "own" } = params;
+    const result = await this.request<{ pages: PageListItem[] }>("GET", "/api/pages", undefined, {
+      limit,
+      offset,
+      scope,
+    });
+    return result.pages ?? [];
+  }
 
   /** {@inheritDoc ZediClient.getPageContent} */
   getPageContent(pageId: string): Promise<PageContent> {

--- a/server/mcp/src/tools/index.ts
+++ b/server/mcp/src/tools/index.ts
@@ -38,6 +38,25 @@ export function registerAllTools(server: McpServer, client: ZediClient): void {
 
   // ── Pages ───────────────────────────────────────────────────────────────
   server.registerTool(
+    "zedi_list_pages",
+    {
+      title: "List pages",
+      description:
+        "Lists the caller's pages, paginated and ordered by `updated_at` DESC. Use `scope: own` for own pages or `shared` to also include pages attached to notes the caller is a member of. Returns `{ id, title, content_preview, updated_at }`.",
+      inputSchema: {
+        limit: z.number().int().min(1).max(100).optional(),
+        offset: z.number().int().min(0).optional(),
+        scope: SearchScopeEnum.optional(),
+      },
+    },
+    async (args) =>
+      wrapToolHandler(async (input) => {
+        const pages = await client.listPages(input);
+        return jsonResult(pages);
+      }, args),
+  );
+
+  server.registerTool(
     "zedi_get_page",
     {
       title: "Get page content",
@@ -358,6 +377,7 @@ export function registerAllTools(server: McpServer, client: ZediClient): void {
 /** Zedi MCP サーバーが公開するツール名一覧 (テスト/UI 用)。 / List of all tool names exposed by the Zedi MCP server. */
 export const ALL_TOOL_NAMES = [
   "zedi_get_current_user",
+  "zedi_list_pages",
   "zedi_get_page",
   "zedi_create_page",
   "zedi_update_page_content",


### PR DESCRIPTION
## 概要

ページ一覧を取得するための新しい API エンドポイント `GET /api/pages` を実装しました。ページネーション（limit/offset）とスコープフィルタリング（own/shared）に対応しており、MCP サーバーのツール `zedi_list_pages` として公開されます。

## 変更点

- **API エンドポイント**: `GET /api/pages` を実装
  - `limit` (1-100, デフォルト 20) と `offset` (デフォルト 0) でページネーション対応
  - `scope` パラメータで "own"（自分のページのみ）または "shared"（共有ノート経由のページも含む）を選択可能
  - 更新日時降順でソート
  - 認証必須（`authRequired` ミドルウェア）

- **HTTP クライアント**: `HttpZediClient.listPages()` メソッドを追加
  - API エンドポイントを呼び出し、ページ一覧を返す

- **MCP ツール**: `zedi_list_pages` ツールを登録
  - limit/offset/scope パラメータを受け取り、ページ一覧を返す

- **型定義**: 
  - `PageListItem` インターフェース（id, title, content_preview, updated_at）
  - `ListPagesParams` インターフェース（limit, offset, scope）

- **テスト**: 
  - API エンドポイントの 5 つのテストケース（ページネーション、空配列、shared スコープ、認証、パラメータ clamping）
  - HTTP クライアントの 2 つのテストケース（パラメータ指定、デフォルト値）
  - MCP サーバーの 1 つのテストケース（パラメータ転送）

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

すべてのテストが自動実行されます：
- `server/api/src/__tests__/routes/pages.test.ts` の新規テストケース 5 つ
- `server/mcp/src/__tests__/client/httpClient.test.ts` の新規テストケース 2 つ
- `server/mcp/src/__tests__/server.test.ts` の新規テストケース 1 つ

## チェックリスト

- [x] テストがすべてパスする
- [x] 必要に応じてドキュメントを更新した（コメント、JSDoc）
- [x] 型安全性を確保した（TypeScript インターフェース）

https://claude.ai/code/session_01EvedohKAL3F3kNNJSyi1He
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
