### PR TITLE
feat: Add per-endpoint rate limiting for MCP routes (#562)

### DIFF
--- a/server/api/src/__tests__/middleware/rateLimit.test.ts
+++ b/server/api/src/__tests__/middleware/rateLimit.test.ts
@@ -14,15 +14,36 @@ import type { Context } from "hono";
 import type { AppEnv } from "../../types/index.js";
 import { rateLimit } from "../../middleware/rateLimit.js";
 
+/**
+ * rateLimit ミドルウェアは `multi().incr(key).expire(key, ttl).exec()` を呼ぶため、
+ * その最低限の形を満たすインメモリ Redis を用意する。
+ * Minimal in-memory stand-in that mimics the subset of ioredis used by the middleware.
+ */
 function createMockRedis(): AppEnv["Variables"]["redis"] {
   const store = new Map<string, number>();
+  const incr = (key: string): number => {
+    const next = (store.get(key) ?? 0) + 1;
+    store.set(key, next);
+    return next;
+  };
   return {
-    incr: vi.fn(async (key: string) => {
-      const next = (store.get(key) ?? 0) + 1;
-      store.set(key, next);
-      return next;
+    multi: vi.fn(() => {
+      const ops: Array<() => unknown> = [];
+      const chain = {
+        incr(key: string) {
+          ops.push(() => incr(key));
+          return chain;
+        },
+        expire(_key: string, _ttl: number) {
+          ops.push(() => 1);
+          return chain;
+        },
+        async exec() {
+          return ops.map((op) => [null, op()]);
+        },
+      };
+      return chain;
     }),
-    expire: vi.fn(async () => 1),
   } as unknown as AppEnv["Variables"]["redis"];
 }
 
@@ -143,6 +164,62 @@ describe("rateLimit middleware", () => {
     const res = await app.request("/test");
     expect(res.status).toBe(200);
     expect(res.headers.get("X-RateLimit-Limit")).toBe("120");
+  });
+
+  it("hourly bucket reports remaining seconds, not a hardcoded 60s", async () => {
+    // 1h ウィンドウでも Retry-After は実時間で算出し、最大 1 時間まで広がる。
+    // Hourly windows should report actual remaining seconds — cap is 3600.
+    const app = appWith(
+      rateLimit({ limit: 1, windowSec: 60 * 60, keyBy: "user", label: "hour" }),
+      (c) => {
+        c.set("redis", redis);
+        c.set("userId", "user-hour");
+      },
+    );
+    expect((await app.request("/test")).status).toBe(200);
+    const limited = await app.request("/test");
+    expect(limited.status).toBe(429);
+    const retryAfter = Number.parseInt(limited.headers.get("Retry-After") ?? "0", 10);
+    expect(retryAfter).toBeGreaterThanOrEqual(1);
+    expect(retryAfter).toBeLessThanOrEqual(3600);
+  });
+
+  it("uses MULTI/EXEC so INCR and EXPIRE are issued atomically", async () => {
+    // MULTI/EXEC による原子性を保証するため、rateLimit は単独の incr / expire を呼ばない。
+    // The middleware should use `multi()` so a crash cannot leave a TTL-less key.
+    const multiSpy = vi.fn();
+    const fakeRedis = {
+      multi: () => {
+        multiSpy();
+        const chain = {
+          incr: () => chain,
+          expire: () => chain,
+          exec: async () => [
+            [null, 1],
+            [null, 1],
+          ],
+        };
+        return chain;
+      },
+      incr: vi.fn(),
+      expire: vi.fn(),
+    } as unknown as AppEnv["Variables"]["redis"];
+
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("redis", fakeRedis);
+      c.set("userId", "user-atomic");
+      await next();
+    });
+    app.get("/test", rateLimit({ limit: 5, windowSec: 60, keyBy: "user", label: "atomic" }), (c) =>
+      c.json({ ok: true }),
+    );
+    const res = await app.request("/test");
+    expect(res.status).toBe(200);
+    expect(multiSpy).toHaveBeenCalled();
+    expect(
+      (fakeRedis as unknown as { incr: ReturnType<typeof vi.fn> }).incr,
+    ).not.toHaveBeenCalled();
   });
 
   it("keyBy: user falls back to IP when no userId is set", async () => {

--- a/server/api/src/__tests__/middleware/rateLimit.test.ts
+++ b/server/api/src/__tests__/middleware/rateLimit.test.ts
@@ -1,0 +1,164 @@
+/**
+ * rateLimit ミドルウェアのユニットテスト
+ *
+ * - 既存互換: `rateLimit("free")` は 1h ウィンドウで tier 既定値を適用する
+ * - 新 API: `rateLimit({ limit, windowSec, keyBy, label })` が意図通り動く
+ * - 429 応答に Retry-After / X-RateLimit-* ヘッダと RATE_LIMIT_EXCEEDED JSON を返す
+ * - keyBy: "ip" は IP ヘッダでキー付けされ、ユーザーごとの干渉がないこと
+ *
+ * Unit tests for the rate limit middleware (#562).
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { Context } from "hono";
+import type { AppEnv } from "../../types/index.js";
+import { rateLimit } from "../../middleware/rateLimit.js";
+
+function createMockRedis(): AppEnv["Variables"]["redis"] {
+  const store = new Map<string, number>();
+  return {
+    incr: vi.fn(async (key: string) => {
+      const next = (store.get(key) ?? 0) + 1;
+      store.set(key, next);
+      return next;
+    }),
+    expire: vi.fn(async () => 1),
+  } as unknown as AppEnv["Variables"]["redis"];
+}
+
+function appWith(middleware: ReturnType<typeof rateLimit>, setup: (c: Context<AppEnv>) => void) {
+  const app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    setup(c);
+    await next();
+  });
+  app.get("/test", middleware, (c) => c.json({ ok: true }));
+  app.post("/test", middleware, (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe("rateLimit middleware", () => {
+  let redis: AppEnv["Variables"]["redis"];
+
+  beforeEach(() => {
+    redis = createMockRedis();
+  });
+
+  it("passes through when no redis is bound (graceful degradation)", async () => {
+    const app = new Hono<AppEnv>();
+    app.get("/test", rateLimit({ limit: 1, windowSec: 60, keyBy: "user", label: "t" }), (c) =>
+      c.json({ ok: true }),
+    );
+    for (let i = 0; i < 3; i++) {
+      const res = await app.request("/test");
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("rejects after the configured limit with 429 and Retry-After", async () => {
+    const app = appWith(rateLimit({ limit: 2, windowSec: 60, keyBy: "user", label: "t" }), (c) => {
+      c.set("redis", redis);
+      c.set("userId", "user-1");
+    });
+
+    const first = await app.request("/test");
+    const second = await app.request("/test");
+    const third = await app.request("/test");
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(third.status).toBe(429);
+    expect(third.headers.get("Retry-After")).toMatch(/^\d+$/);
+    expect(third.headers.get("X-RateLimit-Limit")).toBe("2");
+    expect(third.headers.get("X-RateLimit-Remaining")).toBe("0");
+    const body = (await third.json()) as {
+      error?: string;
+      retry_after?: number;
+      message?: string;
+    };
+    expect(body.error).toBe("RATE_LIMIT_EXCEEDED");
+    expect(body.message).toMatch(/retry in \d+ seconds/i);
+    expect(typeof body.retry_after).toBe("number");
+  });
+
+  it("scopes buckets by label so different endpoints don't share counters", async () => {
+    // 同じユーザーで label が違えば干渉しないこと。
+    // Same user, different labels → independent buckets.
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("redis", redis);
+      c.set("userId", "user-1");
+      await next();
+    });
+    app.get("/a", rateLimit({ limit: 1, windowSec: 60, keyBy: "user", label: "label-a" }), (c) =>
+      c.json({ ok: true }),
+    );
+    app.get("/b", rateLimit({ limit: 1, windowSec: 60, keyBy: "user", label: "label-b" }), (c) =>
+      c.json({ ok: true }),
+    );
+    expect((await app.request("/a")).status).toBe(200);
+    expect((await app.request("/a")).status).toBe(429);
+    // /b のカウンタは独立している。
+    // /b counter is independent.
+    expect((await app.request("/b")).status).toBe(200);
+  });
+
+  it("keyBy: ip uses the forwarded IP header", async () => {
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("redis", redis);
+      await next();
+    });
+    app.get("/test", rateLimit({ limit: 1, windowSec: 60, keyBy: "ip", label: "ipt" }), (c) =>
+      c.json({ ok: true }),
+    );
+
+    const ok = await app.request("/test", {
+      headers: { "x-forwarded-for": "203.0.113.1" },
+    });
+    expect(ok.status).toBe(200);
+
+    const limited = await app.request("/test", {
+      headers: { "x-forwarded-for": "203.0.113.1" },
+    });
+    expect(limited.status).toBe(429);
+
+    // 別 IP は別バケット。
+    // Different IP → different bucket.
+    const other = await app.request("/test", {
+      headers: { "x-forwarded-for": "203.0.113.2" },
+    });
+    expect(other.status).toBe(200);
+  });
+
+  it("legacy tier string form still enforces hourly limits", async () => {
+    // 既存呼び出し (`rateLimit()` や `rateLimit("free")`) は Free=120/h のまま動く必要がある。
+    // Legacy callers must keep the old semantics.
+    const app = appWith(rateLimit(), (c) => {
+      c.set("redis", redis);
+      c.set("userId", "user-legacy");
+    });
+
+    // 1回目で通ること、ヘッダに 120 が入っていること。
+    // First call succeeds and reports the free-tier ceiling.
+    const res = await app.request("/test");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("120");
+  });
+
+  it("keyBy: user falls back to IP when no userId is set", async () => {
+    // 認証前に rateLimit が走る場合でも IP でキーが決まり、空欄で全通しにはならない。
+    // Even before auth, the middleware keys on IP so it isn't a free pass.
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("redis", redis);
+      await next();
+    });
+    app.get("/test", rateLimit({ limit: 1, windowSec: 60, keyBy: "user", label: "ut" }), (c) =>
+      c.json({ ok: true }),
+    );
+    const a = await app.request("/test", { headers: { "x-forwarded-for": "198.51.100.9" } });
+    expect(a.status).toBe(200);
+    const b = await app.request("/test", { headers: { "x-forwarded-for": "198.51.100.9" } });
+    expect(b.status).toBe(429);
+  });
+});

--- a/server/api/src/__tests__/routes/mcp.test.ts
+++ b/server/api/src/__tests__/routes/mcp.test.ts
@@ -115,10 +115,33 @@ async function parseJsonOrText(res: Response): Promise<{ message?: string }> {
   }
 }
 
-const mockRedis = {} as AppEnv["Variables"]["redis"];
+/**
+ * rateLimit ミドルウェアが `incr` / `expire` を呼ぶため、テスト用の最小 Redis を用意する。
+ * In-memory stand-in for the bits of ioredis that the rateLimit middleware exercises.
+ */
+function createMockRedis(): AppEnv["Variables"]["redis"] {
+  const store = new Map<string, number>();
+  return {
+    incr: vi.fn(async (key: string) => {
+      const next = (store.get(key) ?? 0) + 1;
+      store.set(key, next);
+      return next;
+    }),
+    expire: vi.fn(async () => 1),
+    get: vi.fn(async (key: string) => {
+      const v = store.get(key);
+      return v === undefined ? null : String(v);
+    }),
+    set: vi.fn(async () => "OK"),
+    del: vi.fn(async (key: string) => (store.delete(key) ? 1 : 0)),
+  } as unknown as AppEnv["Variables"]["redis"];
+}
+
+let mockRedis = createMockRedis();
 const mockDb = {} as AppEnv["Variables"]["db"];
 
 beforeEach(() => {
+  mockRedis = createMockRedis();
   vi.mocked(auth.api.getSession).mockResolvedValue(null);
   mockConsumeMcpCode.mockReset();
   mockVerifyPKCE.mockReset();
@@ -447,5 +470,136 @@ describe("POST /api/mcp/revoke-session", () => {
     expect(body.revoked).toBe(true);
     expect(mockStoreMcpRevocation).toHaveBeenCalledOnce();
     expect(mockStoreMcpRevocation).toHaveBeenCalledWith(mockRedis, "user-session-7");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rate limiting / レート制限
+//
+// MCP ルートは外部 Claude Code クライアントが叩くため、既定の tier リミットとは別に
+// エンドポイントごとの short-window な制限を掛ける (#562)。
+//
+// /api/mcp/* endpoints enforce per-endpoint short-window limits; exceeding them
+// yields 429 with Retry-After + a RATE_LIMIT_EXCEEDED body that MCP clients can
+// surface to the user.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("rate limiting (#562)", () => {
+  it("POST /api/mcp/clip returns 429 with Retry-After once the per-user limit is exceeded", async () => {
+    const app = createMcpApp(mockRedis, mockDb);
+    // 30/min/user. 30 回まで通して 31 回目で 429。
+    // Limit is 30/min/user; the 31st call in the window must fail.
+    let firstLimited: Response | null = null;
+    for (let i = 0; i < 31; i++) {
+      const res = await app.request("/api/mcp/clip", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer t",
+          "x-test-mcp-user-id": "user-ratelimit-clip",
+        },
+        body: JSON.stringify({ url: "https://example.com/a" }),
+      });
+      if (res.status === 429 && !firstLimited) {
+        firstLimited = res;
+        break;
+      }
+      expect(res.status).toBe(200);
+    }
+    if (!firstLimited) throw new Error("expected a 429 but never hit the limit");
+    expect(firstLimited.headers.get("Retry-After")).toMatch(/^\d+$/);
+    expect(firstLimited.headers.get("X-RateLimit-Limit")).toBe("30");
+    const body = (await firstLimited.json()) as {
+      error?: string;
+      retry_after?: number;
+      message?: string;
+    };
+    expect(body.error).toBe("RATE_LIMIT_EXCEEDED");
+    expect(typeof body.retry_after).toBe("number");
+    expect(body.message).toMatch(/retry in \d+ seconds/i);
+  });
+
+  it("POST /api/mcp/clip keeps separate buckets for different users", async () => {
+    const app = createMcpApp(mockRedis, mockDb);
+    // ユーザー A を上限まで使い切ってもユーザー B は影響を受けない。
+    // Burning user A's bucket must not bleed into user B's.
+    for (let i = 0; i < 30; i++) {
+      const res = await app.request("/api/mcp/clip", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer t",
+          "x-test-mcp-user-id": "user-a",
+        },
+        body: JSON.stringify({ url: "https://example.com/a" }),
+      });
+      expect(res.status).toBe(200);
+    }
+    const res = await app.request("/api/mcp/clip", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer t",
+        "x-test-mcp-user-id": "user-b",
+      },
+      body: JSON.stringify({ url: "https://example.com/a" }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("POST /api/mcp/session returns 429 once the per-IP limit is exceeded", async () => {
+    mockIsMcpRedirectUriAllowed.mockReturnValue(true);
+    mockConsumeMcpCode.mockResolvedValue(null);
+    const app = createMcpApp(mockRedis, mockDb);
+    let firstLimited: Response | null = null;
+    // session は 10/min/IP。認証前ルートなので userId は無く IP でキー付けされる。
+    // /session is unauthenticated so the bucket is keyed by IP (10/min).
+    for (let i = 0; i < 11; i++) {
+      const res = await app.request("/api/mcp/session", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-forwarded-for": "203.0.113.7",
+        },
+        body: JSON.stringify({
+          grant_type: "authorization_code",
+          code: "c",
+          code_verifier: "v",
+          redirect_uri: "http://127.0.0.1:5173/cb",
+        }),
+      });
+      if (res.status === 429) {
+        firstLimited = res;
+        break;
+      }
+    }
+    expect(firstLimited).not.toBeNull();
+    expect(firstLimited?.headers.get("Retry-After")).toMatch(/^\d+$/);
+    expect(firstLimited?.headers.get("X-RateLimit-Limit")).toBe("10");
+  });
+
+  it("POST /api/mcp/authorize-code is rate limited per user", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue({ user: mockSessionUser } as AuthSession);
+    mockIsMcpRedirectUriAllowed.mockReturnValue(true);
+    const app = createMcpApp(mockRedis, mockDb);
+    let firstLimited: Response | null = null;
+    // authorize-code は 20/min/user。
+    // Limit: 20/min/user.
+    for (let i = 0; i < 21; i++) {
+      const res = await app.request("/api/mcp/authorize-code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          redirect_uri: "http://127.0.0.1:5173/cb",
+          code_challenge: "ch",
+        }),
+      });
+      if (res.status === 429) {
+        firstLimited = res;
+        break;
+      }
+      expect(res.status).toBe(200);
+    }
+    expect(firstLimited).not.toBeNull();
+    expect(firstLimited?.headers.get("X-RateLimit-Limit")).toBe("20");
   });
 });

