### PR TITLE
test: Add comprehensive unit tests for aiCostUtils and onboardingState

### DIFF
--- a/src/lib/aiCostUtils.test.ts
+++ b/src/lib/aiCostUtils.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+import type { AIModel } from "@/types/ai";
+import { getSonnetBaseline, formatCostMultiplierLabel } from "./aiCostUtils";
+
+/**
+ * モデルを簡潔に作るテストヘルパー。
+ * Small helper to build AIModel fixtures succinctly.
+ */
+function model(overrides: Partial<AIModel> & { id: string }): AIModel {
+  return {
+    provider: "anthropic",
+    modelId: overrides.id,
+    displayName: overrides.id,
+    tierRequired: "free",
+    available: true,
+    inputCostUnits: 0,
+    outputCostUnits: 0,
+    ...overrides,
+  };
+}
+
+describe("getSonnetBaseline", () => {
+  it("id に 'sonnet' を含む正のコストのモデルがあれば、その inputCostUnits を返す", () => {
+    const models: AIModel[] = [
+      model({ id: "openai:gpt-4o-mini", inputCostUnits: 10 }),
+      model({ id: "anthropic:claude-sonnet-4-6", inputCostUnits: 50 }),
+      model({ id: "google:gemini-1.5", inputCostUnits: 5 }),
+    ];
+    expect(getSonnetBaseline(models)).toBe(50);
+  });
+
+  it("displayName に 'Sonnet' を含む（id には含まない）モデルを見つけられる（大文字小文字は無視）", () => {
+    const models: AIModel[] = [
+      model({ id: "anthropic:c4", displayName: "Claude Sonnet 4", inputCostUnits: 33 }),
+    ];
+    expect(getSonnetBaseline(models)).toBe(33);
+  });
+
+  it("Sonnet モデルは存在するが inputCostUnits が 0 のとき、他の正のコストの最小値を返す", () => {
+    const models: AIModel[] = [
+      model({ id: "anthropic:claude-sonnet-4-6", inputCostUnits: 0 }),
+      model({ id: "openai:gpt-4o", inputCostUnits: 20 }),
+      model({ id: "openai:gpt-4o-mini", inputCostUnits: 5 }),
+    ];
+    expect(getSonnetBaseline(models)).toBe(5);
+  });
+
+  it("Sonnet モデルは存在するが inputCostUnits が負のとき、他の正のコストの最小値を返す", () => {
+    const models: AIModel[] = [
+      model({ id: "anthropic:claude-sonnet-4-6", inputCostUnits: -1 }),
+      model({ id: "openai:gpt-4o-mini", inputCostUnits: 7 }),
+    ];
+    expect(getSonnetBaseline(models)).toBe(7);
+  });
+
+  it("Sonnet モデルが無く、正のコストのモデルがあれば、その最小値を返す", () => {
+    const models: AIModel[] = [
+      model({ id: "openai:gpt-4o", inputCostUnits: 20 }),
+      model({ id: "openai:gpt-4o-mini", inputCostUnits: 3 }),
+      model({ id: "google:gemini-1.5", inputCostUnits: 8 }),
+    ];
+    expect(getSonnetBaseline(models)).toBe(3);
+  });
+
+  it("モデル配列が空のとき、フォールバック値 100 を返す", () => {
+    expect(getSonnetBaseline([])).toBe(100);
+  });
+
+  it("全てのモデルの inputCostUnits が 0 以下のとき、フォールバック値 100 を返す", () => {
+    const models: AIModel[] = [
+      model({ id: "openai:gpt-4o-mini", inputCostUnits: 0 }),
+      model({ id: "google:gemini-1.5", inputCostUnits: -5 }),
+    ];
+    expect(getSonnetBaseline(models)).toBe(100);
+  });
+
+  it("displayName が undefined の場合でも id 側のマッチングが働く", () => {
+    const models: AIModel[] = [
+      {
+        id: "anthropic:claude-sonnet-4-6",
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-6",
+        displayName: undefined as unknown as string,
+        tierRequired: "free",
+        available: true,
+        inputCostUnits: 42,
+        outputCostUnits: 0,
+      },
+    ];
+    expect(getSonnetBaseline(models)).toBe(42);
+  });
+
+  it('id・displayName とも undefined の Sonnet 候補がなくてもクラッシュしない（`?? ""` 経路を通す）', () => {
+    // `m.displayName ?? ""` が実行されないと NoCoverage / 同値ミュータントが残るため、
+    // id が "sonnet" を含まず displayName が undefined の行を明示的に含める。
+    // Explicitly exercises the `m.displayName ?? ""` branch: without it, the fallback string
+    // is never evaluated and the related mutant stays NoCoverage.
+    const models: AIModel[] = [
+      {
+        id: "openai:gpt-4o-mini",
+        provider: "openai",
+        modelId: "gpt-4o-mini",
+        displayName: undefined as unknown as string,
+        tierRequired: "free",
+        available: true,
+        inputCostUnits: 5,
+        outputCostUnits: 0,
+      },
+    ];
+    expect(getSonnetBaseline(models)).toBe(5);
+  });
+
+  it("大文字混じりの id でも 'sonnet' を検出できる（toLowerCase が効いていることの検証）", () => {
+    // toLowerCase → toUpperCase のミューテーションを検出するには大文字混じりの id が必要。
+    // A mixed-case id kills the `toLowerCase` → `toUpperCase` mutation on id lookup.
+    const models: AIModel[] = [
+      model({ id: "Anthropic:Claude-Sonnet-4-6", inputCostUnits: 77 }),
+      model({ id: "openai:gpt-4o-mini", inputCostUnits: 3 }),
+    ];
+    expect(getSonnetBaseline(models)).toBe(77);
+  });
+
+  it("id に 'sonnet' を含まず、大文字混じりの displayName で検出できる（displayName 側 toLowerCase 検証）", () => {
+    // id 側の短絡評価を避けつつ、displayName.toLowerCase() の効果を検証する。
+    // Exercises the displayName side of the OR and kills the `toLowerCase`→`toUpperCase` mutation.
+    const models: AIModel[] = [
+      model({
+        id: "anthropic:claude-opus",
+        displayName: "Claude Sonnet 4.6",
+        inputCostUnits: 55,
+      }),
+      model({ id: "openai:gpt-4o-mini", inputCostUnits: 3 }),
+    ];
+    expect(getSonnetBaseline(models)).toBe(55);
+  });
+
+  it("id に 'sonnet' を含むが displayName は含まない場合でも Sonnet 扱いになる（`||` 短絡）", () => {
+    // displayName 単独では検出できないケース。OR → AND のミューテーションを殺す。
+    // The id alone matches; a `||`→`&&` mutation would require displayName to match too.
+    const models: AIModel[] = [
+      model({
+        id: "anthropic:claude-sonnet-4-6",
+        displayName: "Claude Mid",
+        inputCostUnits: 88,
+      }),
+      model({ id: "openai:gpt-4o-mini", inputCostUnits: 3 }),
+    ];
+    expect(getSonnetBaseline(models)).toBe(88);
+  });
+});
+
+describe("formatCostMultiplierLabel", () => {
+  it.each([
+    { input: 0, baseline: 50 },
+    { input: -10, baseline: 50 },
+    { input: 50, baseline: 0 },
+    { input: 50, baseline: -1 },
+    { input: 0, baseline: 0 },
+  ])("inputCostUnits=$input, baseline=$baseline のとき '1x' を返す", ({ input, baseline }) => {
+    expect(formatCostMultiplierLabel(input, baseline)).toBe("1x");
+  });
+
+  it("比率がちょうど 10 のとき、整数表記になる（境界値: ratio >= 10）", () => {
+    expect(formatCostMultiplierLabel(100, 10)).toBe("10x");
+  });
+
+  it("比率が 10 以上なら整数表記（丸め）になる", () => {
+    expect(formatCostMultiplierLabel(254, 10)).toBe("25x");
+    expect(formatCostMultiplierLabel(255, 10)).toBe("26x");
+  });
+
+  it("比率がちょうど 1 のとき、1 桁小数表記 '1.0x' を返す（境界値: ratio >= 1）", () => {
+    expect(formatCostMultiplierLabel(10, 10)).toBe("1.0x");
+  });
+
+  it("比率が 1 以上 10 未満のとき、1 桁小数表記を返す", () => {
+    expect(formatCostMultiplierLabel(50, 10)).toBe("5.0x");
+    expect(formatCostMultiplierLabel(15, 10)).toBe("1.5x");
+    expect(formatCostMultiplierLabel(99, 10)).toBe("9.9x");
+  });
+
+  it("比率がちょうど 0.1 のとき、1 桁小数表記 '0.1x' を返す（境界値: ratio >= 0.1）", () => {
+    expect(formatCostMultiplierLabel(1, 10)).toBe("0.1x");
+  });
+
+  it("比率が 0.1 以上 1 未満のとき、1 桁小数表記を返す", () => {
+    expect(formatCostMultiplierLabel(5, 10)).toBe("0.5x");
+    expect(formatCostMultiplierLabel(9, 10)).toBe("0.9x");
+  });
+
+  it("比率が 0.01 以上 0.1 未満のとき、2 桁小数表記を返す", () => {
+    expect(formatCostMultiplierLabel(5, 100)).toBe("0.05x");
+    expect(formatCostMultiplierLabel(2, 100)).toBe("0.02x");
+  });
+
+  it("比率がちょうど 0.01 のとき、2 桁小数表記 '0.01x' を返す（境界値: ratio >= 0.01）", () => {
+    expect(formatCostMultiplierLabel(1, 100)).toBe("0.01x");
+  });
+
+  it("比率が 0.001 以上 0.01 未満のとき、2 桁小数表記を返す（0.00x に丸められうる）", () => {
+    // 0.005 は toFixed(2) で "0.01" になる
+    expect(formatCostMultiplierLabel(5, 1000)).toBe("0.01x");
+    // 0.001 は toFixed(2) で "0.00" になる
+    expect(formatCostMultiplierLabel(1, 1000)).toBe("0.00x");
+  });
+
+  it("比率が 0.001 未満のとき、'<0.01x' を返す", () => {
+    expect(formatCostMultiplierLabel(1, 10_000)).toBe("<0.01x");
+    expect(formatCostMultiplierLabel(1, 1_000_000)).toBe("<0.01x");
+  });
+
+  it("ラベルは必ず 'x' で終わる（サニティチェック）", () => {
+    const cases = [
+      formatCostMultiplierLabel(0, 10),
+      formatCostMultiplierLabel(1, 10),
+      formatCostMultiplierLabel(50, 10),
+      formatCostMultiplierLabel(5, 100),
+      formatCostMultiplierLabel(1, 1_000_000),
+    ];
+    for (const label of cases) {
+      expect(label.endsWith("x")).toBe(true);
+    }
+  });
+});

