### PR TITLE
fix(ui-ci-tests): address PR #636 UI/UX, CI gating, accessibility and small refactors

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -73,14 +73,25 @@ jobs:
     name: Deploy Frontend
     # `verify-server-health` をフロント公開のゲートにする。バックエンドが新版で
     # ヘルスチェックを通らない状態のまま新しい UI を公開すると、ユーザーが壊れた
-    # API を直撃する。ヘルスチェックは `if: vars.API_BASE_URL != ''` 条件付きで
-    # スキップされうるので、ここでは hard dependency にしてもスキップ伝播で blocked
-    # にはならない（GitHub Actions は skipped を success として needs を通す）。
+    # API を直撃する。
+    #
+    # ただし `verify-server-health` は `if: vars.API_BASE_URL != ''` で skip される
+    # 可能性があり、GitHub Actions は upstream が skipped の場合、downstream を
+    # 既定で skip する。そのため明示的に `if` で `success` または `skipped` を
+    # 許容する必要がある（参照: GitHub Docs "Using jobs in a workflow"）。
+    #
     # Gate frontend rollout on backend health so the new UI never points at a
-    # backend that failed to roll out.
+    # backend that failed to roll out. GitHub Actions skips downstream jobs by
+    # default when an upstream job is skipped, so explicitly allow the
+    # `skipped` result here when the health-check job is skipped because
+    # `vars.API_BASE_URL` is unset (current dev configuration).
     needs:
       - migrate
       - verify-server-health
+    if: |
+      always()
+      && needs.migrate.result == 'success'
+      && (needs.verify-server-health.result == 'success' || needs.verify-server-health.result == 'skipped')
     runs-on: ubuntu-latest
     environment: development
     steps:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -71,8 +71,16 @@ jobs:
 
   deploy-frontend:
     name: Deploy Frontend
+    # `verify-server-health` をフロント公開のゲートにする。バックエンドが新版で
+    # ヘルスチェックを通らない状態のまま新しい UI を公開すると、ユーザーが壊れた
+    # API を直撃する。ヘルスチェックは `if: vars.API_BASE_URL != ''` 条件付きで
+    # スキップされうるので、ここでは hard dependency にしてもスキップ伝播で blocked
+    # にはならない（GitHub Actions は skipped を success として needs を通す）。
+    # Gate frontend rollout on backend health so the new UI never points at a
+    # backend that failed to roll out.
     needs:
       - migrate
+      - verify-server-health
     runs-on: ubuntu-latest
     environment: development
     steps:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -74,8 +74,15 @@ jobs:
 
   deploy-frontend:
     name: Deploy Frontend
+    # `verify-server-health` をフロント公開のゲートにする。バックエンドの
+    # ロールアウトに失敗している状態で新しい UI を本番公開すると、ユーザーが
+    # 直撃する。`if: vars.API_BASE_URL != ''` で skip された場合も needs は
+    # 通過する（GitHub Actions は skipped を success 扱いで needs を満たす）。
+    # Gate prod frontend rollout on backend health so a failed backend deploy
+    # cannot still publish the new UI.
     needs:
       - migrate
+      - verify-server-health
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -123,8 +130,11 @@ jobs:
 
   deploy-admin:
     name: Deploy Admin
+    # 同様に admin の本番公開もバックエンドのヘルスチェック通過後にする。
+    # Gate admin rollout on backend health for the same reason as `deploy-frontend`.
     needs:
       - migrate
+      - verify-server-health
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -76,13 +76,24 @@ jobs:
     name: Deploy Frontend
     # `verify-server-health` をフロント公開のゲートにする。バックエンドの
     # ロールアウトに失敗している状態で新しい UI を本番公開すると、ユーザーが
-    # 直撃する。`if: vars.API_BASE_URL != ''` で skip された場合も needs は
-    # 通過する（GitHub Actions は skipped を success 扱いで needs を満たす）。
+    # 直撃する。
+    #
+    # GitHub Actions は upstream が skipped の場合、downstream を既定で skip
+    # するため、`if: vars.API_BASE_URL != ''` 経由で health チェックが skip
+    # された環境では明示的に `skipped` を success と同等に扱う必要がある
+    # （参照: GitHub Docs "Using jobs in a workflow"）。
+    #
     # Gate prod frontend rollout on backend health so a failed backend deploy
-    # cannot still publish the new UI.
+    # cannot still publish the new UI. Explicitly allow the `skipped` result
+    # of `verify-server-health` because GitHub Actions skips downstream jobs
+    # by default when an upstream `needs` job is skipped.
     needs:
       - migrate
       - verify-server-health
+    if: |
+      always()
+      && needs.migrate.result == 'success'
+      && (needs.verify-server-health.result == 'success' || needs.verify-server-health.result == 'skipped')
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -131,10 +142,16 @@ jobs:
   deploy-admin:
     name: Deploy Admin
     # 同様に admin の本番公開もバックエンドのヘルスチェック通過後にする。
+    # `deploy-frontend` と同じ理由で skipped を許容する `if` を明示する。
     # Gate admin rollout on backend health for the same reason as `deploy-frontend`.
+    # Apply the same explicit `if` to allow the skipped result.
     needs:
       - migrate
       - verify-server-health
+    if: |
+      always()
+      && needs.migrate.result == 'success'
+      && (needs.verify-server-health.result == 'success' || needs.verify-server-health.result == 'skipped')
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/admin/src/api/activity.ts
+++ b/admin/src/api/activity.ts
@@ -1,4 +1,4 @@
-import { adminFetch } from "./client";
+import { adminFetch, getErrorMessage } from "./client";
 
 /**
  * 活動ログの種別。
@@ -52,11 +52,6 @@ export interface ActivityListParams {
   to?: string;
   limit?: number;
   offset?: number;
-}
-
-async function getErrorMessage(res: Response, fallback: string): Promise<string> {
-  const err = await res.json().catch(() => ({ message: res.statusText }));
-  return (err as { message?: string }).message ?? fallback;
 }
 
 /**

--- a/admin/src/api/admin.test.ts
+++ b/admin/src/api/admin.test.ts
@@ -11,9 +11,19 @@ import {
   syncAiModels,
 } from "./admin";
 
-vi.mock("./client", () => ({
-  adminFetch: vi.fn(),
-}));
+// `adminFetch` だけモックし、`getErrorMessage` は実装をそのまま使う
+// （admin.ts が getErrorMessage をインポートしているため、mock 不在だと
+// "No 'getErrorMessage' export is defined on the './client' mock" になる）。
+// Mock only `adminFetch` and reuse the real `getErrorMessage` implementation
+// (admin.ts imports it; without this we'd hit "No 'getErrorMessage' export
+// is defined on the './client' mock").
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return {
+    ...actual,
+    adminFetch: vi.fn(),
+  };
+});
 
 const { adminFetch } = await import("./client");
 

--- a/admin/src/api/admin.ts
+++ b/admin/src/api/admin.ts
@@ -1,4 +1,4 @@
-import { adminFetch } from "./client";
+import { adminFetch, getErrorMessage } from "./client";
 
 /** 現在ログイン中の管理者情報 / Current admin user info */
 export interface AdminMe {
@@ -38,11 +38,6 @@ export interface AiModelAdmin {
   isActive: boolean;
   sortOrder: number;
   createdAt: string;
-}
-
-async function getErrorMessage(res: Response, fallback: string): Promise<string> {
-  const err = await res.json().catch(() => ({ message: res.statusText }));
-  return (err as { message?: string }).message ?? fallback;
 }
 
 /**

--- a/admin/src/api/client.ts
+++ b/admin/src/api/client.ts
@@ -42,10 +42,26 @@ export async function adminFetch(path: string, options: RequestInit = {}): Promi
  * the supplied `fallback`. Centralised here so each admin API module does not
  * re-implement the same parsing logic (see PR #636 review).
  *
+ * `message` が空文字 / 全空白の場合や `statusText` が空の場合も、
+ * 呼び出し側で `Error.message` が空にならないよう、最終的に必ず `fallback`
+ * に倒す。`??` ではなく空文字チェックで判定することがポイント。
+ *
+ * Treat empty/whitespace-only `message` and empty `statusText` as absent so
+ * downstream `Error.message` values are never blank — the check is intentionally
+ * "non-empty after trim", not nullish coalescing.
+ *
  * @param res - 失敗した fetch Response / Failed fetch Response
  * @param fallback - 最後の fallback メッセージ / Fallback message
  */
 export async function getErrorMessage(res: Response, fallback: string): Promise<string> {
-  const err = await res.json().catch(() => ({ message: res.statusText }));
-  return (err as { message?: string }).message ?? fallback;
+  const body: unknown = await res.json().catch(() => null);
+  const candidate =
+    typeof body === "object" &&
+    body !== null &&
+    "message" in body &&
+    typeof (body as { message?: unknown }).message === "string"
+      ? (body as { message: string }).message
+      : res.statusText;
+  const trimmed = candidate.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
 }

--- a/admin/src/api/client.ts
+++ b/admin/src/api/client.ts
@@ -32,3 +32,20 @@ export async function adminFetch(path: string, options: RequestInit = {}): Promi
     headers,
   });
 }
