### PR TITLE
fix(api): add missing note_members.status / accepted_user_id migration

### DIFF
--- a/server/api/drizzle/0015_add_note_members_status_accepted_user.sql
+++ b/server/api/drizzle/0015_add_note_members_status_accepted_user.sql
@@ -1,0 +1,26 @@
+-- Add `status` and `accepted_user_id` columns to `note_members`.
+-- `note_members` テーブルに `status` と `accepted_user_id` カラムを追加する。
+--
+-- 招待フロー（メール招待 / 共有リンク受諾 / ノート作成時のオーナー自己登録）が
+-- `pending` / `accepted` / `declined` の状態と、受諾したユーザー ID を保持できるよう
+-- にする。これらのカラムはコード側の Drizzle スキーマ
+-- (`server/api/src/schema/notes.ts`) と `routes/notes/crud.ts` の
+-- `INSERT ... ON CONFLICT DO UPDATE` から既に参照されているが、対応する
+-- マイグレーションが欠落していたため本番 DB では `POST /api/notes` が
+-- `42703 column "status" of relation "note_members" does not exist`
+-- で 500 になっていた。
+--
+-- The membership flow (email invitations, share-link redemptions, and the
+-- implicit owner self-membership created on note creation) needs to track
+-- `pending` / `accepted` / `declined` plus the user that accepted the invite.
+-- The Drizzle schema in `server/api/src/schema/notes.ts` and the
+-- `INSERT ... ON CONFLICT DO UPDATE` in `routes/notes/crud.ts` already use
+-- these columns, but no migration ever added them, so production hit
+-- `42703 column "status" of relation "note_members" does not exist` on
+-- every `POST /api/notes`.
+
+ALTER TABLE "note_members" ADD COLUMN "status" text DEFAULT 'pending' NOT NULL;--> statement-breakpoint
+ALTER TABLE "note_members" ADD COLUMN "accepted_user_id" text;--> statement-breakpoint
+ALTER TABLE "note_members"
+    ADD CONSTRAINT "note_members_accepted_user_id_user_id_fk"
+    FOREIGN KEY ("accepted_user_id") REFERENCES "user"("id") ON DELETE set null ON UPDATE no action;

--- a/server/api/drizzle/0015_add_note_members_status_accepted_user.sql
+++ b/server/api/drizzle/0015_add_note_members_status_accepted_user.sql
@@ -10,6 +10,18 @@
 -- `42703 column "status" of relation "note_members" does not exist`
 -- で 500 になっていた。
 --
+-- 既存の `note_members` 行は、導入前はすべて「アクセス可能なメンバー」を意味して
+-- いた。そのため、このマイグレーションでは未削除のレガシー行を `accepted` に
+-- バックフィルしないと共有アクセスが失われる。`accepted_user_id` は履歴が無い
+-- ため完全には復元できないが、既存 `user` の email と一致する場合はその `id`
+-- を逆引きして保存する。
+--
+-- Legacy `note_members` rows predate the `pending/accepted/declined` state
+-- machine and therefore already represent active access. Backfill non-deleted
+-- rows to `accepted` so existing shared notes keep working after deploy.
+-- `accepted_user_id` cannot be reconstructed perfectly, but when a matching
+-- user already exists we restore it from `member_email`.
+--
 -- The membership flow (email invitations, share-link redemptions, and the
 -- implicit owner self-membership created on note creation) needs to track
 -- `pending` / `accepted` / `declined` plus the user that accepted the invite.
@@ -21,6 +33,16 @@
 
 ALTER TABLE "note_members" ADD COLUMN "status" text DEFAULT 'pending' NOT NULL;--> statement-breakpoint
 ALTER TABLE "note_members" ADD COLUMN "accepted_user_id" text;--> statement-breakpoint
+UPDATE "note_members" AS nm
+SET
+    "status" = 'accepted',
+    "accepted_user_id" = (
+        SELECT u."id"
+        FROM "user" AS u
+        WHERE LOWER(u."email") = LOWER(nm."member_email")
+        LIMIT 1
+    )
+WHERE nm."is_deleted" = false;--> statement-breakpoint
 ALTER TABLE "note_members"
     ADD CONSTRAINT "note_members_accepted_user_id_user_id_fk"
     FOREIGN KEY ("accepted_user_id") REFERENCES "user"("id") ON DELETE set null ON UPDATE no action;

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1777075200000,
       "tag": "0014_add_note_domain_access",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1777161600000,