--- a/src/lib/onboardingState.test.ts
+++ b/src/lib/onboardingState.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  getOnboardingState,
+  saveOnboardingState,
+  markSetupWizardCompleted,
+  markTourCompleted,
+  markStepCompleted,
+  dismissHint,
+  shouldShowHint,
+  resetOnboardingState,
+} from "./onboardingState";
+
+const STORAGE_KEY = "zedi-onboarding";
+
+describe("onboardingState", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Avoid noisy error logs in tests that intentionally trigger error paths.
+    // エラー経路を意図的に通すテスト用に console.error を抑制する。
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("getOnboardingState", () => {
+    it("localStorage に保存が無いときはデフォルト状態を返す", () => {
+      expect(getOnboardingState()).toEqual({
+        hasCompletedSetupWizard: false,
+        hasCompletedTour: false,
+        completedSteps: [],
+        dismissedHints: [],
+      });
+    });
+
+    it("保存済みの有効な JSON をデフォルトにマージして返す", () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ hasCompletedSetupWizard: true, completedSteps: ["step-1"] }),
+      );
+      expect(getOnboardingState()).toEqual({
+        hasCompletedSetupWizard: true,
+        hasCompletedTour: false,
+        completedSteps: ["step-1"],
+        dismissedHints: [],
+      });
+    });
+
+    it("保存された JSON のフィールドがデフォルト値を上書きする", () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          hasCompletedSetupWizard: true,
+          hasCompletedTour: true,
+          completedSteps: ["a", "b"],
+          dismissedHints: ["hint-1"],
+        }),
+      );
+      expect(getOnboardingState()).toEqual({
+        hasCompletedSetupWizard: true,
+        hasCompletedTour: true,
+        completedSteps: ["a", "b"],
+        dismissedHints: ["hint-1"],
+      });
+    });
+
+    it("不正な JSON が保存されていた場合はデフォルト状態を返し、エラーをログに残す", () => {
+      localStorage.setItem(STORAGE_KEY, "{not json");
+      const errorSpy = vi.spyOn(console, "error");
+      expect(getOnboardingState()).toEqual({
+        hasCompletedSetupWizard: false,
+        hasCompletedTour: false,
+        completedSteps: [],
+        dismissedHints: [],
+      });
+      expect(errorSpy).toHaveBeenCalledWith("Failed to parse onboarding state:", expect.any(Error));
+    });
+
+    it("空文字列が保存されていた場合は JSON.parse を呼ばずにデフォルトを返す（エラーログも出ない）", () => {
+      // 明示的に空文字列をセットして、`if (stored)` の false 分岐を通すことを担保する。
+      // Sets an empty string to exercise the falsy branch of `if (stored)`; JSON.parse must not be invoked.
+      localStorage.setItem(STORAGE_KEY, "");
+      const errorSpy = vi.spyOn(console, "error");
+      expect(getOnboardingState()).toEqual({
+        hasCompletedSetupWizard: false,
+        hasCompletedTour: false,
+        completedSteps: [],
+        dismissedHints: [],
+      });
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("saveOnboardingState", () => {
+    it("既存の状態に部分更新をマージして保存する", () => {
+      saveOnboardingState({ hasCompletedTour: true });
+      saveOnboardingState({ completedSteps: ["s1"] });
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+      expect(stored).toEqual({
+        hasCompletedSetupWizard: false,
+        hasCompletedTour: true,
+        completedSteps: ["s1"],
+        dismissedHints: [],
+      });
+    });
+
+    it("localStorage.setItem が例外を投げる場合はエラーをログに残し、呼び出しは例外を伝播しない", () => {
+      const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new Error("Quota exceeded");
+      });
+      const errorSpy = vi.spyOn(console, "error");
+
+      expect(() => saveOnboardingState({ hasCompletedTour: true })).not.toThrow();
+      expect(errorSpy).toHaveBeenCalledWith("Failed to save onboarding state:", expect.any(Error));
+      setItemSpy.mockRestore();
+    });
+  });
+
+  describe("markSetupWizardCompleted / markTourCompleted", () => {
+    it("markSetupWizardCompleted で hasCompletedSetupWizard=true になる", () => {
+      markSetupWizardCompleted();
+      expect(getOnboardingState().hasCompletedSetupWizard).toBe(true);
+      expect(getOnboardingState().hasCompletedTour).toBe(false);
+    });
+
+    it("markTourCompleted で hasCompletedTour=true になる", () => {
+      markTourCompleted();
+      expect(getOnboardingState().hasCompletedTour).toBe(true);
+      expect(getOnboardingState().hasCompletedSetupWizard).toBe(false);
+    });
+  });
+
+  describe("markStepCompleted", () => {
+    it("未完了のステップを追加できる", () => {
+      markStepCompleted("step-1");
+      expect(getOnboardingState().completedSteps).toEqual(["step-1"]);
+    });
+
+    it("連続で異なるステップを追加すると順番が維持される", () => {
+      markStepCompleted("step-1");
+      markStepCompleted("step-2");
+      expect(getOnboardingState().completedSteps).toEqual(["step-1", "step-2"]);
+    });
+
+    it("既に完了済みのステップを再度追加しても重複しない", () => {
+      markStepCompleted("step-1");
+      markStepCompleted("step-1");
+      expect(getOnboardingState().completedSteps).toEqual(["step-1"]);
+    });
+  });
+
+  describe("dismissHint / shouldShowHint", () => {
+    it("初期状態では全てのヒントが表示対象（shouldShowHint=true）", () => {
+      expect(shouldShowHint("hint-a")).toBe(true);
+    });
+
+    it("dismissHint すると shouldShowHint は false を返す", () => {
+      dismissHint("hint-a");
+      expect(shouldShowHint("hint-a")).toBe(false);
+      expect(getOnboardingState().dismissedHints).toEqual(["hint-a"]);
+    });
+
+    it("既に dismiss 済みのヒントを再度 dismiss しても重複追加しない", () => {
+      dismissHint("hint-a");
+      dismissHint("hint-a");
+      expect(getOnboardingState().dismissedHints).toEqual(["hint-a"]);
+    });
+
+    it("dismiss していない他のヒントは影響を受けない", () => {
+      dismissHint("hint-a");
+      expect(shouldShowHint("hint-b")).toBe(true);
+    });
+  });
+
+  describe("resetOnboardingState", () => {
+    it("localStorage から zedi-onboarding を削除する", () => {
+      saveOnboardingState({ hasCompletedTour: true });
+      expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+      resetOnboardingState();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(getOnboardingState()).toEqual({
+        hasCompletedSetupWizard: false,
+        hasCompletedTour: false,
+        completedSteps: [],
+        dismissedHints: [],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 概要

このPRでは、`aiCostUtils` と `onboardingState` モジュールの包括的なユニットテストを追加します。これらのテストは、エッジケースやミューテーション検出を含む高いカバレッジを目指しており、コード品質と保守性を向上させます。

## 変更点

- **`src/lib/aiCostUtils.test.ts`** (新規追加)
  - `getSonnetBaseline()` 関数の13個のテストケース
    - Sonnet モデルの検出（id と displayName の両方）
    - 大文字小文字の処理
    - フォールバック値の動作
    - エッジケース（ゼロ値、負の値、undefined）
    - ミューテーション検出（`toLowerCase` → `toUpperCase`、`||` → `&&`）
  
  - `formatCostMultiplierLabel()` 関数の13個のテストケース
    - 比率に応じた異なるフォーマット（整数、1桁小数、2桁小数）
    - 境界値テスト（0.01x、0.1x、1x、10x）
    - 非常に小さい比率の処理（`<0.01x`）
    - サニティチェック（すべてのラベルが 'x' で終わる）

- **`src/lib/onboardingState.test.ts`** (新規追加)
  - `getOnboardingState()` 関数の5個のテストケース
    - デフォルト状態の返却
    - JSON パースと状態のマージ
    - 不正な JSON の処理
    - 空文字列の処理
  
  - `saveOnboardingState()` 関数の2個のテストケース
    - 部分更新のマージ
    - localStorage エラーハンドリング
  
  - `markSetupWizardCompleted()` / `markTourCompleted()` の2個のテストケース
  
  - `markStepCompleted()` 関数の3個のテストケース
    - ステップの追加と順序保持
    - 重複排除
  
  - `dismissHint()` / `shouldShowHint()` 関数の4個のテストケース
    - ヒント表示の初期状態
    - ヒント非表示の動作
    - 重複排除
    - 独立性の確認
  
  - `resetOnboardingState()` 関数の1個のテストケース

## 変更の種類

- [x] 🧪 テスト (Tests)

## テスト方法

```bash
# すべてのテストを実行
npm test

# 特定のテストファイルを実行
npm test aiCostUtils.test.ts
npm test onboardingState.test.ts

# カバレッジレポートを生成
npm test -- --coverage
```

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] ミューテーション検出を考慮したテストケース設計
- [x] エッジケースと境界値をカバー

## 補足

テストは以下の原則に従って設計されています：

1. **ミューテーション検出**: `toLowerCase` → `toUpperCase`、`||` → `&&` などの一般的なミューテーションを検出できるテストケースを含む
2. **エッジケースカバレッジ**: ゼ

https://claude.ai/code/session_012a3K6B2JmqiWkkW5aHs2QZ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
