### PR TITLE
Add page count to admin users API and UI

### DIFF
--- a/admin/src/api/admin.ts
+++ b/admin/src/api/admin.ts
@@ -24,6 +24,8 @@ export interface UserAdmin {
   suspendedReason: string | null;
   suspendedBy: string | null;
   createdAt: string;
+  /** ユーザーに紐づくアクティブページ数 / Number of active pages owned by the user */
+  pageCount: number;
 }
 
 /** AI モデル管理用のモデル情報 / AI model info for admin */

--- a/admin/src/api/admin.ts
+++ b/admin/src/api/admin.ts
@@ -13,8 +13,15 @@ export type UserRole = "user" | "admin";
 /** ユーザーアカウントステータス / User account status */
 export type UserStatus = "active" | "suspended" | "deleted";
 
-/** 管理者画面で表示するユーザー情報 / User info for admin UI */
-export interface UserAdmin {
+/**
+ * ミューテーション系エンドポイント（PATCH/POST/DELETE）が返すユーザー基本情報。
+ * `pageCount` のような一覧専用の集計フィールドは含まない。
+ *
+ * Basic user info returned by mutation endpoints (PATCH/POST/DELETE).
+ * Aggregate fields such as `pageCount` are excluded because they are
+ * only computed for the list endpoint.
+ */
+export interface UserAdminBase {
   id: string;
   name: string;
   email: string;
@@ -24,6 +31,13 @@ export interface UserAdmin {
   suspendedReason: string | null;
   suspendedBy: string | null;
   createdAt: string;
+}
+
+/**
+ * 管理者画面の一覧で表示するユーザー情報。
+ * User info for the admin user list UI (extends base with aggregate fields).
+ */
+export interface UserAdmin extends UserAdminBase {
   /** ユーザーに紐づくアクティブページ数 / Number of active pages owned by the user */
   pageCount: number;
 }
@@ -235,7 +249,7 @@ export async function getUsers(params?: GetUsersParams): Promise<{
  * @param role - 新しい役割 / New role
  * @returns 更新後のユーザー情報 / Updated user
  */
-export async function patchUserRole(id: string, role: UserRole): Promise<{ user: UserAdmin }> {
+export async function patchUserRole(id: string, role: UserRole): Promise<{ user: UserAdminBase }> {
   const res = await adminFetch(`/api/admin/users/${encodeURIComponent(id)}`, {
     method: "PATCH",
     body: JSON.stringify({ role }),
@@ -254,7 +268,7 @@ export async function patchUserRole(id: string, role: UserRole): Promise<{ user:
  * @param reason - サスペンド理由（任意）/ Suspension reason (optional)
  * @returns 更新後のユーザー情報 / Updated user
  */
-export async function suspendUser(id: string, reason?: string): Promise<{ user: UserAdmin }> {
+export async function suspendUser(id: string, reason?: string): Promise<{ user: UserAdminBase }> {
   const res = await adminFetch(`/api/admin/users/${encodeURIComponent(id)}/suspend`, {
     method: "POST",
     body: JSON.stringify({ reason }),
@@ -272,7 +286,7 @@ export async function suspendUser(id: string, reason?: string): Promise<{ user: 
  * @param id - ユーザー ID / User ID
  * @returns 更新後のユーザー情報 / Updated user
  */
-export async function unsuspendUser(id: string): Promise<{ user: UserAdmin }> {
+export async function unsuspendUser(id: string): Promise<{ user: UserAdminBase }> {
   const res = await adminFetch(`/api/admin/users/${encodeURIComponent(id)}/unsuspend`, {
     method: "POST",
   });
@@ -319,7 +333,7 @@ export async function getUserImpact(id: string): Promise<UserImpact> {
  * @param id - ユーザー ID / User ID
  * @returns 削除後のユーザー情報 / Deleted user info
  */
-export async function deleteUser(id: string): Promise<{ user: UserAdmin }> {
+export async function deleteUser(id: string): Promise<{ user: UserAdminBase }> {
   const res = await adminFetch(`/api/admin/users/${encodeURIComponent(id)}`, {
     method: "DELETE",
   });

--- a/admin/src/pages/users/UserCard.tsx
+++ b/admin/src/pages/users/UserCard.tsx
@@ -70,6 +70,9 @@ export function UserCard({
               <SelectItem value="admin">admin</SelectItem>
             </SelectContent>
           </Select>
+          <span className="text-xs text-slate-500">
+            ページ数: {user.pageCount.toLocaleString("ja-JP")}
+          </span>
           <span className="text-xs text-slate-500">{formatDate(user.createdAt)}</span>
           {!saving && user.status === "deleted" ? (
             <span className="text-muted-foreground text-xs">削除済み</span>

--- a/admin/src/pages/users/UsersContent.test.tsx
+++ b/admin/src/pages/users/UsersContent.test.tsx
@@ -139,6 +139,7 @@ const mockUser: UserAdmin = {
   suspendedReason: null,
   suspendedBy: null,
   createdAt: "2026-01-01T00:00:00Z",
+  pageCount: 0,
 };
 
 const defaultProps = {
@@ -165,6 +166,14 @@ describe("UsersContent", () => {
     render(<UsersContent {...defaultProps} />);
 
     expect(screen.getByText(/1-1 件を表示 \/ 合計 1 件/)).toBeInTheDocument();
+  });
+
+  it("ユーザーのページ数を表示する / displays the user's page count", () => {
+    const userWithPages: UserAdmin = { ...mockUser, pageCount: 1234 };
+    render(<UsersContent {...defaultProps} users={[userWithPages]} />);
+
+    expect(screen.getByText("ページ数")).toBeInTheDocument();
+    expect(screen.getByText("1,234")).toBeInTheDocument();
   });
 
   it("shows pagination when total > pageSize and calls onPageChange when 次へ is clicked", async () => {

--- a/admin/src/pages/users/UsersContent.tsx
+++ b/admin/src/pages/users/UsersContent.tsx
@@ -143,6 +143,7 @@ export function UsersContent({
                   <TableHead className="px-3 py-2">名前</TableHead>
                   <TableHead className="px-3 py-2">ステータス</TableHead>
                   <TableHead className="px-3 py-2">ロール</TableHead>
+                  <TableHead className="px-3 py-2">ページ数</TableHead>
                   <TableHead className="px-3 py-2">作成日</TableHead>
                   <TableHead className="px-3 py-2">操作</TableHead>
                 </TableRow>
@@ -187,6 +188,9 @@ export function UsersContent({
                           <SelectItem value="admin">admin</SelectItem>
                         </SelectContent>
                       </Select>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground px-3 py-2 tabular-nums">
+                      {u.pageCount.toLocaleString("ja-JP")}
                     </TableCell>
                     <TableCell className="text-muted-foreground px-3 py-2">
                       {formatDate(u.createdAt)}

--- a/admin/src/pages/users/index.test.tsx
+++ b/admin/src/pages/users/index.test.tsx
@@ -88,6 +88,7 @@ const mockUsers = (n: number, offset: number) =>
     suspendedReason: null,
     suspendedBy: null,
     createdAt: "2026-01-01T00:00:00Z",
+    pageCount: 0,
   }));
 
 describe("Users (admin)", () => {

--- a/server/api/src/__tests__/routes/admin/index.test.ts
+++ b/server/api/src/__tests__/routes/admin/index.test.ts
@@ -48,22 +48,63 @@ describe("parseAdminUserStatusFilter", () => {
 });
 
 describe("GET /api/admin/users", () => {
-  it("returns 200 with users and total", async () => {
+  it("returns 200 with users, total, and page counts", async () => {
     const u1 = createMockUserRow({ id: "u1", email: "a@example.com", role: "user" });
     const u2 = createMockUserRow({ id: "u2", email: "b@example.com", role: "admin" });
-    const { app } = createAdminTestApp([ADMIN_ROLE_RESULT, [u1, u2], [{ count: 2 }]]);
+    const { app } = createAdminTestApp([
+      ADMIN_ROLE_RESULT,
+      [u1, u2],
+      [{ count: 2 }],
+      [
+        { ownerId: "u1", count: 3 },
+        { ownerId: "u2", count: 7 },
+      ],
+    ]);
 
     const res = await app.request("/api/admin/users", {
       headers: adminAuthHeaders(),
     });
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { users: Record<string, unknown>[]; total: number };
+    const body = (await res.json()) as {
+      users: { id: string; pageCount: number }[];
+      total: number;
+    };
     expect(body).toHaveProperty("users");
     expect(body).toHaveProperty("total", 2);
     expect(body.users).toHaveLength(2);
-    expect(body.users[0]).toMatchObject({ id: "u1", email: "a@example.com", role: "user" });
-    expect(body.users[1]).toMatchObject({ id: "u2", email: "b@example.com", role: "admin" });
+    expect(body.users[0]).toMatchObject({
+      id: "u1",
+      email: "a@example.com",
+      role: "user",
+      pageCount: 3,
+    });
+    expect(body.users[1]).toMatchObject({
+      id: "u2",
+      email: "b@example.com",
+      role: "admin",
+      pageCount: 7,
+    });
+  });
+
+  it("defaults pageCount to 0 when a user has no pages", async () => {
+    const u1 = createMockUserRow({ id: "u1" });
+    const u2 = createMockUserRow({ id: "u2" });
+    const { app } = createAdminTestApp([
+      ADMIN_ROLE_RESULT,
+      [u1, u2],
+      [{ count: 2 }],
+      [{ ownerId: "u1", count: 5 }], // u2 has no pages row
+    ]);
+
+    const res = await app.request("/api/admin/users", {
+      headers: adminAuthHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { users: { id: string; pageCount: number }[] };
+    expect(body.users[0]).toMatchObject({ id: "u1", pageCount: 5 });
+    expect(body.users[1]).toMatchObject({ id: "u2", pageCount: 0 });
   });
 
   it("returns empty list and total when no users", async () => {
@@ -81,7 +122,12 @@ describe("GET /api/admin/users", () => {
 
   it("honors limit and offset", async () => {
     const u1 = createMockUserRow({ id: "u1" });
-    const { app } = createAdminTestApp([ADMIN_ROLE_RESULT, [u1], [{ count: 100 }]]);
+    const { app } = createAdminTestApp([
+      ADMIN_ROLE_RESULT,
+      [u1],
+      [{ count: 100 }],
+      [{ ownerId: "u1", count: 0 }],
+    ]);
 
     const res = await app.request("/api/admin/users?limit=10&offset=5", {
       headers: adminAuthHeaders(),

--- a/server/api/src/__tests__/routes/admin/setup.ts
+++ b/server/api/src/__tests__/routes/admin/setup.ts
@@ -9,8 +9,14 @@ import type { AppEnv } from "../../../types/index.js";
 import adminRoutes from "../../../routes/admin/index.js";
 import { createMockDb } from "../notes/setup.js";
 
-export const TEST_ADMIN_ID = "user-admin-001";
-export const TEST_ADMIN_EMAIL = "admin@example.com";
+export /**
+ *
+ */
+const TEST_ADMIN_ID = "user-admin-001";
+export /**
+ *
+ */
+const TEST_ADMIN_EMAIL = "admin@example.com";
 
 /** GET /users の select で返す行の形（camelCase） */
 export function createMockUserRow(overrides: Record<string, unknown> = {}) {
@@ -30,7 +36,8 @@ export function createMockUserRow(overrides: Record<string, unknown> = {}) {
  * 先頭に [{ role: 'admin' }] を置き、続けてハンドラ内のクエリ結果を並べる。
  *
  * 例 GET /users:
- *   [ adminRoleCheck, listRows, countRow ]
+ *   [ adminRoleCheck, listRows, countRow, pageCountRows ]
+ *   pageCountRows は省略可（listRows が空のときはクエリが発行されない）。
  * 例 PATCH /users/:id:
  *   [ adminRoleCheck, updateReturning ]
  */
@@ -47,6 +54,9 @@ export function createAdminTestApp(dbResults: unknown[]) {
   return { app, chains };
 }
 
+/**
+ *
+ */
 export function adminAuthHeaders(userId = TEST_ADMIN_ID, userEmail = TEST_ADMIN_EMAIL) {
   return {
     "x-test-user-id": userId,

--- a/server/api/src/__tests__/routes/admin/setup.ts
+++ b/server/api/src/__tests__/routes/admin/setup.ts
@@ -9,14 +9,10 @@ import type { AppEnv } from "../../../types/index.js";
 import adminRoutes from "../../../routes/admin/index.js";
 import { createMockDb } from "../notes/setup.js";
 
-export /**
- *
- */
-const TEST_ADMIN_ID = "user-admin-001";
-export /**
- *
- */
-const TEST_ADMIN_EMAIL = "admin@example.com";
+/** テスト用管理者ユーザー ID / Mock admin user id used in admin API tests */
+export const TEST_ADMIN_ID = "user-admin-001";
+/** テスト用管理者メールアドレス / Mock admin email used in admin API tests */
+export const TEST_ADMIN_EMAIL = "admin@example.com";
 
 /** GET /users の select で返す行の形（camelCase） */
 export function createMockUserRow(overrides: Record<string, unknown> = {}) {
@@ -55,7 +51,12 @@ export function createAdminTestApp(dbResults: unknown[]) {
 }
 
 /**
+ * 管理 API テスト用の認証ヘッダを生成する。
+ * Builds auth headers for admin API tests.
  *
+ * @param userId - テストユーザー ID / Test user id
+ * @param userEmail - テストユーザーのメール / Test user email
+ * @returns 認証ヘッダ / Auth headers
  */
 export function adminAuthHeaders(userId = TEST_ADMIN_ID, userEmail = TEST_ADMIN_EMAIL) {
   return {

--- a/server/api/src/routes/admin/index.ts
+++ b/server/api/src/routes/admin/index.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
-import { eq, like, desc, sql, and, ne } from "drizzle-orm";
+import { eq, like, desc, sql, and, ne, inArray } from "drizzle-orm";
 import { authRequired } from "../../middleware/auth.js";
 import { adminRequired } from "../../middleware/adminAuth.js";
 import { users, session } from "../../schema/users.js";
+import { pages } from "../../schema/pages.js";
 import { recordAuditLog } from "../../lib/auditLog.js";
 import { getUserImpact, anonymizeUser } from "../../lib/userDelete.js";
 import auditLogsRoutes from "./auditLogs.js";
@@ -98,6 +99,24 @@ app.get("/users", async (c) => {
 
   const total = countRow?.count ?? 0;
 
+  // 各ユーザーに紐づいているアクティブ（未削除）ページ数を取得する。
+  // Fetch active (non-deleted) page counts per user.
+  const userIds = rows.map((u) => u.id);
+  const pageCountMap = new Map<string, number>();
+  if (userIds.length > 0) {
+    const pageCounts = await db
+      .select({
+        ownerId: pages.ownerId,
+        count: sql<number>`cast(count(*) as integer)`,
+      })
+      .from(pages)
+      .where(and(inArray(pages.ownerId, userIds), eq(pages.isDeleted, false)))
+      .groupBy(pages.ownerId);
+    for (const row of pageCounts) {
+      pageCountMap.set(row.ownerId, row.count);
+    }
+  }
+
   return c.json({
     users: rows.map((u) => ({
       id: u.id,
@@ -109,6 +128,7 @@ app.get("/users", async (c) => {
       suspendedReason: u.suspendedReason,
       suspendedBy: u.suspendedBy,
       createdAt: u.createdAt,
+      pageCount: pageCountMap.get(u.id) ?? 0,
     })),
     total,
   });


### PR DESCRIPTION
## 概要

管理画面のユーザー一覧に、各ユーザーが所有するアクティブページ数を表示する機能を追加しました。API レスポンスに `pageCount` フィールドを追加し、管理画面の UI でこの情報を表示します。

## 変更点

- **API (`server/api/src/routes/admin/index.ts`)**
  - `/api/admin/users` エンドポイントで、各ユーザーのアクティブ（未削除）ページ数を取得するクエリを追加
  - レスポンスの各ユーザーオブジェクトに `pageCount` フィールドを追加（ページがない場合は 0）

- **API 型定義 (`admin/src/api/admin.ts`)**
  - `UserAdmin` インターフェースに `pageCount: number` フィールドを追加

- **管理画面 UI**
  - `UsersContent.tsx`: ユーザー一覧テーブルに「ページ数」列を追加し、フォーマット済みの数値を表示
  - `UserCard.tsx`: ユーザーカード詳細にページ数を表示

- **テスト**
  - API テスト: ページ数クエリ結果をモック化し、ユーザーがページを持たない場合のデフォルト値（0）をテスト
  - UI テスト: ページ数表示のテストを追加、モックデータに `pageCount` フィールドを追加

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. 既存のテストスイートを実行して、すべてのテストがパスすることを確認
2. 管理画面でユーザー一覧を表示し、「ページ数」列が正しく表示されることを確認
3. 異なるページ数を持つユーザーが正しくフォーマットされた数値で表示されることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] 必要に応じてドキュメントを更新した（JSDoc コメント追加）
- [x] API と UI の型定義が一致している

https://claude.ai/code/session_012ZcxNh2nsf4FgYacQiLd7S
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User profiles now display a page count metric showing each user’s total active pages.
  * Page count is visible in the admin user management interface: user cards and the main users list table.
  * Numbers are formatted with locale-specific separators for improved readability.

* **Tests**
  * Added/updated tests to cover page count display and API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->