### PR TITLE
fix(ui): tune header nav and FAB icon sizes

### DIFF
--- a/src/components/layout/FloatingActionButton.tsx
+++ b/src/components/layout/FloatingActionButton.tsx
@@ -69,7 +69,7 @@ const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({
               // fills the FAB instead of being shrunk to 16px.
               // Button 基底の `[&_svg]:size-4` を上書きし、+ / × アイコンが
               // 16px に縮まらず FAB に見合うサイズで表示されるようにする。
-              "[&_svg]:size-10",
+              "[&_svg]:size-8",
               isMenuOpen && "bg-muted-foreground hover:bg-muted-foreground",
             )}
           >

--- a/src/components/layout/Header/NavigationMenu.tsx
+++ b/src/components/layout/Header/NavigationMenu.tsx
@@ -148,7 +148,7 @@ const NavTrigger = React.forwardRef<
       // its intended size instead of being shrunk to 16px.
       // Button の基底クラス `[&_svg]:size-4` を上書きして、トリガーアイコンを
       // 16px に縮められないよう本来のサイズで表示する。
-      className="h-12 w-12 [&_svg]:size-7"
+      className="h-12 w-12 [&_svg]:size-6"
       aria-label={t("nav.menu")}
       {...props}
     >

--- a/src/components/layout/Header/UnifiedMenu.tsx
+++ b/src/components/layout/Header/UnifiedMenu.tsx
@@ -308,7 +308,7 @@ const GuestTrigger = React.forwardRef<
       // navigation menu trigger size instead of being shrunk to 16px.
       // Button の基底 `[&_svg]:size-4` を上書きし、ナビゲーションメニューと
       // 揃ったサイズでユーザーアイコンを表示する。
-      className="h-12 w-12 [&_svg]:size-7"
+      className="h-12 w-12 [&_svg]:size-6"
       aria-label={t("nav.account", "Account")}
       {...props}
     >


### PR DESCRIPTION
## 概要

#677 で大きくしたヘッダーのナビ／ゲストアイコンと FAB の `+` / `×` アイコンが、利用感としては大きすぎたため、中間サイズに調整します。

## 変更点

- `src/components/layout/Header/NavigationMenu.tsx` — ナビメニュートリガー: `[&_svg]:size-7`(28px) → `[&_svg]:size-6`(24px)
- `src/components/layout/Header/UnifiedMenu.tsx` — ゲスト時アカウントトリガー: `[&_svg]:size-7`(28px) → `[&_svg]:size-6`(24px)
- `src/components/layout/FloatingActionButton.tsx` — FAB: `[&_svg]:size-10`(40px) → `[&_svg]:size-8`(32px)

ボタン外形（`h-12 w-12` / `h-20 w-20`）と `Button` 基底クラスの `[&_svg]:size-4` 上書きという方針は #677 と同じです。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. ヘッダー右の 9 ドット（ナビメニュー）アイコンが #677 マージ時より一回り小さく、ボタン枠とのバランスが取れていることを確認する。
2. 未サインイン時のユーザーアイコンも同じサイズで表示され、ナビトリガーと揃って見えることを確認する。
3. ホームで FAB の `+` / メニュー開閉時の `×` がボタンに対して過剰に大きくなく、視認性も保たれていることを確認する。

## チェックリスト

- [x] コミットは pre-commit（Prettier / ESLint）を通過
- [ ] 全体 `format:check` / `test:run` はリポジトリの既存差分・依存解決の事情でローカルでは安定しないため CI に委ねる

## 関連 Issue

Related to #677

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted icon sizes across the floating action button, navigation menu, and user menu components for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->