+      "tag": "0015_add_note_members_status_accepted_user",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## 概要

本番 (`api.zedi-note.app`) でノート作成 (`POST /api/notes`) と一覧取得 (`GET /api/notes`) が **すべて 500** になっていた問題を修正する。Railway (`api-prod`) のログには次の生 Postgres エラーが出ていた。

```
cause: error: column "status" of relation "note_members" does not exist
code: '42703'
```

`server/api/src/schema/notes.ts` の `noteMembers` 定義と `routes/notes/crud.ts` の招待用 `INSERT ... ON CONFLICT DO UPDATE` は既に `status` / `accepted_user_id` を参照していたが、対応する Drizzle マイグレーションが一度も生成されておらず、本番 DB が古いスキーマのままになっていた。

The Drizzle schema and the note-creation route already reference `note_members.status` / `note_members.accepted_user_id`, but no migration ever added them, so production has been hitting `42703` on every `POST /api/notes`. This PR adds the missing migration so `bunx drizzle-kit migrate` brings the DB back in sync with the code.

## 変更点

- `server/api/drizzle/0015_add_note_members_status_accepted_user.sql` を追加。
  - `ALTER TABLE "note_members" ADD COLUMN "status" text DEFAULT 'pending' NOT NULL;`
  - `ALTER TABLE "note_members" ADD COLUMN "accepted_user_id" text;`
  - `accepted_user_id` → `user.id` の FK（`ON DELETE SET NULL`、スキーマ定義と一致）。
- `server/api/drizzle/meta/_journal.json` に新エントリを追記。

`note_members` のスキーマ宣言（参考）:

```ts
status: text("status", { enum: ["pending", "accepted", "declined"] })
  .notNull()
  .default("pending"),
acceptedUserId: text("accepted_user_id").references(() => users.id, { onDelete: "set null" }),
```

`status` の enum 制約はアプリ層で表現しているため、SQL 側はプロジェクトの既存マイグレーション (`0005_add_user_status.sql` など) と同じく純粋な `text` で扱う。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. ローカル DB に対して以下を実行し、追加 SQL のみ走ることを確認する。
   ```bash
   cd server/api
   DATABASE_URL=... bunx drizzle-kit migrate
   ```
2. `\d note_members` で `status` / `accepted_user_id` カラムと FK が追加されていることを確認。
3. `bun run test:run src/__tests__/routes/notes/crud.test.ts` がパスする（このブランチで確認済: 26/26 ✅）。
4. デプロイ後、本番で:
   - サインイン状態でノート作成 → `201 Created` になる。
   - `GET /api/notes` がメンバーシップ込みで 200 を返す。
   - Railway `api-prod` ログに `42703` が出ない:
     ```bash
     railway logs --service api-prod --environment production --since 30m \
       --filter "@level:error" --lines 200 --json
     ```

## チェックリスト

- [x] テストがすべてパスする (`server/api`: `crud.test.ts` 26/26)
- [x] Lint エラーがない (`bun run lint`: 0 errors)
- [x] 既存の `note_members` 行は `status DEFAULT 'pending'` でバックフィルされる（NULL を許容しない設計）
- [x] コミットメッセージが Conventional Commits に従っている

## デプロイ時の注意

- `main` への release マージ時に `.github/workflows/deploy-prod.yml` の `migrate` ジョブが `bunx drizzle-kit migrate` を自動実行するため、追加の手動操作は不要。
- 既存の `note_members` 行（オーナー自己メンバーを含む）は `status = 'pending'` で初期化される。後段で必要であれば `UPDATE note_members SET status = 'accepted', accepted_user_id = invited_by_user_id WHERE invited_by_user_id IS NOT NULL` のようなバックフィルを別 PR で検討する。

## 関連 Issue

<!-- Closes #NNN — 専用 Issue が無ければ未指定 -->


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated backend to track membership invitation status and an accepted-user reference for notes.
  * Backfilled existing accepted memberships so prior invites remain recognized.
  * Ensures accepted-user links are cleared if the associated account is removed, improving invite reliability and data consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->