### PR TITLE
fix(db): make 0015 note_members migration idempotent

### DIFF
--- a/server/api/drizzle/0015_add_note_members_status_accepted_user.sql
+++ b/server/api/drizzle/0015_add_note_members_status_accepted_user.sql
@@ -38,14 +38,34 @@
 -- `bunx drizzle-kit migrate` が落ち、`Deploy Development` が継続的に失敗していた。
 --
 -- 重要な設計ポイント (PR #698 のレビュー指摘に対応):
--- バックフィル `UPDATE` は **このマイグレーションがカラムを実際に新規作成した
--- ときだけ** 走らせる。事前に手動でカラムが追加されていた dev のような環境では
--- アプリ (`POST /notes/:id/members` など) が既に `status='pending'` で本物の
--- 未受諾招待を書き込んでいる可能性があり、レガシー行と区別できないため、状態だけ
--- を見て一律 `accepted` に昇格させると本物の招待を勝手に承諾扱いにし、
--- `pageAccessService` が即座にアクセスを許可してしまう。事前カラム追加環境での
+-- バックフィル `UPDATE` の発火条件は次の対称ガードとする:
+--   IF NOT (status_existed AND accepted_user_id_existed) THEN ...
+-- すなわち「**このマイグレーションが少なくともどちらか片方のカラムを新規作成した
+-- ときだけ** バックフィルを走らせる」。アプリの schema (`server/api/src/schema/notes.ts`)
+-- と `INSERT ... ON CONFLICT DO UPDATE` (`routes/notes/crud.ts`) は両カラムを
+-- 同時に参照するので、片方でも欠けていればアプリの INSERT は `42703` で失敗し、
+-- その状態で生まれた `note_members` 行は存在しない。よって両方が事前から揃って
+-- いた dev 系環境を除き、未削除行はすべてレガシー扱いで安全にバックフィルできる。
+--
+-- 反対に「両カラムとも事前に追加されていた」環境では、アプリ
+-- (`POST /notes/:id/members` など) が既に `status='pending'` で本物の未受諾
+-- 招待を書き込んでいる可能性があり、レガシー行と区別できないため、状態だけを
+-- 見て一律 `accepted` に昇格させると本物の招待を勝手に承諾扱いにし、
+-- `pageAccessService` が即座にアクセスを許可してしまう。事前カラム追加環境の
 -- レガシー行整合は、運用側がカットオフ時刻を把握しているので別途 ad-hoc な
 -- `UPDATE` で対応する想定。
+--
+-- 加えて `accepted_user_id` の更新は `COALESCE(nm."accepted_user_id", ...)`
+-- で既存値を優先し、たとえ片方先行追加された環境で何らかの値が入っていても
+-- 上書きしない（防御的措置）。
+--
+-- 4 ケース表:
+--   status_existed | accepted_user_id_existed | 動作
+--   ---------------+--------------------------+--------------------------------
+--   false          | false                    | バックフィル実行 (prod 想定)
+--   false          | true                     | バックフィル実行 (非対称・防御)
+--   true           | false                    | バックフィル実行 (非対称・防御)
+--   true           | true                     | スキップ (dev 想定)
 --
 -- This migration is idempotent.
 -- The dev DB had `status` / `accepted_user_id` added manually before this
@@ -53,15 +73,35 @@
 -- crash with `42701` and broke `Deploy Development` on every push.
 --
 -- Important design point (addresses PR #698 review feedback):
--- The legacy backfill `UPDATE` only runs when **this migration actually creates
--- the columns**. In environments where the columns were hot-added before the
--- migration (e.g. dev), the application has been writing real `status='pending'`
--- rows for genuine unaccepted invites via `POST /notes/:id/members`. Those rows
--- are indistinguishable from legacy pre-column rows by state alone, so blindly
--- promoting them to `accepted` would silently grant access through
--- `pageAccessService` before the invitee actually accepted. Operators on such
--- environments must run a targeted backfill out of band using a known cutoff
--- timestamp instead.
+-- The legacy backfill `UPDATE` runs when at least one of the two columns was
+-- newly created by this migration:
+--   IF NOT (status_existed AND accepted_user_id_existed) THEN ...
+-- The application schema (`server/api/src/schema/notes.ts`) and the
+-- `INSERT ... ON CONFLICT DO UPDATE` in `routes/notes/crud.ts` reference both
+-- columns together, so if either one was missing the app's INSERT would have
+-- failed with `42703` and no `note_members` row could have been written under
+-- that state. So unless BOTH columns were present before this migration, every
+-- non-deleted row is legacy and safe to backfill.
+--
+-- Conversely, when BOTH columns existed before, the app may already have
+-- written real `status='pending'` rows for genuine unaccepted invites via
+-- `POST /notes/:id/members`. Those rows are indistinguishable from legacy
+-- pre-column rows by state alone, so blindly promoting them to `accepted`
+-- would silently grant access through `pageAccessService` before the invitee
+-- actually accepted. Operators on such environments must run a targeted
+-- backfill out of band using a known cutoff timestamp instead.
+--
+-- The `accepted_user_id` assignment is wrapped in `COALESCE` to preserve any
+-- preexisting value (defensive: handles the unlikely asymmetric case where
+-- one column was hot-added with non-NULL data).
+--
+-- Truth table:
+--   status_existed | accepted_user_id_existed | action
+--   ---------------+--------------------------+----------------------------
+--   false          | false                    | backfill (prod path)
+--   false          | true                     | backfill (asymmetric, safe)
+--   true           | false                    | backfill (asymmetric, safe)
+--   true           | true                     | skip (dev path)
 
 DO $$
 DECLARE
@@ -94,22 +134,28 @@ BEGIN
             ADD COLUMN "accepted_user_id" text;
     END IF;
 
-    -- Only backfill when WE just created both columns. If either column already
-    -- existed, the application has been writing real `pending`/`accepted`/
-    -- `declined` values to it, and rows where `status = 'pending' AND
-    -- accepted_user_id IS NULL` could be EITHER pre-column legacy rows OR
-    -- genuine unaccepted invites. Promoting all of them to `accepted` would
-    -- silently grant access. Skip the backfill in that case and let operators
-    -- run a targeted UPDATE with a known legacy cutoff out of band.
-    IF NOT status_existed AND NOT accepted_user_id_existed THEN
+    -- Backfill when at least one of the two columns was newly added by this
+    -- migration. The application's `INSERT ... ON CONFLICT DO UPDATE`
+    -- references both columns together, so if either was missing the app
+    -- could not have inserted any state-machine row, and every existing
+    -- non-deleted row is legacy. Only when BOTH columns pre-existed (the
+    -- documented dev case) might `status = 'pending'` rows include genuine
+    -- unaccepted invites; in that case we skip and defer to operators.
+    --
+    -- `COALESCE` preserves any preexisting `accepted_user_id` value so we
+    -- never overwrite real data with a (possibly-NULL) email lookup result.
+    IF NOT (status_existed AND accepted_user_id_existed) THEN
         UPDATE "note_members" AS nm
         SET
             "status" = 'accepted',
-            "accepted_user_id" = (
-                SELECT u."id"
-                FROM "user" AS u
-                WHERE LOWER(u."email") = LOWER(nm."member_email")
-                LIMIT 1
+            "accepted_user_id" = COALESCE(
+                nm."accepted_user_id",
+                (
+                    SELECT u."id"
+                    FROM "user" AS u
+                    WHERE LOWER(u."email") = LOWER(nm."member_email")
+                    LIMIT 1
+                )
             )
         WHERE nm."is_deleted" = false;
     END IF;

--- a/server/api/drizzle/0015_add_note_members_status_accepted_user.sql
+++ b/server/api/drizzle/0015_add_note_members_status_accepted_user.sql
@@ -30,9 +30,19 @@
 -- these columns, but no migration ever added them, so production hit
 -- `42703 column "status" of relation "note_members" does not exist` on
 -- every `POST /api/notes`.
+--
+-- このマイグレーションは冪等 (`IF NOT EXISTS` / 制約存在チェック) になっている。
+-- 一部の環境 (特に dev) では本マイグレーション追加前に `note_members.status` /
+-- `note_members.accepted_user_id` カラムを手動で追加していたため、素朴な
+-- `ALTER TABLE ... ADD COLUMN` だと `42701 column ... already exists` で
+-- `bunx drizzle-kit migrate` が落ち、`Deploy Development` が継続的に失敗していた。
+-- This migration is idempotent (`IF NOT EXISTS` and constraint existence check).
+-- The dev DB had `status` / `accepted_user_id` added manually before this
+-- migration was committed, which made the original `ALTER TABLE ... ADD COLUMN`
+-- crash with `42701` and broke `Deploy Development` on every push.
 
-ALTER TABLE "note_members" ADD COLUMN "status" text DEFAULT 'pending' NOT NULL;--> statement-breakpoint
-ALTER TABLE "note_members" ADD COLUMN "accepted_user_id" text;--> statement-breakpoint
+ALTER TABLE "note_members" ADD COLUMN IF NOT EXISTS "status" text DEFAULT 'pending' NOT NULL;--> statement-breakpoint
+ALTER TABLE "note_members" ADD COLUMN IF NOT EXISTS "accepted_user_id" text;--> statement-breakpoint
 UPDATE "note_members" AS nm
 SET
     "status" = 'accepted',
@@ -42,7 +52,18 @@ SET
         WHERE LOWER(u."email") = LOWER(nm."member_email")
         LIMIT 1
     )
-WHERE nm."is_deleted" = false;--> statement-breakpoint
-ALTER TABLE "note_members"
-    ADD CONSTRAINT "note_members_accepted_user_id_user_id_fk"
-    FOREIGN KEY ("accepted_user_id") REFERENCES "user"("id") ON DELETE set null ON UPDATE no action;
+WHERE nm."is_deleted" = false
+  AND nm."status" = 'pending'
+  AND nm."accepted_user_id" IS NULL;--> statement-breakpoint
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'note_members_accepted_user_id_user_id_fk'
+    ) THEN
+        ALTER TABLE "note_members"
+            ADD CONSTRAINT "note_members_accepted_user_id_user_id_fk"
+            FOREIGN KEY ("accepted_user_id") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+    END IF;
+END$$;

--- a/server/api/drizzle/0015_add_note_members_status_accepted_user.sql
+++ b/server/api/drizzle/0015_add_note_members_status_accepted_user.sql
@@ -31,39 +31,103 @@
 -- `42703 column "status" of relation "note_members" does not exist` on
 -- every `POST /api/notes`.
 --
--- このマイグレーションは冪等 (`IF NOT EXISTS` / 制約存在チェック) になっている。
+-- このマイグレーションは冪等にしてある。
 -- 一部の環境 (特に dev) では本マイグレーション追加前に `note_members.status` /
 -- `note_members.accepted_user_id` カラムを手動で追加していたため、素朴な
 -- `ALTER TABLE ... ADD COLUMN` だと `42701 column ... already exists` で
 -- `bunx drizzle-kit migrate` が落ち、`Deploy Development` が継続的に失敗していた。
--- This migration is idempotent (`IF NOT EXISTS` and constraint existence check).
+--
+-- 重要な設計ポイント (PR #698 のレビュー指摘に対応):
+-- バックフィル `UPDATE` は **このマイグレーションがカラムを実際に新規作成した
+-- ときだけ** 走らせる。事前に手動でカラムが追加されていた dev のような環境では
+-- アプリ (`POST /notes/:id/members` など) が既に `status='pending'` で本物の
+-- 未受諾招待を書き込んでいる可能性があり、レガシー行と区別できないため、状態だけ
+-- を見て一律 `accepted` に昇格させると本物の招待を勝手に承諾扱いにし、
+-- `pageAccessService` が即座にアクセスを許可してしまう。事前カラム追加環境での
+-- レガシー行整合は、運用側がカットオフ時刻を把握しているので別途 ad-hoc な
+-- `UPDATE` で対応する想定。
+--
+-- This migration is idempotent.
 -- The dev DB had `status` / `accepted_user_id` added manually before this
 -- migration was committed, which made the original `ALTER TABLE ... ADD COLUMN`
 -- crash with `42701` and broke `Deploy Development` on every push.
+--
+-- Important design point (addresses PR #698 review feedback):
+-- The legacy backfill `UPDATE` only runs when **this migration actually creates
+-- the columns**. In environments where the columns were hot-added before the
+-- migration (e.g. dev), the application has been writing real `status='pending'`
+-- rows for genuine unaccepted invites via `POST /notes/:id/members`. Those rows
+-- are indistinguishable from legacy pre-column rows by state alone, so blindly
+-- promoting them to `accepted` would silently grant access through
+-- `pageAccessService` before the invitee actually accepted. Operators on such
+-- environments must run a targeted backfill out of band using a known cutoff
+-- timestamp instead.
 
-ALTER TABLE "note_members" ADD COLUMN IF NOT EXISTS "status" text DEFAULT 'pending' NOT NULL;--> statement-breakpoint
-ALTER TABLE "note_members" ADD COLUMN IF NOT EXISTS "accepted_user_id" text;--> statement-breakpoint
-UPDATE "note_members" AS nm
-SET
-    "status" = 'accepted',
-    "accepted_user_id" = (
-        SELECT u."id"
-        FROM "user" AS u
-        WHERE LOWER(u."email") = LOWER(nm."member_email")
-        LIMIT 1
-    )
-WHERE nm."is_deleted" = false
-  AND nm."status" = 'pending'
-  AND nm."accepted_user_id" IS NULL;--> statement-breakpoint
 DO $$
+DECLARE
+    status_existed              boolean;
+    accepted_user_id_existed    boolean;
 BEGIN
+    SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'note_members'
+          AND column_name = 'status'
+    ) INTO status_existed;
+
+    SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'note_members'
+          AND column_name = 'accepted_user_id'
+    ) INTO accepted_user_id_existed;
+
+    IF NOT status_existed THEN
+        ALTER TABLE "note_members"
+            ADD COLUMN "status" text DEFAULT 'pending' NOT NULL;
+    END IF;
+
+    IF NOT accepted_user_id_existed THEN
+        ALTER TABLE "note_members"
+            ADD COLUMN "accepted_user_id" text;
+    END IF;
+
+    -- Only backfill when WE just created both columns. If either column already
+    -- existed, the application has been writing real `pending`/`accepted`/
+    -- `declined` values to it, and rows where `status = 'pending' AND
+    -- accepted_user_id IS NULL` could be EITHER pre-column legacy rows OR
+    -- genuine unaccepted invites. Promoting all of them to `accepted` would
+    -- silently grant access. Skip the backfill in that case and let operators
+    -- run a targeted UPDATE with a known legacy cutoff out of band.
+    IF NOT status_existed AND NOT accepted_user_id_existed THEN
+        UPDATE "note_members" AS nm
+        SET
+            "status" = 'accepted',
+            "accepted_user_id" = (
+                SELECT u."id"
+                FROM "user" AS u
+                WHERE LOWER(u."email") = LOWER(nm."member_email")
+                LIMIT 1
+            )
+        WHERE nm."is_deleted" = false;
+    END IF;
+
+    -- PostgreSQL has no `ADD CONSTRAINT IF NOT EXISTS`, so check `pg_constraint`
+    -- scoped to the target table (`conrelid`) to avoid false positives from
+    -- same-named constraints elsewhere in the catalog.
     IF NOT EXISTS (
         SELECT 1
         FROM pg_constraint
         WHERE conname = 'note_members_accepted_user_id_user_id_fk'
+          AND conrelid = '"note_members"'::regclass
     ) THEN
         ALTER TABLE "note_members"
             ADD CONSTRAINT "note_members_accepted_user_id_user_id_fk"
-            FOREIGN KEY ("accepted_user_id") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+            FOREIGN KEY ("accepted_user_id")
+            REFERENCES "user"("id")
+            ON DELETE SET NULL
+            ON UPDATE NO ACTION;
     END IF;
 END$$;


### PR DESCRIPTION
## 概要

PR #692 (`af8f847`) のマージ以降、`Deploy Development` ワークフローが `develop` への push のたびに毎回失敗し、dev フロントが #692 以降 1 度もロールアウトできていなかった問題を修正する。

直接の原因は `server/api/drizzle/0015_add_note_members_status_accepted_user.sql` の最初のステートメント:

```sql
ALTER TABLE "note_members" ADD COLUMN "status" text DEFAULT 'pending' NOT NULL;
```

が development DB では `42701 column "status" of relation "note_members" already exists` で落ちることだった。dev DB は #692 を作る前の障害対応で、当該カラムが手動で先行追加されており、Drizzle の `__drizzle_migrations` 側に `0015` が記録されていない状態になっていた。マイグレーションは原子的なので、最初の `ALTER` で失敗するとジャーナルへの記録もされず、`develop` への push があるたびに `migrate` ジョブが同じ `0015` を再実行 → 同じエラーで失敗 → `deploy-frontend` が `needs.migrate.result == 'success'` でゲートされてスキップ、というループに陥っていた。

最新の失敗ラン: [Deploy Development #345 (24709427242)](https://github.com/otomatty/zedi/actions/runs/24709427242)

dev / prod / 新規ローカル DB のいずれでも安全に再実行できるよう、マイグレーションを冪等化する。schema 上の最終形は変更しない。

## 変更点

### `server/api/drizzle/0015_add_note_members_status_accepted_user.sql`

- `ALTER TABLE ... ADD COLUMN` を `ADD COLUMN IF NOT EXISTS` に変更（`status` / `accepted_user_id` 両方）。
- バックフィル `UPDATE` の対象を「マイグレーション前の形のままの行」に限定（`status = 'pending' AND accepted_user_id IS NULL`）。すでに `accepted` になっている dev データを誤って上書きしないようにし、再実行も安全にする。
- FK `note_members_accepted_user_id_user_id_fk` の追加を `DO $$ ... END$$` ブロックでラップし、`pg_constraint` を見て未存在のときだけ `ADD CONSTRAINT` を実行する（PostgreSQL には `ADD CONSTRAINT IF NOT EXISTS` が無いため）。
- 経緯と冪等化の理由を SQL 冒頭コメントに日英併記で追記。

ジャーナル (`server/api/drizzle/meta/_journal.json`) や Drizzle スキーマ (`server/api/src/schema/notes.ts`) は変更していない。生成済み migration の SQL 修正のみ。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. develop マージ後、自動で走る [Deploy Development](https://github.com/otomatty/zedi/actions/workflows/deploy-dev.yml) の `migrate` ジョブが成功し、`deploy-frontend` まで到達することを確認する（PR #692 以降止まっていた dev フロントが更新される）。
2. ローカルで dev DB と同じ「カラムは既にあるが `__drizzle_migrations` に `0015` が無い」状況を再現してマイグレーションを流す:
   ```bash
   cd server/api
   # 例: dev DB に向けて
   DATABASE_URL=... bunx drizzle-kit migrate
   ```
   - 何度実行しても成功し、2 回目以降は `IF NOT EXISTS` / FK 存在チェックで no-op になることを確認。
3. クリーンな空 DB に対しても流して、想定どおりカラムと FK が追加されることを確認:
   ```bash
   DATABASE_URL=postgres://...empty-db bunx drizzle-kit migrate
   psql "$DATABASE_URL" -c "\d note_members"
   ```
4. `bun run test:run server/api` で既存のノート/メンバー周りのテストが通ることを確認。

## チェックリスト

- [x] テストがすべてパスする（既存テストは schema 互換のため影響なし、ローカル `crud.test.ts` は #692 で 26/26 確認済み）
- [x] Lint エラーがない（pre-commit の `format:check` 通過）
- [x] 必要に応じてドキュメントを更新した（マイグレーション冒頭コメントに経緯を追記）
- [x] コミットメッセージが Conventional Commits に従っている (`fix(db):`)

## デプロイ時の注意

- 本番 DB はまだ `0015` が当たっていない (release-please での `develop → main` 反映待ち)。本 PR のマージで先に develop の `Deploy Development` を回復させ、その後の通常リリースで本番にも冪等版の `0015` が適用される。
- マイグレーション後の最終的な schema は #692 と完全に同一。

## 関連 Issue / PR

- 起点となった本番障害修正: #692
- 失敗していたワークフロー: [Deploy Development runs](https://github.com/otomatty/zedi/actions/workflows/deploy-dev.yml)（直近 6 連続 failure）

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Safer, idempotent database migration to reduce deployment risk.
  * Conditional schema and constraint changes to avoid duplicate operations during upgrades.
* **Bug Fixes**
  * Targeted data backfill that preserves existing values instead of overwriting them.
  * Reduced chance of failed migrations and unintended data changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->