--- a/server/api/src/__tests__/routes/mcp.test.ts
+++ b/server/api/src/__tests__/routes/mcp.test.ts
@@ -121,13 +121,31 @@ async function parseJsonOrText(res: Response): Promise<{ message?: string }> {
  */
 function createMockRedis(): AppEnv["Variables"]["redis"] {
   const store = new Map<string, number>();
+  const incr = (key: string): number => {
+    const next = (store.get(key) ?? 0) + 1;
+    store.set(key, next);
+    return next;
+  };
   return {
-    incr: vi.fn(async (key: string) => {
-      const next = (store.get(key) ?? 0) + 1;
-      store.set(key, next);
-      return next;
+    // rateLimit ミドルウェアが使う MULTI/EXEC を満たす最小のチェインを返す。
+    // Minimal multi() chain: the rateLimit middleware only issues incr + expire.
+    multi: vi.fn(() => {
+      const ops: Array<() => unknown> = [];
+      const chain = {
+        incr(key: string) {
+          ops.push(() => incr(key));
+          return chain;
+        },
+        expire(_key: string, _ttl: number) {
+          ops.push(() => 1);
+          return chain;
+        },
+        async exec() {
+          return ops.map((op) => [null, op()]);
+        },
+      };
+      return chain;
     }),
-    expire: vi.fn(async () => 1),
     get: vi.fn(async (key: string) => {
       const v = store.get(key);
       return v === undefined ? null : String(v);

--- a/server/api/src/middleware/rateLimit.ts
+++ b/server/api/src/middleware/rateLimit.ts
@@ -1,6 +1,21 @@
+/**
+ * rateLimit — Redis ベースのシンプルなレート制限ミドルウェア
+ *
+ * 使い方 / Usage:
+ *   - 既存 API: `rateLimit()` もしくは `rateLimit("pro")`
+ *     → 時間単位 (1h) の tier ごとの上限 (free=120, pro=600) を適用する。
+ *   - 任意構成: `rateLimit({ limit: 30, windowSec: 60, keyBy: "user", label: "mcp:clip" })`
+ *     → MCP のような細かい per-endpoint 制限を掛けたい場合に使う。
+ *
+ * 429 応答には `Retry-After` / `X-RateLimit-*` ヘッダと、
+ * MCP クライアントが解釈できる JSON ボディを返す。
+ *
+ * Simple Redis-based rate limiter. Supports the legacy string-tier call form
+ * and a richer options object for per-endpoint limits (windowSec, keyBy, label).
+ */
+import type { Context } from "hono";
 import type { Redis } from "ioredis";
 import { createMiddleware } from "hono/factory";
-import { HTTPException } from "hono/http-exception";
 import type { AppEnv } from "../types/index.js";
 
 const TIER_LIMITS: Record<string, number> = {
@@ -8,31 +23,136 @@ const TIER_LIMITS: Record<string, number> = {
   pro: 600,
 };
 
-function currentWindow(): string {
-  return new Date().toISOString().slice(0, 13); // per-hour window
+const HOUR_WINDOW_SEC = 3_600;
+
+/**
+ * レート制限のキー戦略 / Key strategy for the rate limit bucket.
+ *
+ * - `user`  : `userId` を優先し、無ければ IP にフォールバック。
+ * - `ip`    : 常に IP を使う。認証前のエンドポイント (例: /api/mcp/session) 向け。
+ * - `userOrIp` : `user` と同義 (別名として公開)。
+ */
+export type RateLimitKeyBy = "user" | "ip" | "userOrIp";
+
+/**
+ * rateLimit の詳細オプション / Options for the rate limit middleware.
+ */
+export interface RateLimitOptions {
+  /** このウィンドウ内に許可する最大リクエスト数。 Max requests allowed per window. */
+  limit: number;
+  /** ウィンドウ長 (秒)。 Window length in seconds. */
+  windowSec: number;
+  /** キーの導出元。省略時は `user`。 Key derivation source; defaults to `user`. */
+  keyBy?: RateLimitKeyBy;
+  /** Redis キーの接頭辞 (エンドポイントの区別に使う)。 Redis key prefix used to scope the bucket per endpoint. */
+  label?: string;
 }
 
-export function rateLimit(tier: string = "free") {
+function isOptions(arg: unknown): arg is RateLimitOptions {
+  return typeof arg === "object" && arg !== null && "limit" in arg && "windowSec" in arg;
+}
+
+function currentHourWindow(): string {
+  // Per-hour window (ISO string truncated to the hour).
+  return new Date().toISOString().slice(0, 13);
+}
+
+function currentWindowBucket(windowSec: number): number {
+  return Math.floor(Date.now() / 1000 / windowSec);
+}
+
+/**
+ * Hono の `c.req.header` からクライアント IP を抽出する。プロキシ背後では
+ * `x-forwarded-for` の先頭、直結時は `x-real-ip` をフォールバックとして使う。
+ * Extracts the best-effort client IP from common proxy headers.
+ */
+function extractClientIp(c: Context<AppEnv>): string | null {
+  const forwarded = c.req.header("x-forwarded-for");
+  if (forwarded) {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const real = c.req.header("x-real-ip");
+  if (real) return real.trim();
+  return null;
+}
+
+/**
+ * レート制限ミドルウェアを生成する。
+ * Returns a Hono middleware that enforces a rate limit backed by Redis.
+ *
+ * @param arg - 既存互換の tier 文字列 (`"free"` / `"pro"`) もしくは {@link RateLimitOptions}.
+ */
+export function rateLimit(arg: string | RateLimitOptions = "free") {
+  const options: Required<RateLimitOptions> = isOptions(arg)
+    ? {
+        limit: arg.limit,
+        windowSec: arg.windowSec,
+        keyBy: arg.keyBy ?? "user",
+        label: arg.label ?? "default",
+      }
+    : {
+        limit: TIER_LIMITS[arg] ?? TIER_LIMITS.free ?? 120,
+        windowSec: HOUR_WINDOW_SEC,
+        keyBy: "user",
+        label: `tier:${arg}`,
+      };
+
   return createMiddleware<AppEnv>(async (c, next) => {
     const redis = c.get("redis") as Redis | undefined;
-    const userId = c.get("userId");
-
-    if (!redis || !userId) {
+    if (!redis) {
       await next();
       return;
     }
 
-    const key = `ratelimit:${userId}:${currentWindow()}`;
-    const count = await redis.incr(key);
-    if (count === 1) await redis.expire(key, 7200);
+    const userId = c.get("userId");
+    const ip = extractClientIp(c);
 
-    const limit = TIER_LIMITS[tier] ?? TIER_LIMITS.free ?? 120;
-    if (count > limit) {
-      throw new HTTPException(429, { message: "RATE_LIMIT_EXCEEDED" });
+    // Resolve the subject we key on. `user` prefers userId and falls back to IP,
+    // `ip` always uses IP. If neither is available we let the request through
+    // (no reliable way to key the bucket).
+    const subject = options.keyBy === "ip" ? ip : (userId ?? ip);
+    if (!subject) {
+      await next();
+      return;
     }
 
-    c.header("X-RateLimit-Limit", String(limit));
-    c.header("X-RateLimit-Remaining", String(Math.max(0, limit - count)));
+    const windowToken =
+      options.windowSec === HOUR_WINDOW_SEC
+        ? currentHourWindow()
+        : String(currentWindowBucket(options.windowSec));
+    const key = `ratelimit:${options.label}:${subject}:${windowToken}`;
+
+    const count = await redis.incr(key);
+    if (count === 1) {
+      // Give the key a small safety margin over the window so counts never
+      // outlive the bucket they belong to.
+      await redis.expire(key, Math.max(options.windowSec * 2, options.windowSec + 60));
+    }
+
+    if (count > options.limit) {
+      // Remaining seconds until the current bucket rolls over.
+      const retryAfter =
+        options.windowSec === HOUR_WINDOW_SEC
+          ? 60
+          : Math.max(1, options.windowSec - (Math.floor(Date.now() / 1000) % options.windowSec));
+      return c.json(
+        {
+          error: "RATE_LIMIT_EXCEEDED",
+          message: `Rate limited, retry in ${retryAfter} seconds`,
+          retry_after: retryAfter,
+        },
+        429,
+        {
+          "Retry-After": String(retryAfter),
+          "X-RateLimit-Limit": String(options.limit),
+          "X-RateLimit-Remaining": "0",
+        },
+      );
+    }
+
+    c.header("X-RateLimit-Limit", String(options.limit));
+    c.header("X-RateLimit-Remaining", String(Math.max(0, options.limit - count)));
     await next();
   });
 }

--- a/server/api/src/middleware/rateLimit.ts
+++ b/server/api/src/middleware/rateLimit.ts
@@ -123,19 +123,26 @@ export function rateLimit(arg: string | RateLimitOptions = "free") {
         : String(currentWindowBucket(options.windowSec));
     const key = `ratelimit:${options.label}:${subject}:${windowToken}`;
 
-    const count = await redis.incr(key);
-    if (count === 1) {
-      // Give the key a small safety margin over the window so counts never
-      // outlive the bucket they belong to.
-      await redis.expire(key, Math.max(options.windowSec * 2, options.windowSec + 60));
-    }
+    // INCR と EXPIRE をトランザクションで発行することで、INCR 後にアプリが落ちても
+    // TTL 無しのキーが残り続けることを防ぐ。ioredis の `multi().exec()` は Redis
+    // の MULTI/EXEC を使うためサーバ側でアトミック。
+    // Wrap INCR + EXPIRE in a MULTI/EXEC transaction so a crash between the two
+    // commands cannot leave a TTL-less key lingering in Redis.
+    const ttl = Math.max(options.windowSec * 2, options.windowSec + 60);
+    const results = await redis.multi().incr(key).expire(key, ttl).exec();
+    const incrResult = results?.[0];
+    const count =
+      Array.isArray(incrResult) && typeof incrResult[1] === "number" ? incrResult[1] : 0;
 
     if (count > options.limit) {
-      // Remaining seconds until the current bucket rolls over.
-      const retryAfter =
-        options.windowSec === HOUR_WINDOW_SEC
-          ? 60
-          : Math.max(1, options.windowSec - (Math.floor(Date.now() / 1000) % options.windowSec));
+      // 現在のウィンドウが終わるまでの残り秒数。1h ウィンドウも実時間で計算する
+      // (固定 60 秒だと legacy tier の呼び出し元でリトライが早すぎた)。
+      // Remaining seconds until the current bucket rolls over — compute from
+      // wall-clock so legacy hourly callers get an accurate Retry-After too.
+      const retryAfter = Math.max(
+        1,
+        options.windowSec - (Math.floor(Date.now() / 1000) % options.windowSec),
+      );
       return c.json(
         {
           error: "RATE_LIMIT_EXCEEDED",

--- a/server/api/src/routes/mcp.ts
+++ b/server/api/src/routes/mcp.ts
@@ -14,6 +14,7 @@ import { HTTPException } from "hono/http-exception";
 import { randomBytes } from "node:crypto";
 import { authRequired } from "../middleware/auth.js";
 import { mcpReadRequired, mcpWriteRequired } from "../middleware/mcpAuth.js";
+import { rateLimit } from "../middleware/rateLimit.js";
 import {
   consumeMcpCode,
   isMcpRedirectUriAllowed,
@@ -30,6 +31,36 @@ import type { AppEnv } from "../types/index.js";
 
 const ALLOWED_SCOPES = new Set([MCP_SCOPE_READ, MCP_SCOPE_WRITE]);
 
+// ── Rate limit policies ─────────────────────────────────────────────────────
+// 意図:
+//  - `/authorize-code` はセッション有りで呼ばれるので per-user。CSRF 防止の観点で
+//    短いウィンドウに抑える。
+//  - `/session` は認証前 (code 交換) のため per-IP。PKCE ブルートフォース対策。
+//  - `/clip` は per-user の書き込み。スクレイピングを抑制するため分単位で制限。
+//
+// Rationale:
+//   authorize-code is called with a Better Auth session (per-user), /session is
+//   unauthenticated (per-IP, PKCE brute-force guard), /clip is the main MCP
+//   write path (per-user, throttle scraping).
+const authorizeCodeRateLimit = rateLimit({
+  limit: 20,
+  windowSec: 60,
+  keyBy: "user",
+  label: "mcp:authorize-code",
+});
+const sessionRateLimit = rateLimit({
+  limit: 10,
+  windowSec: 60,
+  keyBy: "ip",
+  label: "mcp:session",
+});
+const clipRateLimit = rateLimit({
+  limit: 30,
+  windowSec: 60,
+  keyBy: "user",
+  label: "mcp:clip",
+});
+
 const app = new Hono<AppEnv>();
 
 // ── POST /authorize-code ────────────────────────────────────────────────────
@@ -37,7 +68,7 @@ const app = new Hono<AppEnv>();
 // 後続で CLI / Web 側が `/session` に code + verifier を送って JWT に交換する。
 //
 // Issues a one-time PKCE code for an authenticated user; later exchanged at /session for a JWT.
-app.post("/authorize-code", authRequired, async (c) => {
+app.post("/authorize-code", authRequired, authorizeCodeRateLimit, async (c) => {
   const redis = c.get("redis");
   if (!redis) {
     throw new HTTPException(503, { message: "Redis unavailable" });
@@ -89,7 +120,7 @@ app.post("/authorize-code", authRequired, async (c) => {
 // ── POST /session ───────────────────────────────────────────────────────────
 // PKCE code + verifier を交換して MCP 用 JWT を発行する。
 // Exchanges a one-time code + PKCE verifier for an MCP-scoped JWT.
-app.post("/session", async (c) => {
+app.post("/session", sessionRateLimit, async (c) => {
   const redis = c.get("redis");
   if (!redis) {
     throw new HTTPException(503, { message: "Redis unavailable" });
@@ -194,7 +225,7 @@ app.post("/revoke-session", authRequired, async (c) => {
 // 本体ロジックは `clipAndCreate` を共有するため重複実装はしない。
 //
 // MCP-authenticated wrapper around clipAndCreate (shares the same implementation as /api/ext/clip-and-create).
-app.post("/clip", mcpWriteRequired, async (c) => {
+app.post("/clip", mcpWriteRequired, clipRateLimit, async (c) => {
   const userId = c.get("userId");
   const db = c.get("db");
 

--- a/server/mcp/src/__tests__/client/httpClient.test.ts
+++ b/server/mcp/src/__tests__/client/httpClient.test.ts
@@ -290,6 +290,46 @@ describe("HttpZediClient error normalization", () => {
     });
   });
 
+  it("tags 429 responses with isRateLimit and extracts Retry-After header", async () => {
+    // 429 はミドルウェア由来。Retry-After ヘッダを秒数として拾い isRateLimit を立てる。
+    // 429 comes from the rateLimit middleware; we pick up the header as seconds.
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "RATE_LIMIT_EXCEEDED", retry_after: 42 }), {
+        status: 429,
+        headers: { "Content-Type": "application/json", "Retry-After": "42" },
+      }),
+    );
+    let error: unknown;
+    try {
+      await client.clipUrl("https://example.com/a");
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(ZediApiError);
+    const apiError = error as ZediApiError;
+    expect(apiError.status).toBe(429);
+    expect(apiError.isRateLimit).toBe(true);
+    expect(apiError.retryAfterSec).toBe(42);
+  });
+
+  it("falls back to body.retry_after when Retry-After header is absent", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "RATE_LIMIT_EXCEEDED", retry_after: 7 }), {
+        status: 429,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    let error: unknown;
+    try {
+      await client.clipUrl("https://example.com/a");
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(ZediApiError);
+    expect((error as ZediApiError).isRateLimit).toBe(true);
+    expect((error as ZediApiError).retryAfterSec).toBe(7);
+  });
+
   it("throws ZediApiError(status=0) for fetch network failure", async () => {
     fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
     let error: unknown;

--- a/server/mcp/src/__tests__/tools/helpers.test.ts
+++ b/server/mcp/src/__tests__/tools/helpers.test.ts
@@ -1,0 +1,72 @@
+/**
+ * MCP ツールヘルパのユニットテスト
+ *
+ * - `wrapToolHandler` が `ZediApiError` を `isError: true` の結果に正規化すること
+ * - 429 (レート制限) は専用メッセージを出すこと
+ * - その他の例外は "Unexpected error" にまとめること
+ *
+ * Tests for the MCP tool helpers, including #562 rate-limit rendering.
+ */
+import { describe, it, expect } from "vitest";
+import { wrapToolHandler } from "../../tools/helpers.js";
+import { ZediApiError } from "../../client/errors.js";
+
+describe("wrapToolHandler", () => {
+  it("returns a rate-limit message with retry seconds for 429 errors", async () => {
+    const result = await wrapToolHandler(async () => {
+      throw new ZediApiError(429, "RATE_LIMIT_EXCEEDED", undefined, 42);
+    }, {});
+    expect(result.isError).toBe(true);
+    const text = result.content[0]?.text ?? "";
+    expect(text).toMatch(/rate limited/i);
+    expect(text).toMatch(/42 seconds/);
+  });
+
+  it("falls back to a generic retry message when retryAfterSec is missing", async () => {
+    const result = await wrapToolHandler(async () => {
+      throw new ZediApiError(429, "RATE_LIMIT_EXCEEDED");
+    }, {});
+    expect(result.isError).toBe(true);
+    const text = result.content[0]?.text ?? "";
+    expect(text).toMatch(/rate limited/i);
+    expect(text).toMatch(/retry later/i);
+  });
+
+  it("renders non-rate-limit ZediApiError with its status and message", async () => {
+    const result = await wrapToolHandler(async () => {
+      throw new ZediApiError(404, "Page not found");
+    }, {});
+    expect(result.isError).toBe(true);
+    const text = result.content[0]?.text ?? "";
+    expect(text).toMatch(/HTTP 404/);
+    expect(text).toMatch(/Page not found/);
+  });
+
+  it("labels fetch network failures (status=0) as 'network'", async () => {
+    const result = await wrapToolHandler(async () => {
+      throw new ZediApiError(0, "ECONNREFUSED");
+    }, {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/network/i);
+  });
+
+  it("falls back to Unexpected error for non-ZediApiError throws", async () => {
+    const result = await wrapToolHandler(async () => {
+      throw new Error("boom");
+    }, {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/Unexpected error/);
+    expect(result.content[0]?.text).toMatch(/boom/);
+  });
+
+  it("passes through successful results untouched", async () => {
+    const result = await wrapToolHandler(
+      async (input: { x: number }) => ({
+        content: [{ type: "text" as const, text: `x=${input.x}` }],
+      }),
+      { x: 7 },
+    );
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]?.text).toBe("x=7");
+  });
+});

--- a/server/mcp/src/client/errors.ts
+++ b/server/mcp/src/client/errors.ts
@@ -4,22 +4,43 @@
  * すべての HTTP 4xx/5xx 応答および fetch 自体の失敗 (ネットワークエラー) を
  * `ZediApiError` にまとめる。MCP ツール側はこれを `isError: true` の応答に変換する。
  *
- * Normalized error class for Zedi REST API calls; MCP tools convert this to error responses.
+ * 429 (レート制限) は `isRateLimit` / `retryAfterSec` を立てて付加情報を持たせる。
+ * `Retry-After` ヘッダもしくはレスポンス本文の `retry_after` を数秒単位で取り出す。
+ *
+ * Normalized error class for Zedi REST API calls; MCP tools convert this to
+ * error responses. 429 responses are tagged with `isRateLimit` and an optional
+ * `retryAfterSec` so callers can render a useful message to end users.
  */
 export class ZediApiError extends Error {
+  /**
+   * HTTP 429 で、サーバから提案された再試行秒数を取り出せたかどうか。
+   * Whether this error represents a rate limit rejection.
+   */
+  public readonly isRateLimit: boolean;
+
+  /**
+   * 429 時の再試行までの秒数 (サーバから得られた場合)。
+   * Suggested retry delay in seconds, if available.
+   */
+  public readonly retryAfterSec: number | null;
+
   /**
    * 新しい ZediApiError を生成する。Constructs a new ZediApiError.
    *
    * @param status - HTTP ステータスコード (ネットワーク失敗時は 0)。
    * @param message - サーバーからのメッセージ、もしくは fetch 失敗の説明。
    * @param body - サーバー応答本文 (パース可能なら JSON、不可なら文字列)。デバッグ用途。
+   * @param retryAfterSec - 429 応答に含まれていた再試行秒数 (オプション)。
    */
   constructor(
     public readonly status: number,
     message: string,
     public readonly body?: unknown,
+    retryAfterSec: number | null = null,
   ) {
     super(message);
     this.name = "ZediApiError";
+    this.isRateLimit = status === 429;
+    this.retryAfterSec = retryAfterSec;
   }
 }

--- a/server/mcp/src/client/httpClient.ts
+++ b/server/mcp/src/client/httpClient.ts
@@ -29,6 +29,24 @@ import type {
   ClipResult,
 } from "./ZediClient.js";
 
+/**
+ * 429 応答から再試行秒数を取り出す (ヘッダ優先、次に JSON 本文)。
+ * Extracts a retry-after value in seconds from a 429 response.
+ */
+function extractRetryAfter(res: Response, parsed: unknown): number | null {
+  const header = res.headers.get("Retry-After");
+  if (header) {
+    // RFC 7231: HTTP-date or delta-seconds. 秒で来ているときだけ採用する。
+    const seconds = Number.parseInt(header, 10);
+    if (Number.isFinite(seconds) && seconds >= 0) return seconds;
+  }
+  if (parsed && typeof parsed === "object" && "retry_after" in parsed) {
+    const raw = (parsed as { retry_after?: unknown }).retry_after;
+    if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) return raw;
+  }
+  return null;
+}
+
 /** HttpZediClient のコンストラクタオプション / Options for HttpZediClient. */
 export interface HttpZediClientOptions {
   /** Zedi API の baseUrl。末尾スラッシュは正規化される。 Base URL for the Zedi API; trailing slashes are normalized. */
@@ -119,7 +137,8 @@ export class HttpZediClient implements ZediClient {
         (parsed && typeof parsed === "object" && "message" in parsed
           ? String((parsed as { message: unknown }).message)
           : null) ?? (typeof parsed === "string" ? parsed : `HTTP ${res.status}`);
-      throw new ZediApiError(res.status, message, parsed);
+      const retryAfterSec = res.status === 429 ? extractRetryAfter(res, parsed) : null;
+      throw new ZediApiError(res.status, message, parsed, retryAfterSec);
     }
 
     return parsed as T;

--- a/server/mcp/src/tools/helpers.ts
+++ b/server/mcp/src/tools/helpers.ts
@@ -38,6 +38,16 @@ export async function wrapToolHandler<A>(
     return await handler(args);
   } catch (err) {
     if (err instanceof ZediApiError) {
+      if (err.isRateLimit) {
+        // レート制限は専用メッセージで Claude Code に再試行タイミングを伝える。
+        // Render a dedicated message so the MCP client can present retry guidance.
+        const retry =
+          err.retryAfterSec != null ? `retry in ${err.retryAfterSec} seconds` : "retry later";
+        return {
+          isError: true,
+          content: [{ type: "text", text: `Rate limited, ${retry}.` }],
+        };
+      }
       const status = err.status === 0 ? "network" : `HTTP ${err.status}`;
       return {
         isError: true,


### PR DESCRIPTION
## 概要

MCP エンドポイント (`/api/mcp/*`) に対して、既存の tier ベースのレート制限とは別に、エンドポイントごとの短いウィンドウ (分単位) でのレート制限を追加します。これにより、外部 Claude Code クライアントからのスクレイピングやブルートフォース攻撃を防ぎます。

## 変更点

- **rateLimit ミドルウェアの拡張**
  - 既存 API (`rateLimit("free")`) は時間単位の tier ベース制限を維持
  - 新しいオプション形式 (`rateLimit({ limit, windowSec, keyBy, label })`) で細かい制限を実装
  - `keyBy: "user"` (userId 優先、IP フォールバック) と `keyBy: "ip"` (常に IP) をサポート
  - 429 応答に `Retry-After` / `X-RateLimit-*` ヘッダと JSON ボディを返す

- **MCP ルートへの制限適用**
  - `/authorize-code`: 20/min/user (セッション有り、CSRF 防止)
  - `/session`: 10/min/IP (認証前、PKCE ブルートフォース対策)
  - `/clip`: 30/min/user (メイン書き込みパス、スクレイピング抑制)

- **エラーハンドリングの改善**
  - `ZediApiError` に `isRateLimit` / `retryAfterSec` フィールドを追加
  - MCP ツールヘルパで 429 エラーを専用メッセージで表示
  - `Retry-After` ヘッダと JSON 本文の `retry_after` から再試行秒数を抽出

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm test` で新規追加のユニットテストが全てパスすることを確認
   - `server/api/src/__tests__/middleware/rateLimit.test.ts`: ミドルウェアの動作確認
   - `server/api/src/__tests__/routes/mcp.test.ts`: MCP ルートの制限確認
   - `server/mcp/src/__tests__/tools/helpers.test.ts`: エラーハンドリング確認
   - `server/mcp/src/__tests__/client/httpClient.test.ts`: 429 応答の解析確認

2. 既存テストが全てパスすることを確認 (破壊的変更なし)

## チェックリスト

- [x] テストがすべてパスする
- [x] 必要に応じてドキュメントを更新した (コード内コメント)
- [x] 既存 API との互換性を維持

## 関連 Issue

Closes #562

https://claude.ai/code/session_015rBDafXfPCRPFEkRsnLxvc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
