### PR TITLE
fix(security): close TOCTOU windows, gate proxy headers, hide internal pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,14 @@ POLAR_PRO_YEARLY_PRODUCT_ID=YOUR_POLAR_YEARLY_PRODUCT_ID
 # For Chrome extension: add chrome-extension://<extension-id> (get ID from chrome://extensions).
 # CORS_ORIGIN=
 
+# Trust proxy headers for client IP extraction (server/api/src/lib/clientIp.ts).
+# Set to "true" only when this API sits behind a trusted reverse proxy
+# (Railway / Cloudflare / nginx) that overwrites x-forwarded-for / x-real-ip.
+# When unset or false, proxy headers are ignored and the socket peer address is
+# used so spoofed XFF cannot bypass per-IP rate limiting on unauth endpoints.
+# 信頼できるプロキシ配下に置く本番では "true"。直接公開・開発時は未設定のままにする。
+# TRUST_PROXY=false
+
 # Resend (email sending for note invitations)
 # Get an API key at https://resend.com/api-keys
 # RESEND_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,18 @@ POLAR_PRO_YEARLY_PRODUCT_ID=YOUR_POLAR_YEARLY_PRODUCT_ID
 # (Railway / Cloudflare / nginx) that overwrites x-forwarded-for / x-real-ip.
 # When unset or false, proxy headers are ignored and the socket peer address is
 # used so spoofed XFF cannot bypass per-IP rate limiting on unauth endpoints.
+#
+# ⚠️ Deployment migration note:
+#   Existing production deployments behind a reverse proxy (e.g. Railway) MUST
+#   set TRUST_PROXY=true when upgrading to this release. Otherwise the socket
+#   peer is the proxy itself, so every request appears to share one IP and
+#   per-IP rate limits on unauthenticated endpoints (e.g. /api/mcp/session
+#   PKCE brute-force guard) collapse into a single shared bucket.
+#
 # 信頼できるプロキシ配下に置く本番では "true"。直接公開・開発時は未設定のままにする。
+# ⚠️ 既存の本番（リバースプロキシ配下）からアップグレードする場合は必ず TRUST_PROXY=true を
+# 設定すること。未設定だとソケット IP がプロキシ自身の IP になり、per-IP レートリミットが
+# 全リクエストで共有バケットに退化する。
 # TRUST_PROXY=false
 
 # Resend (email sending for note invitations)

--- a/server/api/src/__tests__/lib/auditLog.test.ts
+++ b/server/api/src/__tests__/lib/auditLog.test.ts
@@ -2,7 +2,7 @@
  * `lib/auditLog.ts` のユニットテスト。
  * Unit tests for the audit-log helper (extractClientIp, recordAuditLog).
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Context } from "hono";
 import type { AppEnv } from "../../types/index.js";
 import { extractClientIp, recordAuditLog } from "../../lib/auditLog.js";
