### PR TITLE
refactor: simplify navigation menu styling and icon

### DIFF
--- a/src/components/layout/Header/NavigationMenu.test.tsx
+++ b/src/components/layout/Header/NavigationMenu.test.tsx
@@ -80,6 +80,18 @@ describe("NavigationMenu", () => {
   it("does not vary item styling based on the current route", async () => {
     const user = userEvent.setup();
 
+    // Render at /home first, capture class names for both tiles.
+    // /home で描画し、両タイルの className を取得する。
+    const firstRender = renderAt("/home");
+    await user.click(screen.getByRole("button", { name: "メニュー" }));
+    const homeOnHome = await screen.findByRole("menuitem", { name: "ホーム" });
+    const notesOnHome = await screen.findByRole("menuitem", { name: "ノート" });
+    const homeClassOnHome = homeOnHome.className;
+    const notesClassOnHome = notesOnHome.className;
+    firstRender.unmount();
+
+    // Re-render at /notes and compare the same tiles.
+    // /notes で再描画し、同じタイル同士で比較する。
     renderAt("/notes");
     await user.click(screen.getByRole("button", { name: "メニュー" }));
 
@@ -90,6 +102,11 @@ describe("NavigationMenu", () => {
     // 現在のパスに応じたアクティブ状態のクラスが付与されていないことを確認する。
     expect(notesOnNotes.className).not.toMatch(/bg-accent/);
     expect(homeOnNotes.className).not.toMatch(/bg-accent/);
+
+    // Same tile renders with an identical className regardless of the route.
+    // 同一タイルの className がルートに関わらず一致することを保証する。
+    expect(homeOnNotes.className).toBe(homeClassOnHome);
+    expect(notesOnNotes.className).toBe(notesClassOnHome);
     expect(notesOnNotes.className).toBe(homeOnNotes.className);
   });
 

--- a/src/components/layout/Header/NavigationMenu.test.tsx
+++ b/src/components/layout/Header/NavigationMenu.test.tsx
@@ -77,16 +77,20 @@ describe("NavigationMenu", () => {
     expect(notesLink).toHaveAttribute("href", "/notes");
   });
 
-  it("applies active styling to the item matching the current route", async () => {
+  it("does not vary item styling based on the current route", async () => {
     const user = userEvent.setup();
+
     renderAt("/notes");
     await user.click(screen.getByRole("button", { name: "メニュー" }));
 
-    const notesLink = await screen.findByRole("menuitem", { name: "ノート" });
-    const homeLink = await screen.findByRole("menuitem", { name: "ホーム" });
+    const notesOnNotes = await screen.findByRole("menuitem", { name: "ノート" });
+    const homeOnNotes = await screen.findByRole("menuitem", { name: "ホーム" });
 
-    expect(notesLink.className).toMatch(/bg-accent/);
-    expect(homeLink.className).not.toMatch(/bg-accent/);
+    // No active-state classes should be applied based on the current path.
+    // 現在のパスに応じたアクティブ状態のクラスが付与されていないことを確認する。
+    expect(notesOnNotes.className).not.toMatch(/bg-accent/);
+    expect(homeOnNotes.className).not.toMatch(/bg-accent/);
+    expect(notesOnNotes.className).toBe(homeOnNotes.className);
   });
 
   it("renders a Sheet-based menu on mobile", async () => {

--- a/src/components/layout/Header/NavigationMenu.tsx
+++ b/src/components/layout/Header/NavigationMenu.tsx
@@ -88,9 +88,9 @@ const NavTile: React.FC<NavTileProps> = ({ entry, label, onNavigate, as }) => {
         onSelect={onNavigate}
         className={cn("cursor-pointer p-0 focus:bg-transparent focus:text-inherit")}
       >
-        <Link to={entry.path} aria-label={label} className={TILE_BASE_CLASS}>
+        <Link to={entry.path} className={TILE_BASE_CLASS}>
           <span className={ICON_WRAP_CLASS}>
-            <Icon className="text-muted-foreground h-5 w-5" />
+            <Icon aria-hidden="true" className="text-muted-foreground h-5 w-5" />
           </span>
           <span className={LABEL_CLASS}>{label}</span>
         </Link>
@@ -99,7 +99,7 @@ const NavTile: React.FC<NavTileProps> = ({ entry, label, onNavigate, as }) => {
   }
 
   return (
-    <Link to={entry.path} onClick={onNavigate} aria-label={label} className={TILE_BASE_CLASS}>
+    <Link to={entry.path} onClick={onNavigate} className={TILE_BASE_CLASS}>
       <span className={ICON_WRAP_CLASS}>
         <Icon className="text-muted-foreground h-5 w-5" />
       </span>

--- a/src/components/layout/Header/NavigationMenu.tsx
+++ b/src/components/layout/Header/NavigationMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
-import { Link, useMatch } from "react-router-dom";
-import { Menu, Home, FileText } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Home, FileText } from "lucide-react";
 import {
   Button,
   cn,
@@ -24,37 +24,48 @@ interface NavEntry {
   path: string;
   icon: React.FC<{ className?: string }>;
   i18nKey: string;
-  /** Treat only exact `path` as active. / 完全一致のみアクティブ扱いにする。 */
-  exact?: boolean;
 }
 
 const NAV_ENTRIES: readonly NavEntry[] = [
-  { path: "/home", icon: Home, i18nKey: "nav.home", exact: true },
+  { path: "/home", icon: Home, i18nKey: "nav.home" },
   { path: "/notes", icon: FileText, i18nKey: "nav.notes" },
 ] as const;
 
 const TILE_BASE_CLASS =
   "flex flex-col items-center gap-2 rounded-lg p-3 transition-colors hover:bg-muted data-[highlighted]:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1";
-const TILE_ACTIVE_CLASS = "bg-accent text-accent-foreground";
 const ICON_WRAP_CLASS = "bg-muted h-10 w-10 rounded-lg flex items-center justify-center";
 const LABEL_CLASS = "text-xs font-medium";
 
 /**
- * Reads `useMatch` for a nav entry. Hooks-per-item is safe because the list is
- * static (length/order never change between renders).
+ * 9-dot grid icon used as the navigation menu trigger. Rendered as an
+ * inline SVG so spacing stays precise across viewports.
  *
- * ナビ項目ごとに `useMatch` を評価する。項目リストは静的なので、配列長・順序は
- * レンダー間で変わらず、Hook 呼び出し順は安定する。
+ * ナビゲーションメニューのトリガーに使う 9 点グリッドアイコン。
+ * ビューポートを跨いでも余白が崩れないよう、インライン SVG で描画する。
  */
-function useIsEntryActive(entry: NavEntry): boolean {
-  const match = useMatch({ path: entry.path, end: entry.exact ?? false });
-  return match != null;
-}
+const DotGridIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+    focusable="false"
+    className={className}
+  >
+    <circle cx="5" cy="5" r="1.75" />
+    <circle cx="12" cy="5" r="1.75" />
+    <circle cx="19" cy="5" r="1.75" />
+    <circle cx="5" cy="12" r="1.75" />
+    <circle cx="12" cy="12" r="1.75" />
+    <circle cx="19" cy="12" r="1.75" />
+    <circle cx="5" cy="19" r="1.75" />
+    <circle cx="12" cy="19" r="1.75" />
+    <circle cx="19" cy="19" r="1.75" />
+  </svg>
+);
 
 interface NavTileProps {
   entry: NavEntry;
   label: string;
-  active: boolean;
   onNavigate: () => void;
   as: "menuitem" | "link";
 }
@@ -67,9 +78,8 @@ interface NavTileProps {
  * 1 件のナビ項目を表すタイル。デスクトップは `DropdownMenuItem`（選択で閉じる）、
  * モバイルはシート内の通常の `<Link>` として描画する。
  */
-const NavTile: React.FC<NavTileProps> = ({ entry, label, active, onNavigate, as }) => {
+const NavTile: React.FC<NavTileProps> = ({ entry, label, onNavigate, as }) => {
   const Icon = entry.icon;
-  const className = cn(TILE_BASE_CLASS, active && TILE_ACTIVE_CLASS);
 
   if (as === "menuitem") {
     return (
@@ -78,7 +88,7 @@ const NavTile: React.FC<NavTileProps> = ({ entry, label, active, onNavigate, as 
         onSelect={onNavigate}
         className={cn("cursor-pointer p-0 focus:bg-transparent focus:text-inherit")}
       >
-        <Link to={entry.path} aria-label={label} className={className}>
+        <Link to={entry.path} aria-label={label} className={TILE_BASE_CLASS}>
           <span className={ICON_WRAP_CLASS}>
             <Icon className="text-muted-foreground h-5 w-5" />
           </span>
@@ -89,7 +99,7 @@ const NavTile: React.FC<NavTileProps> = ({ entry, label, active, onNavigate, as 
   }
 
   return (
-    <Link to={entry.path} onClick={onNavigate} aria-label={label} className={className}>
+    <Link to={entry.path} onClick={onNavigate} aria-label={label} className={TILE_BASE_CLASS}>
       <span className={ICON_WRAP_CLASS}>
         <Icon className="text-muted-foreground h-5 w-5" />
       </span>
@@ -112,7 +122,7 @@ const NavGrid: React.FC<NavGridProps> = ({ onNavigate, as }) => {
   return (
     <div className="grid grid-cols-3 gap-2 p-2">
       {NAV_ENTRIES.map((entry) => (
-        <NavGridEntry
+        <NavTile
           key={entry.path}
           entry={entry}
           label={t(entry.i18nKey)}
@@ -122,18 +132,6 @@ const NavGrid: React.FC<NavGridProps> = ({ onNavigate, as }) => {
       ))}
     </div>
   );
-};
-
-interface NavGridEntryProps {
-  entry: NavEntry;
-  label: string;
-  onNavigate: () => void;
-  as: "menuitem" | "link";
-}
-
-const NavGridEntry: React.FC<NavGridEntryProps> = ({ entry, label, onNavigate, as }) => {
-  const active = useIsEntryActive(entry);
-  return <NavTile entry={entry} label={label} active={active} onNavigate={onNavigate} as={as} />;
 };
 
 const NavTrigger = React.forwardRef<
@@ -150,7 +148,7 @@ const NavTrigger = React.forwardRef<
       aria-label={t("nav.menu")}
       {...props}
     >
-      <Menu className="h-5 w-5" />
+      <DotGridIcon className="h-5 w-5" />
     </Button>
   );
 });

--- a/src/components/layout/Header/NavigationMenu.tsx
+++ b/src/components/layout/Header/NavigationMenu.tsx
@@ -101,7 +101,7 @@ const NavTile: React.FC<NavTileProps> = ({ entry, label, onNavigate, as }) => {
   return (
     <Link to={entry.path} onClick={onNavigate} className={TILE_BASE_CLASS}>
       <span className={ICON_WRAP_CLASS}>
-        <Icon className="text-muted-foreground h-5 w-5" />
+        <Icon aria-hidden="true" className="text-muted-foreground h-5 w-5" />
       </span>
       <span className={LABEL_CLASS}>{label}</span>
     </Link>


### PR DESCRIPTION
## 概要

ナビゲーションメニューコンポーネントを簡素化し、ルートベースのアクティブ状態スタイリングを削除しました。メニューアイコンをカスタム SVG グリッドアイコンに変更し、不要なコンポーネント階層を統合しました。

## 変更点

- `useMatch` フックと `useIsEntryActive` 関数を削除し、ルートベースのアクティブ状態スタイリングを廃止
- `NavEntry` インターフェースから `exact` プロパティを削除
- `TILE_ACTIVE_CLASS` スタイルを削除（すべてのナビタイルが統一されたスタイルを使用）
- `Menu` アイコン（lucide-react）をカスタム `DotGridIcon` SVG コンポーネントに置き換え
- `NavGridEntry` ラッパーコンポーネントを削除し、`NavGrid` から直接 `NavTile` を呼び出すように簡素化
- `NavTile` コンポーネントから `active` プロップを削除
- テストを更新し、アクティブ状態スタイリングが適用されないことを確認

## 変更の種類

- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)

## テスト方法

1. 既存のテストスイートを実行して、すべてのテストがパスすることを確認
2. ナビゲーションメニューを開き、メニューアイコンが 9 点グリッドアイコンとして表示されることを確認
3. 異なるルートに移動してメニューを開き、すべてのナビタイルが同じスタイルで表示されることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した

https://claude.ai/code/session_01ELMEfbA61LKKJrTuDMMnxg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Rewrote navigation menu test to stop asserting route-based active styling; now checks that menu item class names remain consistent across routes.

* **UI Changes**
  * Navigation menu items no longer show route-based active highlighting.
  * Replaced menu trigger icon with a new design.
  * Menu item icons marked aria-hidden to improve screen-reader behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->