+
+/**
+ * Response の JSON ボディから `message` を取り出してエラーメッセージを組み立てる。
+ * JSON parse に失敗した場合は statusText、最終的には fallback を返す。
+ *
+ * Extracts an error message from a JSON response body's `message` field,
+ * falling back to `res.statusText` (when the body is not JSON) and finally to
+ * the supplied `fallback`. Centralised here so each admin API module does not
+ * re-implement the same parsing logic (see PR #636 review).
+ *
+ * @param res - 失敗した fetch Response / Failed fetch Response
+ * @param fallback - 最後の fallback メッセージ / Fallback message
+ */
+export async function getErrorMessage(res: Response, fallback: string): Promise<string> {
+  const err = await res.json().catch(() => ({ message: res.statusText }));
+  return (err as { message?: string }).message ?? fallback;
+}

--- a/admin/src/api/lint.ts
+++ b/admin/src/api/lint.ts
@@ -1,4 +1,4 @@
-import { adminFetch } from "./client";
+import { adminFetch, getErrorMessage } from "./client";
 
 /**
  * Lint ルール名の型。
@@ -39,11 +39,6 @@ export interface LintFindingItem {
 export interface LintRunSummaryItem {
   rule: LintRule;
   count: number;
-}
-
-async function getErrorMessage(res: Response, fallback: string): Promise<string> {
-  const err = await res.json().catch(() => ({ message: res.statusText }));
-  return (err as { message?: string }).message ?? fallback;
 }
 
 /**

--- a/admin/src/pages/ActivityLog.tsx
+++ b/admin/src/pages/ActivityLog.tsx
@@ -90,20 +90,29 @@ export default function ActivityLog() {
   const [actorFilter, setActorFilter] = useState<ActivityActor | undefined>(undefined);
 
   const mountedRef = useRef(true);
+  // フィルタ切り替え／連打などで複数のリクエストが in-flight になったとき、
+  // 古いリクエストが新しいリクエストの後に解決されると stale なテーブル内容で
+  // 上書きされる。requestIdRef で発行順を記録し、最新リクエスト以外の結果は
+  // 破棄することで out-of-order 上書きを防ぐ。
+  // Track in-flight request id so older listActivity responses cannot overwrite
+  // newer ones if the user toggles filters or taps reload before the previous
+  // request resolves.
+  const requestIdRef = useRef(0);
 
   const load = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     if (mountedRef.current) setLoading(true);
     if (mountedRef.current) setError(null);
     try {
       const result = await listActivity({ kind: kindFilter, actor: actorFilter, limit: 100 });
-      if (!mountedRef.current) return;
+      if (!mountedRef.current || requestId !== requestIdRef.current) return;
       setEntries(result.entries);
       setTotal(result.total);
     } catch (e) {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current || requestId !== requestIdRef.current) return;
       setError(e instanceof Error ? e.message : String(e));
     } finally {
-      if (mountedRef.current) setLoading(false);
+      if (mountedRef.current && requestId === requestIdRef.current) setLoading(false);
     }
   }, [kindFilter, actorFilter]);
 

--- a/admin/src/pages/wiki-health/index.tsx
+++ b/admin/src/pages/wiki-health/index.tsx
@@ -19,19 +19,26 @@ export default function WikiHealth() {
   const [ruleFilter, setRuleFilter] = useState<LintRule | undefined>(undefined);
 
   const isMountedRef = useRef(true);
+  // 連打や解決アクション直後の reload で複数の getLintFindings が同時に
+  // 走ることがある。requestId を発行して最新の応答以外を破棄しないと
+  // 古いリクエストの結果で findings が上書きされ、解決済み項目が再表示される。
+  // Track in-flight request id so older getLintFindings responses cannot
+  // overwrite a newer one (e.g. reload tapped twice or resolve+reload race).
+  const requestIdRef = useRef(0);
 
   const loadFindings = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     if (isMountedRef.current) setLoading(true);
     if (isMountedRef.current) setError(null);
     try {
       const result = await getLintFindings();
-      if (!isMountedRef.current) return;
+      if (!isMountedRef.current || requestId !== requestIdRef.current) return;
       setFindings(result.findings);
     } catch (e) {
-      if (!isMountedRef.current) return;
+      if (!isMountedRef.current || requestId !== requestIdRef.current) return;
       setError(e instanceof Error ? e.message : String(e));
     } finally {
-      if (isMountedRef.current) setLoading(false);
+      if (isMountedRef.current && requestId === requestIdRef.current) setLoading(false);
     }
   }, []);
 

--- a/server/api/src/__tests__/routes/ext.test.ts
+++ b/server/api/src/__tests__/routes/ext.test.ts
@@ -58,12 +58,18 @@ vi.mock("../../lib/extAuth.js", () => ({
   storeExtensionCode: (...args: unknown[]) => mockStoreExtensionCode(...args),
 }));
 
+const mockClipAndCreate = vi.fn().mockResolvedValue({
+  page_id: "page-mock-001",
+  title: "Mock Title",
+  thumbnail_url: "https://example.com/thumb.png",
+});
 vi.mock("../../lib/clipAndCreate.js", () => ({
-  clipAndCreate: vi.fn().mockResolvedValue({
-    page_id: "page-mock-001",
-    title: "Mock Title",
-    thumbnail_url: "https://example.com/thumb.png",
-  }),
+  clipAndCreate: (...args: unknown[]) => mockClipAndCreate(...args),
+}));
+
+const mockResolveAiConfigForRequest = vi.fn();
+vi.mock("../../lib/aiAccessHelpers.js", () => ({
+  resolveAiConfigForRequest: (...args: unknown[]) => mockResolveAiConfigForRequest(...args),
 }));
 
 vi.mock("../../lib/clipUrlPolicy.js", async (importOriginal) => {
@@ -101,6 +107,12 @@ async function parseJsonOrText(res: Response): Promise<{ message?: string }> {
 describe("POST /api/ext/clip-and-create", () => {
   const mockRedis = {} as AppEnv["Variables"]["redis"];
   const mockDb = {} as AppEnv["Variables"]["db"];
+
+  beforeEach(() => {
+    mockClipAndCreate.mockClear();
+    mockResolveAiConfigForRequest.mockReset();
+    mockResolveAiConfigForRequest.mockResolvedValue(null);
+  });
 
   it("returns 401 when Authorization Bearer is missing", async () => {
     const app = createExtApp(mockRedis, mockDb);
@@ -232,6 +244,81 @@ describe("POST /api/ext/clip-and-create", () => {
     expect(body.page_id).toBe("page-mock-001");
     expect(body.title).toBe("Mock Title");
     expect(body.thumbnail_url).toBe("https://example.com/thumb.png");
+  });
+
+  it("does not resolve AI config for non-YouTube URLs even when provider/model are present", async () => {
+    const app = createExtApp(mockRedis, mockDb);
+    const res = await app.request("/api/ext/clip-and-create", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer fake-token",
+        "x-test-ext-user-id": "user-1",
+      },
+      body: JSON.stringify({
+        url: "https://example.com/article",
+        provider: "openai",
+        model: "openai:gpt-4o-mini",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockResolveAiConfigForRequest).not.toHaveBeenCalled();
+    expect(mockClipAndCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://example.com/article",
+        aiProvider: undefined,
+        aiModel: undefined,
+        aiApiKey: undefined,
+      }),
+    );
+  });
+
+  it("resolves AI config for YouTube URLs before clipAndCreate", async () => {
+    mockResolveAiConfigForRequest.mockResolvedValue({
+      provider: "openai",
+      apiModelId: "gpt-4o-mini",
+      apiKey: "test-api-key",
+      internalModelId: "openai:gpt-4o-mini",
+      tier: "free",
+      modelInfo: {
+        provider: "openai",
+        apiModelId: "gpt-4o-mini",
+        inputCostUnits: 1,
+        outputCostUnits: 1,
+      },
+    });
+
+    const app = createExtApp(mockRedis, mockDb);
+    const res = await app.request("/api/ext/clip-and-create", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer fake-token",
+        "x-test-ext-user-id": "user-1",
+      },
+      body: JSON.stringify({
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        provider: "openai",
+        model: "openai:gpt-4o-mini",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockResolveAiConfigForRequest).toHaveBeenCalledWith({
+      userId: "user-1",
+      db: mockDb,
+      provider: "openai",
+      model: "openai:gpt-4o-mini",
+    });
+    expect(mockClipAndCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        aiProvider: "openai",
+        aiModel: "gpt-4o-mini",
+        aiApiKey: "test-api-key",
+      }),
+    );
   });
 });
 

--- a/server/api/src/lib/aiAccessHelpers.ts
+++ b/server/api/src/lib/aiAccessHelpers.ts
@@ -11,8 +11,10 @@
  * This utility maps them to proper client-facing 4xx exceptions.
  */
 import { HTTPException } from "hono/http-exception";
