### PR TITLE
refactor: simplify mobile header to inline search bar only

### DIFF
--- a/src/components/layout/HomePageCount.test.tsx
+++ b/src/components/layout/HomePageCount.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * HomePageCount: home page total count badge. Desktop-only — hidden on mobile
+ * because the bottom nav already surfaces page-related affordances and the
+ * floating count would otherwise crowd the FAB thumb-reach area.
+ *
+ * ホームページ用の総ページ数バッジ。モバイルではボトムナビが関連アクションを
+ * 提供しており、FAB の親指リーチ領域と重なってしまうため非表示にする。
+ */
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HomePageCount } from "./HomePageCount";
+import { usePagesSummary } from "@/hooks/usePageQueries";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) =>
+      options?.count !== undefined ? `${key}:${options.count}` : key,
+    i18n: { language: "ja" },
+  }),
+}));
+
+vi.mock("@/hooks/usePageQueries", () => ({
+  usePagesSummary: vi.fn(),
+}));
+
+describe("HomePageCount", () => {
+  it("returns null while pages summary is loading", () => {
+    vi.mocked(usePagesSummary).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof usePagesSummary>);
+
+    const { container } = render(<HomePageCount />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the total count excluding deleted pages on desktop", () => {
+    vi.mocked(usePagesSummary).mockReturnValue({
+      data: [
+        { id: "a", isDeleted: false },
+        { id: "b", isDeleted: false },
+        { id: "c", isDeleted: true },
+      ],
+      isLoading: false,
+    } as unknown as ReturnType<typeof usePagesSummary>);
+
+    render(<HomePageCount />);
+    expect(screen.getByText(/home\.totalPages:2/)).toBeInTheDocument();
+  });
+
+  it("is hidden on mobile viewports via Tailwind utilities", () => {
+    vi.mocked(usePagesSummary).mockReturnValue({
+      data: [{ id: "a", isDeleted: false }],
+      isLoading: false,
+    } as unknown as ReturnType<typeof usePagesSummary>);
+
+    const { container } = render(<HomePageCount />);
+    const badge = container.firstElementChild as HTMLElement | null;
+    expect(badge).not.toBeNull();
+    // `hidden` with an `md:*` override ensures the badge only appears at
+    // desktop widths (Tailwind md breakpoint = 768px).
+    // `hidden` + `md:*` で md (768px) 以上のみ表示されることを担保する。
+    expect(badge?.className).toMatch(/\bhidden\b/);
+    expect(badge?.className).toMatch(/\bmd:(flex|inline-flex|block)\b/);
+  });
+});

