### PR TITLE
🎨 Increase UI component sizes for better accessibility

### DIFF
--- a/src/components/layout/FloatingActionButton.tsx
+++ b/src/components/layout/FloatingActionButton.tsx
@@ -61,14 +61,14 @@ const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({
             onClick={() => setIsMenuOpen(!isMenuOpen)}
             disabled={isCreating}
             className={cn(
-              "h-16 w-16 rounded-full",
+              "h-20 w-20 rounded-full",
               "shadow-elevated",
               "transition-all duration-300 ease-in-out",
               "hover:bg-primary hover:scale-105",
               isMenuOpen && "bg-muted-foreground hover:bg-muted-foreground",
             )}
           >
-            {isMenuOpen ? <X className="h-10 w-10" /> : <Plus className="h-10 w-10" />}
+            {isMenuOpen ? <X className="h-12 w-12" /> : <Plus className="h-12 w-12" />}
           </Button>
         </TooltipTrigger>
         {!isMenuOpen && <TooltipContent side="left">{t("common.createPageAction")}</TooltipContent>}

--- a/src/components/layout/Header/HeaderSearchBar.tsx
+++ b/src/components/layout/Header/HeaderSearchBar.tsx
@@ -196,7 +196,7 @@ export function HeaderSearchBar() {
     <Popover open={dropdownOpen} onOpenChange={setDropdownOpen}>
       <PopoverAnchor asChild>
         <div className="relative flex w-full min-w-0 flex-1">
-          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3.5 h-5 w-5 shrink-0 -translate-y-1/2" />
+          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-4 h-6 w-6 shrink-0 -translate-y-1/2" />
           <Input
             ref={inputRef}
             type="search"
@@ -224,12 +224,12 @@ export function HeaderSearchBar() {
               })
             }
             className={cn(
-              "border-muted-foreground/20 bg-muted/50 h-10 w-full rounded-md pr-3 pl-10 sm:pr-16",
-              "placeholder:text-muted-foreground text-sm",
+              "border-muted-foreground/20 bg-muted/50 h-12 w-full rounded-md pr-3 pl-12 sm:pr-20",
+              "placeholder:text-muted-foreground text-base",
             )}
           />
           <span
-            className="border-border bg-muted/80 text-muted-foreground pointer-events-none absolute top-1/2 right-3.5 hidden -translate-y-1/2 items-center rounded border px-2 py-1 text-xs sm:inline-flex"
+            className="border-border bg-muted/80 text-muted-foreground pointer-events-none absolute top-1/2 right-4 hidden -translate-y-1/2 items-center rounded border px-2.5 py-1 text-sm sm:inline-flex"
             aria-hidden
           >
             {SHORTCUT_HINT}

--- a/src/components/layout/Header/NavigationMenu.tsx
+++ b/src/components/layout/Header/NavigationMenu.tsx
@@ -144,11 +144,11 @@ const NavTrigger = React.forwardRef<
       ref={ref}
       variant="ghost"
       size="icon"
-      className="h-9 w-9"
+      className="h-12 w-12"
       aria-label={t("nav.menu")}
       {...props}
     >
-      <DotGridIcon className="h-5 w-5" />
+      <DotGridIcon className="h-6 w-6" />
     </Button>
   );
 });

--- a/src/components/layout/Header/UnifiedMenu.tsx
+++ b/src/components/layout/Header/UnifiedMenu.tsx
@@ -272,11 +272,11 @@ const AvatarTrigger = React.forwardRef<
     <Button
       ref={ref}
       variant="ghost"
-      className="relative h-9 w-9 rounded-full"
+      className="relative h-12 w-12 rounded-full"
       aria-label={t("nav.account", "Account")}
       {...props}
     >
-      <Avatar className="h-9 w-9">
+      <Avatar className="h-12 w-12">
         <AvatarImage
           src={avatarUrl || user?.imageUrl}
           alt={displayName || user?.fullName || "User"}
@@ -286,7 +286,7 @@ const AvatarTrigger = React.forwardRef<
       {dotColor && (
         <span
           className={cn(
-            "border-background absolute right-0 bottom-0 h-2.5 w-2.5 rounded-full border-2",
+            "border-background absolute right-0 bottom-0 h-3 w-3 rounded-full border-2",
             dotColor,
           )}
         />
@@ -306,11 +306,11 @@ const GuestTrigger = React.forwardRef<
       ref={ref}
       variant="ghost"
       size="icon"
-      className="h-9 w-9"
+      className="h-12 w-12"
       aria-label={t("nav.account", "Account")}
       {...props}
     >
-      <User className="h-5 w-5" />
+      <User className="h-6 w-6" />
     </Button>
   );
 });


### PR DESCRIPTION
## 概要

ヘッダーとフローティングアクションボタンのコンポーネントサイズを拡大し、アクセシビリティと操作性を向上させました。

## 変更点

- **UnifiedMenu.tsx**: アバターボタンを h-9 w-9 から h-12 w-12 に拡大、ステータスドットを h-2.5 w-2.5 から h-3 w-3 に拡大、ゲストユーザーアイコンボタンを h-9 w-9 から h-12 w-12 に拡大
- **HeaderSearchBar.tsx**: 検索バーの高さを h-10 から h-12 に拡大、検索アイコンを h-5 w-5 から h-6 w-6 に拡大、テキストサイズを sm から base に拡大、キーボードショートカットヒントのテキストサイズを xs から sm に拡大
- **FloatingActionButton.tsx**: FABボタンを h-16 w-16 から h-20 w-20 に拡大、内部アイコンを h-10 w-10 から h-12 w-12 に拡大
- **NavigationMenu.tsx**: ナビゲーションメニュートリガーボタンを h-9 w-9 から h-12 w-12 に拡大、アイコンを h-5 w-5 から h-6 w-6 に拡大

## 変更の種類

- [x] 🎨 スタイル/リファクタリング (Style/Refactor)

## テスト方法

1. ブラウザで各ページを開く
2. ヘッダーのアバターボタン、検索バー、ナビゲーションメニューが拡大されていることを確認
3. フローティングアクションボタンが拡大されていることを確認
4. すべてのボタンが正常に機能することを確認

## チェックリスト

- [x] Lint エラーがない
- [x] コンポーネントの機能に変更なし

https://claude.ai/code/session_01RZVRw2PQzcbkHf7jfqGncB
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