-import { validateModelAccess } from "../services/usageService.js";
-import type { Database, UserTier } from "../types/index.js";
+import { checkUsage, validateModelAccess } from "../services/usageService.js";
+import { getProviderApiKeyName } from "../services/aiProviders.js";
+import { getUserTier } from "../services/subscriptionService.js";
+import type { AIProviderType, Database, UserTier } from "../types/index.js";
 
 /**
  * `validateModelAccess()` を呼び、既知のエラーは適切な HTTPException に変換する。
@@ -42,4 +44,100 @@ export async function validateModelAccessOrThrow(
     }
     throw err;
   }
+}
+
+/**
+ * 現在サポートしている AI プロバイダー一覧。
+ * Set of AI providers currently supported by API endpoints accepting
+ * `provider` / `model` parameters (clip, ext, ingest, ...).
+ */
+export const SUPPORTED_AI_PROVIDERS: readonly AIProviderType[] = [
+  "openai",
+  "anthropic",
+  "google",
+] as const;
+
+/**
+ * 解決済みの AI 設定。
+ * Resolved AI configuration: provider/apiModelId は DB 上のレコードから来る
+ * （クライアント入力ではない）ので、呼び出し側はそのままプロバイダー呼び出しに
+ * 渡してよい。
+ *
+ * Resolved AI config – `provider` / `apiModelId` come from the DB record
+ * (not the client input) so callers can pass them straight to provider calls.
+ */
+export interface ResolvedAiConfig {
+  provider: AIProviderType;
+  apiModelId: string;
+  apiKey: string;
+}
+
+/**
+ * `provider` / `model` を受け付けるエンドポイント共通の検証・解決処理。
+ * Shared validation/resolution for endpoints that accept `provider` / `model`
+ * (clip.ts /youtube, ext.ts /clip-and-create, ...).
+ *
+ * 1. provider / model は両方指定するか両方省略するかのどちらかを強制する。
+ * 2. provider はサポート一覧に含まれている必要がある。
+ * 3. tier ベースのモデルアクセス・月次予算チェック。
+ * 4. DB 上の provider / apiModelId を「正」として返し、対応する API キーを
+ *    環境変数から取り出す。
+ *
+ * 1. require provider/model to be specified together,
+ * 2. ensure the provider is supported,
+ * 3. enforce tier-based model access and monthly budget,
+ * 4. return the canonical provider/apiModelId from the DB along with the
+ *    resolved env-var API key.
+ *
+ * @param input.userId - 呼び出しユーザー ID / Calling user id
+ * @param input.db - Drizzle DB instance
+ * @param input.provider - クライアント指定の provider（任意） / Client-supplied provider (optional)
+ * @param input.model - クライアント指定の model（任意） / Client-supplied model (optional)
+ * @returns provider/model が指定されていれば {@link ResolvedAiConfig}、未指定なら null
+ */
+export async function resolveAiConfigForRequest(input: {
+  userId: string;
+  db: Database;
+  provider: string | undefined;
+  model: string | undefined;
+}): Promise<ResolvedAiConfig | null> {
+  const { userId, db, provider, model } = input;
+  const hasProvider = typeof provider === "string" && provider.trim().length > 0;
+  const hasModel = typeof model === "string" && model.trim().length > 0;
+  if (hasProvider !== hasModel) {
+    throw new HTTPException(400, {
+      message: "provider and model must be specified together",
+    });
+  }
+  if (!hasProvider || !hasModel) return null;
+
+  const providerInput = (provider as string).trim() as AIProviderType;
+  const modelInput = (model as string).trim();
+  if (!SUPPORTED_AI_PROVIDERS.includes(providerInput)) {
+    throw new HTTPException(400, { message: `unsupported provider: ${providerInput}` });
+  }
+
+  const tier = await getUserTier(userId, db);
+  const modelInfo = await validateModelAccessOrThrow(modelInput, tier, db);
+  const usageCheck = await checkUsage(userId, tier, db);
+  if (!usageCheck.allowed) {
+    throw new HTTPException(429, { message: "Monthly budget exceeded" });
+  }
+
+  // DB 上の provider を「正」とする（API キー取得もこちらに合わせる）。
+  // Trust the DB-resolved provider over the client's input (and fetch the
+  // matching env API key) so a client can't request a provider mismatch.
+  const resolvedProvider = modelInfo.provider as AIProviderType;
+  const resolvedApiModelId = modelInfo.apiModelId;
+  const apiKeyName = getProviderApiKeyName(resolvedProvider);
+  const apiKey = process.env[apiKeyName];
+  if (!apiKey) {
+    throw new HTTPException(503, { message: `API key not configured: ${apiKeyName}` });
+  }
+
+  return {
+    provider: resolvedProvider,
+    apiModelId: resolvedApiModelId,
+    apiKey,
+  };
 }

--- a/server/api/src/lib/aiAccessHelpers.ts
+++ b/server/api/src/lib/aiAccessHelpers.ts
@@ -70,6 +70,30 @@ export interface ResolvedAiConfig {
   provider: AIProviderType;
   apiModelId: string;
   apiKey: string;
+  /**
+   * 内部 composite モデル ID（`aiModels.id`）。クライアント入力をトリムした後の値で、
+   * `aiUsageLogs.modelId` の FK に対応する。`recordUsage()` にはこちらを渡す。
+   *
+   * Internal composite model ID (`aiModels.id`) – the trimmed client input that
+   * matches the FK target of `aiUsageLogs.modelId`. Pass this to `recordUsage()`.
+   */
+  internalModelId: string;
+  /**
+   * 解決時に取得した呼び出しユーザーの tier。
+   * 呼び出し側で usage 記録のために再度 `getUserTier` を呼ばずに済むよう公開する。
+   *
+   * Caller's tier captured during resolution. Exposed so usage-recording paths
+   * don't need to re-query `getUserTier`.
+   */
+  tier: UserTier;
+  /**
+   * 解決時に取得したモデル情報（コスト単価など）。
+   * `validateModelAccess()` の戻り値そのもので、cost 計算に再利用できる。
+   *
+   * Model info captured during resolution (cost units, provider, etc.).
+   * Reused for cost calculation without re-calling `validateModelAccess`.
+   */
+  modelInfo: Awaited<ReturnType<typeof validateModelAccess>>;
 }
 
 /**
@@ -139,5 +163,8 @@ export async function resolveAiConfigForRequest(input: {
     provider: resolvedProvider,
     apiModelId: resolvedApiModelId,
     apiKey,
+    internalModelId: modelInput,
+    tier,
+    modelInfo,
   };
 }

--- a/server/api/src/lib/articleExtractor.ts
+++ b/server/api/src/lib/articleExtractor.ts
@@ -198,7 +198,7 @@ export function extractTextFromTiptap(node: TiptapNode | null): string {
  * YouTube URL から動画 ID を抽出する（サーバーサイド版）。
  * Extracts a YouTube video ID from various YouTube URL formats (server-side).
  */
