### PR TITLE
Consolidate primary navigation config into shared module

### DIFF
--- a/src/components/layout/BottomNav/BottomNav.test.tsx
+++ b/src/components/layout/BottomNav/BottomNav.test.tsx
@@ -28,7 +28,16 @@ const { signedInAuth } = vi.hoisted(() => {
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string, fallback?: string) => fallback ?? key,
+    t: (key: string, fallback?: string) => {
+      const table: Record<string, string> = {
+        "nav.home": "Home",
+        "nav.notes": "Notes",
+        "nav.ai": "AI",
+        "nav.account": "Account",
+        "nav.primary": "Primary navigation",
+      };
+      return table[key] ?? fallback ?? key;
+    },
     i18n: { language: "ja" },
   }),
 }));
@@ -88,6 +97,15 @@ describe("BottomNav", () => {
     renderAt("/ai");
     const aiLink = screen.getByRole("link", { name: /^ai$/i });
     expect(aiLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("marks the AI tab as aria-current on /ai/:conversationId and /ai/history", () => {
+    const detail = renderAt("/ai/conv-123");
+    expect(screen.getByRole("link", { name: /^ai$/i })).toHaveAttribute("aria-current", "page");
+    detail.unmount();
+
+    renderAt("/ai/history");
+    expect(screen.getByRole("link", { name: /^ai$/i })).toHaveAttribute("aria-current", "page");
   });
 
   it("fixes the nav at the bottom with safe-area padding", () => {

--- a/src/components/layout/BottomNav/index.tsx
+++ b/src/components/layout/BottomNav/index.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from "react";
-import { useMatch } from "react-router-dom";
-import { Home, FileText, Sparkles } from "lucide-react";
+import { useLocation } from "react-router-dom";
 import { Sheet, SheetContent, SheetDescription, SheetTitle, cn } from "@zedi/ui";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { Avatar, AvatarFallback, AvatarImage } from "@zedi/ui";
@@ -8,26 +7,25 @@ import { useTranslation } from "react-i18next";
 import { SignedIn, SignedOut, useAuth, useUser } from "@/hooks/useAuth";
 import { useProfile } from "@/hooks/useProfile";
 import { useSyncStatusDotColor } from "../Header/UnifiedMenuSyncStatus";
+import { PRIMARY_NAV_ITEMS, isPrimaryNavActive } from "../navigationItems";
 import { SignedInMenuContent, SignedOutMenuContent } from "./BottomNavMeContent";
 import { BottomNavTab } from "./BottomNavTab";
 
 /**
- * Mobile bottom navigation with four tabs (Home / Notes / AI / Me). The Me
- * tab opens a sheet that reuses the signed-in / signed-out menu content from
- * {@link UnifiedMenu}, keeping the two surfaces in sync.
+ * Mobile bottom navigation. Renders the shared {@link PRIMARY_NAV_ITEMS} as
+ * tabs followed by a Me tab. The Me tab opens a sheet that reuses the
+ * signed-in / signed-out menu content from {@link UnifiedMenu}, so the
+ * account surfaces stay in sync; the primary tabs stay in sync with the
+ * header dropdown because both read from the same config.
  *
- * モバイル用のボトムナビゲーション（Home / Notes / AI / Me の 4 タブ）。
- * Me タブは {@link UnifiedMenu} と共通のメニュー内容を Sheet で表示するので、
- * デスクトップとモバイルのアカウントメニューが二重実装にならない。
+ * モバイル用のボトムナビゲーション。共通の {@link PRIMARY_NAV_ITEMS} をタブとして描画し、
+ * 末尾に Me タブを追加する。Me タブは {@link UnifiedMenu} と同じメニュー内容を Sheet で
+ * 表示しアカウント UI の二重実装を避ける。プライマリタブはヘッダーのドロップダウンと
+ * 同じ配列を参照するので表示項目が常に一致する。
  */
 export const BottomNav: React.FC = () => {
   const { t } = useTranslation();
-  const homeMatch = useMatch({ path: "/home", end: true });
-  const notesMatch = useMatch({ path: "/notes" });
-  const aiMatch = useMatch({ path: "/ai" });
-  const aiDetailMatch = useMatch({ path: "/ai/:conversationId" });
-  const aiHistoryMatch = useMatch({ path: "/ai/history" });
-  const aiActive = aiMatch != null || aiDetailMatch != null || aiHistoryMatch != null;
+  const { pathname } = useLocation();
   const [meOpen, setMeOpen] = useState(false);
   const closeMe = useCallback(() => setMeOpen(false), []);
   const sheetTitle = t("nav.account", "Account");
@@ -42,19 +40,15 @@ export const BottomNav: React.FC = () => {
       style={{ height: "calc(var(--app-bottom-nav-height, 3.5rem) + env(safe-area-inset-bottom))" }}
     >
       <ul className="mx-auto flex h-[var(--app-bottom-nav-height,3.5rem)] max-w-md items-stretch">
-        <BottomNavTab
-          to="/home"
-          icon={Home}
-          label={t("nav.home", "Home")}
-          active={homeMatch != null}
-        />
-        <BottomNavTab
-          to="/notes"
-          icon={FileText}
-          label={t("nav.notes", "Notes")}
-          active={notesMatch != null}
-        />
-        <BottomNavTab to="/ai" icon={Sparkles} label={t("nav.ai", "AI")} active={aiActive} />
+        {PRIMARY_NAV_ITEMS.map((item) => (
+          <BottomNavTab
+            key={item.path}
+            to={item.path}
+            icon={item.icon}
+            label={t(item.i18nKey)}
+            active={isPrimaryNavActive(item, pathname)}
+          />
+        ))}
         <li className="flex-1">
           <MeTab open={meOpen} onOpenChange={setMeOpen} />
         </li>

--- a/src/components/layout/Header/NavigationMenu.test.tsx
+++ b/src/components/layout/Header/NavigationMenu.test.tsx
@@ -1,10 +1,13 @@
 /**
  * Tests for {@link NavigationMenu}, the header dropdown that consolidates the
- * functional navigation (Home / Notes) into a single trigger with a grid of
- * icon-plus-label tiles.
+ * primary navigation (Home / Notes / AI) into a single trigger with a grid of
+ * icon-plus-label tiles. The entries come from the shared
+ * {@link PRIMARY_NAV_ITEMS} config so the header and the mobile bottom
+ * navigation stay in sync.
  *
- * ヘッダーの機能ナビゲーション（Home / Notes）を 1 つのドロップダウンに集約した
- * {@link NavigationMenu} のテスト。タイル型（アイコン + ラベル）を検証する。
+ * ヘッダーの機能ナビゲーション（Home / Notes / AI）を 1 つのドロップダウンに集約した
+ * {@link NavigationMenu} のテスト。項目は共通の {@link PRIMARY_NAV_ITEMS} を参照し、
+ * ヘッダーとモバイルボトムナビの表示項目が常に一致することを保証する。
  */
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -20,6 +23,7 @@ vi.mock("react-i18next", () => ({
         "nav.menu": "メニュー",
         "nav.home": "ホーム",
         "nav.notes": "ノート",
+        "nav.ai": "AI",
       };
       return table[key] ?? fallback ?? key;
     },
@@ -63,18 +67,21 @@ describe("NavigationMenu", () => {
     renderAt("/home");
     expect(screen.queryByRole("link", { name: "ホーム" })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "ノート" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "AI" })).not.toBeInTheDocument();
   });
 
-  it("reveals Home and Notes links after opening", async () => {
+  it("reveals Home, Notes, and AI links after opening", async () => {
     const user = userEvent.setup();
     renderAt("/home");
     await user.click(screen.getByRole("button", { name: "メニュー" }));
 
     const homeLink = await screen.findByRole("menuitem", { name: "ホーム" });
     const notesLink = await screen.findByRole("menuitem", { name: "ノート" });
+    const aiLink = await screen.findByRole("menuitem", { name: "AI" });
 
     expect(homeLink).toHaveAttribute("href", "/home");
     expect(notesLink).toHaveAttribute("href", "/notes");
+    expect(aiLink).toHaveAttribute("href", "/ai");
   });
 
   it("does not vary item styling based on the current route", async () => {

--- a/src/components/layout/Header/NavigationMenu.tsx
+++ b/src/components/layout/Header/NavigationMenu.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from "react";
 import { Link } from "react-router-dom";
-import { Home, FileText } from "lucide-react";
 import {
   Button,
   cn,
@@ -15,21 +14,7 @@ import {
 } from "@zedi/ui";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useTranslation } from "react-i18next";
-
-/**
- * One entry in the navigation grid inside the header dropdown / sheet.
- * ヘッダーのナビグリッドに並ぶ 1 項目。
- */
-interface NavEntry {
-  path: string;
-  icon: React.FC<{ className?: string }>;
-  i18nKey: string;
-}
-
-const NAV_ENTRIES: readonly NavEntry[] = [
-  { path: "/home", icon: Home, i18nKey: "nav.home" },
-  { path: "/notes", icon: FileText, i18nKey: "nav.notes" },
-] as const;
+import { PRIMARY_NAV_ITEMS, type PrimaryNavItem } from "../navigationItems";
 
 const TILE_BASE_CLASS =
   "flex flex-col items-center gap-2 rounded-lg p-3 transition-colors hover:bg-muted data-[highlighted]:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1";
@@ -64,7 +49,7 @@ const DotGridIcon: React.FC<{ className?: string }> = ({ className }) => (
 );
 
 interface NavTileProps {
-  entry: NavEntry;
+  entry: PrimaryNavItem;
   label: string;
   onNavigate: () => void;
   as: "menuitem" | "link";
@@ -121,7 +106,7 @@ const NavGrid: React.FC<NavGridProps> = ({ onNavigate, as }) => {
   const { t } = useTranslation();
   return (
     <div className="grid grid-cols-3 gap-2 p-2">
-      {NAV_ENTRIES.map((entry) => (
+      {PRIMARY_NAV_ITEMS.map((entry) => (
         <NavTile
           key={entry.path}
           entry={entry}
@@ -193,13 +178,14 @@ const MobileNavigationMenu: React.FC = () => {
 };
 
 /**
- * Consolidated header navigation. Presents Home / Notes (and future entries)
- * as an icon-plus-label tile grid inside a dropdown on desktop and a sheet on
- * mobile. Replaces the previous always-visible `PrimaryNav`.
+ * Consolidated header navigation. Renders the shared
+ * {@link PRIMARY_NAV_ITEMS} as an icon-plus-label tile grid inside a dropdown
+ * on desktop and a sheet on mobile, so it stays in sync with the mobile
+ * bottom navigation that consumes the same list.
  *
- * ヘッダーの機能ナビゲーションを集約したメニュー。Home / Notes（および将来追加分）を
- * 「アイコン+ラベル」のタイルとしてグリッド表示する。デスクトップはドロップダウン、
- * モバイルはシートで開く。常時表示だった従来の `PrimaryNav` を置き換える。
+ * ヘッダーの機能ナビゲーションを集約したメニュー。共通の {@link PRIMARY_NAV_ITEMS} を
+ * 「アイコン+ラベル」のタイルとしてグリッド表示し、デスクトップはドロップダウン、
+ * モバイルはシートで開く。モバイルのボトムナビと同じ配列を参照するため表示項目が常に一致する。
  */
 export const NavigationMenu: React.FC = () => {
   const isMobile = useIsMobile();

--- a/src/components/layout/navigationItems.test.ts
+++ b/src/components/layout/navigationItems.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for the shared primary navigation config. The header dropdown and
+ * mobile bottom navigation both consume {@link PRIMARY_NAV_ITEMS}, so this
+ * suite guards the canonical shape and entries.
+ *
+ * 共通のプライマリナビ設定 {@link PRIMARY_NAV_ITEMS} のテスト。ヘッダーのドロップダウンと
+ * モバイルのボトムナビが同じ配列を参照するため、型と項目内容の単一ソースを保証する。
+ */
+import { describe, it, expect } from "vitest";
+import { PRIMARY_NAV_ITEMS, isPrimaryNavActive, type PrimaryNavItem } from "./navigationItems";
+
+describe("PRIMARY_NAV_ITEMS", () => {
+  it("exposes Home, Notes, and AI as the canonical primary entries", () => {
+    const paths = PRIMARY_NAV_ITEMS.map((item) => item.path);
+    expect(paths).toEqual(["/home", "/notes", "/ai"]);
+  });
+
+  it("assigns an i18n key and an icon component to every entry", () => {
+    for (const item of PRIMARY_NAV_ITEMS) {
+      expect(item.i18nKey).toMatch(/^nav\./);
+      // lucide-react icons are forwardRef components, so `typeof` can be
+      // either "function" or "object" depending on React internals.
+      // lucide-react のアイコンは forwardRef コンポーネントで `typeof` が
+      // "function" にも "object" にもなり得るため、存在のみを検証する。
+      expect(item.icon).toBeTruthy();
+    }
+  });
+
+  it("uses unique paths across entries", () => {
+    const paths = PRIMARY_NAV_ITEMS.map((item) => item.path);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it("covers /ai, /ai/:conversationId, and /ai/history via matchPaths", () => {
+    const ai = PRIMARY_NAV_ITEMS.find((item) => item.path === "/ai");
+    expect(ai?.matchPaths).toEqual(["/ai", "/ai/:conversationId", "/ai/history"]);
+  });
+});
+
+describe("isPrimaryNavActive", () => {
+  const homeItem = PRIMARY_NAV_ITEMS.find((item) => item.path === "/home") as PrimaryNavItem;
+  const aiItem = PRIMARY_NAV_ITEMS.find((item) => item.path === "/ai") as PrimaryNavItem;
+
+  it("returns true when any matchPath matches the current pathname", () => {
+    expect(isPrimaryNavActive(aiItem, "/ai")).toBe(true);
+    expect(isPrimaryNavActive(aiItem, "/ai/conv-123")).toBe(true);
+    expect(isPrimaryNavActive(aiItem, "/ai/history")).toBe(true);
+  });
+
+  it("falls back to an exact path match when matchPaths is not provided", () => {
+    expect(isPrimaryNavActive(homeItem, "/home")).toBe(true);
+    expect(isPrimaryNavActive(homeItem, "/home/anything")).toBe(false);
+  });
+
+  it("returns false for unrelated pathnames", () => {
+    expect(isPrimaryNavActive(homeItem, "/notes")).toBe(false);
+    expect(isPrimaryNavActive(aiItem, "/settings")).toBe(false);
+  });
+});

--- a/src/components/layout/navigationItems.ts
+++ b/src/components/layout/navigationItems.ts
@@ -1,0 +1,62 @@
+import { Home, FileText, Sparkles } from "lucide-react";
+import { matchPath } from "react-router-dom";
+import type React from "react";
+
+/**
+ * One entry in the primary navigation. The header dropdown and the mobile
+ * bottom navigation both render the same list so the two surfaces stay in
+ * sync. User-menu / account entries are intentionally excluded; they live on
+ * the header avatar and the bottom nav "Me" tab respectively.
+ *
+ * プライマリナビゲーションの 1 項目。ヘッダーのドロップダウンとモバイルのボトムナビが
+ * 同じリストを参照するため、表示項目が常に一致する。ユーザーメニュー・アカウント関連は
+ * ここには含めず、引き続きヘッダーのアバターとボトムナビの Me タブに分離する。
+ */
+export interface PrimaryNavItem {
+  /** Link target. 遷移先パス。*/
+  path: string;
+  /** Icon component rendered in the tile / tab. タイルやタブに描画するアイコン。*/
+  icon: React.FC<{ className?: string }>;
+  /** i18n key for the label. ラベルの i18n キー。*/
+  i18nKey: string;
+  /**
+   * Additional pathname patterns that should mark this entry as the active
+   * tab. When omitted, only an exact match against {@link path} activates it.
+   *
+   * この項目をアクティブ扱いにする追加のパスパターン。未指定時は {@link path} と
+   * 完全一致した場合のみアクティブになる。
+   */
+  matchPaths?: readonly string[];
+}
+
+/**
+ * Canonical primary navigation items shared by the header dropdown and the
+ * mobile bottom navigation. Adding, removing, or reordering entries here
+ * updates both surfaces at once.
+ *
+ * ヘッダーのドロップダウンとモバイルボトムナビで共有する、プライマリナビの正本。
+ * 追加・削除・並び替えはこの配列だけを編集すれば両方のUIに反映される。
+ */
+export const PRIMARY_NAV_ITEMS: readonly PrimaryNavItem[] = [
+  { path: "/home", icon: Home, i18nKey: "nav.home" },
+  { path: "/notes", icon: FileText, i18nKey: "nav.notes" },
+  {
+    path: "/ai",
+    icon: Sparkles,
+    i18nKey: "nav.ai",
+    matchPaths: ["/ai", "/ai/:conversationId", "/ai/history"],
+  },
+] as const;
+
+/**
+ * Returns true when `pathname` should mark `item` as the active primary nav
+ * entry. Uses {@link PrimaryNavItem.matchPaths} when provided; otherwise
+ * falls back to an exact match against {@link PrimaryNavItem.path}.
+ *
+ * `pathname` が `item` をアクティブ扱いすべきかを返す。{@link PrimaryNavItem.matchPaths}
+ * があればそのいずれかにマッチ、無ければ {@link PrimaryNavItem.path} との完全一致を使う。
+ */
+export function isPrimaryNavActive(item: PrimaryNavItem, pathname: string): boolean {
+  const patterns = item.matchPaths ?? [item.path];
+  return patterns.some((pattern) => matchPath({ path: pattern, end: true }, pathname) != null);
+}


### PR DESCRIPTION
## 概要

ヘッダーのドロップダウンメニューとモバイルボトムナビゲーションで使用するプライマリナビゲーション項目（Home / Notes / AI）を、新しい共通モジュール `navigationItems.ts` に統一しました。これにより、両方の UI が常に同じ項目を表示するようになり、保守性が向上します。

## 変更点

- **新規ファイル**: `src/components/layout/navigationItems.ts`
  - `PrimaryNavItem` インターフェース：ナビゲーション項目の型定義
  - `PRIMARY_NAV_ITEMS` 定数：Home / Notes / AI の 3 項目を定義（AI は `/ai`、`/ai/:conversationId`、`/ai/history` にマッチ）
  - `isPrimaryNavActive()` 関数：現在のパスに基づいてナビ項目がアクティブかを判定

- **新規ファイル**: `src/components/layout/navigationItems.test.ts`
  - `PRIMARY_NAV_ITEMS` の構造と内容を検証するテスト
  - `isPrimaryNavActive()` の動作を検証するテスト

- **修正**: `src/components/layout/BottomNav/index.tsx`
  - ハードコードされたナビゲーション項目を削除
  - `PRIMARY_NAV_ITEMS` をループして動的にタブを生成
  - 複数の `useMatch()` 呼び出しを `useLocation()` と `isPrimaryNavActive()` に統一

- **修正**: `src/components/layout/Header/NavigationMenu.tsx`
  - ローカルの `NavEntry` インターフェースと `NAV_ENTRIES` 定数を削除
  - `PRIMARY_NAV_ITEMS` を参照するように変更
  - AI 項目がグリッドに含まれるようになった

- **修正**: `src/components/layout/BottomNav/BottomNav.test.tsx`
  - i18n モックを拡張（`nav.ai` キーを追加）
  - AI タブが `/ai/:conversationId` と `/ai/history` でもアクティブになることを検証するテストを追加

- **修正**: `src/components/layout/Header/NavigationMenu.test.tsx`
  - テストコメントを更新（AI 項目を含めるよう記述を修正）
  - AI リンクの表示と属性を検証するテストを追加

## 変更の種類

- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm test` または `vitest` を実行して、新規テストと既存テストがすべてパスすることを確認
2. ブラウザで以下を確認：
   - ヘッダーのナビゲーションメニューを開き、Home / Notes / AI の 3 項目が表示されること
   - モバイルボトムナビゲーションに Home / Notes / AI / Me の 4 タブが表示されること
   - `/ai`、`/ai/conv-123`、`/ai/history` のいずれかにアクセスしたとき、AI タブがアクティブ（`aria-current="page"`）になること

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新

https://claude.ai/code/session_01LA1B3Hqzh19zaU2oP3dEwL
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI as a primary navigation option, accessible from the bottom navigation bar and header menu. The AI section is properly highlighted when viewing AI-related routes.

* **Tests**
  * Updated navigation tests to include new AI entry and added comprehensive test coverage for shared navigation configuration and route-matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->