### PR TITLE
refactor(layout): let content scroll under BottomNav for backdrop-blur

### DIFF
--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -93,4 +93,45 @@ describe("AppLayout", () => {
     expect(style).toContain("--app-bottom-nav-height");
     expect(style).toContain("3.5rem");
   });
+
+  /**
+   * Regression: on mobile, the bottom-nav + safe-area padding must live on
+   * `<main>` (the scroll container), not on an intermediate wrapper. Putting
+   * it on the wrapper clips the scroll region at the top edge of the
+   * translucent BottomNav, which defeats its `backdrop-blur`.
+   *
+   * 回帰防止: モバイルでは BottomNav + safe-area 分の padding-bottom を
+   * スクロールコンテナである `<main>` 自身に持たせる。ラッパー側に置くと
+   * スクロール領域が BottomNav 上端で切り詰められ、`backdrop-blur` が機能
+   * しなくなる。
+   */
+  it("puts bottom-nav + safe-area padding on <main> (scroll container), not on its wrapper, on mobile", () => {
+    vi.mocked(useIsMobile).mockReturnValue(true);
+    render(
+      <AppLayout>
+        <p>Main content</p>
+      </AppLayout>,
+    );
+    const main = screen.getByRole("main");
+    const mainStyle = main.getAttribute("style") ?? "";
+    expect(mainStyle).toContain("padding-bottom");
+    expect(mainStyle).toContain("--app-bottom-nav-height");
+    expect(mainStyle).toContain("env(safe-area-inset-bottom)");
+
+    const wrapper = main.parentElement;
+    const wrapperStyle = wrapper?.getAttribute("style") ?? "";
+    expect(wrapperStyle).not.toContain("padding-bottom");
+  });
+
+  it("does not set an inline padding-bottom on <main> on desktop", () => {
+    vi.mocked(useIsMobile).mockReturnValue(false);
+    render(
+      <AppLayout>
+        <p>Main content</p>
+      </AppLayout>,
+    );
+    const main = screen.getByRole("main");
+    const mainStyle = main.getAttribute("style") ?? "";
+    expect(mainStyle).not.toContain("padding-bottom");
+  });
 });

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -32,23 +32,28 @@ export function AppLayout({ children }: AppLayoutProps) {
     >
       <Header />
       {/* min-h-0: flex 子が親より伸びてページ全体がスクロールするのを防ぐ。
-          モバイルでは BottomNav が fixed で main の下端に被さるため、
-          padding-bottom で BottomNav 分（safe-area 含む）の余白を確保する。
-          On mobile, BottomNav is `position: fixed` and overlays the bottom of
-          `<main>`, so reserve that height (plus the safe-area inset) as
-          padding-bottom to keep page content scrollable past the nav. */}
-      <div
-        className="flex min-h-0 flex-1 overflow-hidden"
-        style={
-          isMobile
-            ? {
-                paddingBottom:
-                  "calc(var(--app-bottom-nav-height, 3.5rem) + env(safe-area-inset-bottom))",
-              }
-            : undefined
-        }
-      >
-        <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto overscroll-contain">
+          BottomNav は fixed で `<main>` の下端に被さる。ラッパーで
+          padding-bottom を確保するとスクロール領域が BottomNav の上端で
+          切り詰められ、backdrop-blur の下にコンテンツが流れ込まない。
+          スクロール範囲はビューポート下端まで伸ばし、最終行が nav に
+          常時隠れないよう `<main>` 側に padding-bottom を持たせる。
+          `<main>` is the scroll container; keep its scroll range running
+          all the way to the viewport bottom so content passes under the
+          translucent BottomNav and gets blurred. Put the bottom-nav +
+          safe-area padding on `<main>` itself so the last line still
+          settles above the nav instead of being clipped behind it. */}
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <main
+          className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto overscroll-contain"
+          style={
+            isMobile
+              ? {
+                  paddingBottom:
+                    "calc(var(--app-bottom-nav-height, 3.5rem) + env(safe-area-inset-bottom))",
+                }
+              : undefined
+          }
+        >
           {children}
         </main>
       </div>


### PR DESCRIPTION
## Summary

- Drops the `padding-bottom` from the wrapper around `<main>` in [AppLayout.tsx](src/components/layout/AppLayout.tsx) and moves the same `calc(var(--app-bottom-nav-height) + env(safe-area-inset-bottom))` padding onto `<main>` itself (the scroll container).
- Lets scroll content pass **under** the translucent `BottomNav` so its `backdrop-blur` is actually visible as you scroll — the previous wrapper padding clipped the scroll region at the top edge of the nav, so nothing ever scrolled underneath.
- Keeps the last line reachable above the nav (content isn't permanently hidden behind it) thanks to the padding now living on `<main>`.
- Preserves the scroll fix from [#694](https://github.com/otomatty/zedi/pull/694): `<main>` remains the `overflow-y-auto overscroll-contain` scroll container. This PR is layered on top of #694; once #694 merges, the diff here reduces to just the padding move + tests + comment update.
- Desktop is a no-op: `--app-bottom-nav-height` is `0px` there, so the padding collapses to `env(safe-area-inset-bottom)` — same effective behavior as before.

Context: review comment from gemini-code-assist on [#694](https://github.com/otomatty/zedi/pull/694) pointed out that the backdrop-blur never actually blurs anything because the parent wrapper's `padding-bottom` truncates the scroll range at the nav's top edge.

### BottomNav translucency
`BottomNav` ([`src/components/layout/BottomNav/index.tsx:37`](src/components/layout/BottomNav/index.tsx:37)) already has `bg-background/95 supports-[backdrop-filter]:bg-background/80 ... backdrop-blur`, so no change was needed there — the translucent + blur layer was just never being exercised.

### Tests

Added two regression tests in [AppLayout.test.tsx](src/components/layout/AppLayout.test.tsx):
- On mobile, `padding-bottom` must live on `<main>` (the scroll container) with both `--app-bottom-nav-height` and `env(safe-area-inset-bottom)`, and must NOT be on the intermediate wrapper.
- On desktop, `<main>` must NOT carry an inline `padding-bottom` (the wrapper collapses to zero and safe-area handling is delegated to Tailwind utilities on the actual content where needed).

## Test plan

- [x] `bun x vitest run src/components/layout/AppLayout.test.tsx` — 7/7 pass
- [x] `bun x eslint` on the two changed files — clean
- [x] `bun x prettier --check` on the two changed files — clean
- [ ] **Manual verification on mobile viewport (Chrome DevTools iPhone profile):**
  - [ ] Open a long note with TipTap editor on a mobile viewport
  - [ ] Scroll to the bottom — last line should be reachable above the BottomNav (not permanently hidden behind it)
  - [ ] While scrolling, content passing under the BottomNav should be visibly blurred through the `backdrop-blur` layer
  - [ ] iOS safe-area (home-bar) padding should still be respected at the bottom
- [ ] Sanity-check desktop: no BottomNav, `<main>` has no inline `padding-bottom`, scrolling unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile scrolling so content no longer gets clipped by the fixed bottom navigation; safe-area insets and bottom padding are now applied where needed.

* **Tests**
  * Added regression tests verifying mobile and desktop layout behavior and correct application of bottom padding for safe-area handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->