### PR TITLE
fix(layout): モバイルで TipTap エディタがスクロールできない問題を再修正

### DIFF
--- a/src/components/ai-chat/ContentWithAIChat.tsx
+++ b/src/components/ai-chat/ContentWithAIChat.tsx
@@ -80,7 +80,13 @@ export function ContentWithAIChat({
   if (isMobile) {
     return (
       <>
-        {children}
+        {/* モバイル用スクロールコンテナ。PageEditorLayout が overflow-hidden の
+            flex-col であるため、ここで overflow-y-auto を付けないと TipTap など
+            の子コンテンツがクリップされ、タッチスクロールが効かなくなる。
+            Mobile scroll container. PageEditorLayout is a flex-col with
+            overflow-hidden, so without this wrapper child content (e.g. the
+            TipTap editor) gets clipped and touch scrolling does not engage. */}
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">{children}</div>
         {floatingAction && (
           <div
             className="pointer-events-none fixed right-0 bottom-0 z-40 flex flex-col items-end gap-1 p-2 pr-[env(safe-area-inset-right)]"

--- a/src/components/ai-chat/ContentWithAIChat.tsx
+++ b/src/components/ai-chat/ContentWithAIChat.tsx
@@ -80,13 +80,17 @@ export function ContentWithAIChat({
   if (isMobile) {
     return (
       <>
-        {/* モバイル用スクロールコンテナ。PageEditorLayout が overflow-hidden の
-            flex-col であるため、ここで overflow-y-auto を付けないと TipTap など
-            の子コンテンツがクリップされ、タッチスクロールが効かなくなる。
-            Mobile scroll container. PageEditorLayout is a flex-col with
-            overflow-hidden, so without this wrapper child content (e.g. the
-            TipTap editor) gets clipped and touch scrolling does not engage. */}
-        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">{children}</div>
+        {/* モバイル用スクロールコンテナ。親が overflow-hidden の flex-col の
+            場合に子コンテンツ（エディタ等）がクリップされるのを防ぎ、タッチ
+            スクロールを可能にする。`relative` は絶対位置指定された子要素
+            （BubbleMenu 等）のコンテナイングブロックとするために付与し、
+            デスクトップ分岐とも揃える。
+            Mobile scroll container. Prevents child content (e.g. the editor)
+            from being clipped when the parent is an overflow-hidden flex-col,
+            and enables touch scrolling. `relative` makes this the containing
+            block for absolutely-positioned descendants (e.g. the BubbleMenu),
+            matching the desktop branch. */}
+        <div className="relative min-h-0 flex-1 overflow-y-auto overscroll-contain">{children}</div>
         {floatingAction && (
           <div
             className="pointer-events-none fixed right-0 bottom-0 z-40 flex flex-col items-end gap-1 p-2 pr-[env(safe-area-inset-right)]"


### PR DESCRIPTION
## 概要

#694 では AppLayout 内側の `<main>` を `overflow-y-auto` にしたが、その内側にある `PageEditorLayout`（`overflow-hidden` な flex-col）のために、モバイル環境では TipTap のコンテンツ（`min-h-[calc(100vh-200px)]`）がクリップされ、タッチスクロールが効かない状態のままだった。

デスクトップでは [`ContentWithAIChat`](src/components/ai-chat/ContentWithAIChat.tsx) が children を `overflow-y-auto` な div でラップしているが、モバイル分岐は Fragment のまま children を返していたため、`PageEditorLayout` 内部にスクロール可能な領域が存在しなかった。

ContentWithAIChat のモバイル分岐にもデスクトップと同様のスクロールコンテナを追加することで再修正する。

## 変更点

- [src/components/ai-chat/ContentWithAIChat.tsx](src/components/ai-chat/ContentWithAIChat.tsx) のモバイル分岐で、`{children}` を `<div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">` でラップ
- アプリシェルのプルリフレッシュ誤爆を防ぐため `overscroll-contain` を付与（#694 と同ポリシー）

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. モバイル実機、または DevTools のモバイルエミュレーションでノート編集画面を開く
2. 本文を十分な長さまで入力し、指でスワイプ（またはタッチエミュレーション）してエディタがスクロールすること
3. カーソル移動（Enter 連打や最終行への入力）で自動スクロールすること
4. スクロール時に BottomNav の下に本文が隠れないこと
5. デスクトップでは従来通りスクロールでき、AI チャットパネル開閉でレイアウト崩れがないこと

## チェックリスト

- [x] テストがすべてパスする（`PageEditorLayout.test.tsx` 5/5 pass）
- [x] Lint エラーがない（既存の警告のみ、errors は 0）
- [ ] 必要に応じてドキュメントを更新した（不要）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue / PR

- 再修正対象: #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile chat layout: content is now placed inside a dedicated scrollable container on mobile, yielding smoother vertical scrolling, proper touch behavior, and correct positioning for overlay elements (e.g., bubble menus). Desktop behavior and existing floating action/drawer interactions remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->