### PR TITLE
ci: Add server health verification and deployment documentation

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -32,7 +32,43 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
-  # Railway deploys api and hocuspocus via GitHub integration (configure in Railway Dashboard)
+  # Railway deploys server/api, server/hocuspocus, and server/mcp via GitHub integration
+  # (each Railway service is configured with the matching Root Directory).
+  # See AGENTS.md §「ワークスペース構成とデプロイ」and issue #564 for the full deployment notes.
+  # Required Railway env vars per service:
+  #   - server/api:        BETTER_AUTH_SECRET, MCP_REDIRECT_URI_ALLOW (required for MCP auth code flow)
+  #   - server/mcp:        ZEDI_API_URL (internal API URL), BETTER_AUTH_SECRET (must match the API service)
+  #   - server/hocuspocus: (see server/hocuspocus/README / existing setup)
+  verify-server-health:
+    name: Verify Server Health
+    needs:
+      - migrate
+    runs-on: ubuntu-latest
+    environment: development
+    if: ${{ vars.API_BASE_URL != '' }}
+    steps:
+      # Railway deploys asynchronously after the push event, so retry the
+      # health endpoints to give the platform time to roll out the new image.
+      # Railway は push を受けてから非同期にロールアウトするため、
+      # ヘルスエンドポイントはリトライ付きで検証する。
+      - name: Wait for API /api/health
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 10
+          timeout_minutes: 2
+          retry_wait_seconds: 30
+          command: |
+            curl --fail --show-error --silent "${{ vars.API_BASE_URL }}/api/health"
+      - name: Wait for MCP /health
+        if: ${{ vars.MCP_BASE_URL != '' }}
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 10
+          timeout_minutes: 2
+          retry_wait_seconds: 30
+          command: |
+            curl --fail --show-error --silent "${{ vars.MCP_BASE_URL }}/health"
+
   deploy-frontend:
     name: Deploy Frontend
     needs:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -35,7 +35,43 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
