### PR TITLE
feat(ui): mobile header search padding and PageHeader tweaks

### DIFF
--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -79,7 +79,7 @@ describe("AppLayout", () => {
     expect(screen.getByTestId("bottom-nav")).toBeInTheDocument();
   });
 
-  it("sets mobile layout CSS variables (--app-header-height: 3rem, --app-bottom-nav-height: 3.5rem)", () => {
+  it("sets mobile layout CSS variables (--app-header-height: 3.5rem, --app-bottom-nav-height: 3.5rem)", () => {
     vi.mocked(useIsMobile).mockReturnValue(true);
     const { container } = render(
       <AppLayout>
@@ -88,10 +88,8 @@ describe("AppLayout", () => {
     );
     const wrapper = container.firstElementChild as HTMLElement | null;
     const style = wrapper?.getAttribute("style") ?? "";
-    expect(style).toContain("--app-header-height");
-    expect(style).toContain("3rem");
-    expect(style).toContain("--app-bottom-nav-height");
-    expect(style).toContain("3.5rem");
+    expect(style).toMatch(/--app-header-height:\s*3\.5rem/);
+    expect(style).toMatch(/--app-bottom-nav-height:\s*3\.5rem/);
   });
 
   /**

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -24,7 +24,7 @@ export function AppLayout({ children }: AppLayoutProps) {
       className="flex h-svh min-h-0 flex-col overflow-hidden"
       style={
         {
-          "--app-header-height": isMobile ? "3rem" : "4.5rem",
+          "--app-header-height": isMobile ? "3.5rem" : "4.5rem",
           "--app-bottom-nav-height": isMobile ? "3.5rem" : "0px",
           "--ai-chat-width": "22rem",
         } as React.CSSProperties

--- a/src/components/layout/MobileHeader.test.tsx
+++ b/src/components/layout/MobileHeader.test.tsx
@@ -1,10 +1,10 @@
 /**
- * MobileHeader: compact h-12 title bar that shows ONLY the search bar inline.
+ * MobileHeader: compact h-14 title bar that shows ONLY the search bar inline.
  * The logo, the search-sheet toggle, and the legacy desktop widgets
  * (NavigationMenu / UnifiedMenu) must NOT render — their roles have moved
  * to the bottom nav.
  *
- * モバイルヘッダー: h-12 のタイトルバーに検索バーのみをインラインで描画する。
+ * モバイルヘッダー: h-14 のタイトルバーに検索バーのみをインラインで描画する。
  * ロゴ・検索 Sheet のトグル・既存のデスクトップウィジェット（NavigationMenu /
  * UnifiedMenu）は描画されない（役割はボトムナビへ移動）。
  */
@@ -58,11 +58,11 @@ function renderHeader() {
 }
 
 describe("MobileHeader", () => {
-  it("renders a compact h-12 sticky title bar", () => {
+  it("renders a compact h-14 sticky title bar", () => {
     const { container } = renderHeader();
     const header = container.querySelector("header");
     expect(header).toBeInTheDocument();
-    expect(header?.className).toMatch(/h-12/);
+    expect(header?.className).toMatch(/h-14/);
     expect(header?.className).toMatch(/sticky/);
   });
 
@@ -124,7 +124,7 @@ describe("MobileHeader", () => {
     // caught.
     const header = container.querySelector("header");
     expect(header).toBeInTheDocument();
-    expect(header?.className).toMatch(/h-12/);
+    expect(header?.className).toMatch(/h-14/);
     vi.doUnmock("@/contexts/GlobalSearchContext");
   });
 });

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -11,13 +11,16 @@ interface MobileHeaderProps {
 /**
  * Compact mobile title bar that shows ONLY the search bar inline. Navigation,
  * AI toggle, and the user menu have moved to the bottom nav, so this bar
- * stays deliberately minimal (h-12) and surfaces the single most-used input
- * without an extra tap through a Sheet.
+ * stays deliberately minimal (h-14) and surfaces the single most-used input
+ * without an extra tap through a Sheet. The slight vertical padding around
+ * the h-12 search input prevents the bar from feeling cramped on small
+ * viewports.
  *
  * モバイル用のコンパクトなタイトルバー。検索バーのみをインラインで表示する。
  * ナビゲーション・AI 開閉・ユーザーメニューはボトムナビへ移譲済みのため、
- * 高さ h-12 を維持しつつ、最も利用頻度の高い検索を Sheet を介さず直接操作で
- * きるようにしている。
+ * 高さ h-14 を維持しつつ、最も利用頻度の高い検索を Sheet を介さず直接操作で
+ * きるようにしている。h-12 の検索入力の上下にわずかな余白を持たせて、
+ * 小さなビューポートでも詰まった印象にならないようにしている。
  */
 export const MobileHeader: React.FC<MobileHeaderProps> = ({ className }) => {
   const searchContext = useGlobalSearchContextOptional();
@@ -26,14 +29,14 @@ export const MobileHeader: React.FC<MobileHeaderProps> = ({ className }) => {
   return (
     <header
       className={cn(
-        "border-border sticky top-0 z-50 h-12 border-b",
+        "border-border sticky top-0 z-50 h-14 border-b",
         "bg-background/95 supports-[backdrop-filter]:bg-background/60 backdrop-blur",
         className,
       )}
     >
-      <Container className="flex h-12 items-center">
+      <Container className="flex h-14 items-center">
         {hasSearchContext && (
-          <div className="min-w-0 flex-1">
+          <div className="min-w-0 flex-1 py-1">
             <HeaderSearchBar />
           </div>
         )}

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ArrowLeft } from "lucide-react";
 import { Link } from "react-router-dom";
-import { Button, cn } from "@zedi/ui";
+import { Button } from "@zedi/ui";
 import Container from "@/components/layout/Container";
 
 /**
@@ -42,13 +42,24 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
   className,
 }) => {
   return (
-    <div className={cn("border-border/60 border-b", className)}>
+    <div className={className}>
       <Container className="flex min-h-14 flex-wrap items-center justify-between gap-3 py-2">
         <div className="flex min-w-0 items-center gap-3">
           {backTo && (
-            <Button asChild variant="ghost" size="icon" className="shrink-0">
+            <Button
+              asChild
+              variant="ghost"
+              size="icon"
+              // Override `size="icon"` (h-10 w-10) and the base `[&_svg]:size-4`
+              // so the back button is a touch larger and easier to tap on
+              // mobile without dwarfing neighbouring controls.
+              // `size="icon"`（h-10 w-10）と基底の `[&_svg]:size-4` を上書きし、
+              // 戻るボタンを少し大きくしてモバイルでもタップしやすくする。
+              // ただし周囲のコントロールを圧倒しない程度に抑える。
+              className="h-11 w-11 shrink-0 [&_svg]:size-6"
+            >
               <Link to={backTo} aria-label={backLabel}>
-                <ArrowLeft className="h-5 w-5" aria-hidden />
+                <ArrowLeft aria-hidden />
               </Link>
             </Button>
           )}


### PR DESCRIPTION
## 概要

モバイルのトップバーで検索バー周りに上下の余白を追加し、`--app-header-height` を実際のヘッダー高さ（3.5rem）に合わせました。`PageHeader` の戻るボタンを少し大きくし、サブヘッダー直下の下線（`border-b`）を削除しました。

## 変更点

- `src/components/layout/MobileHeader.tsx` — ヘッダーを `h-14` にし、検索ラッパーに `py-1` を付与して検索入力の上下に余白を確保
- `src/components/layout/MobileHeader.test.tsx` — 高さ `h-14` に合わせてテストを更新
- `src/components/layout/AppLayout.tsx` — モバイル時の `--app-header-height` を `3rem` → `3.5rem` に変更（`develop` 側のレイアウト変更とマージ済み）
- `src/components/layout/AppLayout.test.tsx` — 上記 CSS 変数の期待値を更新
- `src/components/layout/PageHeader.tsx` — ルートの `border-b` を削除、戻るボタンを `h-11 w-11`・アイコン `size-6` に調整

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. モバイル幅（または DevTools のデバイスモード）でアプリを開き、トップの検索バー上下に適度な余白があることを確認する
2. `backTo` 付きのページ（設定・料金・寄付など）で `PageHeader` の戻るボタンが従来より少し大きく、サブヘッダー直下に横線が出ていないことを確認する

## チェックリスト

- [x] テストがすべてパスする（対象: `MobileHeader.test.tsx`, `AppLayout.test.tsx`）
- [x] Lint エラーがない（`bun run lint` は既存警告のみ）
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

<!-- レビュー時にモバイルの Before/After を添付推奨 -->

## 関連 Issue

<!-- なし -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Mobile header height increased to provide better visual spacing and overall balance in the application
  * Back-button styling enhanced with improved sizing for better accessibility in page headers
  * Header layout spacing and element positioning adjusted throughout mobile views for improved visual consistency
  * Overall header appearance and proportions refined across the application for a more polished user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->