### PR TITLE
fix(server): close race conditions in wiki schema, ingest, lint, and YouTube usage

### DIFF
--- a/server/api/drizzle/0012_add_sources_kind_hash_unique.sql
+++ b/server/api/drizzle/0012_add_sources_kind_hash_unique.sql
@@ -1,0 +1,22 @@
+-- Add a partial unique index on `sources` for rows without a URL.
+-- URL の無い sources (kind="conversation" 等) を (owner, kind, content_hash) で
+-- 一意にする部分ユニーク制約を追加する。
+--
+-- Why / 背景:
+--   既存の `uq_sources_owner_url_hash` は `WHERE url IS NOT NULL` の部分インデックス
+--   なので、kind="conversation" のように url が NULL のレコードは重複検出されない。
+--   そのため `POST /api/ingest/apply` で同一 contentHash を持つ会話が並行で投入されると
+--   2 件入ってしまい、`ON CONFLICT DO NOTHING + re-SELECT` の race-safe path が機能しない。
+--   この部分ユニーク制約を入れることで、url=NULL の場合も DB レベルで重複が阻止され、
+--   勝者の行に決定的に収束する。
+--
+--   The existing `uq_sources_owner_url_hash` is partial (`WHERE url IS NOT NULL`), so
+--   conversation rows without a URL can race past `ON CONFLICT DO NOTHING` and end up
+--   duplicated. This partial unique index closes that gap, deterministically
+--   converging concurrent inserts on a single winner that the re-SELECT can find.
+--
+-- See PR otomatty/zedi#645 (CodeRabbit review feedback on ingest.ts).
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_sources_owner_kind_hash_when_url_null"
+    ON "sources" ("owner_id", "kind", "content_hash")
+    WHERE "url" IS NULL AND "content_hash" IS NOT NULL;

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1776816000000,
       "tag": "0011_add_page_special_kind",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1776902400000,
+      "tag": "0012_add_sources_kind_hash_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/src/__tests__/services/ingestPlanner.test.ts
+++ b/server/api/src/__tests__/services/ingestPlanner.test.ts
@@ -222,6 +222,23 @@ describe("buildIngestPlannerPrompt", () => {
     expect(messages[0]?.content).not.toContain("User-defined wiki schema");
   });
 
