### PR TITLE
fix(web): remove COEP header to unblock YouTube embeds

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,3 +1,2 @@
 /*
   Cross-Origin-Opener-Policy: same-origin-allow-popups
-  Cross-Origin-Embedder-Policy: credentialless


### PR DESCRIPTION
Cross-Origin-Embedder-Policy: credentialless on the parent document
caused cross-origin iframes without their own COEP header (e.g. YouTube
/embed) to be refused, showing "www.youtube.com で接続が拒否されました"
inside the Tiptap YouTube embed node across all environments that hit
the web deployment. No code in the repo currently relies on cross-origin
isolation (no SharedArrayBuffer / Atomics / threaded WASM usage), so
removing the header is safe. COOP is kept as-is.

親ドキュメントの COEP: credentialless により、自身で COEP を返さない
クロスオリジン iframe (YouTube /embed など) が拒否され、Tiptap の
YouTube 埋め込みが全 Web 環境で「接続が拒否されました」を表示していた。
SharedArrayBuffer 等 cross-origin isolation に依存する実装は現状存在
しないため、COEP を外して解消する。COOP はそのまま維持。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted cross-origin resource sharing security configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->