### PR TITLE
fix(layout): モバイルで TipTap エディタがスクロールできない問題を修正

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -48,7 +48,7 @@ export function AppLayout({ children }: AppLayoutProps) {
             : undefined
         }
       >
-        <main className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-y-auto overscroll-contain [-webkit-overflow-scrolling:touch]">
+        <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto overscroll-contain">
           {children}
         </main>
       </div>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -48,7 +48,7 @@ export function AppLayout({ children }: AppLayoutProps) {
             : undefined
         }
       >
-        <main className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        <main className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-y-auto overscroll-contain [-webkit-overflow-scrolling:touch]">
           {children}
         </main>
       </div>


### PR DESCRIPTION
## 概要

モバイル表示時に TipTap エディタを含むページコンテンツがスクロールできない問題を修正する。

## 変更点

- `AppLayout` の内側 `<main>` を `overflow-hidden` から `overflow-y-auto overscroll-contain [-webkit-overflow-scrolling:touch]` に変更。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## 原因と修正の方針

`AppLayout.tsx` のルート / 中間ラッパー / `<main>` の 3 層すべてが `overflow-hidden` となっており、スクロールコンテナが存在しなかった。一方 `PageEditorContent.tsx` の TipTap エディタは `min-h-[calc(100vh-200px)]` を指定しているため、モバイルの短いビューポートでは常にコンテンツが親を超える。結果としてはみ出し分が単純にクリップされ、タッチスクロール自体が発火しない状態になっていた。

`<main>` を唯一のスクロールコンテナに昇格させることで、`AppLayout.tsx` のコメントで既に約束されている「BottomNav 下までコンテンツをスクロールできる」挙動を実際に成立させる。`overscroll-contain` で背景へのスクロール伝播を防ぎ、iOS Safari 向けに `-webkit-overflow-scrolling: touch` で慣性スクロールを確保している。

#693 のレイアウト統合リファクタ時に抜け落ちたと思われる。

## テスト方法

1. モバイル幅 (例: Chrome DevTools の iPhone プロファイル、または実機) でアプリを開く。
2. 長文のページを開き、TipTap エディタの末尾付近にカーソルを置く／下方向にタッチスクロールする。
3. エディタを含むページ全体が縦方向にスクロールでき、BottomNav の下まで内容を読めることを確認する。
4. デスクトップ幅でも既存のスクロール挙動が変わっていないこと（ヘッダーが固定、`main` 内がスクロール）を確認する。

## チェックリスト

- [x] Lint/Format エラーがない（pre-commit フックを通過）
- [ ] テストがすべてパスする
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

<!-- Before/After のスクリーンショット -->

## 関連 Issue

<!-- Closes #xxx -->

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled vertical scrolling within the main content area.
  * Improved touch and overscroll behavior on mobile and WebKit browsers for smoother scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->