--- a/src/components/layout/HomePageCount.tsx
+++ b/src/components/layout/HomePageCount.tsx
@@ -4,7 +4,10 @@ import { usePagesSummary } from "@/hooks/usePageQueries";
 
 /**
  * ホーム用の総ページ数表示。削除済みを除いた件数を表示する。
- * Home page total count label (excludes deleted pages).
+ * モバイルでは FAB の親指リーチ領域と重なるため非表示にする。
+ *
+ * Home page total count label (excludes deleted pages). Hidden on mobile
+ * because it would overlap the FAB's thumb-reach area.
  */
 export const HomePageCount: React.FC = () => {
   const { t } = useTranslation();
@@ -16,7 +19,7 @@ export const HomePageCount: React.FC = () => {
   }
 
   return (
-    <span className="border-border bg-background text-muted-foreground flex items-center gap-2 border px-2.5 py-1 text-sm">
+    <span className="border-border bg-background text-muted-foreground hidden items-center gap-2 border px-2.5 py-1 text-sm md:flex">
       <span>{t("home.pageCountLabel")}</span>
       <span className="bg-border h-4 w-px shrink-0" aria-hidden />
       <span>{t("home.totalPages", { count: pageCount })}</span>

--- a/src/components/layout/MobileHeader.test.tsx
+++ b/src/components/layout/MobileHeader.test.tsx
@@ -1,15 +1,16 @@
 /**
- * MobileHeader: compact h-12 title bar, search icon opens a Sheet, and the
- * legacy desktop widgets (AIChatButton / NavigationMenu / UnifiedMenu) must
- * NOT render — their roles moved to the bottom nav.
+ * MobileHeader: compact h-12 title bar that shows ONLY the search bar inline.
+ * The logo, the search-sheet toggle, and the legacy desktop widgets
+ * (AIChatButton / NavigationMenu / UnifiedMenu) must NOT render — their roles
+ * have moved to the bottom nav.
  *
- * モバイルヘッダー: h-12 のタイトルバー、検索アイコンから Sheet、そして
- * 既存のデスクトップウィジェット（AIChatButton / NavigationMenu / UnifiedMenu）
- * は描画されないことを検証する（役割はボトムナビへ移動）。
+ * モバイルヘッダー: h-12 のタイトルバーに検索バーのみをインラインで描画する。
+ * ロゴ・検索 Sheet のトグル・既存のデスクトップウィジェット（AIChatButton /
+ * NavigationMenu / UnifiedMenu）は描画されない（役割はボトムナビへ移動）。
  */
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { MobileHeader } from "./MobileHeader";
 
@@ -61,13 +62,31 @@ function renderHeader() {
 }
 
 describe("MobileHeader", () => {
-  it("renders a compact h-12 title bar with the logo", () => {
+  it("renders a compact h-12 sticky title bar", () => {
     const { container } = renderHeader();
     const header = container.querySelector("header");
     expect(header).toBeInTheDocument();
     expect(header?.className).toMatch(/h-12/);
     expect(header?.className).toMatch(/sticky/);
-    expect(screen.getByTestId("header-logo")).toBeInTheDocument();
+  });
+
+  it("renders the search bar inline as the only header content", () => {
+    renderHeader();
+    // 検索バーはインラインで表示されているべき（Sheet の背後ではない）。
+    // The search bar must be rendered inline, not behind a Sheet.
+    expect(screen.getByTestId("header-search")).toBeInTheDocument();
+  });
+
+  it("does not render the logo (mobile header is search-only)", () => {
+    renderHeader();
+    expect(screen.queryByTestId("header-logo")).not.toBeInTheDocument();
+  });
+
+  it("does not expose a search sheet toggle button", () => {
+    renderHeader();
+    // 検索アイコンボタン（Sheet オープン用）は存在しないこと。
+    // The search-sheet toggle icon button must not exist.
+    expect(screen.queryByRole("button", { name: /search/i })).not.toBeInTheDocument();
   });
 
   it("does not render the desktop-only widgets", () => {
@@ -88,10 +107,23 @@ describe("MobileHeader", () => {
     expect(unifiedMenuMock).not.toHaveBeenCalled();
   });
 
-  it("opens the search sheet when the search icon is tapped", async () => {
-    renderHeader();
-    const searchButton = screen.getByRole("button", { name: /search/i });
-    fireEvent.click(searchButton);
-    expect(await screen.findByTestId("header-search")).toBeInTheDocument();
+  it("omits the search bar when no search context is provided", async () => {
+    // When the global search context is not available (e.g. pre-auth
+    // screens), the mobile header should render nothing interactive so it
+    // behaves like a plain spacer.
+    // GlobalSearchContext が無い画面（ログイン前など）では検索バーを出さず、
+    // 単純なスペーサーのように振る舞うこと。
+    vi.resetModules();
+    vi.doMock("@/contexts/GlobalSearchContext", () => ({
+      useGlobalSearchContextOptional: () => null,
+    }));
+    const { MobileHeader: FreshMobileHeader } = await import("./MobileHeader");
+    render(
+      <MemoryRouter>
+        <FreshMobileHeader />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByTestId("header-search")).not.toBeInTheDocument();
+    vi.doUnmock("@/contexts/GlobalSearchContext");
   });
 });

--- a/src/components/layout/MobileHeader.test.tsx
+++ b/src/components/layout/MobileHeader.test.tsx
@@ -118,12 +118,20 @@ describe("MobileHeader", () => {
       useGlobalSearchContextOptional: () => null,
     }));
     const { MobileHeader: FreshMobileHeader } = await import("./MobileHeader");
-    render(
+    const { container } = render(
       <MemoryRouter>
         <FreshMobileHeader />
       </MemoryRouter>,
     );
     expect(screen.queryByTestId("header-search")).not.toBeInTheDocument();
+    // スペーサーとしての `<header>` 自体はレンダリングされ続けることを担保し、
+    // コンポーネントが誤って `null` を返す退行を検出できるようにする。
+    // Ensure the spacer `<header>` shell still renders so a regression to
+    // returning `null` (which would also satisfy the assertion above) is
+    // caught.
+    const header = container.querySelector("header");
+    expect(header).toBeInTheDocument();
+    expect(header?.className).toMatch(/h-12/);
     vi.doUnmock("@/contexts/GlobalSearchContext");
   });
 });

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -1,9 +1,5 @@
-import React, { useState } from "react";
-import { Search } from "lucide-react";
-import { Button, Sheet, SheetContent, SheetDescription, SheetTitle, cn } from "@zedi/ui";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-import { useTranslation } from "react-i18next";
-import { HeaderLogo } from "./Header/HeaderLogo";
+import React from "react";
+import { cn } from "@zedi/ui";
 import { HeaderSearchBar } from "./Header/HeaderSearchBar";
 import Container from "@/components/layout/Container";
 import { useGlobalSearchContextOptional } from "@/contexts/GlobalSearchContext";
@@ -13,21 +9,19 @@ interface MobileHeaderProps {
 }
 
 /**
- * Compact mobile title bar with the app logo on the left and a search icon
- * on the right. Navigation, AI toggle and the user menu have moved to the
- * bottom nav, so this bar stays deliberately minimal (h-12) to keep
- * thumb-reach space for the content beneath it.
+ * Compact mobile title bar that shows ONLY the search bar inline. Navigation,
+ * AI toggle, and the user menu have moved to the bottom nav, so this bar
+ * stays deliberately minimal (h-12) and surfaces the single most-used input
+ * without an extra tap through a Sheet.
  *
- * モバイル用のコンパクトなタイトルバー。左にロゴ、右に検索アイコンだけを置き、
- * ナビゲーション・AI 開閉・ユーザーメニューはボトムナビへ移譲した。片手操作での
- * 親指リーチを確保するため、あえて高さ h-12 に抑えている。
+ * モバイル用のコンパクトなタイトルバー。検索バーのみをインラインで表示する。
+ * ナビゲーション・AI 開閉・ユーザーメニューはボトムナビへ移譲済みのため、
+ * 高さ h-12 を維持しつつ、最も利用頻度の高い検索を Sheet を介さず直接操作で
+ * きるようにしている。
  */
 export const MobileHeader: React.FC<MobileHeaderProps> = ({ className }) => {
-  const { t } = useTranslation();
-  const [searchOpen, setSearchOpen] = useState(false);
   const searchContext = useGlobalSearchContextOptional();
   const hasSearchContext = searchContext != null;
-  const sheetTitle = t("nav.search", "Search");
 
   return (
     <header
@@ -37,31 +31,11 @@ export const MobileHeader: React.FC<MobileHeaderProps> = ({ className }) => {
         className,
       )}
     >
-      <Container className="flex h-12 items-center justify-between gap-3">
-        <div className="flex min-w-0 shrink-0 items-center gap-2">
-          <HeaderLogo />
-        </div>
+      <Container className="flex h-12 items-center gap-3">
         {hasSearchContext && (
-          <>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-9 w-9"
-              aria-label={t("nav.search", "Search")}
-              onClick={() => setSearchOpen(true)}
-            >
-              <Search className="h-5 w-5" />
-            </Button>
-            <Sheet open={searchOpen} onOpenChange={setSearchOpen}>
-              <SheetContent side="top" className="p-4">
-                <VisuallyHidden>
-                  <SheetTitle>{sheetTitle}</SheetTitle>
-                  <SheetDescription>{sheetTitle}</SheetDescription>
-                </VisuallyHidden>
-                <HeaderSearchBar />
-              </SheetContent>
-            </Sheet>
-          </>
+          <div className="min-w-0 flex-1">
+            <HeaderSearchBar />
+          </div>
         )}
       </Container>
     </header>

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -31,7 +31,7 @@ export const MobileHeader: React.FC<MobileHeaderProps> = ({ className }) => {
         className,
       )}
     >
-      <Container className="flex h-12 items-center gap-3">
+      <Container className="flex h-12 items-center">
         {hasSearchContext && (
           <div className="min-w-0 flex-1">
             <HeaderSearchBar />


### PR DESCRIPTION
## 概要

モバイルヘッダーを簡潔化し、検索バーをインラインで直接表示するように変更しました。ロゴ、検索シートトグル、デスクトップウィジェットを削除し、最も利用頻度の高い検索機能を Sheet を介さず直接操作できるようにしました。また、ホームページの総ページ数バッジをモバイルで非表示にする対応も追加しました。

## 変更点

- **MobileHeader.tsx**: 検索バーをインラインで表示する実装に変更
  - ロゴ（HeaderLogo）の削除
  - 検索シート（Sheet）とトグルボタンの削除
  - 検索バーを直接コンテナ内に配置（`flex-1` で拡張）
  - 不要なインポート（useState、Search アイコン、Sheet コンポーネント等）を削除

- **HomePageCount.tsx**: モバイルビューポートでの非表示対応
  - `hidden md:flex` クラスを追加し、md ブレークポイント（768px）以上でのみ表示

- **MobileHeader.test.tsx**: テストケースを更新・追加
  - ロゴが描画されないことを確認するテストを追加
  - 検索シートトグルボタンが存在しないことを確認するテストを追加
  - 検索バーがインラインで表示されることを確認するテストを追加
  - グローバル検索コンテキストが無い場合の動作テストを追加
  - 不要な `fireEvent` インポートを削除

- **HomePageCount.test.tsx**: 新規テストファイルを追加
  - ローディング中は何も描画されないことを確認
  - 削除済みページを除いた総ページ数が表示されることを確認
  - Tailwind ユーティリティで mobile では非表示、desktop では表示されることを確認

## 変更の種類

- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm test` または `vitest` を実行し、すべてのテストがパスすることを確認
2. モバイルビューポート（< 768px）で MobileHeader が検索バーのみを表示することを確認
3. デスクトップビューポート（≥ 768px）で HomePageCount バッジが表示されることを確認
4. グローバル検索コンテキストが無い画面で MobileHeader が空のスペーサーとして機能することを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] 必要に応じてドキュメント（JSDoc コメント）を更新した
- [x] 新規テストファイルを追加した

https://claude.ai/code/session_019dKqjUVQipjX2zd7qr7Kzx
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile header now shows the search bar inline on small screens when search is available.

* **Bug Fixes**
  * Page-count badge is hidden on small screens and visible at medium+ breakpoints.
  * Total pages count excludes deleted pages from the displayed total.

* **Tests**
  * Added/updated tests covering page-count behavior, responsiveness, and mobile header search scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->