### PR TITLE
Migrate YouTube service from Data API v3 to youtubei.js

### DIFF
--- a/server/api/bun.lock
+++ b/server/api/bun.lock
@@ -31,7 +31,7 @@
         "react-dom": "^19.2.4",
         "resend": "^6.10.0",
         "yjs": "^13.6.30",
-        "youtube-transcript": "^1.3.0",
+        "youtubei.js": "^17.0.1",
       },
       "devDependencies": {
         "@types/jsdom": "^28.0.0",
@@ -153,6 +153,8 @@
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.11.0", "", {}, "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ=="],
 
     "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@10.5.0", "", { "dependencies": { "@chevrotain/gast": "10.5.0", "@chevrotain/types": "10.5.0", "lodash": "4.17.21" } }, "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw=="],
 
@@ -776,6 +778,8 @@
 
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
+    "meriyah": ["meriyah@6.1.4", "", {}, "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mysql2": ["mysql2@3.15.3", "", { "dependencies": { "aws-ssl-profiles": "^1.1.1", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.0", "long": "^5.2.1", "lru.min": "^1.0.0", "named-placeholders": "^1.1.3", "seq-queue": "^0.0.5", "sqlstring": "^2.3.2" } }, "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg=="],
@@ -1032,7 +1036,7 @@
 
     "yjs": ["yjs@13.6.30", "", { "dependencies": { "lib0": "^0.2.99" } }, "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ=="],
 
-    "youtube-transcript": ["youtube-transcript@1.3.0", "", {}, "sha512-laWv9RcKIWh6rZUH3hVnOngEvtKAhFMV5UepUO6AgevPYqe2zv8KW/uCkZJDSnPwf5/AdVu0Q66/1RDblKsp6Q=="],
+    "youtubei.js": ["youtubei.js@17.0.1", "", { "dependencies": { "@bufbuild/protobuf": "^2.0.0", "meriyah": "^6.1.4" } }, "sha512-1lO4b8UqMDzE0oh2qEGzbBOd4UYRdxn/4PdpRM7BGTHxM6ddsEsKZTu90jp8V9FHVgC2h1UirQyqoqLiKwl+Zg=="],
 
     "zeptomatch": ["zeptomatch@2.1.0", "", { "dependencies": { "grammex": "^3.1.11", "graphmatch": "^1.1.0" } }, "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA=="],
 

--- a/server/api/package.json
+++ b/server/api/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^19.2.4",
     "resend": "^6.10.0",
     "yjs": "^13.6.30",
-    "youtube-transcript": "^1.3.0"
+    "youtubei.js": "^17.0.1"
   },
   "devDependencies": {
     "@types/jsdom": "^28.0.0",

--- a/server/api/src/services/youtubeService.test.ts
+++ b/server/api/src/services/youtubeService.test.ts
@@ -210,6 +210,38 @@ describe("youtubeService", () => {
       expect(result.metadata.channelTitle).toBe("Author Name");
     });
 
+    it("leaves duration empty when basic_info.duration is missing (no fabricated 0:00)", async () => {
+      mockGetInfo.mockResolvedValueOnce(
+        buildVideoInfoMock({
+          basicInfo: { title: "No duration" }, // no `duration` field
+          transcriptError: new Error("none"),
+        }),
+      );
+
+      const result = await fetchYouTubeContent("noDur123456");
+      expect(result.metadata.duration).toBe("");
+    });
+
+    it("picks the widest thumbnail even when earlier array entries are null", async () => {
+      mockGetInfo.mockResolvedValueOnce(
+        buildVideoInfoMock({
+          basicInfo: {
+            title: "Sparse thumbs",
+            duration: 30,
+            thumbnail: [
+              null,
+              { url: "https://i.ytimg.com/vi/abc/small.jpg", width: 120, height: 90 },
+              { url: "https://i.ytimg.com/vi/abc/large.jpg", width: 1280, height: 720 },
+            ] as unknown[],
+          },
+          transcriptError: new Error("none"),
+        }),
+      );
+
+      const result = await fetchYouTubeContent("sparseThumb");
+      expect(result.metadata.thumbnailUrl).toBe("https://i.ytimg.com/vi/abc/large.jpg");
+    });
+
     it("uses hqdefault thumbnail when basic_info.thumbnail is empty", async () => {
       mockGetInfo.mockResolvedValueOnce(
         buildVideoInfoMock({
@@ -222,6 +254,27 @@ describe("youtubeService", () => {
       expect(result.metadata.thumbnailUrl).toBe(
         "https://img.youtube.com/vi/noThumb1234/hqdefault.jpg",
       );
+    });
+
+    it("retries Innertube.create after a transient initialisation failure", async () => {
+      // 1 回目: create が失敗 → キャッシュをクリアして再試行可能になることを保証
+      // First call rejects; the cache must clear so the next call retries Innertube.create.
+      mockCreate.mockReset();
+      mockCreate.mockRejectedValueOnce(new Error("transient init failure"));
+      mockCreate.mockResolvedValueOnce({ getInfo: mockGetInfo });
+      mockGetInfo.mockResolvedValueOnce(
+        buildVideoInfoMock({
+          basicInfo: { title: "Recovered", duration: 30 },
+          transcriptError: new Error("none"),
+        }),
+      );
+
+      const first = await fetchYouTubeContent("retryTest12");
+      expect(first.metadata.title).toBe("YouTube Video (retryTest12)"); // minimal fallback
+
+      const second = await fetchYouTubeContent("retryTest12");
+      expect(second.metadata.title).toBe("Recovered");
+      expect(mockCreate).toHaveBeenCalledTimes(2);
     });
 
     it("skips transcript segments with empty text or invalid timestamps", async () => {

--- a/server/api/src/services/youtubeService.test.ts
+++ b/server/api/src/services/youtubeService.test.ts
@@ -2,17 +2,59 @@
  * youtubeService の単体テスト。
  * Unit tests for YouTube service (metadata, transcript, utility functions).
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// youtube-transcript パッケージをモック（CJS/ESM 互換性問題回避）
-// Mock youtube-transcript package (CJS/ESM compatibility workaround)
-vi.mock("youtube-transcript", () => ({
-  YoutubeTranscript: {
-    fetchTranscript: vi.fn().mockResolvedValue([]),
+// youtubei.js モック / Mock the Innertube client
+const mockGetInfo = vi.fn();
+const mockCreate = vi.fn();
+vi.mock("youtubei.js", () => ({
+  Innertube: {
+    create: (...args: unknown[]) => mockCreate(...args),
   },
 }));
 
-import { formatDuration, joinTranscriptText, type TranscriptSegment } from "./youtubeService.js";
+import {
+  formatDuration,
+  joinTranscriptText,
+  fetchYouTubeContent,
+  __resetInnertubeForTesting,
+  type TranscriptSegment,
+} from "./youtubeService.js";
+
+/**
+ * basic_info / page / getTranscript を持つ最小限の VideoInfo モックを生成する。
+ * Builds a minimal VideoInfo-like mock with basic_info, page, and getTranscript.
+ */
+function buildVideoInfoMock(opts: {
+  basicInfo?: Record<string, unknown>;
+  microformat?: Record<string, unknown>;
+  transcriptSegments?: Array<{ start_ms: string; end_ms: string; text: string }>;
+  transcriptError?: unknown;
+}) {
+  const transcriptInfo = opts.transcriptError
+    ? null
+    : {
+        transcript: {
+          content: {
+            body: {
+              initial_segments: (opts.transcriptSegments ?? []).map((s) => ({
+                start_ms: s.start_ms,
+                end_ms: s.end_ms,
+                snippet: { toString: () => s.text },
+              })),
+            },
+          },
+        },
+      };
+
+  return {
+    basic_info: opts.basicInfo ?? {},
+    page: [{ microformat: opts.microformat }],
+    getTranscript: vi.fn(() =>
+      opts.transcriptError ? Promise.reject(opts.transcriptError) : Promise.resolve(transcriptInfo),
+    ),
+  };
+}
 
 describe("youtubeService", () => {
   describe("formatDuration", () => {
@@ -71,73 +113,136 @@ describe("youtubeService", () => {
     });
   });
 
-  describe("fetchYouTubeMetadata", () => {
+  describe("fetchYouTubeContent", () => {
     beforeEach(() => {
-      vi.restoreAllMocks();
+      mockGetInfo.mockReset();
+      mockCreate.mockReset();
+      mockCreate.mockResolvedValue({ getInfo: mockGetInfo });
+      __resetInnertubeForTesting();
     });
 
-    it("throws on API error", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response("Not Found", { status: 404 }),
-      );
-
-      const { fetchYouTubeMetadata } = await import("./youtubeService.js");
-      await expect(fetchYouTubeMetadata("test123456_", "fake-key")).rejects.toThrow(
-        /YouTube Data API failed: 404/,
-      );
+    afterEach(() => {
+      __resetInnertubeForTesting();
     });
 
-    it("throws when video not found (empty items)", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response(JSON.stringify({ items: [] }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
-
-      const { fetchYouTubeMetadata } = await import("./youtubeService.js");
-      await expect(fetchYouTubeMetadata("test123456_", "fake-key")).rejects.toThrow(
-        /YouTube video not found/,
-      );
-    });
-
-    it("parses valid API response", async () => {
-      const mockResponse = {
-        items: [
-          {
-            snippet: {
-              title: "Test Video",
-              description: "A test video description",
-              channelTitle: "Test Channel",
-              publishedAt: "2024-01-15T10:00:00Z",
-              thumbnails: {
-                high: { url: "https://i.ytimg.com/vi/test/hqdefault.jpg", width: 480, height: 360 },
-              },
-              tags: ["test", "video"],
-            },
-            contentDetails: {
-              duration: "PT10M30S",
-            },
+    it("returns metadata and transcript from a successful Innertube response", async () => {
+      mockGetInfo.mockResolvedValueOnce(
+        buildVideoInfoMock({
+          basicInfo: {
+            title: "Test Video",
+            short_description: "A test video description",
+            channel: { id: "UCxxx", name: "Test Channel", url: "" },
+            duration: 630, // 10:30
+            thumbnail: [
+              { url: "https://i.ytimg.com/vi/abc/default.jpg", width: 120, height: 90 },
+              { url: "https://i.ytimg.com/vi/abc/maxres.jpg", width: 1280, height: 720 },
+            ],
+            tags: ["test", "video"],
           },
-        ],
-      };
-
-      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response(JSON.stringify(mockResponse), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
+          microformat: { publish_date: "2024-01-15" },
+          transcriptSegments: [
+            { start_ms: "0", end_ms: "1500", text: "Hello" },
+            { start_ms: "1500", end_ms: "3000", text: "world" },
+          ],
         }),
       );
 
-      const { fetchYouTubeMetadata } = await import("./youtubeService.js");
-      const result = await fetchYouTubeMetadata("test123456_", "fake-key");
+      const result = await fetchYouTubeContent("abc12345678");
 
-      expect(result.title).toBe("Test Video");
-      expect(result.description).toBe("A test video description");
-      expect(result.channelTitle).toBe("Test Channel");
-      expect(result.duration).toBe("PT10M30S");
-      expect(result.tags).toEqual(["test", "video"]);
-      expect(result.thumbnailUrl).toBe("https://i.ytimg.com/vi/test/hqdefault.jpg");
+      expect(result.metadata.title).toBe("Test Video");
+      expect(result.metadata.description).toBe("A test video description");
+      expect(result.metadata.channelTitle).toBe("Test Channel");
+      expect(result.metadata.publishedAt).toBe("2024-01-15");
+      expect(result.metadata.duration).toBe("PT10M30S");
+      expect(result.metadata.thumbnailUrl).toBe("https://i.ytimg.com/vi/abc/maxres.jpg");
+      expect(result.metadata.tags).toEqual(["test", "video"]);
+
+      expect(result.transcript).toEqual([
+        { text: "Hello", offset: 0, duration: 1.5 },
+        { text: "world", offset: 1.5, duration: 1.5 },
+      ]);
+      expect(result.transcriptText).toBe("Hello world");
+    });
+
+    it("returns transcript=null when captions are unavailable", async () => {
+      mockGetInfo.mockResolvedValueOnce(
+        buildVideoInfoMock({
+          basicInfo: { title: "No Caps", duration: 60, channel: { name: "Ch", id: "", url: "" } },
+          transcriptError: new Error("Transcript is disabled on this video"),
+        }),
+      );
+
+      const result = await fetchYouTubeContent("noCaps12345");
+
+      expect(result.metadata.title).toBe("No Caps");
+      expect(result.transcript).toBeNull();
+      expect(result.transcriptText).toBe("");
+    });
+
+    it("falls back to minimal metadata when getInfo throws", async () => {
+      mockGetInfo.mockRejectedValueOnce(new Error("Video unavailable"));
+
+      const result = await fetchYouTubeContent("badvideoXYZ");
+
+      expect(result.metadata.title).toBe("YouTube Video (badvideoXYZ)");
+      expect(result.metadata.description).toBe("");
+      expect(result.metadata.thumbnailUrl).toBe(
+        "https://img.youtube.com/vi/badvideoXYZ/hqdefault.jpg",
+      );
+      expect(result.transcript).toBeNull();
+      expect(result.transcriptText).toBe("");
+    });
+
+    it("falls back to author when channel.name is missing", async () => {
+      mockGetInfo.mockResolvedValueOnce(
+        buildVideoInfoMock({
+          basicInfo: {
+            title: "By author",
+            author: "Author Name",
+            channel: null,
+            duration: 30,
+          },
+          transcriptError: new Error("none"),
+        }),
+      );
+
+      const result = await fetchYouTubeContent("authorTest1");
+      expect(result.metadata.channelTitle).toBe("Author Name");
+    });
+
+    it("uses hqdefault thumbnail when basic_info.thumbnail is empty", async () => {
+      mockGetInfo.mockResolvedValueOnce(
+        buildVideoInfoMock({
+          basicInfo: { title: "No thumb", duration: 30, thumbnail: [] },
+          transcriptError: new Error("none"),
+        }),
+      );
+
+      const result = await fetchYouTubeContent("noThumb1234");
+      expect(result.metadata.thumbnailUrl).toBe(
+        "https://img.youtube.com/vi/noThumb1234/hqdefault.jpg",
+      );
+    });
+
+    it("skips transcript segments with empty text or invalid timestamps", async () => {
+      mockGetInfo.mockResolvedValueOnce(
+        buildVideoInfoMock({
+          basicInfo: { title: "Filter", duration: 30 },
+          transcriptSegments: [
+            { start_ms: "0", end_ms: "1000", text: "good" },
+            { start_ms: "1000", end_ms: "2000", text: "   " },
+            { start_ms: "not-a-number", end_ms: "3000", text: "broken" },
+            { start_ms: "2000", end_ms: "3000", text: "alsoGood" },
+          ],
+        }),
+      );
+
+      const result = await fetchYouTubeContent("filter12345");
+      expect(result.transcript).toEqual([
+        { text: "good", offset: 0, duration: 1 },
+        { text: "alsoGood", offset: 2, duration: 1 },
+      ]);
+      expect(result.transcriptText).toBe("good alsoGood");
     });
   });
 });

--- a/server/api/src/services/youtubeService.test.ts
+++ b/server/api/src/services/youtubeService.test.ts
@@ -210,6 +210,25 @@ describe("youtubeService", () => {
       expect(result.metadata.channelTitle).toBe("Author Name");
     });
 
+    it("falls back to minimal metadata when VideoInfo is malformed (contract: never throws)", async () => {
+      // basic_info を欠いた VideoInfo を返し、extractMetadata が TypeError で落ちる状況を再現。
+      // Simulate a malformed VideoInfo (missing basic_info) that makes
+      // extractMetadata throw — the caller must still get a graceful fallback.
+      mockGetInfo.mockResolvedValueOnce({
+        // basic_info is intentionally absent
+        page: [{}],
+        getTranscript: vi.fn().mockRejectedValue(new Error("none")),
+      });
+
+      const result = await fetchYouTubeContent("malformed12");
+      expect(result.metadata.title).toBe("YouTube Video (malformed12)");
+      expect(result.metadata.thumbnailUrl).toBe(
+        "https://img.youtube.com/vi/malformed12/hqdefault.jpg",
+      );
+      expect(result.transcript).toBeNull();
+      expect(result.transcriptText).toBe("");
+    });
+
     it("leaves duration empty when basic_info.duration is missing (no fabricated 0:00)", async () => {
       mockGetInfo.mockResolvedValueOnce(
         buildVideoInfoMock({

--- a/server/api/src/services/youtubeService.ts
+++ b/server/api/src/services/youtubeService.ts
@@ -1,14 +1,27 @@
 /**
- * YouTube Data API v3 + 字幕取得サービス。
- * YouTube Data API v3 metadata retrieval and transcript fetching service.
+ * YouTube メタデータ + 字幕取得サービス（youtubei.js ベース）。
+ * YouTube metadata and transcript fetching service (powered by youtubei.js).
  *
- * - メタデータ: YouTube Data API v3 (videos.list) を使用
- * - 字幕テキスト: youtube-transcript パッケージ（非公式、API キー不要）を使用
+ * 旧実装は YouTube Data API v3 + youtube-transcript の組み合わせだったが、
+ * - youtube-transcript@1.3.0 の ESM パッケージング不具合
+ * - YouTube Data API v3 のクォータ消費
+ * の 2 点を回避するため youtubei.js (Innertube クライアント) に統合。
  *
- * YouTube Data API の captions.download は OAuth2（動画オーナーのみ）が必要なため、
- * 公開字幕の取得には youtube-transcript を使用する。
+ * The previous implementation combined the YouTube Data API v3 and the
+ * youtube-transcript package. We migrated to youtubei.js (an InnerTube
+ * client) to avoid the ESM packaging bug in youtube-transcript@1.3.0 and
+ * to eliminate YouTube Data API quota consumption — both metadata and
+ * transcripts are fetched from a single Innertube session.
  */
-import { YoutubeTranscript, type TranscriptResponse } from "youtube-transcript";
+import { Innertube } from "youtubei.js";
+import type { YT, YTNodes, Misc } from "youtubei.js";
+
+// 公開エクスポートされた namespace 経由で型を取り出す。
+// Pull internal class types via the package's public namespace re-exports.
+type TranscriptInfo = YT.TranscriptInfo;
+type PlayerMicroformat = YTNodes.PlayerMicroformat;
+type TranscriptSegmentClass = YTNodes.TranscriptSegment;
+type Thumbnail = Misc.Thumbnail;
 
 /**
  * YouTube 外部 API 呼び出しのデフォルトタイムアウト（ミリ秒）。
@@ -20,7 +33,7 @@ export const YT_FETCH_TIMEOUT_MS = 10_000;
 
 /**
  * YouTube 動画メタデータ。
- * YouTube video metadata retrieved from the Data API.
+ * YouTube video metadata retrieved via Innertube.
  */
 export interface YouTubeMetadata {
   /** 動画タイトル / Video title */
@@ -29,9 +42,9 @@ export interface YouTubeMetadata {
   description: string;
   /** チャンネル名 / Channel name */
   channelTitle: string;
-  /** 公開日時 (ISO 8601) / Published date */
+  /** 公開日時 (YYYY-MM-DD またはそれに近い ISO 文字列) / Published date */
   publishedAt: string;
-  /** 再生時間 (ISO 8601 duration) / Duration */
+  /** 再生時間 (ISO 8601 duration, 例: "PT1H2M3S") / Duration as ISO 8601 */
   duration: string;
   /** サムネイル URL (最大解像度) / Thumbnail URL (max resolution) */
   thumbnailUrl: string;
@@ -65,7 +78,7 @@ export interface YouTubeContent {
   transcriptText: string;
 }
 
-// ── Metadata ──────────────────────────────────────────────────────────────
+// ── Duration helpers ──────────────────────────────────────────────────────
 
 /**
  * ISO 8601 duration (e.g. "PT1H2M3S") を人間が読みやすい形式に変換する。
@@ -93,91 +106,62 @@ export function formatDuration(iso: string): string {
 }
 
 /**
- * YouTube Data API v3 で動画メタデータを取得する。
- * Fetches video metadata from YouTube Data API v3.
+ * 秒数を ISO 8601 duration 文字列に変換する。
+ * Converts a number of seconds to an ISO 8601 duration string.
  *
- * @param videoId - YouTube 動画 ID / YouTube video ID
- * @param apiKey - YouTube Data API キー / YouTube Data API key
- * @returns メタデータ / Video metadata
- * @throws API エラーまたはレスポンス解析失敗時 / On API error or parse failure
+ * youtubei.js は再生時間を秒で返すが、`formatDuration` および下流コードは
+ * ISO 8601 形式 (例 "PT1H2M3S") を前提としているため変換する。
+ *
+ * youtubei.js exposes the duration in seconds, but `formatDuration` and
+ * downstream consumers expect ISO 8601 form (e.g. "PT1H2M3S").
  */
-export async function fetchYouTubeMetadata(
-  videoId: string,
-  apiKey: string,
-  timeoutMs: number = YT_FETCH_TIMEOUT_MS,
-): Promise<YouTubeMetadata> {
-  const url = new URL("https://www.googleapis.com/youtube/v3/videos");
-  url.searchParams.set("part", "snippet,contentDetails");
-  url.searchParams.set("id", videoId);
-  url.searchParams.set("key", apiKey);
-
-  // タイムアウト付きの fetch（上流の遅延で全体をブロックしないようにする）
-  // Fetch with abort-based timeout so slow upstream doesn't pin the request
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-
-  let res: Response;
-  try {
-    res = await fetch(url.toString(), { signal: controller.signal });
-  } catch (err) {
-    if (err instanceof Error && err.name === "AbortError") {
-      throw new Error(`YouTube Data API request timed out after ${timeoutMs}ms`);
-    }
-    throw err;
-  } finally {
-    clearTimeout(timer);
-  }
-
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`YouTube Data API failed: ${res.status} - ${text}`);
-  }
-
-  const data = (await res.json()) as {
-    items?: Array<{
-      snippet: {
-        title: string;
-        description: string;
-        channelTitle: string;
-        publishedAt: string;
-        thumbnails: Record<string, { url: string; width: number; height: number }>;
-        tags?: string[];
-      };
-      contentDetails: {
-        duration: string;
-      };
-    }>;
-  };
-
-  if (!data.items || data.items.length === 0) {
-    throw new Error(`YouTube video not found: ${videoId}`);
-  }
-
-  const item = data.items[0] as NonNullable<(typeof data.items)[number]>;
-  const snippet = item.snippet;
-  const thumbnails = snippet.thumbnails;
-
-  // 最大解像度のサムネイルを選択 / Select highest resolution thumbnail
-  const thumbnailUrl =
-    thumbnails.maxres?.url ||
-    thumbnails.standard?.url ||
-    thumbnails.high?.url ||
-    thumbnails.medium?.url ||
-    thumbnails.default?.url ||
-    `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
-
-  return {
-    title: snippet.title,
-    description: snippet.description,
-    channelTitle: snippet.channelTitle,
-    publishedAt: snippet.publishedAt,
-    duration: item.contentDetails?.duration ?? "",
-    thumbnailUrl,
-    tags: snippet.tags ?? [],
-  };
+function secondsToIso8601Duration(totalSeconds: number): string {
+  const safe = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const seconds = safe % 60;
+  let out = "PT";
+  if (hours > 0) out += `${hours}H`;
+  if (minutes > 0) out += `${minutes}M`;
+  // 0 秒の動画は事実上ないが、空文字 "PT" を避けるため秒を常に出力
+  // Always emit the seconds component to avoid producing a bare "PT".
+  if (seconds > 0 || (hours === 0 && minutes === 0)) out += `${seconds}S`;
+  return out;
 }
 
-// ── Transcript ────────────────────────────────────────────────────────────
+// ── Innertube singleton ───────────────────────────────────────────────────
+
+/**
+ * Innertube インスタンスは初期化に外部 HTTP リクエストを伴うため、
+ * プロセス内でシングルトンとしてキャッシュする。
+ *
+ * Innertube initialisation issues outbound HTTP requests, so the instance
+ * is memoised per process to amortise that cost across calls.
+ */
+let innertubePromise: Promise<Innertube> | null = null;
+
+async function getInnertube(): Promise<Innertube> {
+  if (!innertubePromise) {
+    // retrieve_player: false でセッション初期化を高速化（字幕/メタデータ取得には player.js 不要）。
+    // Skip JS player retrieval — it is only needed for stream deciphering.
+    innertubePromise = Innertube.create({
+      retrieve_player: false,
+    });
+  }
+  return innertubePromise;
+}
+
+/**
+ * テスト用に Innertube シングルトンキャッシュをリセットする。
+ * Resets the cached Innertube singleton (test-only helper).
+ *
+ * @internal
+ */
+export function __resetInnertubeForTesting(): void {
+  innertubePromise = null;
+}
+
+// ── Promise timeout helper ────────────────────────────────────────────────
 
 /**
  * Promise にタイムアウトを付与する。タイムアウト時は reject。
@@ -201,60 +185,114 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): 
   });
 }
 
+// ── Metadata extraction ───────────────────────────────────────────────────
+
 /**
- * YouTube 動画の公開字幕テキストを取得する。
- * Fetches public captions/subtitles for a YouTube video.
- *
- * youtube-transcript パッケージを使用（非公式、API キー不要）。
- * 字幕が利用できない場合は空配列を返す（エラーは throw しない）。
- * 上流が応答しない場合に備え、各試行に `timeoutMs` のタイムアウトを適用する。
- *
- * Uses the youtube-transcript package (unofficial, no API key required).
- * Returns an empty array when captions are unavailable (never throws).
- * Each attempt is bounded by `timeoutMs` to avoid hanging on a slow upstream.
- *
- * @param videoId - YouTube 動画 ID / YouTube video ID
- * @param timeoutMs - 各フェッチ試行のタイムアウト (ms) / Per-attempt timeout in ms
- * @returns 字幕セグメント配列 / Transcript segments (empty if unavailable)
+ * Innertube `VideoInfo` からアプリ層が必要とするメタデータを抽出する。
+ * Extracts the metadata fields the app cares about from an Innertube `VideoInfo`.
  */
-export async function fetchYouTubeTranscript(
+function extractMetadata(
   videoId: string,
-  timeoutMs: number = YT_FETCH_TIMEOUT_MS,
-): Promise<TranscriptSegment[]> {
-  // youtube-transcript は signal を受け付けないため、タイムアウトは Promise.race で実装
-  // youtube-transcript does not accept a signal, so timeout is enforced via promise race
-  try {
-    const transcriptItems = await withTimeout<TranscriptResponse[]>(
-      YoutubeTranscript.fetchTranscript(videoId, { lang: "ja" }),
-      timeoutMs,
-      "YouTube transcript fetch (ja)",
-    );
+  info: Awaited<ReturnType<Innertube["getInfo"]>>,
+): YouTubeMetadata {
+  const basic = info.basic_info;
 
-    return transcriptItems.map((item) => ({
-      text: item.text,
-      offset: item.offset / 1000, // ms → sec
-      duration: item.duration / 1000, // ms → sec
-    }));
-  } catch {
-    // 日本語字幕が無い場合、言語指定なしで再試行
-    // If Japanese subtitles unavailable, retry without language preference
-    try {
-      const transcriptItems = await withTimeout<TranscriptResponse[]>(
-        YoutubeTranscript.fetchTranscript(videoId),
-        timeoutMs,
-        "YouTube transcript fetch",
-      );
+  // タイトル: basic_info を優先、なければ ID ベースのフォールバック
+  // Prefer basic_info.title, fall back to id-based label
+  const title = basic.title?.trim() || `YouTube Video (${videoId})`;
 
-      return transcriptItems.map((item) => ({
-        text: item.text,
-        offset: item.offset / 1000,
-        duration: item.duration / 1000,
-      }));
-    } catch {
-      // 字幕なし動画 — 空配列を返す / No captions available
-      return [];
-    }
+  // 説明文: basic_info.short_description が公式 description
+  // basic_info.short_description holds the canonical description string
+  const description = basic.short_description ?? "";
+
+  // チャンネル名: basic_info.channel.name → basic_info.author の順で fallback
+  // Channel name: prefer basic_info.channel.name, then basic_info.author
+  const channelTitle = basic.channel?.name ?? basic.author ?? "";
+
+  // 公開日時: PlayerMicroformat.publish_date (例 "2024-01-15") を優先
+  // basic_info.start_timestamp (Date) があればそちらを ISO に
+  // Prefer PlayerMicroformat.publish_date (e.g. "2024-01-15"), fall back to start_timestamp.
+  const microformat = info.page[0]?.microformat as PlayerMicroformat | undefined;
+  const publishedAt =
+    microformat?.publish_date ?? basic.start_timestamp?.toISOString() ?? "";
+
+  // 再生時間: 秒数を ISO 8601 duration に変換
+  // Duration: convert seconds to ISO 8601 duration
+  const duration = secondsToIso8601Duration(basic.duration ?? 0);
+
+  // サムネイル: 最大解像度のものを選択。配列が空なら hqdefault に fallback
+  // Thumbnail: pick the largest by width; fall back to hqdefault when none returned.
+  const thumbnailUrl = pickLargestThumbnail(basic.thumbnail) ??
+    `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+
+  // タグ: basic_info.tags / keywords どちらかが入る場合あり
+  // Tags: basic_info.tags or basic_info.keywords (whichever is populated)
+  const tags = basic.tags ?? basic.keywords ?? [];
+
+  return {
+    title,
+    description,
+    channelTitle,
+    publishedAt,
+    duration,
+    thumbnailUrl,
+    tags,
+  };
+}
+
+/**
+ * サムネイル配列から最大幅の URL を選ぶ。空配列なら null。
+ * Returns the URL of the widest thumbnail, or null when the list is empty.
+ */
+function pickLargestThumbnail(thumbnails: Thumbnail[] | undefined | null): string | null {
+  if (!thumbnails || thumbnails.length === 0) return null;
+  let best = thumbnails[0];
+  if (!best) return null;
+  for (const t of thumbnails) {
+    if (t && t.width > best.width) best = t;
   }
+  return best.url;
+}
+
+// ── Transcript extraction ─────────────────────────────────────────────────
+
+/**
+ * Innertube `TranscriptInfo` から `TranscriptSegment[]` を抽出する。
+ * Extracts plain `TranscriptSegment[]` from an Innertube `TranscriptInfo`.
+ */
+function extractTranscriptSegments(transcriptInfo: TranscriptInfo): TranscriptSegment[] {
+  const segments = transcriptInfo.transcript.content?.body?.initial_segments ?? [];
+  const out: TranscriptSegment[] = [];
+  for (const seg of segments) {
+    // セクションヘッダーは無視（字幕本文ではない）
+    // Skip section headers (they are not transcript content)
+    if (!isTranscriptSegment(seg)) continue;
+    const startMs = Number.parseInt(seg.start_ms, 10);
+    const endMs = Number.parseInt(seg.end_ms, 10);
+    if (Number.isNaN(startMs) || Number.isNaN(endMs)) continue;
+    const text = seg.snippet.toString().trim();
+    if (!text) continue;
+    out.push({
+      text,
+      offset: startMs / 1000,
+      duration: Math.max(0, (endMs - startMs) / 1000),
+    });
+  }
+  return out;
+}
+
+/**
+ * `TranscriptSegment | TranscriptSectionHeader` を識別する型ガード。
+ * Type guard distinguishing `TranscriptSegment` from `TranscriptSectionHeader`.
+ */
+function isTranscriptSegment(node: unknown): node is TranscriptSegmentClass {
+  return (
+    typeof node === "object" &&
+    node !== null &&
+    "start_ms" in node &&
+    "end_ms" in node &&
+    "snippet" in node
+  );
 }
 
 /**
@@ -268,11 +306,11 @@ export function joinTranscriptText(segments: TranscriptSegment[]): string {
   return segments.map((s) => s.text).join(" ");
 }
 
-// ── Combined ──────────────────────────────────────────────────────────────
+// ── Public entry point ────────────────────────────────────────────────────
 
 /**
- * API キー未指定時の最小限のメタデータを返す。
- * Returns minimal metadata when the Data API key is missing or fails.
+ * 最小限のメタデータ（取得失敗時のフォールバック）。
+ * Minimal metadata used as a fallback when Innertube fails entirely.
  */
 function buildMinimalMetadata(videoId: string): YouTubeMetadata {
   return {
@@ -290,66 +328,61 @@ function buildMinimalMetadata(videoId: string): YouTubeMetadata {
  * YouTube 動画のメタデータと字幕を一括取得する。
  * Fetches both metadata and transcript for a YouTube video.
  *
- * YouTube Data API キーが指定されていない場合、メタデータは最小限の情報のみ返す。
- * キーが指定されているがメタデータ取得に失敗した場合（quota 超過・無効キー等）も、
- * 字幕のみでフォールバックを提供する。
+ * Innertube の `getInfo()` 1 回でメタデータと字幕（`getTranscript()`）の
+ * 両方を取得する。字幕が利用できない動画では transcript フィールドが
+ * null になるが、メタデータ取得自体が失敗した場合でも最小限のメタデータで
+ * フォールバックを返す。
  *
- * When no API key is provided, returns minimal metadata (title from videoId only).
- * Even when a key is provided, a failing metadata request (quota exhausted,
- * invalid key, transient failure) is caught and replaced with minimal metadata
- * so the transcript-only fallback is preserved.
+ * Uses a single Innertube `getInfo()` call followed by `getTranscript()`.
+ * Returns transcript as null when captions are unavailable. Even when the
+ * upstream call fails entirely, returns a minimal metadata fallback so the
+ * caller never throws.
  *
  * @param videoId - YouTube 動画 ID / YouTube video ID
- * @param youtubeApiKey - YouTube Data API キー（任意） / YouTube Data API key (optional)
+ * @param _youtubeApiKey - 互換性のため残存（youtubei.js 移行で不要） / Retained for backward compatibility (no longer used)
  * @returns メタデータと字幕 / Metadata and transcript
  */
 export async function fetchYouTubeContent(
   videoId: string,
-  youtubeApiKey?: string,
+  _youtubeApiKey?: string,
 ): Promise<YouTubeContent> {
-  // 字幕は常に取得を試みる（API キー不要）
-  // Always attempt transcript fetch (no API key required)
-  const transcriptPromise = fetchYouTubeTranscript(videoId);
-
-  let metadata: YouTubeMetadata;
-  if (youtubeApiKey) {
-    // メタデータ取得失敗（quota 超過・無効キー等）でも字幕 fallback を維持する
-    // Keep transcript-only fallback even when metadata fetch fails (quota, invalid key, etc.)
-    const [metaResult, transcriptResult] = await Promise.allSettled([
-      fetchYouTubeMetadata(videoId, youtubeApiKey),
-      transcriptPromise,
-    ]);
-    const transcript = transcriptResult.status === "fulfilled" ? transcriptResult.value : [];
-    if (metaResult.status === "fulfilled") {
-      metadata = metaResult.value;
-    } else {
-      console.error("YouTube metadata fetch failed (falling back to minimal):", metaResult.reason);
-      metadata = buildMinimalMetadata(videoId);
-    }
-    const transcriptText = joinTranscriptText(transcript);
+  let info: Awaited<ReturnType<Innertube["getInfo"]>>;
+  try {
+    const yt = await getInnertube();
+    info = await withTimeout(yt.getInfo(videoId), YT_FETCH_TIMEOUT_MS, "youtubei.js getInfo");
+  } catch (err) {
+    // メタデータ取得失敗 — 最小フォールバックを返す（呼び出し側は throw しない契約）
+    // Metadata fetch failed — return minimal fallback (callers expect no throw).
+    console.error("youtubei.js getInfo failed (falling back to minimal):", err);
+    const fallback = buildMinimalMetadata(videoId);
     return {
-      metadata,
-      transcript: transcript.length > 0 ? transcript : null,
-      transcriptText,
+      metadata: fallback,
+      transcript: null,
+      transcriptText: "",
     };
   }
 
-  // API キーなし — 字幕のみ取得、メタデータは最小限
-  // No API key — transcript only, minimal metadata
-  const transcript = await transcriptPromise;
-  metadata = {
-    title: `YouTube Video (${videoId})`,
-    description: "",
-    channelTitle: "",
-    publishedAt: "",
-    duration: "",
-    thumbnailUrl: `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`,
-    tags: [],
-  };
+  const metadata = extractMetadata(videoId, info);
+
+  // 字幕取得は失敗しても致命的ではないので個別 try/catch
+  // Transcript fetch is best-effort: missing captions must not throw.
+  let segments: TranscriptSegment[] = [];
+  try {
+    const transcriptInfo = await withTimeout(
+      info.getTranscript(),
+      YT_FETCH_TIMEOUT_MS,
+      "youtubei.js getTranscript",
+    );
+    segments = extractTranscriptSegments(transcriptInfo);
+  } catch {
+    // 字幕なし動画 / トランスクリプト無効化動画 — 空配列で続行
+    // No captions available or transcripts disabled — continue with empty list.
+    segments = [];
+  }
 
   return {
     metadata,
-    transcript: transcript.length > 0 ? transcript : null,
-    transcriptText: joinTranscriptText(transcript),
+    transcript: segments.length > 0 ? segments : null,
+    transcriptText: joinTranscriptText(segments),
   };
 }

--- a/server/api/src/services/youtubeService.ts
+++ b/server/api/src/services/youtubeService.ts
@@ -369,7 +369,17 @@ export async function fetchYouTubeContent(
     };
   }
 
-  const metadata = extractMetadata(videoId, info);
+  // extractMetadata は `info` の想定形状に依存するため、youtubei.js が
+  // 予期せぬ構造を返した場合でも "throw しない" 契約を守るために包む。
+  // extractMetadata assumes a well-formed `info`; guard against unexpected
+  // upstream shapes so the documented "never throws" contract still holds.
+  let metadata: YouTubeMetadata;
+  try {
+    metadata = extractMetadata(videoId, info);
+  } catch (err) {
+    console.error("extractMetadata failed (falling back to minimal):", err);
+    metadata = buildMinimalMetadata(videoId);
+  }
 
   // 字幕取得は失敗しても致命的ではないので個別 try/catch
   // Transcript fetch is best-effort: missing captions must not throw.

--- a/server/api/src/services/youtubeService.ts
+++ b/server/api/src/services/youtubeService.ts
@@ -144,8 +144,14 @@ async function getInnertube(): Promise<Innertube> {
   if (!innertubePromise) {
     // retrieve_player: false でセッション初期化を高速化（字幕/メタデータ取得には player.js 不要）。
     // Skip JS player retrieval — it is only needed for stream deciphering.
+    // 初期化失敗時はキャッシュをクリアし、次回呼び出しで再試行できるようにする。
+    // Reset the cache on failure so transient initialisation errors don't
+    // permanently break the service for the rest of the process lifetime.
     innertubePromise = Innertube.create({
       retrieve_player: false,
+    }).catch((err) => {
+      innertubePromise = null;
+      throw err;
     });
   }
   return innertubePromise;
@@ -213,17 +219,17 @@ function extractMetadata(
   // basic_info.start_timestamp (Date) があればそちらを ISO に
   // Prefer PlayerMicroformat.publish_date (e.g. "2024-01-15"), fall back to start_timestamp.
   const microformat = info.page[0]?.microformat as PlayerMicroformat | undefined;
-  const publishedAt =
-    microformat?.publish_date ?? basic.start_timestamp?.toISOString() ?? "";
+  const publishedAt = microformat?.publish_date ?? basic.start_timestamp?.toISOString() ?? "";
 
-  // 再生時間: 秒数を ISO 8601 duration に変換
-  // Duration: convert seconds to ISO 8601 duration
-  const duration = secondsToIso8601Duration(basic.duration ?? 0);
+  // 再生時間: 値が無い場合は空文字（"PT0S" を捏造して "0:00" 表示にしない）
+  // Duration: leave as empty string when missing — avoid fabricating "PT0S"
+  // which would render as "0:00" downstream and misrepresent the metadata.
+  const duration = basic.duration != null ? secondsToIso8601Duration(basic.duration) : "";
 
   // サムネイル: 最大解像度のものを選択。配列が空なら hqdefault に fallback
   // Thumbnail: pick the largest by width; fall back to hqdefault when none returned.
-  const thumbnailUrl = pickLargestThumbnail(basic.thumbnail) ??
-    `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+  const thumbnailUrl =
+    pickLargestThumbnail(basic.thumbnail) ?? `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
 
   // タグ: basic_info.tags / keywords どちらかが入る場合あり
   // Tags: basic_info.tags or basic_info.keywords (whichever is populated)
@@ -246,12 +252,13 @@ function extractMetadata(
  */
 function pickLargestThumbnail(thumbnails: Thumbnail[] | undefined | null): string | null {
   if (!thumbnails || thumbnails.length === 0) return null;
-  let best = thumbnails[0];
-  if (!best) return null;
+  // 配列内の null/undefined 要素をスキップしつつ最大幅を選ぶ
+  // Walk the entire list so a null/undefined first element doesn't drop later valid entries.
+  let best: Thumbnail | null = null;
   for (const t of thumbnails) {
-    if (t && t.width > best.width) best = t;
+    if (t && (!best || t.width > best.width)) best = t;
   }
-  return best.url;
+  return best?.url ?? null;
 }
 
 // ── Transcript extraction ─────────────────────────────────────────────────


### PR DESCRIPTION
## 概要

YouTube メタデータと字幕取得を YouTube Data API v3 + youtube-transcript から **youtubei.js (Innertube クライアント)** に統合しました。これにより、ESM パッケージング不具合の回避と YouTube Data API のクォータ消費を削減できます。

## 変更点

- **依存関係の置き換え**: `youtube-transcript` → `youtubei.js@^17.0.1`
- **メタデータ取得**: YouTube Data API v3 の REST エンドポイント → Innertube `getInfo()` に統合
- **字幕取得**: youtube-transcript パッケージ → Innertube `getTranscript()` に統合
- **Innertube シングルトン**: プロセス内でインスタンスをキャッシュし、初期化コストを分散
- **ユーティリティ関数追加**: `secondsToIso8601Duration()` で秒数を ISO 8601 形式に変換
- **メタデータ抽出**: `extractMetadata()` で Innertube `VideoInfo` から必要なフィールドを抽出
- **字幕抽出**: `extractTranscriptSegments()` で Innertube `TranscriptInfo` から字幕セグメントを抽出
- **テスト更新**: youtube-transcript モック → youtubei.js モックに変更、新しい抽出ロジックをカバー

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm test` または `bun test` で既存テストスイートを実行
2. 新しい `fetchYouTubeContent()` テストが以下をカバー:
   - 正常系: メタデータと字幕の両方を取得
   - 字幕なし動画: `transcript: null` を返す
   - メタデータ取得失敗: 最小限のフォールバックメタデータを返す
   - フォールバック: チャンネル名、サムネイル URL の代替値
   - フィルタリング: 無効なタイムスタンプや空の字幕セグメントをスキップ

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## 補足

- `_youtubeApiKey` パラメータは後方互換性のため残存していますが、youtubei.js 移行により使用されません
- `__resetInnertubeForTesting()` はテスト用の内部ヘルパーです
- Innertube の `retrieve_player: false` オプションで初期化を高速化（JS プレイヤー取得をスキップ）

https://claude.ai/code/session_01Gw9HGvDHCzpBTXiLXrDwjz
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