-  # Railway deploys api and hocuspocus via GitHub integration (configure in Railway Dashboard)
+  # Railway deploys server/api, server/hocuspocus, and server/mcp via GitHub integration
+  # (each Railway service is configured with the matching Root Directory).
+  # See AGENTS.md §「ワークスペース構成とデプロイ」and issue #564 for the full deployment notes.
+  # Required Railway env vars per service:
+  #   - server/api:        BETTER_AUTH_SECRET, MCP_REDIRECT_URI_ALLOW (required for MCP auth code flow)
+  #   - server/mcp:        ZEDI_API_URL (internal API URL), BETTER_AUTH_SECRET (must match the API service)
+  #   - server/hocuspocus: (see server/hocuspocus/README / existing setup)
+  verify-server-health:
+    name: Verify Server Health
+    needs:
+      - migrate
+    runs-on: ubuntu-latest
+    environment: production
+    if: ${{ vars.API_BASE_URL != '' }}
+    steps:
+      # Railway deploys asynchronously after the push event, so retry the
+      # health endpoints to give the platform time to roll out the new image.
+      # Railway は push を受けてから非同期にロールアウトするため、
+      # ヘルスエンドポイントはリトライ付きで検証する。
+      - name: Wait for API /api/health
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 10
+          timeout_minutes: 2
+          retry_wait_seconds: 30
+          command: |
+            curl --fail --show-error --silent "${{ vars.API_BASE_URL }}/api/health"
+      - name: Wait for MCP /health
+        if: ${{ vars.MCP_BASE_URL != '' }}
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 10
+          timeout_minutes: 2
+          retry_wait_seconds: 30
+          command: |
+            curl --fail --show-error --silent "${{ vars.MCP_BASE_URL }}/health"
+
   deploy-frontend:
     name: Deploy Frontend
     needs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,27 @@ server/mcp/       # MCP サーバー (stdio / HTTP) — Claude Code 連携
 terraform/        # インフラ定義
 ```
 
+## ワークスペース構成とデプロイ / Workspaces layout and deploy
+
+- ルート `package.json` の `workspaces` は `packages/*` と `admin` のみを含む。`server/api`, `server/hocuspocus`, `server/mcp` は **意図的にルートの Bun workspace から外して**、個別の Bun プロジェクトとして管理する。  
+  _Root `workspaces` covers only `packages/*` and `admin`. The three `server/*` services (`api`, `hocuspocus`, `mcp`) are intentionally kept **outside** the root Bun workspace and managed as standalone Bun projects._
+- 理由 / Rationale:
+  - Railway の Dockerfile ビルドは「各サービスの Root Directory」を build context に取る (例: `server/mcp`)。ここからルート `bun.lock` を参照するのは面倒で、context をサービス単位に閉じるほうが再現性が高い。  
+    _Railway Dockerfile builds take each service's Root Directory as the build context. Scoping `bun.lock` per service keeps the build self-contained and reproducible._
+  - Bun workspace が Railway 上で安定して扱えるようになった時点で再検討する（`.github/workflows/ci.yml` の `api-typecheck` / `mcp-test` ジョブにも同じメモあり）。  
+    _Revisit when Bun workspaces are first-class on Railway (the same note lives in `ci.yml`)._
+- 運用上の影響 / Operational impact:
+  - ルートで `bun install` を実行しても `server/*` の依存は入らない。各サービスに入るには `cd server/<service> && bun install` する必要がある。  
+    _Running `bun install` at the repo root does **not** install `server/*` dependencies; run `bun install` inside each service directory._
+  - CI (`.github/workflows/ci.yml`) でも各サービスディレクトリで個別に `bun install` → typecheck / test を行う。  
+    _CI installs and tests each service individually._
+- デプロイ / Deploy:
+  - `server/api`, `server/hocuspocus`, `server/mcp` は Railway の GitHub 連携で自動デプロイされる (Root Directory をサービスディレクトリに設定)。CI (`deploy-dev.yml` / `deploy-prod.yml`) はフロントエンド (Cloudflare Pages) のデプロイと DB マイグレーションを担当する。  
+    _All three `server/*` services auto-deploy via Railway's GitHub integration (each Railway service is configured with the matching Root Directory). The `deploy-*.yml` workflows cover Cloudflare Pages deploys and DB migrations only._
+  - `server/mcp` は `/health` を Railway のヘルスチェックに使う (`server/mcp/railway.json`)。必須環境変数: `ZEDI_API_URL` (API の内部 URL、例: `http://api.railway.internal:3000`), `BETTER_AUTH_SECRET` (API と同値)。API サービス側には `MCP_REDIRECT_URI_ALLOW` を設定する。  
+    _`server/mcp` uses `/health` as its Railway healthcheck. Required env vars: `ZEDI_API_URL` (internal API URL), `BETTER_AUTH_SECRET` (must match the API service). The API service additionally requires `MCP_REDIRECT_URI_ALLOW`._
+  - 関連 Issue: [#564](https://github.com/otomatty/zedi/issues/564).
+
 ### ローカル専用メモ（`docs/`・Git 追跡外）
 
 クローン直後は `docs/` は存在しない。必要なら次で作成する（コミットされない）。


### PR DESCRIPTION
## 概要

CI/CD ワークフローにサーバーヘルスチェック機能を追加し、Railway デプロイメント構成とワークスペースレイアウトに関する詳細なドキュメントを整備しました。

## 変更点

- **GitHub Actions ワークフロー (`deploy-dev.yml`, `deploy-prod.yml`)**
  - 新しい `verify-server-health` ジョブを追加
  - Railway の非同期デプロイに対応するため、リトライロジック付きでヘルスエンドポイント (`/api/health`, `/health`) を検証
  - API と MCP サービスの起動確認を自動化
  - 環境変数 `API_BASE_URL`, `MCP_BASE_URL` で条件付き実行

- **ドキュメント (`AGENTS.md`)**
  - 「ワークスペース構成とデプロイ」セクションを新規追加
  - `server/api`, `server/hocuspocus`, `server/mcp` がルート Bun workspace から意図的に分離されている理由を説明
  - Railway デプロイメント構成（Root Directory 設定、環境変数要件）を明記
  - ローカル開発時の `bun install` 手順を記載
  - 関連 Issue #564 へのリンク

## 変更の種類

- [x] 🔧 ビルド/CI (Build/CI)
- [x] 📝 ドキュメント (Documentation)

## テスト方法

- CI ワークフローは既存の `migrate` ジョブに依存し、自動実行される
- ヘルスチェックエンドポイントが環境変数で制御されるため、未設定時はスキップ
- Railway デプロイ後、ワークフロー実行ログで `verify-server-health` ジョブの成功を確認

## チェックリスト

- [x] ドキュメントを更新した
- [x] CI ワークフロー構文は有効（GitHub Actions の標準機能のみ使用）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #564

https://claude.ai/code/session_01S12VMMq36LkYWtgGmLoMyF
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
