### PR TITLE
feat: add mobile bottom navigation and responsive header layout

### DIFF
--- a/src/components/ai-chat/ContentWithAIChat.tsx
+++ b/src/components/ai-chat/ContentWithAIChat.tsx
@@ -91,7 +91,18 @@ export function ContentWithAIChat({
       <>
         {children}
         {floatingAction && (
-          <div className="pointer-events-none fixed right-0 bottom-0 z-40 flex flex-col items-end gap-1 p-2 pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)]">
+          <div
+            className="pointer-events-none fixed right-0 bottom-0 z-40 flex flex-col items-end gap-1 p-2 pr-[env(safe-area-inset-right)]"
+            style={{
+              // 親指リーチを確保し、かつボトムナビと重ならないよう safe-area +
+              // ボトムナビ高さ分だけ下余白を空ける。ボトムナビ非表示時は 0px に戻る。
+              // Offset the FAB above the bottom nav while respecting the
+              // device safe area. Falls back to 0px when the bottom nav is
+              // not mounted (desktop / pages without the nav).
+              paddingBottom:
+                "calc(env(safe-area-inset-bottom) + var(--app-bottom-nav-height, 0px) + 0.5rem)",
+            }}
+          >
             {floatingAction}
           </div>
         )}

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -1,11 +1,15 @@
 /**
- * App shell: header, main content (no left sidebar), right AI dock; CSS variables.
- * 共通レイアウト: ヘッダー・メイン（左サイドバーなし）・右 AI ドック、CSS 変数。
+ * App shell: header, main content (no left sidebar), right AI dock (desktop
+ * only), mobile bottom nav, and layout CSS variables.
+ *
+ * 共通レイアウト: ヘッダー・メイン（左サイドバーなし）・右 AI ドック
+ * （デスクトップのみ）・モバイルボトムナビ、および CSS 変数。
  */
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { AppLayout } from "./AppLayout";
+import { useIsMobile } from "@zedi/ui";
 
 vi.mock("./Header", () => ({
   default: () => <header data-testid="header">Header</header>,
@@ -13,9 +17,24 @@ vi.mock("./Header", () => ({
 vi.mock("./AIChatDock", () => ({
   AIChatDock: () => <div data-testid="ai-chat-dock">AIChatDock</div>,
 }));
+vi.mock("./BottomNav", () => ({
+  BottomNav: () => <nav data-testid="bottom-nav">BottomNav</nav>,
+}));
+
+vi.mock("@zedi/ui", async () => {
+  const actual = await vi.importActual<typeof import("@zedi/ui")>("@zedi/ui");
+  return {
+    ...actual,
+    useIsMobile: vi.fn(() => false),
+  };
+});
 
 describe("AppLayout", () => {
-  it("renders Header and AIChatDock and does not render a left sidebar", () => {
+  beforeEach(() => {
+    vi.mocked(useIsMobile).mockReturnValue(false);
+  });
+
+  it("renders Header and AIChatDock and does not render a left sidebar on desktop", () => {
     render(
       <AppLayout>
         <p>Main content</p>
@@ -24,6 +43,7 @@ describe("AppLayout", () => {
     expect(screen.getByTestId("header")).toBeInTheDocument();
     expect(screen.getByTestId("ai-chat-dock")).toBeInTheDocument();
     expect(screen.queryByTestId("app-sidebar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("bottom-nav")).not.toBeInTheDocument();
   });
 
   it("renders children inside the main element", () => {
@@ -36,7 +56,7 @@ describe("AppLayout", () => {
     expect(main).toContainElement(screen.getByText("Main content"));
   });
 
-  it("sets layout CSS variables on the layout wrapper (--app-header-height, --ai-chat-width)", () => {
+  it("sets desktop layout CSS variables (--app-header-height: 4.5rem, --app-bottom-nav-height: 0px)", () => {
     const { container } = render(
       <AppLayout>
         <span>Content</span>
@@ -47,7 +67,35 @@ describe("AppLayout", () => {
     const style = wrapper?.getAttribute("style") ?? "";
     expect(style).toContain("--app-header-height");
     expect(style).toContain("4.5rem");
+    expect(style).toContain("--app-bottom-nav-height");
+    expect(style).toContain("0px");
     expect(style).toContain("--ai-chat-width");
     expect(style).toContain("22rem");
+  });
+
+  it("renders BottomNav and hides AIChatDock on mobile viewports", () => {
+    vi.mocked(useIsMobile).mockReturnValue(true);
+    render(
+      <AppLayout>
+        <p>Main content</p>
+      </AppLayout>,
+    );
+    expect(screen.getByTestId("bottom-nav")).toBeInTheDocument();
+    expect(screen.queryByTestId("ai-chat-dock")).not.toBeInTheDocument();
+  });
+
+  it("sets mobile layout CSS variables (--app-header-height: 3rem, --app-bottom-nav-height: 3.5rem)", () => {
+    vi.mocked(useIsMobile).mockReturnValue(true);
+    const { container } = render(
+      <AppLayout>
+        <span>Content</span>
+      </AppLayout>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement | null;
+    const style = wrapper?.getAttribute("style") ?? "";
+    expect(style).toContain("--app-header-height");
+    expect(style).toContain("3rem");
+    expect(style).toContain("--app-bottom-nav-height");
+    expect(style).toContain("3.5rem");
   });
 });

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,25 +1,32 @@
 import React from "react";
+import { useIsMobile } from "@zedi/ui";
 import Header from "./Header";
 import { AIChatDock } from "./AIChatDock";
+import { BottomNav } from "./BottomNav";
 
 interface AppLayoutProps {
   children: React.ReactNode;
 }
 
 /**
- * Shared layout: sticky header on top, main content, and right-side AI dock.
- * The left sidebar has been removed; functional navigation lives in the header.
+ * Shared layout: sticky header on top, main content, right-side AI dock
+ * (desktop only) and a mobile-only bottom navigation. The left sidebar has
+ * been removed; functional navigation lives in the header on desktop and
+ * in the bottom nav on mobile.
  *
- * 共通レイアウト。上部の固定ヘッダー、メインコンテンツ、右側 AI ドックで構成。
- * 左サイドバーは廃止し、機能ナビゲーションはヘッダー内に集約した。
+ * 共通レイアウト。上部の固定ヘッダー、メインコンテンツ、右側 AI ドック
+ * （デスクトップのみ）、モバイル用のボトムナビで構成。左サイドバーは廃止し、
+ * 機能ナビゲーションはデスクトップではヘッダー、モバイルではボトムナビに集約した。
  */
 export function AppLayout({ children }: AppLayoutProps) {
+  const isMobile = useIsMobile();
   return (
     <div
       className="flex h-svh min-h-0 flex-col overflow-hidden"
       style={
         {
-          "--app-header-height": "4.5rem",
+          "--app-header-height": isMobile ? "3rem" : "4.5rem",
+          "--app-bottom-nav-height": isMobile ? "3.5rem" : "0px",
           "--ai-chat-width": "22rem",
         } as React.CSSProperties
       }
@@ -30,8 +37,9 @@ export function AppLayout({ children }: AppLayoutProps) {
         <main className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
           {children}
         </main>
-        <AIChatDock />
+        {!isMobile && <AIChatDock />}
       </div>
+      {isMobile && <BottomNav />}
     </div>
   );
 }

--- a/src/components/layout/BottomNav/BottomNav.test.tsx
+++ b/src/components/layout/BottomNav/BottomNav.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * BottomNav: 4 tabs (Home / Notes / AI / Me), aria-current on active tab,
+ * safe-area padding, and Me tab opens a Sheet with the account menu content.
+ *
+ * ボトムナビ: 4 タブ（Home / Notes / AI / Me）、アクティブタブの aria-current、
+ * safe-area padding、Me タブの Sheet 表示を検証する。
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { BottomNav } from "./index";
+
+const { signedInAuth } = vi.hoisted(() => {
+  const signedInAuth = {
+    isLoaded: true,
+    isSignedIn: true,
+    userId: "test-user-id",
+    sessionId: "test-session-id",
+    orgId: null,
+    orgRole: null,
+    orgSlug: null,
+    getToken: async () => null as string | null,
+    signOut: async () => {},
+  };
+  return { signedInAuth };
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+    i18n: { language: "ja" },
+  }),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: vi.fn(() => ({ ...signedInAuth })),
+  SignedIn: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SignedOut: () => null,
+  useUser: () => ({ user: null }),
+}));
+
+vi.mock("@/hooks/useProfile", () => ({
+  useProfile: () => ({ displayName: "", avatarUrl: "" }),
+}));
+
+vi.mock("@/hooks/usePageQueries", () => ({
+  useSyncStatus: () => "idle",
+  useSync: () => ({ sync: () => {}, isSyncing: false }),
+}));
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <BottomNav />
+    </MemoryRouter>,
+  );
+}
+
+describe("BottomNav", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders four tabs: Home, Notes, AI, Me", () => {
+    renderAt("/home");
+    expect(screen.getByRole("link", { name: /home/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /notes/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^ai$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /account/i })).toBeInTheDocument();
+  });
+
+  it("marks the Home tab as aria-current when on /home", () => {
+    renderAt("/home");
+    const homeLink = screen.getByRole("link", { name: /home/i });
+    expect(homeLink).toHaveAttribute("aria-current", "page");
+    const notesLink = screen.getByRole("link", { name: /notes/i });
+    expect(notesLink).not.toHaveAttribute("aria-current", "page");
+  });
+
+  it("marks the Notes tab as aria-current when on /notes", () => {
+    renderAt("/notes");
+    const notesLink = screen.getByRole("link", { name: /notes/i });
+    expect(notesLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("marks the AI tab as aria-current when on /ai", () => {
+    renderAt("/ai");
+    const aiLink = screen.getByRole("link", { name: /^ai$/i });
+    expect(aiLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("fixes the nav at the bottom with safe-area padding", () => {
+    const { container } = renderAt("/home");
+    const nav = container.querySelector("nav");
+    expect(nav).toBeInTheDocument();
+    expect(nav?.className).toMatch(/fixed/);
+    expect(nav?.className).toMatch(/bottom-0/);
+    expect(nav?.className).toMatch(/safe-area-inset-bottom/);
+  });
+
+  it("opens the Me sheet when the Me tab is clicked", async () => {
+    renderAt("/home");
+    const meButton = screen.getByRole("button", { name: /account/i });
+    fireEvent.click(meButton);
+    expect(await screen.findByTestId("bottom-nav-me-content")).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/BottomNav/BottomNavMeContent.tsx
+++ b/src/components/layout/BottomNav/BottomNavMeContent.tsx
@@ -1,0 +1,11 @@
+/**
+ * Thin re-export module so the bottom-nav Me tab and the desktop avatar
+ * dropdown share the exact same menu content. This keeps the UnifiedMenu
+ * surface the single source of truth for account actions, sync status and
+ * sign-in / sign-out.
+ *
+ * ボトムナビ Me タブとデスクトップのアバタードロップダウンで同じメニュー内容を
+ * 共有するための薄い再エクスポート。アカウント操作・同期ステータス・サインイン/
+ * サインアウトの単一ソースを {@link UnifiedMenu} に保つ。
+ */
+export { SignedInMenuContent, SignedOutMenuContent } from "../Header/UnifiedMenu";

--- a/src/components/layout/BottomNav/BottomNavTab.tsx
+++ b/src/components/layout/BottomNav/BottomNavTab.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { cn } from "@zedi/ui";
+
+interface BottomNavTabProps {
+  to: string;
+  icon: React.FC<{ className?: string }>;
+  label: string;
+  active: boolean;
+}
+
+/**
+ * One entry in the mobile bottom navigation bar. Always renders as a
+ * `<Link>` inside an `<li>`; active state is communicated via
+ * `aria-current="page"` for assistive tech and via accent color visually.
+ *
+ * モバイルボトムナビの 1 項目。常に `<Link>` として `<li>` 内に描画し、
+ * アクティブ状態は `aria-current="page"` とアクセントカラーで示す。
+ */
+export const BottomNavTab: React.FC<BottomNavTabProps> = ({ to, icon: Icon, label, active }) => {
+  return (
+    <li className="flex-1">
+      <Link
+        to={to}
+        aria-current={active ? "page" : undefined}
+        className={cn(
+          "flex h-full w-full flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors",
+          active ? "text-primary" : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        <Icon className="h-5 w-5" />
+        <span>{label}</span>
+      </Link>
+    </li>
+  );
+};

--- a/src/components/layout/BottomNav/index.tsx
+++ b/src/components/layout/BottomNav/index.tsx
@@ -1,0 +1,138 @@
+import React, { useCallback, useState } from "react";
+import { useMatch } from "react-router-dom";
+import { Home, FileText, Sparkles } from "lucide-react";
+import { Sheet, SheetContent, SheetDescription, SheetTitle, cn } from "@zedi/ui";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import { Avatar, AvatarFallback, AvatarImage } from "@zedi/ui";
+import { useTranslation } from "react-i18next";
+import { SignedIn, SignedOut, useAuth, useUser } from "@/hooks/useAuth";
+import { useProfile } from "@/hooks/useProfile";
+import { useSyncStatusDotColor } from "../Header/UnifiedMenuSyncStatus";
+import { SignedInMenuContent, SignedOutMenuContent } from "./BottomNavMeContent";
+import { BottomNavTab } from "./BottomNavTab";
+
+/**
+ * Mobile bottom navigation with four tabs (Home / Notes / AI / Me). The Me
+ * tab opens a sheet that reuses the signed-in / signed-out menu content from
+ * {@link UnifiedMenu}, keeping the two surfaces in sync.
+ *
+ * モバイル用のボトムナビゲーション（Home / Notes / AI / Me の 4 タブ）。
+ * Me タブは {@link UnifiedMenu} と共通のメニュー内容を Sheet で表示するので、
+ * デスクトップとモバイルのアカウントメニューが二重実装にならない。
+ */
+export const BottomNav: React.FC = () => {
+  const { t } = useTranslation();
+  const homeMatch = useMatch({ path: "/home", end: true });
+  const notesMatch = useMatch({ path: "/notes" });
+  const aiMatch = useMatch({ path: "/ai" });
+  const aiDetailMatch = useMatch({ path: "/ai/:conversationId" });
+  const aiHistoryMatch = useMatch({ path: "/ai/history" });
+  const aiActive = aiMatch != null || aiDetailMatch != null || aiHistoryMatch != null;
+  const [meOpen, setMeOpen] = useState(false);
+  const closeMe = useCallback(() => setMeOpen(false), []);
+  const sheetTitle = t("nav.account", "Account");
+
+  return (
+    <nav
+      aria-label={t("nav.primary", "Primary navigation")}
+      className={cn(
+        "border-border bg-background/95 supports-[backdrop-filter]:bg-background/80 fixed right-0 bottom-0 left-0 z-40 border-t backdrop-blur",
+        "pb-[env(safe-area-inset-bottom)]",
+      )}
+      style={{ height: "calc(var(--app-bottom-nav-height, 3.5rem) + env(safe-area-inset-bottom))" }}
+    >
+      <ul className="mx-auto flex h-[var(--app-bottom-nav-height,3.5rem)] max-w-md items-stretch">
+        <BottomNavTab
+          to="/home"
+          icon={Home}
+          label={t("nav.home", "Home")}
+          active={homeMatch != null}
+        />
+        <BottomNavTab
+          to="/notes"
+          icon={FileText}
+          label={t("nav.notes", "Notes")}
+          active={notesMatch != null}
+        />
+        <BottomNavTab to="/ai" icon={Sparkles} label={t("nav.ai", "AI")} active={aiActive} />
+        <li className="flex-1">
+          <MeTab open={meOpen} onOpenChange={setMeOpen} />
+        </li>
+      </ul>
+
+      <Sheet open={meOpen} onOpenChange={setMeOpen}>
+        <SheetContent side="right" className="w-3/4 max-w-sm p-4">
+          <VisuallyHidden>
+            <SheetTitle>{sheetTitle}</SheetTitle>
+            <SheetDescription>{t("nav.account", "Account")}</SheetDescription>
+          </VisuallyHidden>
+          <div data-testid="bottom-nav-me-content">
+            <SignedIn>
+              <SignedInMenuContent onClose={closeMe} />
+            </SignedIn>
+            <SignedOut>
+              <SignedOutMenuContent onClose={closeMe} />
+            </SignedOut>
+          </div>
+        </SheetContent>
+      </Sheet>
+    </nav>
+  );
+};
+
+interface MeTabProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const MeTab: React.FC<MeTabProps> = ({ open, onOpenChange }) => {
+  const { t } = useTranslation();
+  const { isSignedIn } = useAuth();
+  const { user } = useUser();
+  const { displayName, avatarUrl } = useProfile();
+  const dotColor = useSyncStatusDotColor();
+
+  return (
+    <button
+      type="button"
+      aria-label={t("nav.account", "Account")}
+      aria-haspopup="dialog"
+      aria-expanded={open}
+      onClick={() => onOpenChange(true)}
+      className={cn(
+        "text-muted-foreground hover:text-foreground flex h-full w-full flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors",
+      )}
+    >
+      <span className="relative">
+        {isSignedIn ? (
+          <Avatar className="h-6 w-6">
+            <AvatarImage
+              src={avatarUrl || user?.imageUrl}
+              alt={displayName || user?.fullName || "User"}
+            />
+            <AvatarFallback className="text-[10px]">
+              {(displayName || user?.firstName)?.charAt(0) ?? "U"}
+            </AvatarFallback>
+          </Avatar>
+        ) : (
+          <Avatar className="h-6 w-6">
+            <AvatarFallback className="text-[10px]">
+              {t("nav.account", "Account").charAt(0)}
+            </AvatarFallback>
+          </Avatar>
+        )}
+        {dotColor && (
+          <span
+            className={cn(
+              "border-background absolute right-0 bottom-0 h-2 w-2 rounded-full border",
+              dotColor,
+            )}
+          />
+        )}
+      </span>
+      <span>{t("nav.account", "Account")}</span>
+    </button>
+  );
+};
+
+export default BottomNav;

--- a/src/components/layout/Header/UnifiedMenu.tsx
+++ b/src/components/layout/Header/UnifiedMenu.tsx
@@ -101,7 +101,14 @@ interface MenuContentProps {
   onClose: () => void;
 }
 
-const SignedInMenuContent: React.FC<MenuContentProps> = ({ onClose }) => {
+/**
+ * User menu content for signed-in users. Exported so that other shell
+ * elements (e.g. the mobile bottom nav Me tab) can reuse the same list.
+ *
+ * サインイン済みユーザー向けのメニュー内容。モバイルボトムナビの Me タブ等、
+ * 他のシェル要素からも同じリストを再利用できるよう export している。
+ */
+export const SignedInMenuContent: React.FC<MenuContentProps> = ({ onClose }) => {
   const { user } = useUser();
   const { signOut } = useAuth();
   const { displayName, avatarUrl } = useProfile();
@@ -203,7 +210,14 @@ const DesktopSignedInMenuContent: React.FC<MenuContentProps> = ({ onClose }) => 
   );
 };
 
-const SignedOutMenuContent: React.FC<MenuContentProps> = ({ onClose }) => {
+/**
+ * User menu content for signed-out (guest) users. Exported so that the
+ * mobile bottom nav Me tab can reuse the same list.
+ *
+ * 未サインインユーザー向けのメニュー内容。モバイルボトムナビの Me タブから
+ * 再利用できるよう export している。
+ */
+export const SignedOutMenuContent: React.FC<MenuContentProps> = ({ onClose }) => {
   const { t } = useTranslation();
   const items = useAccountActionItems();
 

--- a/src/components/layout/Header/index.test.tsx
+++ b/src/components/layout/Header/index.test.tsx
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import Header from "./index";
 import { useAuth } from "@/hooks/useAuth";
+import { useIsMobile } from "@zedi/ui";
 
 const { signedInAuth, signedOutAuth } = vi.hoisted(() => {
   /** Matches `useAuth` return shape (Better Auth) for typed mocks. */
@@ -45,6 +46,18 @@ vi.mock("@/contexts/GlobalSearchContext", () => ({
   useGlobalSearchContextOptional: () => null,
 }));
 
+vi.mock("@zedi/ui", async () => {
+  const actual = await vi.importActual<typeof import("@zedi/ui")>("@zedi/ui");
+  return {
+    ...actual,
+    useIsMobile: vi.fn(() => false),
+  };
+});
+
+vi.mock("../MobileHeader", () => ({
+  MobileHeader: () => <header data-testid="mobile-header">MobileHeader</header>,
+}));
+
 vi.mock("@/components/layout/Container", () => ({
   default: ({ children, className }: { children: React.ReactNode; className?: string }) => (
     <div className={className} data-testid="container">
@@ -72,6 +85,7 @@ vi.mock("./AIChatButton", () => ({
 describe("Header", () => {
   beforeEach(() => {
     vi.mocked(useAuth).mockReturnValue({ ...signedInAuth });
+    vi.mocked(useIsMobile).mockReturnValue(false);
   });
 
   it("renders the navigation menu", () => {
@@ -110,5 +124,14 @@ describe("Header", () => {
     vi.mocked(useAuth).mockReturnValue({ ...signedOutAuth });
     render(<Header />);
     expect(screen.getByText("common.guestSyncPrompt")).toBeInTheDocument();
+  });
+
+  it("delegates to MobileHeader on mobile viewports", () => {
+    vi.mocked(useIsMobile).mockReturnValue(true);
+    render(<Header />);
+    expect(screen.getByTestId("mobile-header")).toBeInTheDocument();
+    expect(screen.queryByTestId("navigation-menu")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("unified-menu")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("ai-chat-btn")).not.toBeInTheDocument();
   });
 });

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import Container from "@/components/layout/Container";
-import { cn } from "@zedi/ui";
+import { cn, useIsMobile } from "@zedi/ui";
 import { HeaderLogo } from "./HeaderLogo";
 import { HeaderSearchBar } from "./HeaderSearchBar";
 import { NavigationMenu } from "./NavigationMenu";
 import { UnifiedMenu } from "./UnifiedMenu";
 import { AIChatButton } from "./AIChatButton";
+import { MobileHeader } from "../MobileHeader";
 import { useAuth } from "@/hooks/useAuth";
 import { useTranslation } from "react-i18next";
 import { useGlobalSearchContextOptional } from "@/contexts/GlobalSearchContext";
@@ -15,17 +16,27 @@ interface HeaderProps {
 }
 
 /**
- * Sticky app header. Hosts the logo, the search bar, the AI chat toggle, a
- * navigation dropdown (Home / Notes) and the user-only menu.
+ * Sticky app header. On desktop hosts the logo, the search bar, the AI
+ * chat toggle, a navigation dropdown (Home / Notes) and the user-only
+ * menu. On mobile delegates to {@link MobileHeader} — the mobile bar is a
+ * compact title with only a search icon; navigation / AI / account moved
+ * to the bottom nav.
  *
- * 固定ヘッダー。ロゴ、検索、AI チャット開閉に加え、機能ナビゲーション（Home / Notes）
- * のドロップダウンとユーザー専用メニューを並べる。
+ * 固定ヘッダー。デスクトップではロゴ・検索・AI チャット開閉・機能ナビゲーション
+ * （Home / Notes）・ユーザー専用メニューを並べる。モバイルでは {@link MobileHeader}
+ * にデリゲートし、コンパクトなタイトル + 検索アイコンだけを表示する（ナビ・AI・
+ * アカウントはボトムナビへ移譲）。
  */
 const Header: React.FC<HeaderProps> = ({ className }) => {
   const { isSignedIn } = useAuth();
   const { t } = useTranslation();
   const searchContext = useGlobalSearchContextOptional();
   const hasSearchContext = searchContext != null;
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return <MobileHeader className={className} />;
+  }
 
   return (
     <header

--- a/src/components/layout/MobileHeader.test.tsx
+++ b/src/components/layout/MobileHeader.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * MobileHeader: compact h-12 title bar, search icon opens a Sheet, and the
+ * legacy desktop widgets (AIChatButton / NavigationMenu / UnifiedMenu) must
+ * NOT render — their roles moved to the bottom nav.
+ *
+ * モバイルヘッダー: h-12 のタイトルバー、検索アイコンから Sheet、そして
+ * 既存のデスクトップウィジェット（AIChatButton / NavigationMenu / UnifiedMenu）
+ * は描画されないことを検証する（役割はボトムナビへ移動）。
+ */
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { MobileHeader } from "./MobileHeader";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+    i18n: { language: "ja" },
+  }),
+}));
+
+vi.mock("@/contexts/GlobalSearchContext", () => ({
+  useGlobalSearchContextOptional: () => ({}),
+}));
+
+vi.mock("./Header/HeaderSearchBar", () => ({
+  HeaderSearchBar: () => <div data-testid="header-search">Search</div>,
+}));
+
+vi.mock("./Header/HeaderLogo", () => ({
+  HeaderLogo: () => <div data-testid="header-logo">Logo</div>,
+}));
+
+function renderHeader() {
+  return render(
+    <MemoryRouter>
+      <MobileHeader />
+    </MemoryRouter>,
+  );
+}
+
+describe("MobileHeader", () => {
+  it("renders a compact h-12 title bar with the logo", () => {
+    const { container } = renderHeader();
+    const header = container.querySelector("header");
+    expect(header).toBeInTheDocument();
+    expect(header?.className).toMatch(/h-12/);
+    expect(header?.className).toMatch(/sticky/);
+    expect(screen.getByTestId("header-logo")).toBeInTheDocument();
+  });
+
+  it("does not render the desktop-only widgets", () => {
+    renderHeader();
+    expect(screen.queryByTestId("ai-chat-btn")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("navigation-menu")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("unified-menu")).not.toBeInTheDocument();
+  });
+
+  it("opens the search sheet when the search icon is tapped", async () => {
+    renderHeader();
+    const searchButton = screen.getByRole("button", { name: /search/i });
+    fireEvent.click(searchButton);
+    expect(await screen.findByTestId("header-search")).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from "react";
+import { Search } from "lucide-react";
+import { Button, Sheet, SheetContent, SheetDescription, SheetTitle, cn } from "@zedi/ui";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import { useTranslation } from "react-i18next";
+import { HeaderLogo } from "./Header/HeaderLogo";
+import { HeaderSearchBar } from "./Header/HeaderSearchBar";
+import Container from "@/components/layout/Container";
+import { useGlobalSearchContextOptional } from "@/contexts/GlobalSearchContext";
+
+interface MobileHeaderProps {
+  className?: string;
+}
+
+/**
+ * Compact mobile title bar with the app logo on the left and a search icon
+ * on the right. Navigation, AI toggle and the user menu have moved to the
+ * bottom nav, so this bar stays deliberately minimal (h-12) to keep
+ * thumb-reach space for the content beneath it.
+ *
+ * モバイル用のコンパクトなタイトルバー。左にロゴ、右に検索アイコンだけを置き、
+ * ナビゲーション・AI 開閉・ユーザーメニューはボトムナビへ移譲した。片手操作での
+ * 親指リーチを確保するため、あえて高さ h-12 に抑えている。
+ */
+export const MobileHeader: React.FC<MobileHeaderProps> = ({ className }) => {
+  const { t } = useTranslation();
+  const [searchOpen, setSearchOpen] = useState(false);
+  const searchContext = useGlobalSearchContextOptional();
+  const hasSearchContext = searchContext != null;
+  const sheetTitle = t("nav.search", "Search");
+
+  return (
+    <header
+      className={cn(
+        "border-border sticky top-0 z-50 h-12 border-b",
+        "bg-background/95 supports-[backdrop-filter]:bg-background/60 backdrop-blur",
+        className,
+      )}
+    >
+      <Container className="flex h-12 items-center justify-between gap-3">
+        <div className="flex min-w-0 shrink-0 items-center gap-2">
+          <HeaderLogo />
+        </div>
+        {hasSearchContext && (
+          <>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-9 w-9"
+              aria-label={t("nav.search", "Search")}
+              onClick={() => setSearchOpen(true)}
+            >
+              <Search className="h-5 w-5" />
+            </Button>
+            <Sheet open={searchOpen} onOpenChange={setSearchOpen}>
+              <SheetContent side="top" className="p-4">
+                <VisuallyHidden>
+                  <SheetTitle>{sheetTitle}</SheetTitle>
+                  <SheetDescription>{sheetTitle}</SheetDescription>
+                </VisuallyHidden>
+                <HeaderSearchBar />
+              </SheetContent>
+            </Sheet>
+          </>
+        )}
+      </Container>
+    </header>
+  );
+};
+
+export default MobileHeader;

--- a/src/pages/NoteView/NoteView.test.tsx
+++ b/src/pages/NoteView/NoteView.test.tsx
@@ -42,6 +42,23 @@ vi.mock("@/components/layout/AppLayout", () => ({
     <div data-testid="app-layout">{children}</div>
   ),
 }));
+vi.mock("@/components/ai-chat/ContentWithAIChat", () => ({
+  ContentWithAIChat: ({
+    children,
+    floatingAction,
+  }: {
+    children: React.ReactNode;
+    floatingAction?: React.ReactNode;
+  }) => (
+    <div data-testid="content-with-ai-chat">
+      {children}
+      {floatingAction}
+    </div>
+  ),
+}));
+vi.mock("@/components/layout/FloatingActionButton", () => ({
+  default: () => <button data-testid="fab">FAB</button>,
+}));
 vi.mock("@/components/layout/Container", () => ({
   default: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="container">{children}</div>

--- a/src/pages/NoteView/index.tsx
+++ b/src/pages/NoteView/index.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import Container from "@/components/layout/Container";
+import FloatingActionButton from "@/components/layout/FloatingActionButton";
+import { ContentWithAIChat } from "@/components/ai-chat/ContentWithAIChat";
 import { NoteVisibilityBadge } from "@/components/note/NoteVisibilityBadge";
 import { Badge, useToast } from "@zedi/ui";
 import {
@@ -127,49 +129,59 @@ const NoteView: React.FC = () => {
   }
 
   return (
-    <main className="min-h-0 flex-1 overflow-y-auto py-6">
-      <Container>
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2">
-              <h1 className="truncate text-xl font-semibold">
-                {note.title || t("notes.untitledNote")}
-              </h1>
-              <NoteVisibilityBadge visibility={note.visibility} />
-              {note.isOfficial && <Badge variant="secondary">{t("notes.officialBadge")}</Badge>}
-            </div>
-            <p className="text-muted-foreground mt-1 text-sm">
-              {t("notes.pagesCount", { count: notePages.length })}
-            </p>
+    <ContentWithAIChat
+      floatingAction={
+        canEdit ? (
+          <div className="mr-4 mb-4">
+            <FloatingActionButton />
           </div>
-          <NoteViewHeaderActions
+        ) : null
+      }
+    >
+      <main className="min-h-0 flex-1 overflow-y-auto py-6">
+        <Container>
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <h1 className="truncate text-xl font-semibold">
+                  {note.title || t("notes.untitledNote")}
+                </h1>
+                <NoteVisibilityBadge visibility={note.visibility} />
+                {note.isOfficial && <Badge variant="secondary">{t("notes.officialBadge")}</Badge>}
+              </div>
+              <p className="text-muted-foreground mt-1 text-sm">
+                {t("notes.pagesCount", { count: notePages.length })}
+              </p>
+            </div>
+            <NoteViewHeaderActions
+              noteId={note.id}
+              canManageMembers={canManageMembers}
+              isSignedIn={isSignedIn}
+              canView={Boolean(access?.canView)}
+              canShowAddPage={canShowAddPage}
+              isAddPageOpen={isAddPageOpen}
+              setIsAddPageOpen={setIsAddPageOpen}
+              newPageTitle={newPageTitle}
+              setNewPageTitle={setNewPageTitle}
+              pageFilter={pageFilter}
+              setPageFilter={setPageFilter}
+              filteredPages={filteredPages}
+              canEdit={canEdit}
+              onAddByTitle={handleAddNewPageByTitle}
+              onAddByPageId={handleAddPage}
+              addPagePending={addPageMutation.isPending}
+            />
+          </div>
+          <NoteViewMainContent
             noteId={note.id}
-            canManageMembers={canManageMembers}
-            isSignedIn={isSignedIn}
-            canView={Boolean(access?.canView)}
-            canShowAddPage={canShowAddPage}
-            isAddPageOpen={isAddPageOpen}
-            setIsAddPageOpen={setIsAddPageOpen}
-            newPageTitle={newPageTitle}
-            setNewPageTitle={setNewPageTitle}
-            pageFilter={pageFilter}
-            setPageFilter={setPageFilter}
-            filteredPages={filteredPages}
-            canEdit={canEdit}
-            onAddByTitle={handleAddNewPageByTitle}
-            onAddByPageId={handleAddPage}
-            addPagePending={addPageMutation.isPending}
+            notePages={notePages}
+            isPagesLoading={isPagesLoading}
+            canDeletePage={canDeletePage}
+            onRemovePage={handleRemovePage}
           />
-        </div>
-        <NoteViewMainContent
-          noteId={note.id}
-          notePages={notePages}
-          isPagesLoading={isPagesLoading}
-          canDeletePage={canDeletePage}
-          onRemovePage={handleRemovePage}
-        />
-      </Container>
-    </main>
+        </Container>
+      </main>
+    </ContentWithAIChat>
   );
 };
 


### PR DESCRIPTION
## 概要

モバイルデバイス向けのボトムナビゲーション（Home / Notes / AI / Me）を追加し、デスクトップとモバイルで異なるレイアウト戦略を実装しました。モバイルではコンパクトなヘッダー（h-12）とボトムナビを使用し、デスクトップではフル機能のヘッダーと右側 AI ドックを保持します。

## 変更点

- **BottomNav コンポーネント**: 4 つのタブ（Home / Notes / AI / Me）を持つモバイル用ボトムナビゲーション
  - Me タブはアカウントメニューを Sheet で表示
  - `aria-current="page"` でアクティブタブを示す
  - Safe area inset に対応
  
- **MobileHeader コンポーネント**: モバイル専用のコンパクトなヘッダー
  - ロゴと検索アイコンのみを表示（h-12）
  - 検索は Sheet で展開
  - ナビゲーション・AI 開閉・ユーザーメニューはボトムナビへ移譲

- **AppLayout**: レスポンシブレイアウト対応
  - `useIsMobile()` で画面サイズを判定
  - モバイル時は BottomNav を表示、AIChatDock を非表示
  - CSS 変数 `--app-header-height` と `--app-bottom-nav-height` を動的に設定

- **Header**: モバイル時は MobileHeader にデリゲート
  - デスクトップではフル機能を保持
  - モバイルではコンパクト表示に切り替え

- **UnifiedMenu**: SignedInMenuContent / SignedOutMenuContent をエクスポート
  - ボトムナビの Me タブで再利用可能に

- **ContentWithAIChat**: FAB（FloatingActionButton）の位置調整
  - ボトムナビの高さを考慮した padding-bottom を動的に設定

- **NoteView**: ContentWithAIChat でラップし、FAB を表示

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm test` でユニットテストを実行（BottomNav / MobileHeader / AppLayout のテストが追加）
2. デスクトップ表示で既存機能が動作することを確認
3. モバイル表示（DevTools で 375px 以下）でボトムナビが表示されることを確認
4. ボトムナビの各タブをタップしてナビゲーション動作を確認
5. Me タブをタップしてアカウントメニューが Sheet で開くことを確認
6. 検索アイコンをタップして検索 Sheet が開くことを確認

## チェックリスト

- [x] テストがすべてパスする（BottomNav / MobileHeader / AppLayout / Header のテスト追加）
- [x] 必要に応じてドキュメントを更新した（JSDoc コメント追加）
- [x] コンポーネントが Conventional Commits に従っている

https://claude.ai/code/session_01E2wQZ54b6ocAiSus8aqhbg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
