### PR TITLE
Fix mobile scroll behavior in NotePageView

### DIFF
--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -182,7 +182,9 @@ const NotePageView: React.FC = () => {
         </Container>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-hidden">
+      {/* モバイルは `ContentWithAIChat` が独自のスクロール領域を持たないため、ここをスクロールコンテナにする。
+          On mobile, `ContentWithAIChat` lacks its own scroll viewport, so this div must scroll. */}
+      <div className="min-h-0 flex-1 overflow-y-auto md:overflow-hidden">
         <NoteWorkspaceProvider key={note.id} noteId={note.id}>
           {canEdit ? (
             <NotePageEditorEditable


### PR DESCRIPTION
## 概要

モバイルデバイスでのスクロール動作を修正しました。`ContentWithAIChat` コンポーネントがモバイルで独自のスクロール領域を持たないため、親の div 要素がスクロール可能になるように調整しました。

## 変更点

- `NotePageView.tsx` の親コンテナに `md:overflow-hidden` ブレークポイントを追加
- モバイル (`md` 未満) では `overflow-y-auto` でスクロール可能に
- デスクトップ (`md` 以上) では `overflow-hidden` で既存の動作を維持
- 変更の意図を説明する日本語・英語のコメントを追加

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. モバイルデバイス (またはブラウザのモバイルビュー) でノートページを開く
2. コンテンツが長い場合、スクロール可能であることを確認
3. デスクトップビューで既存のスクロール動作が変わらないことを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

https://claude.ai/code/session_01Pnwt4tzjguRk8LceafKGXc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior on mobile and tablet devices for better usability and responsiveness across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->