@@ -30,7 +30,26 @@ function createMockContext(params: {
 }
 
 describe("extractClientIp", () => {
-  it("returns the leftmost IP from x-forwarded-for", () => {
+  // `extractClientIp` は TRUST_PROXY=true のときのみプロキシヘッダを採用する。
+  // テストでは getConnInfo が呼べないため、ヘッダ採用時は値が返り、それ以外は
+  // ソケット IP 取得が失敗して null になる、という挙動を検証する。
+  // Tests assume getConnInfo throws under the mock context; the helper falls
+  // back to socket IP only when proxy trust is enabled and headers are present.
+  const originalTrustProxy = process.env.TRUST_PROXY;
+
+  beforeEach(() => {
+    process.env.TRUST_PROXY = "true";
+  });
+
+  afterEach(() => {
+    if (originalTrustProxy === undefined) {
+      delete process.env.TRUST_PROXY;
+    } else {
+      process.env.TRUST_PROXY = originalTrustProxy;
+    }
+  });
+
+  it("returns the leftmost IP from x-forwarded-for when TRUST_PROXY=true", () => {
     const c = createMockContext({
       headers: { "x-forwarded-for": "203.0.113.10, 10.0.0.1, 172.16.0.1" },
     });
@@ -49,13 +68,29 @@ describe("extractClientIp", () => {
     expect(extractClientIp(c)).toBe("192.0.2.42");
   });
 
-  it("returns null when neither header is present", () => {
+  it("returns null (no socket info) when neither header is present", () => {
     const c = createMockContext({ headers: {} });
     expect(extractClientIp(c)).toBeNull();
   });
 
-  it("returns null when x-forwarded-for is empty", () => {
+  it("returns null (no socket info) when x-forwarded-for is empty", () => {
     const c = createMockContext({ headers: { "x-forwarded-for": "  " } });
+    expect(extractClientIp(c)).toBeNull();
+  });
+
+  it("ignores x-forwarded-for when TRUST_PROXY is not set", () => {
+    process.env.TRUST_PROXY = "false";
+    const c = createMockContext({
+      headers: { "x-forwarded-for": "203.0.113.10" },
+    });
+    // プロキシヘッダは無視され、テスト Context にはソケット情報がないので null。
+    // Spoofed XFF must not be trusted; without socket info the helper returns null.
+    expect(extractClientIp(c)).toBeNull();
+  });
+
+  it("ignores x-real-ip when TRUST_PROXY is not set", () => {
+    process.env.TRUST_PROXY = "false";
+    const c = createMockContext({ headers: { "x-real-ip": "192.0.2.42" } });
     expect(extractClientIp(c)).toBeNull();
   });
 });
@@ -78,8 +113,22 @@ function createFakeDb() {
 }
 
 describe("recordAuditLog", () => {
+  // recordAuditLog は extractClientIp を経由するため、IP を期待するテストでは
+  // TRUST_PROXY=true を有効にしてプロキシヘッダを採用させる。
+  // recordAuditLog uses extractClientIp; enable proxy trust where IP is asserted.
+  const originalTrustProxy = process.env.TRUST_PROXY;
+
   beforeEach(() => {
     vi.restoreAllMocks();
+    process.env.TRUST_PROXY = "true";
+  });
+
+  afterEach(() => {
+    if (originalTrustProxy === undefined) {
+      delete process.env.TRUST_PROXY;
+    } else {
+      process.env.TRUST_PROXY = originalTrustProxy;
+    }
   });
 
   it("inserts a row with actor, action, target, before/after, ip, and user-agent", async () => {

--- a/server/api/src/__tests__/lib/auditLog.test.ts
+++ b/server/api/src/__tests__/lib/auditLog.test.ts
@@ -78,7 +78,7 @@ describe("extractClientIp", () => {
     expect(extractClientIp(c)).toBeNull();
   });
 
-  it("ignores x-forwarded-for when TRUST_PROXY is not set", () => {
+  it("ignores x-forwarded-for when TRUST_PROXY=false", () => {
     process.env.TRUST_PROXY = "false";
     const c = createMockContext({
       headers: { "x-forwarded-for": "203.0.113.10" },
@@ -88,7 +88,7 @@ describe("extractClientIp", () => {
     expect(extractClientIp(c)).toBeNull();
   });
 
-  it("ignores x-real-ip when TRUST_PROXY is not set", () => {
+  it("ignores x-real-ip when TRUST_PROXY=false", () => {
     process.env.TRUST_PROXY = "false";
     const c = createMockContext({ headers: { "x-real-ip": "192.0.2.42" } });
     expect(extractClientIp(c)).toBeNull();

--- a/server/api/src/__tests__/middleware/rateLimit.test.ts
+++ b/server/api/src/__tests__/middleware/rateLimit.test.ts
@@ -8,7 +8,7 @@
  *
  * Unit tests for the rate limit middleware (#562).
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import type { AppEnv } from "../../types/index.js";
@@ -61,8 +61,23 @@ function appWith(middleware: ReturnType<typeof rateLimit>, setup: (c: Context<Ap
 describe("rateLimit middleware", () => {
   let redis: AppEnv["Variables"]["redis"];
 
+  // `extractClientIp` は TRUST_PROXY=true のときだけ x-forwarded-for を採用するため、
+  // IP ベースのバケットを検証するテスト中は明示的にプロキシ信頼を有効にする。
+  // `extractClientIp` only reads x-forwarded-for when TRUST_PROXY=true, so enable
+  // proxy trust for the duration of these tests to exercise IP-scoped buckets.
+  const originalTrustProxy = process.env.TRUST_PROXY;
+
   beforeEach(() => {
     redis = createMockRedis();
+    process.env.TRUST_PROXY = "true";
+  });
+
+  afterEach(() => {
+    if (originalTrustProxy === undefined) {
+      delete process.env.TRUST_PROXY;
+    } else {
+      process.env.TRUST_PROXY = originalTrustProxy;
+    }
   });
 
   it("passes through when no redis is bound (graceful degradation)", async () => {

--- a/server/api/src/__tests__/routes/mcp.test.ts
+++ b/server/api/src/__tests__/routes/mcp.test.ts
@@ -9,7 +9,7 @@
  *
  * Tests for /api/mcp routes: PKCE code issuance, code exchange, revocation, and MCP clip endpoint.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Context, Next } from "hono";
 import type { AppEnv } from "../../types/index.js";
 
@@ -502,6 +502,24 @@ describe("POST /api/mcp/revoke-session", () => {
 // surface to the user.
 // ─────────────────────────────────────────────────────────────────────────────
 describe("rate limiting (#562)", () => {
+  // per-IP バケットの検証には x-forwarded-for を使うため、プロキシ信頼を
+  // このブロック内だけ有効化する（`extractClientIp` が XFF を採用する条件）。
+  // Enable proxy trust for this block so per-IP tests can drive the bucket
+  // via x-forwarded-for (extractClientIp reads the header only when trusted).
+  const originalTrustProxy = process.env.TRUST_PROXY;
+
+  beforeEach(() => {
+    process.env.TRUST_PROXY = "true";
+  });
+
+  afterEach(() => {
+    if (originalTrustProxy === undefined) {
+      delete process.env.TRUST_PROXY;
+    } else {
+      process.env.TRUST_PROXY = originalTrustProxy;
+    }
+  });
+
   it("POST /api/mcp/clip returns 429 with Retry-After once the per-user limit is exceeded", async () => {
     const app = createMcpApp(mockRedis, mockDb);
     // 30/min/user. 30 回まで通して 31 回目で 429。

--- a/server/api/src/__tests__/routes/media.test.ts
+++ b/server/api/src/__tests__/routes/media.test.ts
@@ -385,7 +385,14 @@ describe("GET /api/media/:id — proxy stream (no redirect to storage)", () => {
   });
 });
 
-describe("DELETE /api/media/:id — storage-first deletion order", () => {
+describe("DELETE /api/media/:id — DB-first deletion order", () => {
+  // DB 削除を先に行うのは、SELECT と DELETE の間に所有権が変わる TOCTOU 窓で
+  // 他人の行に紐づく S3 オブジェクトを消してしまわないため。DB 削除が 0 行だった
+  // 場合は S3 を触らずに 403 を返す。
+  //
+  // The handler deletes the DB row first under an ownership-scoped WHERE. Only
+  // after the DELETE returns a row do we touch S3, so a TOCTOU ownership change
+  // cannot trigger an S3 delete on someone else's object.
   const s3Key = `users/${TEST_USER_ID}/media/${MEDIA_ID}/photo.png`;
   const mediaRow = {
     id: MEDIA_ID,
@@ -398,9 +405,82 @@ describe("DELETE /api/media/:id — storage-first deletion order", () => {
     createdAt: new Date(),
   };
 
-  it("deletes storage object before DB row when both succeed", async () => {
+  it("deletes DB row before storage object when both succeed", async () => {
     mockS3Send.mockResolvedValueOnce({});
-    const { db } = createMockDb([[mediaRow], []]);
+    const { db, chains } = createMockDb([[mediaRow], [{ s3Key }]]);
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/media", mediaRoutes);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(200);
+    // DB 削除が先に走り、その成功後に S3 を 1 回呼ぶ。
+    // DB DELETE runs first; S3 send runs exactly once, after the DB succeeds.
+    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
+    expect(deleteCalls).toHaveLength(1);
+    expect(mockS3Send).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 403 without touching storage when DB delete matches no rows (TOCTOU)", async () => {
+    // SELECT 後に ownerId が変わった（並行削除・移管）シナリオ。
+    // Ownership changed between SELECT and DELETE; S3 must not be touched.
+    const { db, chains } = createMockDb([[mediaRow], []]);
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/media", mediaRoutes);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(403);
+    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
+    expect(deleteCalls).toHaveLength(1);
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+
+  it("still returns 200 when storage delete fails with unexpected error (orphan logged)", async () => {
+    // DB 行は既に削除済みなので、S3 側の失敗は孤立オブジェクトとして残すのみ。
+    // 呼び出し元から見れば削除は成功しているので 200 を返す。
+    // The DB row is already gone; a post-DB S3 failure cannot be rolled back.
+    // The orphan is logged for ops sweep, but the API still reports success.
+    mockS3Send.mockRejectedValueOnce(new Error("network down"));
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { db } = createMockDb([[mediaRow], [{ s3Key }]]);
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/media", mediaRoutes);
+
+    const res = await app.request(`/api/media/${MEDIA_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(200);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("returns 200 when storage reports NoSuchKey (idempotent, DB already deleted)", async () => {
+    mockS3Send.mockRejectedValueOnce({
+      name: "NoSuchKey",
+      $metadata: { httpStatusCode: 404 },
+    });
+    const { db } = createMockDb([[mediaRow], [{ s3Key }]]);
     const app = new Hono<AppEnv>();
     app.use("*", async (c, next) => {
       c.set("db", db as unknown as AppEnv["Variables"]["db"]);
@@ -417,74 +497,14 @@ describe("DELETE /api/media/:id — storage-first deletion order", () => {
     expect(mockS3Send).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps DB row and returns 502 when storage deletion fails with unexpected error", async () => {
-    mockS3Send.mockRejectedValueOnce(new Error("network down"));
-    const { db, chains } = createMockDb([[mediaRow]]);
+  it("returns 403 when media belongs to another user (no storage call, no DB delete)", async () => {
+    const { chains, db } = createMockDb([[{ ...mediaRow, ownerId: ATTACKER_ID }]]);
     const app = new Hono<AppEnv>();
     app.use("*", async (c, next) => {
       c.set("db", db as unknown as AppEnv["Variables"]["db"]);
       await next();
     });
     app.route("/api/media", mediaRoutes);
-
-    const res = await app.request(`/api/media/${MEDIA_ID}`, {
-      method: "DELETE",
-      headers: { "x-test-user-id": TEST_USER_ID },
-    });
-
-    expect(res.status).toBe(502);
-    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
-    expect(deleteCalls).toHaveLength(0);
-  });
-
-  it("proceeds to delete DB row when storage reports NoSuchKey (idempotent)", async () => {
-    mockS3Send.mockRejectedValueOnce({
-      name: "NoSuchKey",
-      $metadata: { httpStatusCode: 404 },
-    });
-    const { db, chains } = createMockDb([[mediaRow], []]);
-    const app = new Hono<AppEnv>();
-    app.use("*", async (c, next) => {
-      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
-      await next();
-    });
-    app.route("/api/media", mediaRoutes);
-
-    const res = await app.request(`/api/media/${MEDIA_ID}`, {
-      method: "DELETE",
-      headers: { "x-test-user-id": TEST_USER_ID },
-    });
-
-    expect(res.status).toBe(200);
-    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
-    expect(deleteCalls).toHaveLength(1);
-  });
-
-  it("keeps DB row and returns 502 for NoSuchBucket 404 (config failure, not idempotent)", async () => {
-    mockS3Send.mockRejectedValueOnce({
-      name: "NoSuchBucket",
-      $metadata: { httpStatusCode: 404 },
-    });
-    const { db, chains } = createMockDb([[mediaRow]]);
-    const app = new Hono<AppEnv>();
-    app.use("*", async (c, next) => {
-      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
-      await next();
-    });
-    app.route("/api/media", mediaRoutes);
-
-    const res = await app.request(`/api/media/${MEDIA_ID}`, {
-      method: "DELETE",
-      headers: { "x-test-user-id": TEST_USER_ID },
-    });
-
-    expect(res.status).toBe(502);
-    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
-    expect(deleteCalls).toHaveLength(0);
-  });
-
-  it("returns 403 when media belongs to another user (no storage call)", async () => {
-    const app = createMediaApp([[{ ...mediaRow, ownerId: ATTACKER_ID }]]);
 
     const res = await app.request(`/api/media/${MEDIA_ID}`, {
       method: "DELETE",
@@ -492,11 +512,19 @@ describe("DELETE /api/media/:id — storage-first deletion order", () => {
     });
 
     expect(res.status).toBe(403);
+    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
+    expect(deleteCalls).toHaveLength(0);
     expect(mockS3Send).not.toHaveBeenCalled();
   });
 
-  it("returns 404 when media row is missing (no storage call)", async () => {
-    const app = createMediaApp([[]]);
+  it("returns 404 when media row is missing (no storage call, no DB delete)", async () => {
+    const { chains, db } = createMockDb([[]]);
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/media", mediaRoutes);
 
     const res = await app.request(`/api/media/${MEDIA_ID}`, {
       method: "DELETE",
@@ -504,6 +532,8 @@ describe("DELETE /api/media/:id — storage-first deletion order", () => {
     });
 
     expect(res.status).toBe(404);
+    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
+    expect(deleteCalls).toHaveLength(0);
     expect(mockS3Send).not.toHaveBeenCalled();
   });
 });

--- a/server/api/src/__tests__/routes/pages.test.ts
+++ b/server/api/src/__tests__/routes/pages.test.ts
@@ -191,6 +191,41 @@ describe("GET /api/pages", () => {
 
     expect(res.status).toBe(200);
   });
+
+  it("filters out internal special pages (special_kind, is_schema) by default", async () => {
+    const { app, chains } = createPagesAppWithChains([{ rows: [] }]);
+
+    const res = await app.request("/api/pages", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    // execute() に渡された SQL チャンクに special_kind / is_schema の除外句が
+    // 含まれていることを検証する（Drizzle sql テンプレートの queryChunks を文字列化）。
+    // Verify the SQL passed to execute() contains the special-kind exclusion clause.
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    expect(executeChain).toBeDefined();
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).toContain("special_kind IS NULL");
+    expect(serialised).toContain("is_schema = false");
+  });
+
+  it("includes internal special pages when include_special=true", async () => {
+    const { app, chains } = createPagesAppWithChains([{ rows: [] }]);
+
+    const res = await app.request("/api/pages?include_special=true", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    expect(executeChain).toBeDefined();
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).not.toContain("special_kind IS NULL");
+    expect(serialised).not.toContain("is_schema = false");
+  });
 });
 
 describe("PUT /api/pages/:id/content", () => {

--- a/server/api/src/__tests__/routes/thumbnail/serve.test.ts
+++ b/server/api/src/__tests__/routes/thumbnail/serve.test.ts
@@ -71,7 +71,12 @@ beforeEach(() => {
   mockS3Send.mockReset();
 });
 
-describe("DELETE /api/thumbnail/serve/:id — storage-first deletion order", () => {
+describe("DELETE /api/thumbnail/serve/:id — DB-first deletion order", () => {
+  // media.ts と同様、SELECT と DELETE の TOCTOU 窓で他者の S3 オブジェクトを
+  // 誤削除しないよう、DB 削除が 1 行返した場合のみ S3 に触る。
+  //
+  // Mirrors the media delete pattern: the DB row is removed first under an
+  // ownership-scoped WHERE, and S3 is only touched after DELETE returns a row.
   const s3Key = `thumbnails/${TEST_USER_ID}/${OBJECT_ID}.jpg`;
   const thumbRow = {
     id: OBJECT_ID,
@@ -81,9 +86,60 @@ describe("DELETE /api/thumbnail/serve/:id — storage-first deletion order", () 
     createdAt: new Date(),
   };
 
-  it("deletes storage object before DB row when both succeed", async () => {
+  it("deletes DB row before storage object when both succeed", async () => {
     mockS3Send.mockResolvedValueOnce({});
-    const { app } = createServeApp([[thumbRow], []]);
+    const { app, chains } = createServeApp([[thumbRow], [{ s3Key }]]);
+
+    const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(200);
+    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
+    expect(deleteCalls).toHaveLength(1);
+    expect(mockS3Send).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 404 without touching storage when DB delete matches no rows (TOCTOU)", async () => {
+    // SELECT 後に userId が変わったか並行削除された。S3 は触らない。
+    // Ownership changed after SELECT (or a concurrent DELETE won); skip S3.
+    const { app, chains } = createServeApp([[thumbRow], []]);
+
+    const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(404);
+    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
+    expect(deleteCalls).toHaveLength(1);
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+
+  it("still returns 200 when storage delete fails with unexpected error (orphan logged)", async () => {
+    // DB 行は既に削除済み。S3 失敗は孤立オブジェクトとして残すのみで 200 を返す。
+    // DB row is gone; a post-DB S3 failure is logged for sweeping — API returns 200.
+    mockS3Send.mockRejectedValueOnce(new Error("network down"));
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { app } = createServeApp([[thumbRow], [{ s3Key }]]);
+
+    const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
+      method: "DELETE",
+      headers: { "x-test-user-id": TEST_USER_ID },
+    });
+
+    expect(res.status).toBe(200);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("returns 200 when storage reports NoSuchKey (idempotent, DB already deleted)", async () => {
+    mockS3Send.mockRejectedValueOnce({
+      name: "NoSuchKey",
+      $metadata: { httpStatusCode: 404 },
+    });
+    const { app } = createServeApp([[thumbRow], [{ s3Key }]]);
 
     const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
       method: "DELETE",
@@ -94,56 +150,8 @@ describe("DELETE /api/thumbnail/serve/:id — storage-first deletion order", () 
     expect(mockS3Send).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps DB row and returns 502 when storage deletion fails with unexpected error", async () => {
-    mockS3Send.mockRejectedValueOnce(new Error("network down"));
-    const { app, chains } = createServeApp([[thumbRow]]);
-
-    const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
-      method: "DELETE",
-      headers: { "x-test-user-id": TEST_USER_ID },
-    });
-
-    expect(res.status).toBe(502);
-    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
-    expect(deleteCalls).toHaveLength(0);
-  });
-
-  it("proceeds to delete DB row when storage reports NoSuchKey (idempotent)", async () => {
-    mockS3Send.mockRejectedValueOnce({
-      name: "NoSuchKey",
-      $metadata: { httpStatusCode: 404 },
-    });
-    const { app, chains } = createServeApp([[thumbRow], []]);
-
-    const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
-      method: "DELETE",
-      headers: { "x-test-user-id": TEST_USER_ID },
-    });
-
-    expect(res.status).toBe(200);
-    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
-    expect(deleteCalls).toHaveLength(1);
-  });
-
-  it("keeps DB row and returns 502 for NoSuchBucket 404 (config failure, not idempotent)", async () => {
-    mockS3Send.mockRejectedValueOnce({
-      name: "NoSuchBucket",
-      $metadata: { httpStatusCode: 404 },
-    });
-    const { app, chains } = createServeApp([[thumbRow]]);
-
-    const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
-      method: "DELETE",
-      headers: { "x-test-user-id": TEST_USER_ID },
-    });
-
-    expect(res.status).toBe(502);
-    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
-    expect(deleteCalls).toHaveLength(0);
-  });
-
   it("returns 404 when DB row is missing or belongs to another user (no storage call)", async () => {
-    const { app } = createServeApp([[]]);
+    const { app, chains } = createServeApp([[]]);
 
     const res = await app.request(`/api/thumbnail/serve/${OBJECT_ID}`, {
       method: "DELETE",
@@ -151,6 +159,8 @@ describe("DELETE /api/thumbnail/serve/:id — storage-first deletion order", () 
     });
 
     expect(res.status).toBe(404);
+    const deleteCalls = chains.filter((c) => c.startMethod === "delete");
+    expect(deleteCalls).toHaveLength(0);
     expect(mockS3Send).not.toHaveBeenCalled();
   });
 

--- a/server/api/src/lib/auditLog.ts
+++ b/server/api/src/lib/auditLog.ts
@@ -20,6 +20,7 @@
 import { randomUUID } from "node:crypto";
 import type { Context } from "hono";
 import { adminAuditLogs } from "../schema/auditLogs.js";
+import { extractClientIp as extractClientIpShared } from "./clientIp.js";
 import type { AppEnv, Database } from "../types/index.js";
 
 /**
@@ -40,25 +41,18 @@ export interface RecordAuditLogParams {
 }
 
 /**
- * x-forwarded-for ヘッダ（プロキシ経由）から最も左の IP を取得する。
- * Extract the leftmost IP from `x-forwarded-for` (proxy-aware), falling back
- * to `x-real-ip`, then `null`.
+ * クライアント IP を抽出する（{@link ../lib/clientIp.ts} の薄いラッパー）。
+ * `TRUST_PROXY=true` のときのみ `x-forwarded-for` / `x-real-ip` を採用し、
+ * それ以外はソケット由来の peer IP を返す。
+ *
+ * Re-exports the shared client-IP extractor so audit logging cannot trust
+ * spoofed proxy headers without explicit `TRUST_PROXY=true` opt-in.
  *
  * @param c - Hono Context
  * @returns Client IP string or null
  */
 export function extractClientIp(c: Context<AppEnv>): string | null {
-  const xff = c.req.header("x-forwarded-for");
-  if (xff) {
-    const first = xff.split(",")[0]?.trim();
-    if (first) return first;
-  }
-  const realIp = c.req.header("x-real-ip");
-  if (realIp) {
-    const trimmed = realIp.trim();
-    if (trimmed) return trimmed;
-  }
-  return null;
+  return extractClientIpShared(c);
 }
 
 /**

--- a/server/api/src/lib/clientIp.ts
+++ b/server/api/src/lib/clientIp.ts
@@ -31,14 +31,18 @@ export function isProxyTrusted(): boolean {
 }
 
 /**
- * `x-forwarded-for` の最左 IP を返す。空・無効な場合は null。
- * Return the leftmost IP from `x-forwarded-for`, or null when absent/empty.
+ * `x-forwarded-for` の最左の非空 IP を返す。先頭にカンマが並ぶ不正値も許容する。
+ * Return the leftmost non-empty IP from `x-forwarded-for`; tolerates
+ * malformed leading commas (e.g. `", 203.0.113.1"`).
  */
 function readForwardedFor(c: Context<AppEnv>): string | null {
   const xff = c.req.header("x-forwarded-for");
   if (!xff) return null;
-  const first = xff.split(",")[0]?.trim();
-  return first ? first : null;
+  const first = xff
+    .split(",")
+    .map((v) => v.trim())
+    .find((v) => v.length > 0);
+  return first ?? null;
 }
 
 /**

--- a/server/api/src/lib/clientIp.ts
+++ b/server/api/src/lib/clientIp.ts
@@ -1,0 +1,85 @@
+/**
+ * クライアント IP の抽出ヘルパー / Client IP extraction helpers.
+ *
+ * `x-forwarded-for` と `x-real-ip` は本来クライアントが任意に送れるヘッダのため、
+ * 信頼してよいかは「アプリの直前にプロキシ（Railway, Cloudflare, nginx, ...）が
+ * 必ず存在し、かつそれが正しく XFF を上書きする構成か」に依存する。
+ * 環境変数 `TRUST_PROXY=true` のときだけプロキシヘッダを採用し、それ以外では
+ * ソケット由来の peer IP（`@hono/node-server` の conninfo）を使う。これにより、
+ * 直接公開されたサーバや、信頼できないプロキシ経由のリクエストで XFF を偽装した
+ * クライアントが per-IP レートリミットを回避できないようにする。
+ *
+ * `x-forwarded-for` and `x-real-ip` are client-controllable. We only trust them
+ * when `TRUST_PROXY=true` so unauthenticated clients cannot rotate those headers
+ * to bypass per-IP throttling. When the proxy is not trusted (or no proxy is
+ * configured), fall back to the socket peer address.
+ */
+import type { Context } from "hono";
+import { getConnInfo } from "@hono/node-server/conninfo";
+import type { AppEnv } from "../types/index.js";
+
+/**
+ * `TRUST_PROXY` 環境変数が真と評価されるかを返す。
+ * `"true" | "1" | "yes"` を真として扱い、それ以外は偽。
+ *
+ * Returns whether `TRUST_PROXY` env should enable proxy-header trust.
+ * Recognises `"true" | "1" | "yes"` as truthy.
+ */
+export function isProxyTrusted(): boolean {
+  const raw = process.env.TRUST_PROXY?.trim().toLowerCase();
+  return raw === "true" || raw === "1" || raw === "yes";
+}
+
+/**
+ * `x-forwarded-for` の最左 IP を返す。空・無効な場合は null。
+ * Return the leftmost IP from `x-forwarded-for`, or null when absent/empty.
+ */
+function readForwardedFor(c: Context<AppEnv>): string | null {
+  const xff = c.req.header("x-forwarded-for");
+  if (!xff) return null;
+  const first = xff.split(",")[0]?.trim();
+  return first ? first : null;
+}
+
+/**
+ * `x-real-ip` を返す。空の場合は null。
+ * Return the trimmed `x-real-ip` value, or null when absent/empty.
+ */
+function readRealIp(c: Context<AppEnv>): string | null {
+  const real = c.req.header("x-real-ip")?.trim();
+  return real ? real : null;
+}
+
+/**
+ * ソケット接続元 IP を返す。取得できなければ null。
+ * Return the underlying socket peer address, or null when not available.
+ */
+function readSocketIp(c: Context<AppEnv>): string | null {
+  try {
+    const info = getConnInfo(c);
+    const addr = info.remote.address?.trim();
+    return addr ? addr : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * クライアント IP を抽出する。
+ *
+ * - `TRUST_PROXY=true` のとき: `x-forwarded-for` → `x-real-ip` → ソケット の順で採用。
+ * - それ以外: ソケット IP のみを採用（プロキシヘッダは無視）。
+ *
+ * Extract the best-effort client IP. Trust proxy headers only when
+ * `TRUST_PROXY=true`; otherwise rely on the socket peer address so spoofed
+ * `x-forwarded-for` / `x-real-ip` values cannot influence callers.
+ */
+export function extractClientIp(c: Context<AppEnv>): string | null {
+  if (isProxyTrusted()) {
+    const fromXff = readForwardedFor(c);
+    if (fromXff) return fromXff;
+    const fromReal = readRealIp(c);
+    if (fromReal) return fromReal;
+  }
+  return readSocketIp(c);
+}

--- a/server/api/src/middleware/rateLimit.ts
+++ b/server/api/src/middleware/rateLimit.ts
@@ -13,9 +13,9 @@
  * Simple Redis-based rate limiter. Supports the legacy string-tier call form
  * and a richer options object for per-endpoint limits (windowSec, keyBy, label).
  */
-import type { Context } from "hono";
 import type { Redis } from "ioredis";
 import { createMiddleware } from "hono/factory";
+import { extractClientIp } from "../lib/clientIp.js";
 import type { AppEnv } from "../types/index.js";
 
 const TIER_LIMITS: Record<string, number> = {
@@ -59,22 +59,6 @@ function currentHourWindow(): string {
 
 function currentWindowBucket(windowSec: number): number {
   return Math.floor(Date.now() / 1000 / windowSec);
-}
-
-/**
- * Hono の `c.req.header` からクライアント IP を抽出する。プロキシ背後では
- * `x-forwarded-for` の先頭、直結時は `x-real-ip` をフォールバックとして使う。
- * Extracts the best-effort client IP from common proxy headers.
- */
-function extractClientIp(c: Context<AppEnv>): string | null {
-  const forwarded = c.req.header("x-forwarded-for");
-  if (forwarded) {
-    const first = forwarded.split(",")[0]?.trim();
-    if (first) return first;
-  }
-  const real = c.req.header("x-real-ip");
-  if (real) return real.trim();
-  return null;
 }
 
 /**

--- a/server/api/src/routes/media.ts
+++ b/server/api/src/routes/media.ts
@@ -1,7 +1,7 @@
 import { Readable } from "node:stream";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import {
   S3Client,
   PutObjectCommand,
@@ -265,7 +265,11 @@ app.delete("/:id", authRequired, async (c) => {
     }
   }
 
-  await db.delete(media).where(eq(media.id, mediaId));
+  // 認可は SELECT 時にも検証済みだが、行所有権が読み取り後に変わる TOCTOU を防ぐため
+  // DELETE の WHERE にも `ownerId` を含めて、書き込み段階でも所有者スコープを保つ。
+  // Re-assert ownership in the DELETE predicate to close the read-then-delete TOCTOU
+  // window: rows whose ownership changed after the SELECT must not be removed here.
+  await db.delete(media).where(and(eq(media.id, mediaId), eq(media.ownerId, userId)));
 
   return c.json({ success: true });
 });

--- a/server/api/src/routes/media.ts
+++ b/server/api/src/routes/media.ts
@@ -240,36 +240,53 @@ app.delete("/:id", authRequired, async (c) => {
     throw new HTTPException(403, { message: "You can only delete your own media" });
   }
 
-  // ストレージ→DB の順で削除する。ストレージ側が失敗した場合に DB レコードだけ消えて
-  // オブジェクトが孤児化するのを防ぐため。NoSuchKey 等の冪等エラーは DB 削除まで進める。
+  // DB 削除を先に行い、所有者スコープの WHERE が一致した場合のみ S3 を削除する。
+  // これにより (a) SELECT 後に所有権が変わった TOCTOU 窓では DB 削除が 0 行となり、
+  // 他人の行に属する S3 オブジェクトを誤って消すことがない、(b) DB 行と S3 オブジェクトの
+  // 不整合（行は残っているのにオブジェクトだけ消える）を回避できる。DB 削除後に S3 削除が
+  // 失敗した場合は孤立オブジェクトが残るが、これは後続の GC で回収可能なので DB 不整合より
+  // 安全側に倒している。
   //
-  // Delete storage object before the DB row so a storage failure cannot leave an
-  // orphaned object behind. Idempotent errors (NoSuchKey) still advance to DB delete.
+  // Delete the DB row first under an ownership-scoped WHERE, and only touch S3 when
+  // the row count confirms we owned it. If ownership changed after the SELECT the
+  // DELETE becomes a no-op (0 rows) and we surface 403 instead of silently wiping
+  // someone else's storage object. An orphaned S3 object from a post-DB failure is
+  // reclaimable by a background sweeper; an orphaned DB row pointing at missing
+  // storage is not — so we accept the former, not the latter.
+  const deleted = await db
+    .delete(media)
+    .where(and(eq(media.id, mediaId), eq(media.ownerId, userId)))
+    .returning({ s3Key: media.s3Key });
+
+  const deletedRow = deleted[0];
+  if (!deletedRow) {
+    // SELECT と DELETE の間で所有権が移動したか、並行して削除されたケース。
+    // Ownership changed (or the row was deleted concurrently) between SELECT and DELETE.
+    throw new HTTPException(403, { message: "You can only delete your own media" });
+  }
+
   try {
     await s3.send(
       new DeleteObjectCommand({
         Bucket: BUCKET,
-        Key: row.s3Key,
+        Key: deletedRow.s3Key,
       }),
     );
   } catch (err) {
-    // NoSuchKey のみを冪等として扱う。NoSuchBucket 等、別の 404 応答は
-    // 本当の設定不整合なので 502 に倒して DB を残す。
+    // DB 行は既に削除済み。NoSuchKey は冪等として無視し、それ以外の失敗は
+    // 孤立オブジェクトとして警告だけ残す（DB と storage の再同期は別経路に任せる）。
     //
-    // Only treat an explicit NoSuchKey as idempotent; other 404-class errors
-    // (e.g. NoSuchBucket) indicate real config failures — surface 502 and keep the DB row.
+    // DB row is already gone. Treat NoSuchKey as idempotent; log other failures
+    // so ops can sweep the orphaned S3 object — do NOT resurrect the DB row.
     const s3Err = err as { name?: string } | null;
     if (s3Err?.name !== "NoSuchKey") {
-      console.error("[media] S3 DeleteObject failed:", err);
-      throw new HTTPException(502, { message: "Failed to delete object from storage" });
+      console.error("[media] S3 DeleteObject failed after DB delete (orphaned object):", {
+        mediaId,
+        s3Key: deletedRow.s3Key,
+        err,
+      });
     }
   }
-
-  // 認可は SELECT 時にも検証済みだが、行所有権が読み取り後に変わる TOCTOU を防ぐため
-  // DELETE の WHERE にも `ownerId` を含めて、書き込み段階でも所有者スコープを保つ。
-  // Re-assert ownership in the DELETE predicate to close the read-then-delete TOCTOU
-  // window: rows whose ownership changed after the SELECT must not be removed here.
-  await db.delete(media).where(and(eq(media.id, mediaId), eq(media.ownerId, userId)));
 
   return c.json({ success: true });
 });

--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -98,10 +98,23 @@ app.get("/", authRequired, async (c) => {
         )`
       : sql`p.owner_id = ${userId}`;
 
+  // Wiki の内部システムページ（`special_kind` が `__index__` / `__log__`、
+  // および `is_schema = true` のスキーマページ）は通常一覧から除外する。
+  // クライアントがそれらを編集するための専用 UI が別にあるため、`/api/pages`
+  // で返すと NotFound 化したり、ヘッダ付きカードの中に編集不能な行が混ざる。
+  // include_special=true を指定したクライアントのみオプトインで取得できる。
+  // Hide internal/system pages (special_kind set or is_schema=true) from the
+  // generic listing; clients that need them can opt in with include_special=true.
+  const includeSpecial = c.req.query("include_special") === "true";
+  const specialKindFilter = includeSpecial
+    ? sql`TRUE`
+    : sql`p.special_kind IS NULL AND p.is_schema = false`;
+
   const result = await db.execute(sql`
     SELECT p.id, p.title, p.content_preview, p.updated_at
     FROM pages p
     WHERE p.is_deleted = false
+      AND ${specialKindFilter}
       AND ${accessFilter}
     ORDER BY p.updated_at DESC
     LIMIT ${limit}

--- a/server/api/src/routes/thumbnail/serve.ts
+++ b/server/api/src/routes/thumbnail/serve.ts
@@ -124,7 +124,13 @@ app.delete("/:id", authRequired, async (c) => {
     }
   }
 
-  await db.delete(thumbnailObjects).where(eq(thumbnailObjects.id, objectId));
+  // 認可は SELECT 時にも検証済みだが、所有権が読み取り後に変わる TOCTOU を防ぐため
+  // DELETE の WHERE にも `userId` を含めて、書き込み段階でも所有者スコープを保つ。
+  // Re-assert ownership in the DELETE predicate to close the read-then-delete TOCTOU
+  // window: rows whose ownership changed after the SELECT must not be removed here.
+  await db
+    .delete(thumbnailObjects)
+    .where(and(eq(thumbnailObjects.id, objectId), eq(thumbnailObjects.userId, userId)));
 
   return c.json({ success: true });
 });

--- a/server/api/src/routes/thumbnail/serve.ts
+++ b/server/api/src/routes/thumbnail/serve.ts
@@ -99,38 +99,50 @@ app.delete("/:id", authRequired, async (c) => {
     return c.json({ error: "Not found" }, 404);
   }
 
-  // ストレージ→DB の順で削除する。ストレージ側が失敗した場合に DB レコードだけ消えて
-  // オブジェクトが孤児化するのを防ぐため。NoSuchKey 等の冪等エラーは DB 削除まで進める。
+  // DB 削除を先に行い、所有者スコープの WHERE が一致した場合のみ S3 を削除する。
+  // これにより (a) SELECT 後に所有権が変わった TOCTOU 窓では DB 削除が 0 行となり、
+  // 他人の行に属する S3 オブジェクトを誤って消すことがない、(b) DB 行が残ったまま
+  // S3 だけ消える不整合を回避できる。S3 削除が失敗した孤立オブジェクトは GC で回収可能。
   //
-  // Delete storage object before the DB row so a storage failure cannot leave an
-  // orphaned object behind. Idempotent errors (NoSuchKey) still advance to DB delete.
+  // Delete the DB row first under an ownership-scoped WHERE and only touch S3 when
+  // the row count confirms we owned it. Ownership changes during the TOCTOU window
+  // show up as 0 rows deleted, so we surface 404 instead of wiping someone else's
+  // storage object. Orphaned S3 objects from a post-DB failure are reclaimable by a
+  // background sweeper — safer than the inverse (DB row pointing to missing blob).
+  const deleted = await db
+    .delete(thumbnailObjects)
+    .where(and(eq(thumbnailObjects.id, objectId), eq(thumbnailObjects.userId, userId)))
+    .returning({ s3Key: thumbnailObjects.s3Key });
+
+  const deletedRow = deleted[0];
+  if (!deletedRow) {
+    // SELECT と DELETE の間で所有権が移動したか、並行して削除された。
+    // Ownership changed (or the row was deleted concurrently) between SELECT and DELETE.
+    return c.json({ error: "Not found" }, 404);
+  }
+
   try {
     await s3.send(
       new DeleteObjectCommand({
         Bucket: BUCKET,
-        Key: row.s3Key,
+        Key: deletedRow.s3Key,
       }),
     );
   } catch (err) {
-    // NoSuchKey のみを冪等として扱う。NoSuchBucket 等、別の 404 応答は
-    // 本当の設定不整合なので 502 に倒して DB を残す。
+    // DB 行は既に削除済み。NoSuchKey は冪等として無視し、他の失敗は
+    // 孤立オブジェクトとしてログだけ残す（DB 行は復活させない）。
     //
-    // Only treat an explicit NoSuchKey as idempotent; other 404-class errors
-    // (e.g. NoSuchBucket) indicate real config failures — surface 502 and keep the DB row.
+    // DB row is already gone. Treat NoSuchKey as idempotent; log other failures
+    // so ops can sweep the orphaned S3 object — do NOT resurrect the DB row.
     const s3Err = err as { name?: string } | null;
     if (s3Err?.name !== "NoSuchKey") {
-      console.error("[thumbnail/serve] S3 DeleteObject failed:", err);
-      return c.json({ error: "Failed to delete object from storage" }, 502);
+      console.error("[thumbnail/serve] S3 DeleteObject failed after DB delete (orphaned object):", {
+        objectId,
+        s3Key: deletedRow.s3Key,
+        err,
+      });
     }
   }
-
-  // 認可は SELECT 時にも検証済みだが、所有権が読み取り後に変わる TOCTOU を防ぐため
-  // DELETE の WHERE にも `userId` を含めて、書き込み段階でも所有者スコープを保つ。
-  // Re-assert ownership in the DELETE predicate to close the read-then-delete TOCTOU
-  // window: rows whose ownership changed after the SELECT must not be removed here.
-  await db
-    .delete(thumbnailObjects)
-    .where(and(eq(thumbnailObjects.id, objectId), eq(thumbnailObjects.userId, userId)));
 
   return c.json({ success: true });
 });

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5566,7 +5566,7 @@ dependencies = [
 
 [[package]]
 name = "zedi"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "dirs 5.0.1",
  "serde",


### PR DESCRIPTION
## 概要

[Release PR #636](https://github.com/otomatty/zedi/pull/636) のレビューコメント (CodeRabbit / Devin) で指摘されたセキュリティ系問題を develop に向けて修正する PR の 1 本目。Release は止めて、各カテゴリ別 PR を develop に積んでからリリースし直す方針。

このPR は **Critical/Major のセキュリティ系 4 件** をまとめて修正する:

- TOCTOU 窓 (`media`, `thumbnail` の DELETE)
- `x-forwarded-for` 信頼問題 (rate limiting バイパス)
- 内部システムページの一覧漏洩 (`GET /api/pages`)

## 変更点

| 領域 | 主な変更 |
| ---- | -------- |
| `server/api/src/lib/clientIp.ts` | 共通の client-IP 抽出ヘルパーを新設。`TRUST_PROXY=true` のときだけ `x-forwarded-for` / `x-real-ip` を採用し、それ以外は `@hono/node-server/conninfo` から socket peer を取得 |
| `server/api/src/middleware/rateLimit.ts` | 旧 `extractClientIp` を削除し共通ヘルパーへ。XFF 偽装による per-IP throttling 回避を防ぐ |
| `server/api/src/lib/auditLog.ts` | `extractClientIp` を共通ヘルパーへ委譲。挙動の一元化 |
| `server/api/src/routes/media.ts` | `DELETE /api/media/:id` の WHERE に `ownerId` を追加。read-then-delete 間の所有権変更で他人の行が消える窓を塞ぐ |
| `server/api/src/routes/thumbnail/serve.ts` | `DELETE /api/thumbnail/serve/:id` の WHERE に `userId` を追加 |
| `server/api/src/routes/pages.ts` | `GET /api/pages` から `special_kind IS NULL AND is_schema = false` を既定で適用。`include_special=true` でオプトイン取得可 |
| `.env.example` | `TRUST_PROXY` のドキュメント追記 |
| テスト | `auditLog.test.ts` を `TRUST_PROXY=true` 前提に更新 + 偽装拒否テストを追加。`pages.test.ts` に special-kind フィルタの assertion を追加 |

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

セキュリティ修正だが API シグネチャの破壊的変更ではない（`include_special` クエリは新規・後方互換）。

## テスト方法

```bash
# Server 単体テスト (auditLog 11 件 + pages 14 件)
cd server/api
bunx vitest run src/__tests__/lib/auditLog.test.ts src/__tests__/routes/pages.test.ts
```

手動確認:

1. `TRUST_PROXY` 未設定で `curl -H 'x-forwarded-for: 1.2.3.4' http://localhost:3000/api/...` → IP は socket 由来になり、XFF は無視される（rate-limit バケット rotation 不可）
2. `TRUST_PROXY=true` を設定すると XFF が採用される
3. `GET /api/pages` で `special_kind` 入りページや `is_schema=true` の行が混ざらないこと
4. `GET /api/pages?include_special=true` で従来どおり全件取得できること
5. 他ユーザー所有の `/api/media/:id` を DELETE しても 403、自分所有の DELETE は 200

## チェックリスト

- [x] テストがすべてパスする (`vitest` 25/25)
- [x] Lint エラーがない (`bun run lint` 0 errors)
- [x] `.env.example` を更新した (`TRUST_PROXY`)
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue / PR

Related to #636

レビュー出典:
- coderabbitai #3107034178 (media ownership-scoped delete)
- coderabbitai #3107034182 (thumbnail userId-scoped delete)
- coderabbitai #3107034175 (XFF spoofing in rate limiter)
- devin #3107020247 (internal pages leakage)

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional TRUST_PROXY env var to control proxy header usage.
  * Internal/system wiki pages are excluded from listings by default (toggleable via query).

* **Bug Fixes**
  * Media and thumbnail deletes now validate ownership and perform DB-first deletion; S3 errors are logged without reverting DB changes.
  * Client IP extraction improved for consistent rate-limiting and audit logs.

* **Documentation**
  * .env example updated with TRUST_PROXY guidance and migration notes.

* **Tests**
  * Test suites updated to make TRUST_PROXY-driven behavior deterministic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->