### PR TITLE
fix(lint-engine): normalize fact values, count distinct ghost sources, surface exact-title dups

### DIFF
--- a/server/api/src/services/lintEngine/rules/conflict.test.ts
+++ b/server/api/src/services/lintEngine/rules/conflict.test.ts
@@ -35,7 +35,28 @@ describe("extractFacts", () => {
     const text = "富士山の標高は 3,776m である。";
     const facts = extractFacts(text);
     expect(facts.length).toBeGreaterThanOrEqual(1);
-    expect(facts.some((f) => f.value.includes("3,776m"))).toBe(true);
+    // カンマは正規化で除去されるため `3776m` として保存される。
+    // Commas are normalized away so the canonical value is `3776m`.
+    expect(facts.some((f) => f.value === "3776m")).toBe(true);
+  });
+
+  it("カンマ・空白違いを同一値として正規化する / normalises separator-only variants", () => {
+    // `1,000円` と `1000円` は同じ事実なので、抽出後の value も同一文字列になる。
+    // `1,000円` and `1000円` represent the same fact and should normalize equal.
+    const a = extractFacts("月額料金は 1,000円 です。");
+    const b = extractFacts("月額料金は 1000円 です。");
+    expect(a[0]?.value).toBe("1000円");
+    expect(b[0]?.value).toBe("1000円");
+    expect(a[0]?.value).toBe(b[0]?.value);
+  });
+
+  it("日付の format 違いを同一値として正規化する / normalises date format variants", () => {
+    const a = extractFacts("リリース日は 2026-04-19 です。");
+    const b = extractFacts("リリース日は 2026/4/19 です。");
+    const c = extractFacts("リリース日は 2026年4月19日 です。");
+    expect(a[0]?.value).toBe("2026-4-19");
+    expect(b[0]?.value).toBe("2026-4-19");
+    expect(c[0]?.value).toBe("2026-4-19");
   });
 
   it("人口の数値を抽出する / extracts population numbers", () => {

--- a/server/api/src/services/lintEngine/rules/conflict.test.ts
+++ b/server/api/src/services/lintEngine/rules/conflict.test.ts
@@ -50,6 +50,36 @@ describe("extractFacts", () => {
     expect(a[0]?.value).toBe(b[0]?.value);
   });
 
+  it("空白区切りの thousand-grouping を正規化する / normalises whitespace-separated numbers", () => {
+    // `1 000 円` も `1,000円` / `1000円` と同じ事実として扱う。
+    // `1 000 円` must collapse to the same canonical value as other variants.
+    const a = extractFacts("月額料金は 1 000 円 です。");
+    const b = extractFacts("月額料金は 1,000円 です。");
+    expect(a[0]?.value).toBe("1000円");
+    expect(a[0]?.value).toBe(b[0]?.value);
+  });
+
+  it("百万単位の空白区切りを正規化する / normalises million-scale grouped numbers", () => {
+    const facts = extractFacts("年間売上は 1 000 000 円 です。");
+    expect(facts[0]?.value).toBe("1000000円");
+  });
+
+  it("末尾の小数ゼロを正規化する / normalises trailing decimal zeros", () => {
+    // `1000.0円` と `1000円` は同じ数値を指す。parseFloat で末尾ゼロを畳む。
+    // `1000.0円` and `1000円` denote the same number; parseFloat canonicalises.
+    const a = extractFacts("月額料金は 1000.0円 です。");
+    const b = extractFacts("月額料金は 1000円 です。");
+    expect(a[0]?.value).toBe("1000円");
+    expect(a[0]?.value).toBe(b[0]?.value);
+  });
+
+  it("小数を含む数値を正規化する / normalises decimal numbers", () => {
+    const a = extractFacts("富士山の標高は 3.776km である。");
+    const b = extractFacts("富士山の標高は 3.7760km である。");
+    expect(a[0]?.value).toBe("3.776km");
+    expect(a[0]?.value).toBe(b[0]?.value);
+  });
+
   it("日付の format 違いを同一値として正規化する / normalises date format variants", () => {
     const a = extractFacts("リリース日は 2026-04-19 です。");
     const b = extractFacts("リリース日は 2026/4/19 です。");

--- a/server/api/src/services/lintEngine/rules/conflict.ts
+++ b/server/api/src/services/lintEngine/rules/conflict.ts
@@ -9,10 +9,20 @@ import type { LintRuleResult, LintFindingCandidate } from "../types.js";
  * Regex patterns for extracting numeric/date claims from content.
  */
 const DATE_PATTERN = /(\d{4})[年/-](\d{1,2})[月/-](\d{1,2})[日]?/g;
-// `\d[\d,.]*` (not `+`) so single-digit claims like `3人` / `7km` / `5年` are
-// matched. `+` would require at least two numeric characters.
-// `+` だと 2 文字以上必要になり 1 桁の主張 (3人 等) を取りこぼすため `*` を使う。
-const NUMBER_PATTERN = /(\d[\d,.]*)\s*(km|m|kg|g|人|円|ドル|年|歳|万|億)/g;
+// 数値パターン:
+//   - `\d[\d,.]*` は `1`, `1,000`, `3.14` 等を吸収。`*` (not `+`) なので 1 桁
+//     の主張 `3人` / `7km` / `5年` も取りこぼさない。
+//   - `(?: \d{3})*` で「半角スペース + 3 桁」の繰り返しを許容し、thousand-
+//     grouping の別表記 `1 000 円` / `1 000 000 円` を吸収する。
+//     ASCII スペース以外は受けない（`100 3人` のような偽マッチを避けるため、
+//     3 桁ずつでないと拾わない）。
+// Numeric pattern:
+//   - `\d[\d,.]*` matches `1`, `1,000`, `3.14`, etc. Using `*` (not `+`) keeps
+//     single-digit claims (`3人` / `7km` / `5年`) from being dropped.
+//   - `(?: \d{3})*` accepts space-grouped thousands (`1 000 円` /
+//     `1 000 000 円`). Requiring exactly 3 digits after each space prevents
+//     false grouping like `100 3人` → `1003人`.
+const NUMBER_PATTERN = /(\d[\d,.]*(?: \d{3})*)\s*(km|m|kg|g|人|円|ドル|年|歳|万|億)/g;
 
 /**
  * 日付値を `YYYY-M-D` (パディングなし) に正規化する。`2026-04-19` と
@@ -32,14 +42,31 @@ function normalizeDateValue(raw: string): string {
 }
 
 /**
- * 数値値から区切り文字（カンマ・空白）を取り除き正規化する。
- * `1,000円` と `1000円`、`1 000 円` を同値として扱う。
+ * 数値値を canonical な `<number><unit>` 形式に正規化する。
+ * - 区切り文字（カンマ・空白）を除去
+ * - 単位を末尾から切り出して `parseFloat` で数値化し、末尾ゼロや `.0` を畳む
+ *   （`1,000円` / `1000円` / `1 000 円` / `1000.0円` → すべて `1000円`）
  *
- * Normalize a matched number+unit string so separator-only variants
- * (`1,000円` vs `1000円` vs `1 000 円`) collapse to the same value.
+ * Normalize a matched number+unit string to a canonical `<number><unit>` form.
+ * Thousands separators (comma/space) are stripped and the numeric portion is
+ * run through `parseFloat` so format-only variants — separators as well as
+ * trailing decimal zeros (`1000` vs `1000.0`) — all collapse to one value.
+ *
+ * NOTE: 入力は常に日本語 / 英語圏の表記 (`.` = 小数点、`,` = 千単位) を前提
+ * とする。ロケール別のカンマ=小数点は対象外（`lintEngine` は現状日本語
+ * コンテンツ向けのため）。
  */
 function normalizeNumberValue(raw: string): string {
-  return raw.replace(/[,\s]+/g, "").toLowerCase();
+  const stripped = raw.replace(/[,\s]+/g, "");
+  const unitMatch = stripped.match(/(km|m|kg|g|人|円|ドル|年|歳|万|億)$/);
+  if (!unitMatch) return stripped.toLowerCase();
+  const unit = unitMatch[0];
+  const numeric = stripped.slice(0, -unit.length);
+  const parsed = Number.parseFloat(numeric);
+  if (!Number.isFinite(parsed)) return stripped.toLowerCase();
+  // `String(Number)` は末尾ゼロを自動で落とす（例: `1000.0` → `1000`）。
+  // `String(Number)` naturally drops trailing decimal zeros.
+  return `${parsed}${unit.toLowerCase()}`;
 }
 
 /**

--- a/server/api/src/services/lintEngine/rules/conflict.ts
+++ b/server/api/src/services/lintEngine/rules/conflict.ts
@@ -15,6 +15,34 @@ const DATE_PATTERN = /(\d{4})[年/-](\d{1,2})[月/-](\d{1,2})[日]?/g;
 const NUMBER_PATTERN = /(\d[\d,.]*)\s*(km|m|kg|g|人|円|ドル|年|歳|万|億)/g;
 
 /**
+ * 日付値を `YYYY-M-D` (パディングなし) に正規化する。`2026-04-19` と
+ * `2026/4/19`、`2026年4月19日` を同一として扱うため。
+ *
+ * Normalize a matched date string into `YYYY-M-D` so format-only variants
+ * (`2026-04-19` vs `2026/4/19` vs `2026年4月19日`) collapse to the same value
+ * and don't trigger false `conflict` findings.
+ */
+function normalizeDateValue(raw: string): string {
+  const m = raw.match(/(\d{4})[年/-](\d{1,2})[月/-](\d{1,2})/);
+  if (!m) return raw;
+  const year = String(parseInt(m[1] ?? "0", 10));
+  const month = String(parseInt(m[2] ?? "0", 10));
+  const day = String(parseInt(m[3] ?? "0", 10));
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * 数値値から区切り文字（カンマ・空白）を取り除き正規化する。
+ * `1,000円` と `1000円`、`1 000 円` を同値として扱う。
+ *
+ * Normalize a matched number+unit string so separator-only variants
+ * (`1,000円` vs `1000円` vs `1 000 円`) collapse to the same value.
+ */
+function normalizeNumberValue(raw: string): string {
+  return raw.replace(/[,\s]+/g, "").toLowerCase();
+}
+
+/**
  * テキストからファクト（数値・日付の主張）を抽出する。
  * Extracts factual claims (numbers, dates) from text content.
  *
@@ -31,7 +59,10 @@ export function extractFacts(text: string): Array<{ key: string; value: string }
     const context = text.substring(Math.max(0, match.index - 20), match.index).trim();
     const contextKey = context.split(/\s+/).slice(-3).join(" ");
     if (contextKey) {
-      facts.push({ key: contextKey, value: match[0] });
+      // 値は YYYY-M-D に正規化して保存し、format 違いで偽陽性が出ないようにする。
+      // Persist the normalized canonical value so format-only differences don't
+      // produce false `conflict` findings.
+      facts.push({ key: contextKey, value: normalizeDateValue(match[0]) });
     }
   }
 
@@ -41,7 +72,7 @@ export function extractFacts(text: string): Array<{ key: string; value: string }
     const context = text.substring(Math.max(0, match.index - 20), match.index).trim();
     const contextKey = context.split(/\s+/).slice(-3).join(" ");
     if (contextKey) {
-      facts.push({ key: contextKey, value: match[0] });
+      facts.push({ key: contextKey, value: normalizeNumberValue(match[0]) });
     }
   }
 

--- a/server/api/src/services/lintEngine/rules/ghostMany.ts
+++ b/server/api/src/services/lintEngine/rules/ghostMany.ts
@@ -22,13 +22,20 @@ const GHOST_LINK_THRESHOLD = 3;
  * @returns Ghost Link 過多の検出結果 / Ghost link excess findings
  */
 export async function runGhostManyRule(ownerId: string, db: Database): Promise<LintRuleResult> {
-  // owner_id でフィルタするため、ghost_links → pages を JOIN して owner を制限
-  // Join ghost_links → pages to filter by owner_id
+  // owner_id でフィルタするため、ghost_links → pages を JOIN して owner を制限。
+  // ルールの意図は「同じ link_text が N+ の **異なるソースページ** に登場する」こと。
+  // `count(*)` だと同一ページ内で同じ link_text が複数回現れるとそれを別件として
+  // 数えてしまい、実質 1 ページしか参照していなくても閾値を超える偽陽性が出る。
+  // `count(DISTINCT source_page_id)` と `array_agg(DISTINCT source_page_id)` で
+  // ページ単位の集計に揃え、HAVING も distinct count で判定する。
+  // Use distinct source page counts so multiple occurrences of the same link
+  // text inside one page are not double-counted as separate sources.
+  // Join ghost_links → pages to filter by owner_id.
   const rows = await db
     .select({
       linkText: ghostLinks.linkText,
-      count: sql<number>`count(*)::int`.as("cnt"),
-      sourcePageIds: sql<string[]>`array_agg(${ghostLinks.sourcePageId}::text)`.as(
+      count: sql<number>`count(DISTINCT ${ghostLinks.sourcePageId})::int`.as("cnt"),
+      sourcePageIds: sql<string[]>`array_agg(DISTINCT ${ghostLinks.sourcePageId}::text)`.as(
         "source_page_ids",
       ),
     })
@@ -36,7 +43,7 @@ export async function runGhostManyRule(ownerId: string, db: Database): Promise<L
     .innerJoin(pages, eq(ghostLinks.sourcePageId, pages.id))
     .where(and(eq(pages.ownerId, ownerId), eq(pages.isDeleted, false)))
     .groupBy(ghostLinks.linkText)
-    .having(sql`count(*) >= ${GHOST_LINK_THRESHOLD}`);
+    .having(sql`count(DISTINCT ${ghostLinks.sourcePageId}) >= ${GHOST_LINK_THRESHOLD}`);
 
   return {
     rule: "ghost_many",

--- a/server/api/src/services/lintEngine/rules/titleSimilar.ts
+++ b/server/api/src/services/lintEngine/rules/titleSimilar.ts
@@ -67,11 +67,14 @@ export async function runTitleSimilarRule(ownerId: string, db: Database): Promis
       const titleA = (a.title ?? "").trim().toLowerCase();
       const titleB = (b.title ?? "").trim().toLowerCase();
 
-      if (titleA === titleB) continue; // exact dup handled elsewhere
-
       const minLen = Math.min(titleA.length, titleB.length);
       if (minLen === 0) continue;
 
+      // 完全一致 (distance=0) は最も強い類似ケースなので別ルールで握り潰さず
+      // ここで `info` として報告する。以前はコメントで「他で処理する」と書かれて
+      // いたが実際にはどこも見ていなかったため、完全一致が黙って素通りしていた。
+      // Treat exact-title pairs as the strongest title_similar case rather than
+      // assuming a separate rule handles them — there is no such rule today.
       const dist = levenshtein(titleA, titleB);
       const threshold = Math.max(1, Math.floor(minLen * SIMILARITY_RATIO));
 

--- a/server/api/src/services/lintEngine/rules/titleSimilar.ts
+++ b/server/api/src/services/lintEngine/rules/titleSimilar.ts
@@ -83,15 +83,25 @@ export async function runTitleSimilarRule(ownerId: string, db: Database): Promis
         if (seen.has(key)) continue;
         seen.add(key);
 
+        // 完全一致 (distance=0) はリンクの曖昧さを生む深刻な重複なので
+        // `warn` に上げ、近似類似 (distance>0) は `info` のまま残す。
+        // Exact-title duplicates (distance=0) create link ambiguity and are
+        // more serious than near-matches, so escalate severity to `warn`.
+        const severity = dist === 0 ? "warn" : "info";
+        const suggestion =
+          dist === 0
+            ? "タイトルが完全に一致しています。統合またはリネームを検討してください / Titles are identical. Consider merging or renaming."
+            : "タイトルが類似しています。統合を検討してください / Titles are similar. Consider merging.";
+
         findings.push({
           rule: "title_similar",
-          severity: "info",
+          severity,
           pageIds: [a.id, b.id],
           detail: {
             titleA: a.title,
             titleB: b.title,
             distance: dist,
-            suggestion: `タイトルが類似しています。統合を検討してください / Titles are similar. Consider merging.`,
+            suggestion,
           },
         });
       }


### PR DESCRIPTION
## 概要

[Release PR #636](https://github.com/otomatty/zedi/pull/636) のレビューコメント (CodeRabbit) で指摘された **Lint エンジンの偽陽性・偽陰性** をまとめて修正する PR の 3 本目。

ユーザーから見える Lint 通知の精度 (= 信頼性) に直結するため、release blocker ではないが UX への影響が大きい。

## 変更点

| 領域 | 主な変更 |
| ---- | -------- |
| `services/lintEngine/rules/conflict.ts` | 抽出した日付を `YYYY-M-D` に、数値はカンマ・空白除去で正規化してから格納。`2026-04-19` vs `2026/4/19` や `1,000円` vs `1000円` のような format-only 差分が誤って `conflict` として通知されないようにする |
| `services/lintEngine/rules/ghostMany.ts` | `count(*)` / `array_agg` を `DISTINCT source_page_id` に変更。同一ページ内で同じ link_text が複数回現れるケースを別ソースとして二重計上していた偽陽性を解消。HAVING も distinct count で判定 |
| `services/lintEngine/rules/titleSimilar.ts` | 完全一致タイトル (`distance=0`) を「別ルールで処理」というコメントだけで握り潰していたが、実際にはどこも処理していなかった。最強の `title_similar` finding として通知 |
| `services/lintEngine/rules/conflict.test.ts` | 日付・数値の正規化テストを追加 |

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

データ移行は不要。lint は再実行で最新ロジックの結果に置き換わる。

## テスト方法

```bash
cd server/api
bunx vitest run src/services/lintEngine
```

手動確認:

1. 同一の事実を異なる format で 2 ページに書く (`2026-04-19` と `2026/4/19`) → conflict が出ないこと
2. 1 ページ内に同じ ghost link を 3 回書く → ghost_many は出ないこと（distinct で 1 ソース）
3. 別々のページに同じ ghost link を 3 回 → ghost_many が出ること
4. 完全に同じタイトルのページが 2 件 → title_similar が出ること

## チェックリスト

- [x] テストがすべてパスする (`vitest` 25/25)
- [x] Lint エラーがない (`bun run lint` 0 errors)
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue / PR

Related to #636, #643, #645

レビュー出典:
- coderabbitai #3107034179 (conflict.ts format-only false positive)
- coderabbitai #3107034180 (ghostMany.ts distinct counting)
- coderabbitai #3107034181 (titleSimilar.ts exact-dup silent skip)

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Canonicalized numeric and date values so format-only variations are treated identically, improving conflict detection.

* **Improvements**
  * Ghost link detection now triggers only when the same link text appears across multiple distinct pages.
  * Title similarity now includes exact duplicates and adjusts severity and suggestions based on match closeness.

* **Tests**
  * Added tests covering number/date normalization and canonical outputs across format variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->