### PR TITLE
Fix microtask race condition in NoteSettings form initialization

### DIFF
--- a/src/pages/NoteSettings/index.tsx
+++ b/src/pages/NoteSettings/index.tsx
@@ -52,13 +52,18 @@ const NoteSettings: React.FC = () => {
   });
 
   useEffect(() => {
-    if (note) {
-      queueMicrotask(() => {
-        setTitle(note.title);
-        setVisibility(note.visibility);
-        setEditPermission(note.editPermission);
-      });
-    }
+    if (!note) return;
+    // Sync local form state from the loaded note. Setters are called directly
+    // (no `queueMicrotask`) so a deferred callback cannot fire after `note`
+    // becomes null — that previously caused unhandled microtask exceptions
+    // surfaced as Stryker `# errors`, plus React `act()` warnings in tests.
+    // ロード済みノートからローカル状態を同期。`queueMicrotask` で遅延すると、
+    // `note` が null/入れ替わった後にコールバックが走って例外となり、
+    // mutation testing の RuntimeError や `act()` 警告の原因になっていた。
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot init from loaded note
+    setTitle(note.title);
+    setVisibility(note.visibility);
+    setEditPermission(note.editPermission);
   }, [note]);
 
   const noteUrl = useMemo(() => {


### PR DESCRIPTION
## 概要

`NoteSettings` コンポーネントの `useEffect` で `queueMicrotask` を使用していたため、`note` が null に変わった後にコールバックが実行され、unhandled microtask 例外や React `act()` 警告が発生していました。遅延なく直接 state setter を呼び出すことで、この競合状態を解決します。

## 変更点

- `queueMicrotask` を削除し、`note` の読み込み後に直接 state setter を呼び出すように変更
- `note` が null の場合は早期リターンで処理を終了
- コンポーネント再マウント時の state 初期化が確実に行われるよう改善
- ESLint ルール無視コメントを追加（one-shot initialization の意図を明示）

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)

## テスト方法

既存のテストスイートが対象の変更をカバーしています。以下を確認してください：

1. `npm test` でテストスイートが全てパスすること
2. React `act()` 警告が消えていることを確認
3. Stryker mutation testing で `# errors` が解消されていることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

https://claude.ai/code/session_01HDbFecTrmyWoZeiPGtjS2A
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