+  it("truncates very long userSchema so it cannot crowd out article/candidate context", () => {
+    // 4,000 を超えるユーザースキーマは prompt 内で切り詰められるはず。
+    // truncate() は "…" を末尾に付けるため、ぴったり 4,000 ではなく 4,001 文字以内になる。
+    const hugeSchema = "X".repeat(20_000);
+    const messages = buildIngestPlannerPrompt({
+      article: sampleArticle,
+      candidates: sampleCandidates,
+      userSchema: hugeSchema,
+    });
+    const systemContent = messages[0]?.content ?? "";
+    expect(systemContent).toContain("User-defined wiki schema");
+    // X の連続が元の 20,000 文字より短くなっている (4,000 + ellipsis 程度)。
+    const xRun = systemContent.match(/X+/)?.[0] ?? "";
+    expect(xRun.length).toBeLessThanOrEqual(4_001);
+    expect(xRun.length).toBeLessThan(20_000);
+  });
+
   it("truncates very long excerpts to avoid prompt blow-up", () => {
     const hugeExcerpt = "A".repeat(10_000);
     const messages = buildIngestPlannerPrompt({

--- a/server/api/src/routes/clip.ts
+++ b/server/api/src/routes/clip.ts
@@ -85,6 +85,11 @@ function extractVideoId(url: string): string | null {
     /^https?:\/\/(?:www\.)?youtube\.com\/watch\?(?:[^&]+&)*v=([a-zA-Z0-9_-]{11})(?:&[^\s]*)?$/i,
     /^https?:\/\/youtu\.be\/([a-zA-Z0-9_-]{11})(?:\?[^\s]*)?$/i,
     /^https?:\/\/(?:www\.)?youtube\.com\/embed\/([a-zA-Z0-9_-]{11})(?:\?[^\s]*)?$/i,
+    // YouTube Shorts (m. サブドメイン含む) は本流の抽出パイプラインで受理されるため、
+    // POST /api/clip/youtube だけが弾かないように同等のパターンを追加する。
+    // YouTube Shorts URLs are accepted by the main extraction pipeline; mirror
+    // them here so this endpoint doesn't reject them with a 400.
+    /^https?:\/\/(?:www\.|m\.)?youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})(?:[?#][^\s]*)?$/i,
   ];
   for (const p of patterns) {
     const m = url.match(p);
@@ -179,13 +184,20 @@ app.post("/youtube", authRequired, rateLimit(), async (c) => {
     // 記録失敗は非致命的 — 抽出結果を破棄しない
     // Bill only when AI actually ran successfully (result.aiUsage !== null)
     // Recording failure is non-fatal — don't discard the extraction result
-    if (result.aiUsage && aiProvider && aiModel && body.model) {
+    //
+    // ここではアクセス検証時にトリム済みの aiModel を使う。生の `body.model` には
+    // 前後空白や別表記が含まれうるため、`validateModelAccess` の再検証も
+    // recordUsage の保存値もトリム後の正規 model id (`aiModel`) で行わないと、
+    // 同一モデルが複数の正規化前文字列で記録され、使用量集計や請求がブレる。
+    // Use the already-trimmed `aiModel` for re-validation and accounting so usage
+    // records are stable for the same model regardless of input whitespace.
+    if (result.aiUsage && aiProvider && aiModel) {
       try {
         // プロバイダーから返された実際のトークン数を使用（概算ではなく）
         // Use actual token counts returned by the provider (not estimates)
         const { inputTokens, outputTokens } = result.aiUsage;
         const tier = await getUserTier(userId, db);
-        const modelInfo = await validateModelAccess(body.model, tier, db);
+        const modelInfo = await validateModelAccess(aiModel, tier, db);
         const costUnits = calculateCost(
           { inputTokens, outputTokens },
           modelInfo.inputCostUnits,
@@ -193,7 +205,7 @@ app.post("/youtube", authRequired, rateLimit(), async (c) => {
         );
         await recordUsage(
           userId,
-          body.model,
+          aiModel,
           "youtube_summary",
           { inputTokens, outputTokens },
           costUnits,

--- a/server/api/src/routes/clip.ts
+++ b/server/api/src/routes/clip.ts
@@ -87,9 +87,12 @@ function extractVideoId(url: string): string | null {
     /^https?:\/\/(?:www\.)?youtube\.com\/embed\/([a-zA-Z0-9_-]{11})(?:\?[^\s]*)?$/i,
     // YouTube Shorts (m. サブドメイン含む) は本流の抽出パイプラインで受理されるため、
     // POST /api/clip/youtube だけが弾かないように同等のパターンを追加する。
+    // 11 文字 ID の後に `/` `?` `#` のいずれが来ても受理する（articleExtractor と整合）。
     // YouTube Shorts URLs are accepted by the main extraction pipeline; mirror
-    // them here so this endpoint doesn't reject them with a 400.
-    /^https?:\/\/(?:www\.|m\.)?youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})(?:[?#][^\s]*)?$/i,
+    // them here so this endpoint doesn't reject them with a 400. Allow `/`, `?`,
+    // or `#` after the 11-char ID to match articleExtractor's pattern (e.g.
+    // `/shorts/<id>/`, `/shorts/<id>?si=...`).
+    /^https?:\/\/(?:www\.|m\.)?youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})(?:[/?#][^\s]*)?$/i,
   ];
   for (const p of patterns) {
     const m = url.match(p);
@@ -122,8 +125,16 @@ app.post("/youtube", authRequired, rateLimit(), async (c) => {
   const youtubeApiKey = process.env.YOUTUBE_DATA_API_KEY;
 
   // AI 要約の設定 / AI summary configuration
+  // `aiModel` は `aiModels.id` (例: "openai:gpt-4o") を保持し、
+  // `validateModelAccess` / `recordUsage` のキーとして使う。
+  // `apiModelId` はプロバイダー API 呼び出し用の生モデル名 (例: "gpt-4o") で
+  // YouTube extractor 経由でプロバイダー SDK に渡す。
+  // `aiModel` keeps the catalog id (e.g. "openai:gpt-4o") used as the key for
+  // `validateModelAccess` / `recordUsage`. `apiModelId` is the provider-facing
+  // model name (e.g. "gpt-4o") forwarded to the provider SDK via the extractor.
   let aiProvider: AIProviderType | undefined;
   let aiModel: string | undefined;
+  let apiModelId: string | undefined;
   let aiApiKey: string | undefined;
 
   const supportedProviders: AIProviderType[] = ["openai", "anthropic", "google"];
@@ -160,8 +171,16 @@ app.post("/youtube", authRequired, rateLimit(), async (c) => {
     // モデル情報から provider を上書き（DB 上の provider が正）
     // Override provider from model info (DB is authoritative)
     // API キーは上書き後の provider で取得する（provider 不一致バグ防止）
+    // `aiModel` は catalog id のまま保持し、プロバイダー SDK 用に
+    // `apiModelId` を別変数で保持する。両者を混同すると validateModelAccess /
+    // recordUsage が apiModelId で aiModels.id を引いてしまい、catch に落ちて
+    // 課金記録が静かにスキップされる。
+    // Keep `aiModel` as the catalog id; expose `apiModelId` separately for the
+    // provider SDK. Mixing them silently breaks usage accounting because
+    // validateModelAccess looks up `aiModels.id` and the apiModelId form will
+    // not match, swallowed by the non-fatal catch below.
     aiProvider = modelInfo.provider as AIProviderType;
-    aiModel = modelInfo.apiModelId;
+    apiModelId = modelInfo.apiModelId;
 
     const apiKeyName = getProviderApiKeyName(aiProvider);
     aiApiKey = process.env[apiKeyName];
@@ -175,7 +194,9 @@ app.post("/youtube", authRequired, rateLimit(), async (c) => {
       videoId,
       youtubeApiKey,
       aiProvider,
-      aiModel,
+      // プロバイダー SDK には provider 側のモデル名を渡す。
+      // Pass the provider-facing model name to the SDK.
+      aiModel: apiModelId,
       aiApiKey,
     });
 

--- a/server/api/src/routes/ingest.ts
+++ b/server/api/src/routes/ingest.ts
@@ -368,6 +368,13 @@ app.post("/apply", authRequired, rateLimit(), async (c) => {
   }
 
   if (!sourceId) {
+    // 上の preflight SELECT と本 INSERT の間に同一ペアが他リクエストから入ると、
+    // `uq_sources_owner_url_hash` (partial unique on owner_id+url+content_hash)
+    // で 1 つは衝突して 500 か重複行が発生する。`onConflictDoNothing` で衝突時は
+    // 何もしない返却にしてから、勝者の行を再 SELECT して採用する。
+    // Race-safe insert: pre-flight SELECT then INSERT can lose to a concurrent
+    // request and trip the partial unique index. ON CONFLICT DO NOTHING + re-SELECT
+    // converges on the winner without raising 500 / leaving a duplicate.
     const [inserted] = await db
       .insert(sources)
       .values({
@@ -380,11 +387,30 @@ app.post("/apply", authRequired, rateLimit(), async (c) => {
         extractedAt: now,
         createdAt: now,
       })
+      .onConflictDoNothing()
       .returning({ id: sources.id });
-    if (!inserted) {
+
+    if (inserted) {
+      sourceId = inserted.id;
+    } else if (body.contentHash) {
+      const [winner] = await db
+        .select({ id: sources.id })
+        .from(sources)
+        .where(
+          and(
+            eq(sources.ownerId, userId),
+            eq(sources.contentHash, body.contentHash),
+            body.url ? eq(sources.url, body.url) : eq(sources.kind, body.kind),
+          ),
+        )
+        .limit(1);
+      if (!winner) {
+        throw new HTTPException(500, { message: "Failed to create source" });
+      }
+      sourceId = winner.id;
+    } else {
       throw new HTTPException(500, { message: "Failed to create source" });
     }
-    sourceId = inserted.id;
   }
 
   // Link source to page (ownership already verified above).

--- a/server/api/src/routes/wikiSchema.ts
+++ b/server/api/src/routes/wikiSchema.ts
@@ -141,22 +141,18 @@ app.put("/", authRequired, async (c) => {
     return resolvedPageId;
   });
 
-  // recordActivity の失敗で 500 を返すと、スキーマは既にコミット済みなのに
-  // クライアントには「失敗」と見えるパーシャル状態になる。activity ログは
-  // ベストエフォートで処理し、失敗はログだけ残してレスポンスは 200 を維持する。
-  // Activity logging is non-fatal: the schema commit already succeeded; surface
-  // failures via console.error only so callers don't see a misleading 500.
-  try {
-    await recordActivity(db, {
-      ownerId: userId,
-      kind: "wiki_schema_update",
-      actor: "user",
-      targetPageIds: [pageId],
-      detail: { title, contentLength: content.length },
-    });
-  } catch (err) {
-    console.error("[wikiSchema] recordActivity failed (non-fatal):", err);
-  }
+  // `recordActivity` は内部で例外を握り console.error でログするだけなので、
+  // ここでの try/catch は不要。スキーマコミット成功後にログ書き込みが失敗しても
+  // レスポンスは 200 のまま返り、運用は console.error で検知できる。
+  // `recordActivity` already swallows errors internally (logged via console.error),
+  // so wrapping it again here is unnecessary; the 200 response is preserved.
+  await recordActivity(db, {
+    ownerId: userId,
+    kind: "wiki_schema_update",
+    actor: "user",
+    targetPageIds: [pageId],
+    detail: { title, contentLength: content.length },
+  });
 
   return c.json({ pageId, title, content });
 });

--- a/server/api/src/routes/wikiSchema.ts
+++ b/server/api/src/routes/wikiSchema.ts
@@ -11,7 +11,7 @@
  */
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { authRequired } from "../middleware/auth.js";
 import { pages } from "../schema/pages.js";
 import { pageContents } from "../schema/pageContents.js";
@@ -86,20 +86,21 @@ app.put("/", authRequired, async (c) => {
   const content = body.content;
   const now = new Date();
 
-  // Wrap the read-modify-write in a transaction so concurrent PUTs from the
-  // same user cannot both INSERT and race the (owner_id) WHERE is_schema=true
-  // unique index, AND so that the pages row and its page_contents body are
-  // committed atomically (otherwise a partial failure could leave a schema
-  // page with no body / mismatched body).
-  // 同一ユーザーの並行 PUT が両方 INSERT して一意インデックスで衝突するのを防ぎ、
-  // かつ pages 行と page_contents 本体をアトミックにコミットするため、
-  // 全更新をトランザクションで囲む。
+  // 同一ユーザーの並行 PUT を直列化するため、トランザクション内で advisory lock を
+  // 取得する。`SELECT ... FOR UPDATE` は対象行が無い初回作成時には何もロックできず、
+  // 2 つのトランザクションが両方 INSERT に進んで `idx_pages_unique_schema_per_owner`
+  // で衝突 → 片方が 500 になる窓があった。advisory_xact_lock は (owner_id) 空間で
+  // セマンティックに排他化するため、初回作成も後続更新もこの 1 つのロックで安全に
+  // 直列化できる。ロックはトランザクション終了で自動解放。
+  // pg_advisory_xact_lock serialises concurrent schema upserts per owner, closing
+  // the create-time race that `FOR UPDATE` cannot cover (no row to lock yet).
   const pageId = await db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`wiki_schema:${userId}`}))`);
+
     const [existing] = await tx
       .select({ id: pages.id })
       .from(pages)
       .where(and(eq(pages.ownerId, userId), eq(pages.isSchema, true), eq(pages.isDeleted, false)))
-      .for("update")
       .limit(1);
 
     let resolvedPageId: string;
@@ -140,13 +141,22 @@ app.put("/", authRequired, async (c) => {
     return resolvedPageId;
   });
 
-  await recordActivity(db, {
-    ownerId: userId,
-    kind: "wiki_schema_update",
-    actor: "user",
-    targetPageIds: [pageId],
-    detail: { title, contentLength: content.length },
-  });
+  // recordActivity の失敗で 500 を返すと、スキーマは既にコミット済みなのに
+  // クライアントには「失敗」と見えるパーシャル状態になる。activity ログは
+  // ベストエフォートで処理し、失敗はログだけ残してレスポンスは 200 を維持する。
+  // Activity logging is non-fatal: the schema commit already succeeded; surface
+  // failures via console.error only so callers don't see a misleading 500.
+  try {
+    await recordActivity(db, {
+      ownerId: userId,
+      kind: "wiki_schema_update",
+      actor: "user",
+      targetPageIds: [pageId],
+      detail: { title, contentLength: content.length },
+    });
+  } catch (err) {
+    console.error("[wikiSchema] recordActivity failed (non-fatal):", err);
+  }
 
   return c.json({ pageId, title, content });
 });

--- a/server/api/src/schema/sources.ts
+++ b/server/api/src/schema/sources.ts
@@ -59,6 +59,15 @@ export const sources = pgTable(
     uniqueIndex("uq_sources_owner_url_hash")
       .on(table.ownerId, table.url, table.contentHash)
       .where(sql`${table.url} IS NOT NULL`),
+    // URL が無いソース（kind="conversation" 等）は (owner, kind, content_hash) で
+    // 一意にする。これが無いと並行 ingest が同一 contentHash で同じ会話を二重に
+    // 挿入し、`onConflictDoNothing` での再 SELECT 経路が機能しない。
+    // Partial unique index for sources without a URL (e.g. kind="conversation"):
+    // ensures (owner, kind, content_hash) is unique so concurrent inserts
+    // converge via ON CONFLICT DO NOTHING + re-SELECT.
+    uniqueIndex("uq_sources_owner_kind_hash_when_url_null")
+      .on(table.ownerId, table.kind, table.contentHash)
+      .where(sql`${table.url} IS NULL AND ${table.contentHash} IS NOT NULL`),
   ],
 );
 

--- a/server/api/src/services/ingestPlanner.ts
+++ b/server/api/src/services/ingestPlanner.ts
@@ -20,6 +20,17 @@
 import type { AIMessage, AIProviderType } from "../types/index.js";
 
 /**
+ * `userSchema` を system prompt に注入する際の最大文字数。
+ * 経験則として、article excerpt 4,000 chars + candidates と合算しても
+ * 大半のモデル context window に収まり、かつスキーマの主要セクションが
+ * 落ちにくいサイズとして 4,000 を採用。
+ *
+ * Hard cap on injected user-defined wiki schema to keep the planner system
+ * prompt within typical model context windows alongside article + candidates.
+ */
+const USER_SCHEMA_MAX_CHARS = 4_000;
+
+/**
  * Ingest プランが取れるアクション。
  * Possible actions an ingest plan can propose.
  */
@@ -144,8 +155,13 @@ export function buildIngestPlannerPrompt(input: BuildIngestPlannerPromptInput): 
 
   const systemParts = [SYSTEM_PROMPT_JA_EN];
   if (userSchema && userSchema.trim().length > 0) {
+    // article / candidate と同じく、ユーザースキーマも上限文字数で必ず切り詰める。
+    // 切り詰めずに system prompt へ流し込むと、長大なスキーマがプランナーの
+    // コンテキストを食い潰し、要約や候補比較が劣化したり 4xx になりうる。
+    // Bound user schema length so an oversized schema cannot crowd out article/
+    // candidate context or push the planner over the model context window.
     systemParts.push(
-      `User-defined wiki schema (apply when choosing titles and sections):\n${userSchema.trim()}`,
+      `User-defined wiki schema (apply when choosing titles and sections):\n${truncate(userSchema.trim(), USER_SCHEMA_MAX_CHARS)}`,
     );
   }
 

--- a/server/api/src/services/lintEngine/index.ts
+++ b/server/api/src/services/lintEngine/index.ts
@@ -56,25 +56,19 @@ export async function runAllLintRules(ownerId: string, db: Database): Promise<Li
     }
   });
 
-  // Record the run in activity_log (non-fatal on failure).
-  // findings は既にコミット済みなので、activity_log への書き込み失敗で
-  // 戻り値を捨てさせるわけにはいかない。例外を try/catch で握って
-  // ログだけ残し、Lint 結果は呼び出し元へそのまま返す。
-  // findings have already been committed; swallow logging failures so a
-  // transient activity_log error doesn't turn a successful run into 500.
-  try {
-    await recordActivity(db, {
-      ownerId,
-      kind: "lint_run",
-      actor: "user",
-      detail: {
-        total: allFindings.length,
-        summary: results.map((r) => ({ rule: r.rule, count: r.findings.length })),
-      },
-    });
-  } catch (err) {
-    console.error("[lintEngine] recordActivity failed (non-fatal):", err);
-  }
+  // `recordActivity` は内部で例外を握る (activityLogService.ts) ため、
+  // 呼び出し側で改めて try/catch する必要はない。findings コミット後にログ
+  // 書き込みが失敗しても、Lint 結果はそのまま呼び出し元へ返る。
+  // `recordActivity` swallows errors internally; no wrapper try/catch needed.
+  await recordActivity(db, {
+    ownerId,
+    kind: "lint_run",
+    actor: "user",
+    detail: {
+      total: allFindings.length,
+      summary: results.map((r) => ({ rule: r.rule, count: r.findings.length })),
+    },
+  });
 
   return results;
 }

--- a/server/api/src/services/lintEngine/index.ts
+++ b/server/api/src/services/lintEngine/index.ts
@@ -57,16 +57,24 @@ export async function runAllLintRules(ownerId: string, db: Database): Promise<Li
   });
 
   // Record the run in activity_log (non-fatal on failure).
-  // 活動ログに Lint 実行を記録（失敗しても全体を巻き込まない）。
-  await recordActivity(db, {
-    ownerId,
-    kind: "lint_run",
-    actor: "user",
-    detail: {
-      total: allFindings.length,
-      summary: results.map((r) => ({ rule: r.rule, count: r.findings.length })),
-    },
-  });
+  // findings は既にコミット済みなので、activity_log への書き込み失敗で
+  // 戻り値を捨てさせるわけにはいかない。例外を try/catch で握って
+  // ログだけ残し、Lint 結果は呼び出し元へそのまま返す。
+  // findings have already been committed; swallow logging failures so a
+  // transient activity_log error doesn't turn a successful run into 500.
+  try {
+    await recordActivity(db, {
+      ownerId,
+      kind: "lint_run",
+      actor: "user",
+      detail: {
+        total: allFindings.length,
+        summary: results.map((r) => ({ rule: r.rule, count: r.findings.length })),
+      },
+    });
+  } catch (err) {
+    console.error("[lintEngine] recordActivity failed (non-fatal):", err);
+  }
 
   return results;
 }


### PR DESCRIPTION
## 概要

[Release PR #636](https://github.com/otomatty/zedi/pull/636) のレビューコメント (CodeRabbit / Codex) で指摘された **race condition / partial-failure / ID 正規化** 系を develop に向けて修正する PR の 2 本目。

並行リクエスト下で 500 を返したり請求がブレる問題をまとめて潰す。API シグネチャの破壊的変更なし。

## 変更点

| 領域 | 主な変更 |
| ---- | -------- |
| `server/api/src/routes/wikiSchema.ts` | `pg_advisory_xact_lock(hashtext('wiki_schema:'||userId))` で同一ユーザーの並行 PUT を直列化。`SELECT FOR UPDATE` が初回作成時に何もロックできず partial unique index で衝突する race を解消。`recordActivity` を try/catch で非致命扱いにし、ログ書き込み失敗で 500 になる窓を塞ぐ |
| `server/api/src/services/lintEngine/index.ts` | findings コミット後の `recordActivity` を try/catch で握る (transient activity_log 失敗で lint 結果が捨てられないように) |
| `server/api/src/routes/clip.ts` | (1) `/youtube` の usage accounting を生 `body.model` ではなくトリム済み正規 `aiModel` で行うよう修正 — 同一モデルの請求ブレを解消。(2) `extractVideoId` に YouTube Shorts (`m.` サブドメイン含む) を追加 — 本流抽出パイプラインが受理する URL を弾く不整合を解消 |
| `server/api/src/routes/ingest.ts` | source 作成を `ON CONFLICT DO NOTHING + re-SELECT` に変更し、preflight SELECT → INSERT 間で `uq_sources_owner_url_hash` 衝突 → 500 になる race を解消 |
| `server/api/src/services/ingestPlanner.ts` | 注入する `userSchema` を 4,000 文字で truncate (新定数 `USER_SCHEMA_MAX_CHARS`)。巨大スキーマが context を食い潰すのを防ぐ |
| テスト | `ingestPlanner.test.ts` に userSchema truncate ケースを追加 |

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## テスト方法

```bash
cd server/api
bunx vitest run src/__tests__/services/ingestPlanner.test.ts \
                src/__tests__/services/lintEngine \
                src/__tests__/routes/clip.test.ts
```

手動確認:

1. `PUT /api/wiki-schema` を初回ユーザーで複数同時実行 → どれも 200 で返り、最終的に行は 1 つだけ
2. `POST /api/ingest/apply` で同一 (owner, url, contentHash) を並行 → どれも 200、source は 1 行のみ
3. `POST /api/clip/youtube` に Shorts URL (`https://www.youtube.com/shorts/dQw4w9WgXcQ`) → 受理される
4. 巨大な user wiki schema (>10,000 文字) を保存後にプランナー実行 → context overflow せずに動く

## チェックリスト

- [x] テストがすべてパスする (`vitest` 33/33)
- [x] Lint エラーがない (`bun run lint` 0 errors)
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue / PR

Related to #636, #643

レビュー出典:
- codex #3107021400 (wikiSchema insert race)
- coderabbitai #3107034183 (wikiSchema first creation race)
- coderabbitai #3107034184 (wikiSchema recordActivity fatal)
- codex #3107021398 (clip.ts /youtube model normalization)
- devin #3107020264 (clip.ts /youtube Shorts URL)
- coderabbitai #3107034178 (ingest.ts source dedup race)
- coderabbitai #3107034187 (lintEngine recordActivity fatal)
- coderabbitai #3107034186 (ingestPlanner userSchema bound)

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * YouTube Shorts URLs are now supported for video ingestion and processing.

* **Bug Fixes**
  * More resilient handling of concurrent source creation to avoid insert races.
  * Enforced a max length for user-defined schemas embedded in prompts to prevent oversized inputs.
  * Activity logging failures are now non-fatal so main operations continue.
  * Database now enforces uniqueness for non-URL sources to prevent duplicates.

* **Tests**
  * Added a unit test verifying schema truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->