-function extractYouTubeVideoId(url: string): string | null {
+export function extractYouTubeVideoId(url: string): string | null {
   const patterns = [
     /^https?:\/\/(?:www\.)?youtube\.com\/watch\?(?:[^&]+&)*v=([a-zA-Z0-9_-]{11})(?:&[^\s]*)?$/i,
     /^https?:\/\/youtu\.be\/([a-zA-Z0-9_-]{11})(?:\?[^\s]*)?$/i,

--- a/server/api/src/routes/clip.ts
+++ b/server/api/src/routes/clip.ts
@@ -9,15 +9,9 @@ import { authRequired } from "../middleware/auth.js";
 import { rateLimit } from "../middleware/rateLimit.js";
 import { ClipFetchBlockedError, fetchClipHtmlWithRedirects } from "../lib/clipServerFetch.js";
 import { extractYouTubeContent } from "../lib/youtubeExtractor.js";
-import { validateModelAccessOrThrow } from "../lib/aiAccessHelpers.js";
-import { getProviderApiKeyName } from "../services/aiProviders.js";
+import { resolveAiConfigForRequest } from "../lib/aiAccessHelpers.js";
 import { getUserTier } from "../services/subscriptionService.js";
-import {
-  checkUsage,
-  validateModelAccess,
-  calculateCost,
-  recordUsage,
-} from "../services/usageService.js";
+import { validateModelAccess, calculateCost, recordUsage } from "../services/usageService.js";
 import type { AppEnv, AIProviderType } from "../types/index.js";
 
 const app = new Hono<AppEnv>();
@@ -116,54 +110,18 @@ app.post("/youtube", authRequired, rateLimit(), async (c) => {
 
   const youtubeApiKey = process.env.YOUTUBE_DATA_API_KEY;
 
-  // AI 要約の設定 / AI summary configuration
-  let aiProvider: AIProviderType | undefined;
-  let aiModel: string | undefined;
-  let aiApiKey: string | undefined;
-
-  const supportedProviders: AIProviderType[] = ["openai", "anthropic", "google"];
-
-  // provider/model は両方指定するか両方省略する必要がある（ext.ts の /clip-and-create と一致させる）
-  // provider/model must be specified together or both omitted (consistent with ext.ts /clip-and-create)
-  const hasProvider = typeof body.provider === "string" && body.provider.trim().length > 0;
-  const hasModel = typeof body.model === "string" && body.model.trim().length > 0;
-  if (hasProvider !== hasModel) {
-    throw new HTTPException(400, {
-      message: "provider and model must be specified together",
-    });
-  }
-
-  if (hasProvider && hasModel) {
-    const providerInput = (body.provider as string).trim() as AIProviderType;
-    const modelInput = (body.model as string).trim();
-    if (!supportedProviders.includes(providerInput)) {
-      throw new HTTPException(400, { message: `unsupported provider: ${providerInput}` });
-    }
-    aiProvider = providerInput;
-    aiModel = modelInput;
-
-    // モデルアクセス・利用量チェック / Model access & usage enforcement
-    // 既知の検証エラーは HTTPException(400/403) として返す
-    // Known validation errors are translated to HTTPException(400/403)
-    const tier = await getUserTier(userId, db);
-    const modelInfo = await validateModelAccessOrThrow(aiModel, tier, db);
-    const usageCheck = await checkUsage(userId, tier, db);
-    if (!usageCheck.allowed) {
-      throw new HTTPException(429, { message: "Monthly budget exceeded" });
-    }
-
-    // モデル情報から provider を上書き（DB 上の provider が正）
-    // Override provider from model info (DB is authoritative)
-    // API キーは上書き後の provider で取得する（provider 不一致バグ防止）
-    aiProvider = modelInfo.provider as AIProviderType;
-    aiModel = modelInfo.apiModelId;
-
-    const apiKeyName = getProviderApiKeyName(aiProvider);
-    aiApiKey = process.env[apiKeyName];
-    if (!aiApiKey) {
-      throw new HTTPException(503, { message: `API key not configured: ${apiKeyName}` });
-    }
-  }
+  // AI 要約の設定（ext.ts の /clip-and-create と検証ロジックを共通化）
+  // AI summary configuration (validation/access-control shared with
+  // ext.ts /clip-and-create via resolveAiConfigForRequest()).
+  const aiConfig = await resolveAiConfigForRequest({
+    userId,
+    db,
+    provider: body.provider,
+    model: body.model,
+  });
+  const aiProvider: AIProviderType | undefined = aiConfig?.provider;
+  const aiModel: string | undefined = aiConfig?.apiModelId;
+  const aiApiKey: string | undefined = aiConfig?.apiKey;
 
   try {
     const result = await extractYouTubeContent({

--- a/server/api/src/routes/clip.ts
+++ b/server/api/src/routes/clip.ts
@@ -10,8 +10,7 @@ import { rateLimit } from "../middleware/rateLimit.js";
 import { ClipFetchBlockedError, fetchClipHtmlWithRedirects } from "../lib/clipServerFetch.js";
 import { extractYouTubeContent } from "../lib/youtubeExtractor.js";
 import { resolveAiConfigForRequest } from "../lib/aiAccessHelpers.js";
-import { getUserTier } from "../services/subscriptionService.js";
-import { validateModelAccess, calculateCost, recordUsage } from "../services/usageService.js";
+import { calculateCost, recordUsage } from "../services/usageService.js";
 import type { AppEnv, AIProviderType } from "../types/index.js";
 
 const app = new Hono<AppEnv>();
@@ -135,15 +134,15 @@ app.post("/youtube", authRequired, rateLimit(), async (c) => {
     // 使用量記録 / Record usage
     // result.aiUsage が null でない場合のみ課金（AI が実際に成功した場合）
     // 記録失敗は非致命的 — 抽出結果を破棄しない
-    // Bill only when AI actually ran successfully (result.aiUsage !== null)
-    // Recording failure is non-fatal — don't discard the extraction result
-    if (result.aiUsage && aiProvider && aiModel && body.model) {
+    // resolveAiConfigForRequest() がアクセスチェック時に取得した tier / modelInfo
+    // をそのまま再利用し、同一リクエスト内での DB クエリ重複を避ける。
+    // Bill only when AI actually ran successfully (result.aiUsage !== null).
+    // Reuse the tier / modelInfo captured during resolveAiConfigForRequest()
+    // to avoid duplicate DB queries within the same request.
+    if (result.aiUsage && aiConfig) {
       try {
-        // プロバイダーから返された実際のトークン数を使用（概算ではなく）
-        // Use actual token counts returned by the provider (not estimates)
         const { inputTokens, outputTokens } = result.aiUsage;
-        const tier = await getUserTier(userId, db);
-        const modelInfo = await validateModelAccess(body.model, tier, db);
+        const { modelInfo, internalModelId } = aiConfig;
         const costUnits = calculateCost(
           { inputTokens, outputTokens },
           modelInfo.inputCostUnits,
@@ -151,7 +150,7 @@ app.post("/youtube", authRequired, rateLimit(), async (c) => {
         );
         await recordUsage(
           userId,
-          body.model,
+          internalModelId,
           "youtube_summary",
           { inputTokens, outputTokens },
           costUnits,

--- a/server/api/src/routes/ext.ts
+++ b/server/api/src/routes/ext.ts
@@ -17,6 +17,7 @@ import {
   issueExtensionToken,
   storeExtensionCode,
 } from "../lib/extAuth.js";
+import { extractYouTubeVideoId } from "../lib/articleExtractor.js";
 import { clipAndCreate } from "../lib/clipAndCreate.js";
 import { isClipUrlAllowed, isClipUrlAllowedAfterDns } from "../lib/clipUrlPolicy.js";
 import { resolveAiConfigForRequest } from "../lib/aiAccessHelpers.js";
@@ -169,19 +170,21 @@ app.post("/clip-and-create", extAuthRequired, async (c) => {
     });
   }
 
-  // YouTube 要約用の AI パラメータ / AI params for YouTube summary
-  // 検証・アクセス制御は clip.ts の /youtube と共通化された
-  // resolveAiConfigForRequest() に委譲する。
-  // Validation / access-control logic is shared with clip.ts /youtube via
-  // resolveAiConfigForRequest().
+  // provider/model は YouTube 要約時だけ意味を持つため、通常の Web クリップでは
+  // AI 設定を解決しない。そうしないと非 YouTube 保存でも 403/429/503 を返しうる。
+  // provider/model only apply to the YouTube-summary path, so skip AI resolution
+  // for regular web clipping and avoid unrelated 403/429/503 failures.
   const youtubeApiKey = process.env.YOUTUBE_DATA_API_KEY;
+  const isYouTubeUrl = extractYouTubeVideoId(url) !== null;
 
-  const aiConfig = await resolveAiConfigForRequest({
-    userId,
-    db,
-    provider: body.provider,
-    model: body.model,
-  });
+  const aiConfig = isYouTubeUrl
+    ? await resolveAiConfigForRequest({
+        userId,
+        db,
+        provider: body.provider,
+        model: body.model,
+      })
+    : null;
   const aiProvider: AIProviderType | undefined = aiConfig?.provider;
   const aiModel: string | undefined = aiConfig?.apiModelId;
   const aiApiKey: string | undefined = aiConfig?.apiKey;

--- a/server/api/src/routes/ext.ts
+++ b/server/api/src/routes/ext.ts
@@ -20,8 +20,7 @@ import {
 import { clipAndCreate } from "../lib/clipAndCreate.js";
 import { isClipUrlAllowed, isClipUrlAllowedAfterDns } from "../lib/clipUrlPolicy.js";
 import { resolveAiConfigForRequest } from "../lib/aiAccessHelpers.js";
-import { getUserTier } from "../services/subscriptionService.js";
-import { validateModelAccess, calculateCost, recordUsage } from "../services/usageService.js";
+import { calculateCost, recordUsage } from "../services/usageService.js";
 import type { AppEnv, AIProviderType } from "../types/index.js";
 
 const app = new Hono<AppEnv>();
@@ -176,8 +175,6 @@ app.post("/clip-and-create", extAuthRequired, async (c) => {
   // Validation / access-control logic is shared with clip.ts /youtube via
   // resolveAiConfigForRequest().
   const youtubeApiKey = process.env.YOUTUBE_DATA_API_KEY;
-  const clientModelId = body.model; // 使用量記録用の元のモデル ID
-  // Original client-supplied model ID (before resolution) for usage recording
 
   const aiConfig = await resolveAiConfigForRequest({
     userId,
@@ -203,13 +200,15 @@ app.post("/clip-and-create", extAuthRequired, async (c) => {
     // 使用量記録 / Record usage
     // result.ai_usage が null でない場合のみ課金（AI が実際に成功した場合）
     // 記録失敗は非致命的
-    // Bill only when AI actually ran successfully (result.ai_usage !== null)
-    // Recording failure is non-fatal
-    if (result.ai_usage && aiProvider && clientModelId) {
+    // resolveAiConfigForRequest() がアクセスチェック時に取得した tier / modelInfo
+    // をそのまま再利用し、同一リクエスト内での DB クエリ重複を避ける。
+    // Bill only when AI actually ran successfully (result.ai_usage !== null).
+    // Reuse the tier / modelInfo captured during resolveAiConfigForRequest()
+    // to avoid duplicate DB queries within the same request.
+    if (result.ai_usage && aiConfig) {
       try {
         const { inputTokens, outputTokens } = result.ai_usage;
-        const tier = await getUserTier(userId, db);
-        const modelInfo = await validateModelAccess(clientModelId, tier, db);
+        const { modelInfo, internalModelId } = aiConfig;
         const costUnits = calculateCost(
           { inputTokens, outputTokens },
           modelInfo.inputCostUnits,
@@ -217,7 +216,7 @@ app.post("/clip-and-create", extAuthRequired, async (c) => {
         );
         await recordUsage(
           userId,
-          clientModelId,
+          internalModelId,
           "youtube_summary",
           { inputTokens, outputTokens },
           costUnits,

--- a/server/api/src/routes/ext.ts
+++ b/server/api/src/routes/ext.ts
@@ -19,15 +19,9 @@ import {
 } from "../lib/extAuth.js";
 import { clipAndCreate } from "../lib/clipAndCreate.js";
 import { isClipUrlAllowed, isClipUrlAllowedAfterDns } from "../lib/clipUrlPolicy.js";
-import { validateModelAccessOrThrow } from "../lib/aiAccessHelpers.js";
-import { getProviderApiKeyName } from "../services/aiProviders.js";
+import { resolveAiConfigForRequest } from "../lib/aiAccessHelpers.js";
 import { getUserTier } from "../services/subscriptionService.js";
-import {
-  checkUsage,
-  validateModelAccess,
-  calculateCost,
-  recordUsage,
-} from "../services/usageService.js";
+import { validateModelAccess, calculateCost, recordUsage } from "../services/usageService.js";
 import type { AppEnv, AIProviderType } from "../types/index.js";
 
 const app = new Hono<AppEnv>();
@@ -177,55 +171,23 @@ app.post("/clip-and-create", extAuthRequired, async (c) => {
   }
 
   // YouTube 要約用の AI パラメータ / AI params for YouTube summary
-  // clip.ts の /youtube と同じ検証・アクセス制御ロジックをミラーする
-  // Mirror the validation / access control logic from clip.ts /youtube
+  // 検証・アクセス制御は clip.ts の /youtube と共通化された
+  // resolveAiConfigForRequest() に委譲する。
+  // Validation / access-control logic is shared with clip.ts /youtube via
+  // resolveAiConfigForRequest().
   const youtubeApiKey = process.env.YOUTUBE_DATA_API_KEY;
-  let aiProvider: AIProviderType | undefined;
-  let aiModel: string | undefined;
-  let aiApiKey: string | undefined;
-  const clientModelId = body.model; // 使用量記録に必要な元の（検証前の）モデル ID
+  const clientModelId = body.model; // 使用量記録用の元のモデル ID
   // Original client-supplied model ID (before resolution) for usage recording
 
-  const supportedProviders: AIProviderType[] = ["openai", "anthropic", "google"];
-
-  // provider/model は両方指定するか両方省略する必要がある
-  // provider/model must be specified together or both omitted
-  const hasProvider = typeof body.provider === "string" && body.provider.trim().length > 0;
-  const hasModel = typeof body.model === "string" && body.model.trim().length > 0;
-  if (hasProvider !== hasModel) {
-    throw new HTTPException(400, {
-      message: "provider and model must be specified together",
-    });
-  }
-
-  if (hasProvider && hasModel) {
-    if (!supportedProviders.includes(body.provider as AIProviderType)) {
-      throw new HTTPException(400, { message: `unsupported provider: ${body.provider}` });
-    }
-
-    // モデルアクセス・利用量チェック / Model access & usage enforcement
-    // 既知の検証エラーは HTTPException(400/403) として返す
-    // Known validation errors are translated to HTTPException(400/403)
-    const tier = await getUserTier(userId, db);
-    const modelInfo = await validateModelAccessOrThrow(body.model as string, tier, db);
-    const usageCheck = await checkUsage(userId, tier, db);
-    if (!usageCheck.allowed) {
-      throw new HTTPException(429, { message: "Monthly budget exceeded" });
-    }
-
-    // モデル情報から provider を上書き（DB 上の provider が正）
-    // 内部 composite ID (例: "openai:gpt-4o") を API model ID (例: "gpt-4o") に解決
-    // Override provider from model info (DB is authoritative)
-    // Resolve internal composite ID (e.g. "openai:gpt-4o") to API model ID (e.g. "gpt-4o")
-    aiProvider = modelInfo.provider as AIProviderType;
-    aiModel = modelInfo.apiModelId;
-
-    const apiKeyName = getProviderApiKeyName(aiProvider);
-    aiApiKey = process.env[apiKeyName];
-    if (!aiApiKey) {
-      throw new HTTPException(503, { message: `API key not configured: ${apiKeyName}` });
-    }
-  }
+  const aiConfig = await resolveAiConfigForRequest({
+    userId,
+    db,
+    provider: body.provider,
+    model: body.model,
+  });
+  const aiProvider: AIProviderType | undefined = aiConfig?.provider;
+  const aiModel: string | undefined = aiConfig?.apiModelId;
+  const aiApiKey: string | undefined = aiConfig?.apiKey;
 
   try {
     const result = await clipAndCreate({

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5566,7 +5566,7 @@ dependencies = [
 
 [[package]]
 name = "zedi"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "dirs 5.0.1",
  "serde",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,6 +118,11 @@ const App = () => (
                         path="/ai-chat/:conversationId"
                         element={<LegacyAIChatConversationRedirect />}
                       />
+                      {/* Bare `/ai-chat` is also a legacy path: redirect to `/ai`
+                          to avoid hitting the catch-all NotFound page.
+                          素の `/ai-chat` も旧パスなので `/ai` にリダイレクトする
+                          （catch-all で NotFound に落ちるのを防ぐ）。 */}
+                      <Route path="/ai-chat" element={<Navigate to="/ai" replace />} />
                       <Route path="/search" element={<SearchResults />} />
                       <Route path="/notes/discover" element={<NotesDiscover />} />
                       <Route path="/notes" element={<Notes />} />

--- a/src/components/ai-chat/PromoteToWikiDialog.tsx
+++ b/src/components/ai-chat/PromoteToWikiDialog.tsx
@@ -95,6 +95,14 @@ function useEntityExtraction(
     if (attemptedRef.current) return;
     attemptedRef.current = true;
 
+    // ダイアログを閉じる／親がアンマウントされた場合に in-flight な抽出
+    // リクエストを中断する。abort せずに放置すると、無駄な LLM コストが
+    // 発生し、unmount 後に setState を試みて警告にもなる。
+    // Abort the in-flight extraction call when the dialog is closed or the
+    // parent unmounts, so we don't keep paying for an LLM run whose result
+    // is discarded (and don't try to setState after unmount).
+    const controller = new AbortController();
+
     const extract = async () => {
       setIsExtracting(true);
       setError(null);
@@ -115,16 +123,27 @@ function useEntityExtraction(
               feature: "entity_extraction",
             },
           },
-          createExtractionHandlers(onEntities, (err) => setError(err.message)),
+          createExtractionHandlers(onEntities, (err) => {
+            if (controller.signal.aborted) return;
+            setError(err.message);
+          }),
+          controller.signal,
         );
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Unknown error");
+        if (controller.signal.aborted) return;
+        const message = err instanceof Error ? err.message : "Unknown error";
+        if (message === "ABORTED") return;
+        setError(message);
       } finally {
-        setIsExtracting(false);
+        if (!controller.signal.aborted) setIsExtracting(false);
       }
     };
 
     void extract();
+
+    return () => {
+      controller.abort();
+    };
   }, [conversationText, existingTitles, onEntities]);
 
   return { isExtracting, error };

--- a/src/components/ai-chat/PromoteToWikiDialog.tsx
+++ b/src/components/ai-chat/PromoteToWikiDialog.tsx
@@ -81,6 +81,27 @@ function createExtractionHandlers(
 /**
  * Runs the extraction LLM call once per open cycle.
  * ダイアログを開くたびに 1 回だけ抽出 LLM を呼ぶ。
+ *
+ * Effect deps を `[]` に固定する理由:
+ * - 親 (`AIChatPanelContent`) が `existingTitles = pageContext?.recentPageTitles ?? []`
+ *   のように毎レンダー新しい配列を生成しており、deps に含めると再レンダー毎に
+ *   cleanup が走り `controller.abort()` が in-flight 抽出を中断する。
+ * - 一方、再エントリは `attemptedRef` で防いでいるため、abort 後に新しい
+ *   抽出が始まらず、`isExtracting` が `true` で固定されたまま停止する。
+ * - ダイアログ open 中の `conversationText` / `existingTitles` / `onEntities`
+ *   は意味的に固定なので、最新値は ref 経由で取得するに留め、effect は
+ *   マウント時のみ実行する形に統一する。
+ *
+ * Why deps are pinned to `[]`:
+ * - The parent (`AIChatPanelContent`) recreates `existingTitles` each render
+ *   (`pageContext?.recentPageTitles ?? []`). Including it in deps caused the
+ *   cleanup to fire on every parent re-render, aborting the in-flight
+ *   extraction.
+ * - Re-entry is gated by `attemptedRef`, so after the abort no new extraction
+ *   ever starts, leaving `isExtracting` stuck at `true`.
+ * - The dialog body is mounted only while `open=true` and the extraction is
+ *   semantically tied to that open cycle, so we read the latest values via
+ *   refs and only run the effect on mount.
  */
 function useEntityExtraction(
   conversationText: string,
@@ -89,12 +110,22 @@ function useEntityExtraction(
 ) {
   const [isExtracting, setIsExtracting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const attemptedRef = useRef(false);
+
+  const conversationTextRef = useRef(conversationText);
+  const existingTitlesRef = useRef(existingTitles);
+  const onEntitiesRef = useRef(onEntities);
 
   useEffect(() => {
-    if (attemptedRef.current) return;
-    attemptedRef.current = true;
+    conversationTextRef.current = conversationText;
+  }, [conversationText]);
+  useEffect(() => {
+    existingTitlesRef.current = existingTitles;
+  }, [existingTitles]);
+  useEffect(() => {
+    onEntitiesRef.current = onEntities;
+  }, [onEntities]);
 
+  useEffect(() => {
     // ダイアログを閉じる／親がアンマウントされた場合に in-flight な抽出
     // リクエストを中断する。abort せずに放置すると、無駄な LLM コストが
     // 発生し、unmount 後に setState を試みて警告にもなる。
@@ -109,7 +140,10 @@ function useEntityExtraction(
       try {
         const settings = await loadAISettings();
         if (!settings) throw new Error("AI not configured");
-        const prompt = buildExtractEntitiesPrompt(conversationText, existingTitles);
+        const prompt = buildExtractEntitiesPrompt(
+          conversationTextRef.current,
+          existingTitlesRef.current,
+        );
         await callAIService(
           { ...settings, isConfigured: true },
           {
@@ -123,10 +157,13 @@ function useEntityExtraction(
               feature: "entity_extraction",
             },
           },
-          createExtractionHandlers(onEntities, (err) => {
-            if (controller.signal.aborted) return;
-            setError(err.message);
-          }),
+          createExtractionHandlers(
+            (entities) => onEntitiesRef.current(entities),
+            (err) => {
+              if (controller.signal.aborted) return;
+              setError(err.message);
+            },
+          ),
           controller.signal,
         );
       } catch (err) {
@@ -144,7 +181,9 @@ function useEntityExtraction(
     return () => {
       controller.abort();
     };
-  }, [conversationText, existingTitles, onEntities]);
+
+    // run once per dialog open cycle; latest values are read via refs above.
+  }, []);
 
   return { isExtracting, error };
 }

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -32,8 +32,23 @@ export function AppLayout({ children }: AppLayoutProps) {
       }
     >
       <Header />
-      {/* min-h-0: flex 子が親より伸びてページ全体がスクロールするのを防ぐ */}
-      <div className="flex min-h-0 flex-1 overflow-hidden">
+      {/* min-h-0: flex 子が親より伸びてページ全体がスクロールするのを防ぐ。
+          モバイルでは BottomNav が fixed で main の下端に被さるため、
+          padding-bottom で BottomNav 分（safe-area 含む）の余白を確保する。
+          On mobile, BottomNav is `position: fixed` and overlays the bottom of
+          `<main>`, so reserve that height (plus the safe-area inset) as
+          padding-bottom to keep page content scrollable past the nav. */}
+      <div
+        className="flex min-h-0 flex-1 overflow-hidden"
+        style={
+          isMobile
+            ? {
+                paddingBottom:
+                  "calc(var(--app-bottom-nav-height, 3.5rem) + env(safe-area-inset-bottom))",
+              }
+            : undefined
+        }
+      >
         <main className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
           {children}
         </main>

--- a/src/components/layout/BottomNav/BottomNav.test.tsx
+++ b/src/components/layout/BottomNav/BottomNav.test.tsx
@@ -94,9 +94,14 @@ describe("BottomNav", () => {
     const { container } = renderAt("/home");
     const nav = container.querySelector("nav");
     expect(nav).toBeInTheDocument();
-    expect(nav?.className).toMatch(/fixed/);
-    expect(nav?.className).toMatch(/bottom-0/);
-    expect(nav?.className).toMatch(/safe-area-inset-bottom/);
+    // 個別のクラストークンで判定する。`className.match(/.../)` だと Tailwind
+    // が他の場所に同名サブストリングを含めたときに偽陽性／偽陰性になる。
+    // Assert per-class token via classList so substring matches in unrelated
+    // classes (or order changes) don't produce false positives or negatives.
+    expect(nav?.classList.contains("fixed")).toBe(true);
+    expect(nav?.classList.contains("bottom-0")).toBe(true);
+    expect(nav?.classList.contains("pb-[env(safe-area-inset-bottom)]")).toBe(true);
+    expect(nav?.getAttribute("style") ?? "").toContain("env(safe-area-inset-bottom)");
   });
 
   it("opens the Me sheet when the Me tab is clicked", async () => {

--- a/src/components/layout/Header/UnifiedMenu.tsx
+++ b/src/components/layout/Header/UnifiedMenu.tsx
@@ -226,12 +226,16 @@ export const SignedOutMenuContent: React.FC<MenuContentProps> = ({ onClose }) =>
       <AccountActionsList items={items} isSignedIn={false} variant="list" onClose={onClose} />
       <hr className="border-border my-1" />
       <div className="p-2">
-        <Link to="/sign-in" onClick={onClose}>
-          <Button className="w-full gap-2">
+        {/* `<Link><Button>` だと <a> の中に <button> が入って不正な HTML に
+            なる。`Button asChild` で Link を Button としてレンダリングする。
+            Avoid nesting <button> inside <a>; render the Link as the button
+            via `asChild` so the markup stays valid (and a11y semantics work). */}
+        <Button asChild className="w-full gap-2">
+          <Link to="/sign-in" onClick={onClose}>
             <LogIn className="h-4 w-4" />
             {t("nav.signIn")}
-          </Button>
-        </Link>
+          </Link>
+        </Button>
       </div>
     </>
   );

--- a/src/components/layout/MobileHeader.test.tsx
+++ b/src/components/layout/MobileHeader.test.tsx
@@ -32,6 +32,26 @@ vi.mock("./Header/HeaderLogo", () => ({
   HeaderLogo: () => <div data-testid="header-logo">Logo</div>,
 }));
 
+// Mock the desktop-only widgets so we can detect (via the rendered placeholder)
+// if MobileHeader regresses and starts importing/rendering them. The previous
+// version of this test queried for test ids that were never produced by the
+// real implementation, so the assertions trivially passed.
+// デスクトップ専用ウィジェットをモックしておき、MobileHeader 側で誤って
+// import / render するようになったら検出できるようにする。
+const aiChatButtonMock = vi.fn(() => <div data-testid="ai-chat-btn">AI</div>);
+const navigationMenuMock = vi.fn(() => <div data-testid="navigation-menu">Nav</div>);
+const unifiedMenuMock = vi.fn(() => <div data-testid="unified-menu">Menu</div>);
+
+vi.mock("./Header/AIChatButton", () => ({
+  AIChatButton: () => aiChatButtonMock(),
+}));
+vi.mock("./Header/NavigationMenu", () => ({
+  NavigationMenu: () => navigationMenuMock(),
+}));
+vi.mock("./Header/UnifiedMenu", () => ({
+  UnifiedMenu: () => unifiedMenuMock(),
+}));
+
 function renderHeader() {
   return render(
     <MemoryRouter>
@@ -51,10 +71,21 @@ describe("MobileHeader", () => {
   });
 
   it("does not render the desktop-only widgets", () => {
+    aiChatButtonMock.mockClear();
+    navigationMenuMock.mockClear();
+    unifiedMenuMock.mockClear();
     renderHeader();
+    // 描画ツリーに存在しないこと、かつコンポーネント自体が呼び出されてい
+    // ないこと（誤 import 検出）を両方検証する。
+    // Verify both that the placeholder is absent and that the component was
+    // never invoked, so accidentally importing the desktop widgets later
+    // would be caught.
     expect(screen.queryByTestId("ai-chat-btn")).not.toBeInTheDocument();
     expect(screen.queryByTestId("navigation-menu")).not.toBeInTheDocument();
     expect(screen.queryByTestId("unified-menu")).not.toBeInTheDocument();
+    expect(aiChatButtonMock).not.toHaveBeenCalled();
+    expect(navigationMenuMock).not.toHaveBeenCalled();
+    expect(unifiedMenuMock).not.toHaveBeenCalled();
   });
 
   it("opens the search sheet when the search icon is tapped", async () => {

--- a/src/components/page/LintSuggestions.tsx
+++ b/src/components/page/LintSuggestions.tsx
@@ -43,6 +43,27 @@ function getApiBaseUrl(): string {
  * stays hidden. Any other non-OK response is thrown so React Query surfaces
  * the failure instead of silently rendering an empty state.
  */
+/**
+ * Response からエラーメッセージを抽出する。`message` が空文字 / `statusText`
+ * が空のケースでも fallback に倒れるよう、`??` ではなくトリム後の長さで判定する。
+ *
+ * Extracts an error message from a Response, falling back to `fallback` when
+ * the body's `message` is empty/whitespace or `statusText` is empty. The check
+ * is intentionally non-empty-after-trim, not nullish coalescing.
+ */
+async function readErrorMessage(res: Response, fallback: string): Promise<string> {
+  const body: unknown = await res.json().catch(() => null);
+  const candidate =
+    typeof body === "object" &&
+    body !== null &&
+    "message" in body &&
+    typeof (body as { message?: unknown }).message === "string"
+      ? (body as { message: string }).message
+      : res.statusText;
+  const trimmed = candidate.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
 async function fetchPageFindings(pageId: string): Promise<LintFindingResponse[]> {
   const baseUrl = getApiBaseUrl();
   const res = await fetch(`${baseUrl}/api/lint/findings/page/${encodeURIComponent(pageId)}`, {
@@ -50,8 +71,7 @@ async function fetchPageFindings(pageId: string): Promise<LintFindingResponse[]>
   });
   if (res.status === 401 || res.status === 403) return [];
   if (!res.ok) {
-    const body = await res.json().catch(() => ({ message: res.statusText }));
-    throw new Error((body as { message?: string }).message ?? "Failed to fetch lint findings");
+    throw new Error(await readErrorMessage(res, "Failed to fetch lint findings"));
   }
   const data = (await res.json()) as { findings: LintFindingResponse[] };
   return data.findings;
@@ -68,8 +88,7 @@ async function resolveFinding(findingId: string): Promise<void> {
     credentials: "include",
   });
   if (!res.ok) {
-    const body = await res.json().catch(() => ({ message: res.statusText }));
-    throw new Error((body as { message?: string }).message ?? "Failed to resolve finding");
+    throw new Error(await readErrorMessage(res, "Failed to resolve finding"));
   }
 }
 
@@ -196,7 +215,9 @@ export function LintSuggestions({ pageId }: LintSuggestionsProps) {
   // findings" (the previous behaviour collapsed silently to null).
   if (isError) {
     return (
-      <div className="mt-6 space-y-3 border-t pt-6">
+      // role="alert" でエラー発生をスクリーンリーダーに通知する。
+      // Announce the failure to assistive tech as a live error region.
+      <div role="alert" className="mt-6 space-y-3 border-t pt-6">
         <div className="text-muted-foreground flex items-center gap-2 text-sm font-medium">
           <AlertTriangle className="h-4 w-4 text-amber-500" />
           <span>Suggestions の取得に失敗しました</span>

--- a/src/components/page/LintSuggestions.tsx
+++ b/src/components/page/LintSuggestions.tsx
@@ -34,13 +34,25 @@ function getApiBaseUrl(): string {
 /**
  * 指定ページに関連する Lint findings を取得する。
  * Fetches lint findings related to a specific page.
+ *
+ * 認証エラー（401/403）はログイン未済を意味するので空配列を返してカードを
+ * 出さない。それ以外のサーバーエラーは throw して React Query の `error` に
+ * 流し、UI 側で「失敗 = findings が無い」と誤解されないようにする。
+ *
+ * 401/403 mean the user is not signed in; return an empty list so the card
+ * stays hidden. Any other non-OK response is thrown so React Query surfaces
+ * the failure instead of silently rendering an empty state.
  */
 async function fetchPageFindings(pageId: string): Promise<LintFindingResponse[]> {
   const baseUrl = getApiBaseUrl();
   const res = await fetch(`${baseUrl}/api/lint/findings/page/${encodeURIComponent(pageId)}`, {
     credentials: "include",
   });
-  if (!res.ok) return [];
+  if (res.status === 401 || res.status === 403) return [];
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ message: res.statusText }));
+    throw new Error((body as { message?: string }).message ?? "Failed to fetch lint findings");
+  }
   const data = (await res.json()) as { findings: LintFindingResponse[] };
   return data.findings;
 }
@@ -150,7 +162,13 @@ interface LintSuggestionsProps {
 export function LintSuggestions({ pageId }: LintSuggestionsProps) {
   const queryClient = useQueryClient();
 
-  const { data: findings, isLoading } = useQuery({
+  const {
+    data: findings,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
     queryKey: ["lintFindings", pageId],
     queryFn: () => fetchPageFindings(pageId),
     staleTime: 1000 * 60, // 1 minute
@@ -168,6 +186,27 @@ export function LintSuggestions({ pageId }: LintSuggestionsProps) {
       <div className="mt-4 space-y-2">
         <Skeleton className="h-4 w-32" />
         <Skeleton className="h-16 w-full" />
+      </div>
+    );
+  }
+
+  // findings 取得失敗を空状態と区別して表示する。空にしてしまうと「指摘なし」
+  // に見えてしまうので、明示的にエラーメッセージと再試行ボタンを出す。
+  // Surface API failures explicitly so an error is not mistaken for "no
+  // findings" (the previous behaviour collapsed silently to null).
+  if (isError) {
+    return (
+      <div className="mt-6 space-y-3 border-t pt-6">
+        <div className="text-muted-foreground flex items-center gap-2 text-sm font-medium">
+          <AlertTriangle className="h-4 w-4 text-amber-500" />
+          <span>Suggestions の取得に失敗しました</span>
+        </div>
+        <p className="text-muted-foreground text-sm">
+          {error instanceof Error ? error.message : "Unknown error"}
+        </p>
+        <Button type="button" variant="outline" size="sm" onClick={() => void refetch()}>
+          再試行
+        </Button>
       </div>
     );
   }
@@ -200,6 +239,7 @@ export function LintSuggestions({ pageId }: LintSuggestionsProps) {
               className="shrink-0"
               onClick={() => resolveMutation.mutate(f.id)}
               disabled={resolveMutation.isPending}
+              aria-label="この Suggestion を解決済みにする / Mark suggestion as resolved"
             >
               <CheckCircle2 className="h-4 w-4" />
             </Button>

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -32,43 +32,34 @@ interface UseImageUploadReturn {
 }
 
 /**
+ * 画像アップロードを管理するカスタムフック。
+ * 設定済みストレージプロバイダーへの単一/複数アップロード、進捗・エラー状態、
+ * AbortSignal によるキャンセルをまとめて扱う。
  *
+ * Custom hook that wraps single/batch image uploads to the configured storage
+ * provider and exposes progress, error and cancellation handling.
  */
 export function useImageUpload(): UseImageUploadReturn {
-  /**
-   *
-   */
   const { settings, isLoading } = useStorageSettings();
-  /**
-   *
-   */
   const { getToken } = useAuth();
-  /**
-   *
-   */
   const [state, setState] = useState<ImageUploadState>({
     isUploading: false,
     progress: null,
     error: null,
   });
 
-  /**
-   *
-   */
   const isConfigured = !isLoading && isStorageConfiguredForUpload(settings);
 
   /**
-   * 単一の画像をアップロード
+   * 単一の画像をアップロードする。
+   * Uploads a single image. JPEG/PNG は WebP に変換してからアップロードする。
+   *
+   * @param file - 対象ファイル / Image file
+   * @param options.signal - 呼び出し側で中断するための AbortSignal / AbortSignal
    */
   const uploadImage = useCallback(
     async (file: File, options: ImageUploadOptions = {}): Promise<string> => {
-      /**
-       *
-       */
       const { signal } = options;
-      /**
-       *
-       */
       const throwIfAborted = () => {
         if (signal?.aborted) {
           throw new DOMException("Image upload aborted", "AbortError");
@@ -77,12 +68,10 @@ export function useImageUpload(): UseImageUploadReturn {
 
       throwIfAborted();
 
-      // ストレージ設定の確認
       if (!isStorageConfiguredForUpload(settings)) {
         throw new Error("ストレージが設定されていません。設定画面でストレージを設定してください。");
       }
 
-      // 画像ファイルの検証
       if (!file.type.startsWith("image/")) {
         throw new Error("画像ファイルのみアップロードできます");
       }
@@ -95,29 +84,15 @@ export function useImageUpload(): UseImageUploadReturn {
       }));
 
       try {
-        // プロバイダーを取得（S3 の場合は getToken を渡す）
-        /**
-         *
-         */
         const provider = getStorageProvider(getSettingsForUpload(settings), {
           getToken,
         });
 
         // JPEG/PNG のみ WebP に変換（GIF はそのまま。APNG は MIME が image/png のため現状は変換対象）
-        /**
-         *
-         */
         const isStaticImage = file.type === "image/jpeg" || file.type === "image/png";
-        /**
-         *
-         */
         const fileToUpload = isStaticImage ? await convertToWebP(file) : file;
         throwIfAborted();
 
-        // アップロード実行
-        /**
-         *
-         */
         const url = await provider.uploadImage(fileToUpload, {
           onProgress: (progress) => {
             setState((prev) => ({ ...prev, progress }));
@@ -140,9 +115,6 @@ export function useImageUpload(): UseImageUploadReturn {
 
         return url;
       } catch (error) {
-        /**
-         *
-         */
         const isAborted =
           signal?.aborted || (error instanceof DOMException && error.name === "AbortError");
         if (isAborted) {
@@ -154,9 +126,6 @@ export function useImageUpload(): UseImageUploadReturn {
           }));
           throw error;
         }
-        /**
-         *
-         */
         const errorMessage = error instanceof Error ? error.message : "アップロードに失敗しました";
         setState((prev) => ({
           ...prev,
@@ -171,14 +140,13 @@ export function useImageUpload(): UseImageUploadReturn {
   );
 
   /**
-   * 複数の画像を並列でアップロード
+   * 複数の画像を並列でアップロードする。
+   * Uploads multiple images in parallel via {@link uploadImage}.
+   *
+   * @param files - 入力ファイル群（image/* 以外は事前に除外する） / Input files (non-image entries are dropped)
    */
   const uploadImages = useCallback(
     async (files: File[]): Promise<string[]> => {
-      // 画像ファイルのみをフィルタリング
-      /**
-       *
-       */
       const imageFiles = files.filter((file) => file.type.startsWith("image/"));
 
       if (imageFiles.length === 0) {
@@ -192,19 +160,12 @@ export function useImageUpload(): UseImageUploadReturn {
       }));
 
       try {
-        // 並列でアップロード
-        /**
-         *
-         */
         const urls = await Promise.all(imageFiles.map((file) => uploadImage(file)));
 
         setState((prev) => ({ ...prev, isUploading: false }));
 
         return urls;
       } catch (error) {
-        /**
-         *
-         */
         const errorMessage = error instanceof Error ? error.message : "アップロードに失敗しました";
         setState((prev) => ({
           ...prev,
@@ -218,7 +179,8 @@ export function useImageUpload(): UseImageUploadReturn {
   );
 
   /**
-   * エラーをクリア
+   * 直近のエラー状態をクリアする。
+   * Clears the latest error state so subsequent uploads start clean.
    */
   const clearError = useCallback(() => {
     setState((prev) => ({ ...prev, error: null }));


### PR DESCRIPTION
## 概要

PR #636 (release) のレビューコメントのうち、UI/UX、CI ゲーティング、アクセシビリティ、admin/フロントの軽微なリファクタ対応をまとめて取り込む。

PR #636 は release を一旦止めずに、修正は develop 向けに 4 本に分けて投げているうちの **PR4 / 4**（残り）。

- PR1 (security-hardening): #643
- PR2 (race-conditions): #645
- PR3 (lint-engine-rules): #646
- PR4 (ui-ci-tests): **このPR**

## 変更点

### CI gating
- `deploy-dev.yml` / `deploy-prod.yml` の `deploy-frontend` / `deploy-admin` を `verify-server-health` に依存させ、バックエンドが落ちている状態で UI を公開しないようにした。
- `if: vars.API_BASE_URL != ''` で skip された場合も needs を通過する（GitHub Actions は skipped を success 扱い）ため、現行の dev 環境（API_BASE_URL 未設定）でも今までどおりデプロイできる。

### UI / a11y
- `src/App.tsx`: 素の `/ai-chat` を `/ai` にリダイレクト（catch-all NotFound 落ち防止）。
- `AppLayout`: モバイル時に BottomNav 分の `padding-bottom`（safe-area 含む）を確保し、下部コンテンツが nav に隠れないようにした。
- `UnifiedMenu`: \`<Link><Button>...</Button></Link>\` を \`<Button asChild><Link>...</Link></Button>\` に変更し、`<a>` の中に `<button>` が入る不正 HTML を解消。
- `LintSuggestions`: 401/403 以外の API 失敗を throw して空状態と区別、エラー時の専用 UI（再試行ボタン付）を表示。Resolve ボタンに `aria-label` を付与。
- `useImageUpload`: 中身が空の TSDoc を一掃し、意味のある説明だけ残した。

### Out-of-order response handling (admin)
- `ActivityLog` / `wiki-health`: 連打やフィルタ切り替えで複数の `listActivity` / `getLintFindings` が in-flight になったとき、古いリクエストで新しい結果を上書きしないよう requestId ベースで破棄。

### Refactors
- `admin/src/api/{lint,activity,admin}.ts` に重複していた `getErrorMessage` を `client.ts` に集約。
- `aiAccessHelpers.ts` に `resolveAiConfigForRequest()` を追加し、`clip.ts /youtube` と `ext.ts /clip-and-create` の AI provider/model 検証・アクセス制御・API キー解決ロジックを共通化。

### Misc
- `PromoteToWikiDialog`: ダイアログ閉鎖／親アンマウント時に entity 抽出 LLM 呼び出しを `AbortController` で中断し、無駄な課金と setState-after-unmount 警告を防ぐ。

### Tests
- `BottomNav`: safe-area padding を `className` 部分一致ではなく `classList.contains` 単位で検証するよう修正（誤判定防止）。
- `MobileHeader`: 「desktop ウィジェット（AIChatButton / NavigationMenu / UnifiedMenu）を描画しない」テストを実コンポーネントの mock 呼び出し回数で確認するよう強化。誤って `import` した時点で検出できるようにした。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. \`bun run lint\` が通ること（既存の警告のみ、エラー 0）。
2. \`bunx tsc --noEmit\`（root / admin / server/api）が通ること（server/api は既存の `youtube-transcript` の型エラーのみ）。
3. \`bunx vitest run src/components/layout/BottomNav src/components/layout/MobileHeader src/components/layout/AppLayout\` が green。
4. \`bunx vitest run server/api/src/__tests__/routes/clip.test.ts server/api/src/__tests__/routes/ext.test.ts\` が green（refactor で挙動変えてないこと確認）。

### 手動確認
- モバイル表示でページ最下部のコンテンツが BottomNav に隠れないこと。
- 未サインインで `/ai-chat` を直接踏むと `/ai` にリダイレクトされること。
- LintSuggestions API を 500 で落としたとき、UI が「エラー＋再試行」になること（空表示にならない）。
- ActivityLog / WikiHealth でフィルタを連打しても、最後に選んだ結果だけが表示されること。
- PromoteToWikiDialog を抽出中に閉じると、ネットワーク通信が中断されること（DevTools Network）。

## チェックリスト

- [x] テストがすべてパスする（既存の `youtube-transcript` 由来の型エラー除く）
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

UI 変更は主にモバイル padding / a11y 修正のため、スクリーンショットは省略。

## 関連 Issue

PR #636 のレビューコメント対応（PR4 / 4）。
- PR1: #643
- PR2: #645
- PR3: #646

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployments now wait for backend health verification before frontend/admin deploys.
  * Centralized server-side AI config resolution with provider/model validation, usage checks, and conditional YouTube-aware AI handling.
  * Legacy /ai-chat route redirects to /ai.

* **Bug Fixes**
  * Prevented stale/in-flight admin activity and wiki-health responses from overwriting newer data.
  * Fixed mobile layout spacing and sign-in markup HTML issues.

* **Improvements**
  * Consistent error-message handling and retryable UI for lint suggestions.
  * Request cancellation for AI extraction dialogs; improved accessibility.

* **Tests**
  * Tighter mocks and assertions for multiple layout and API tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->