### PR TITLE
fix: address PR #702 review comments

### DIFF
--- a/server/api/drizzle/0015_add_note_members_status_accepted_user.sql
+++ b/server/api/drizzle/0015_add_note_members_status_accepted_user.sql
@@ -145,6 +145,19 @@ BEGIN
     -- `COALESCE` preserves any preexisting `accepted_user_id` value so we
     -- never overwrite real data with a (possibly-NULL) email lookup result.
     IF NOT (status_existed AND accepted_user_id_existed) THEN
+        IF EXISTS (
+            SELECT 1
+            FROM "note_members" AS nm
+            JOIN "user" AS u
+              ON LOWER(u."email") = LOWER(nm."member_email")
+            WHERE nm."is_deleted" = false
+            GROUP BY LOWER(nm."member_email")
+            HAVING COUNT(DISTINCT u."id") > 1
+        ) THEN
+            RAISE EXCEPTION
+                '0015_add_note_members_status_accepted_user found multiple users for the same lowercase email; normalize duplicate user.email values before running this migration.';
+        END IF;
+
         UPDATE "note_members" AS nm
         SET
             "status" = 'accepted',
@@ -158,6 +171,9 @@ BEGIN
                 )
             )
         WHERE nm."is_deleted" = false;
+    ELSE
+        RAISE WARNING
+            '0015_add_note_members_status_accepted_user skipped the legacy backfill because both columns already existed; run the documented manual backfill if this environment still has pre-migration note_members rows.';
     END IF;
 
     -- PostgreSQL has no `ADD CONSTRAINT IF NOT EXISTS`, so check `pg_constraint`

--- a/src/components/editor/PageEditor/PageEditorHeader.tsx
+++ b/src/components/editor/PageEditor/PageEditorHeader.tsx
@@ -154,7 +154,13 @@ export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
       )}
     >
       <Container className="flex items-center justify-between gap-4 py-2">
-        <Button variant="ghost" size="icon" onClick={onBack} className="h-12 w-12 shrink-0">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onBack}
+          aria-label={t("common.back", "Back")}
+          className="h-12 w-12 shrink-0"
+        >
           <ArrowLeft className="h-5 w-5" />
         </Button>
 
@@ -179,7 +185,12 @@ export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-12 w-12">
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={t("common.moreActions", "More actions")}
+                className="h-12 w-12"
+              >
                 <MoreHorizontal className="h-5 w-5" />
               </Button>
             </DropdownMenuTrigger>

--- a/src/components/layout/PageLoadingOrDenied.test.tsx
+++ b/src/components/layout/PageLoadingOrDenied.test.tsx
@@ -12,10 +12,10 @@ describe("PageLoadingOrDenied", () => {
     expect(screen.getByTestId("msg")).toBeInTheDocument();
   });
 
-  it("applies the expected scroll-container classes on the wrapper", () => {
-    // Wrapper carries the flex / overflow / padding utilities so nested
-    // AppLayout routes share the same loading-state layout.
-    // Wrapper は AppLayout 配下でローディング表示のレイアウトを揃える役割。
+  it("applies the expected layout classes on the wrapper", () => {
+    // Wrapper carries the flex / padding utilities while the surrounding
+    // layout owns the scroll container.
+    // Wrapper は flex / padding を担い、スクロール責務は外側レイアウトに委譲する。
     const { container } = render(
       <PageLoadingOrDenied>
         <p>loading...</p>
@@ -25,7 +25,6 @@ describe("PageLoadingOrDenied", () => {
     expect(root).not.toBeNull();
     expect(root?.className).toContain("min-h-0");
     expect(root?.className).toContain("flex-1");
-    expect(root?.className).toContain("overflow-y-auto");
     expect(root?.className).toContain("py-10");
   });
 

--- a/src/components/layout/PageLoadingOrDenied.tsx
+++ b/src/components/layout/PageLoadingOrDenied.tsx
@@ -12,17 +12,17 @@ export interface PageLoadingOrDeniedProps {
 
 /**
  * Shared shell for in-shell "loading" and "denied / not found" states.
- * Provides a flex-filling scroll region with the standard `Container`
+ * Provides a flex-filling padded region with the standard `Container`
  * (max-width + horizontal padding) and `py-10` vertical breathing room,
- * matching the other AppLayout-wrapped pages.
+ * while inheriting scroll behavior from the surrounding app-shell layout.
  *
  * `AppLayout` 配下ルートの「読み込み中 / 権限なし・未検出」表示用の共通シェル。
- * スクロール可能な flex 埋め領域に、標準の `Container`（最大幅と左右 padding）と
- * 上下 `py-10` を適用し、他のページと見た目を揃える。
+ * flex 埋め領域に標準の `Container`（最大幅と左右 padding）と上下 `py-10` を適用し、
+ * スクロール責務は外側レイアウトに委譲しつつ、他のページと見た目を揃える。
  */
 export function PageLoadingOrDenied({ children }: PageLoadingOrDeniedProps): React.JSX.Element {
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto py-10">
+    <div className="min-h-0 flex-1 py-10">
       <Container>{children}</Container>
     </div>
   );

--- a/src/components/layout/navigationItems.test.ts
+++ b/src/components/layout/navigationItems.test.ts
@@ -7,7 +7,7 @@
  * モバイルのボトムナビが同じ配列を参照するため、型と項目内容の単一ソースを保証する。
  */
 import { describe, it, expect } from "vitest";
-import { PRIMARY_NAV_ITEMS, isPrimaryNavActive, type PrimaryNavItem } from "./navigationItems";
+import { PRIMARY_NAV_ITEMS, isPrimaryNavActive } from "./navigationItems";
 
 describe("PRIMARY_NAV_ITEMS", () => {
   it("exposes Home, Notes, and AI as the canonical primary entries", () => {
@@ -38,8 +38,13 @@ describe("PRIMARY_NAV_ITEMS", () => {
 });
 
 describe("isPrimaryNavActive", () => {
-  const homeItem = PRIMARY_NAV_ITEMS.find((item) => item.path === "/home") as PrimaryNavItem;
-  const aiItem = PRIMARY_NAV_ITEMS.find((item) => item.path === "/ai") as PrimaryNavItem;
+  const homeItem = PRIMARY_NAV_ITEMS.find((item) => item.path === "/home");
+  const notesItem = PRIMARY_NAV_ITEMS.find((item) => item.path === "/notes");
+  const aiItem = PRIMARY_NAV_ITEMS.find((item) => item.path === "/ai");
+
+  if (!homeItem || !notesItem || !aiItem) {
+    throw new Error("PRIMARY_NAV_ITEMS must include /home, /notes, and /ai");
+  }
 
   it("returns true when any matchPath matches the current pathname", () => {
     expect(isPrimaryNavActive(aiItem, "/ai")).toBe(true);
@@ -50,6 +55,11 @@ describe("isPrimaryNavActive", () => {
   it("falls back to an exact path match when matchPaths is not provided", () => {
     expect(isPrimaryNavActive(homeItem, "/home")).toBe(true);
     expect(isPrimaryNavActive(homeItem, "/home/anything")).toBe(false);
+  });
+
+  it("treats /notes/discover as part of the Notes section", () => {
+    expect(isPrimaryNavActive(notesItem, "/notes")).toBe(true);
+    expect(isPrimaryNavActive(notesItem, "/notes/discover")).toBe(true);
   });
 
   it("returns false for unrelated pathnames", () => {

--- a/src/components/layout/navigationItems.ts
+++ b/src/components/layout/navigationItems.ts
@@ -16,7 +16,7 @@ export interface PrimaryNavItem {
   /** Link target. 遷移先パス。*/
   path: string;
   /** Icon component rendered in the tile / tab. タイルやタブに描画するアイコン。*/
-  icon: React.FC<{ className?: string }>;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   /** i18n key for the label. ラベルの i18n キー。*/
   i18nKey: string;
   /**
@@ -39,7 +39,12 @@ export interface PrimaryNavItem {
  */
 export const PRIMARY_NAV_ITEMS: readonly PrimaryNavItem[] = [
   { path: "/home", icon: Home, i18nKey: "nav.home" },
-  { path: "/notes", icon: FileText, i18nKey: "nav.notes" },
+  {
+    path: "/notes",
+    icon: FileText,
+    i18nKey: "nav.notes",
+    matchPaths: ["/notes", "/notes/discover"],
+  },
   {
     path: "/ai",
     icon: Sparkles,

--- a/src/components/note/NotesLayout.tsx
+++ b/src/components/note/NotesLayout.tsx
@@ -32,7 +32,7 @@ export const NotesLayout: React.FC<NotesLayoutProps> = ({ children }) => {
   };
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto py-6">
+    <div className="min-h-0 flex-1 py-6">
       <Container>
         <div className="border-border mb-6 flex border-b">
           <Link

--- a/src/pages/AIChatHistory.tsx
+++ b/src/pages/AIChatHistory.tsx
@@ -35,7 +35,7 @@ export default function AIChatHistory() {
 
   return (
     <ContentWithAIChat>
-      <div className="min-h-0 flex-1 overflow-y-auto py-6">
+      <div className="min-h-0 flex-1 py-6">
         <Container>
           <h1 className="text-foreground text-2xl font-semibold tracking-tight">
             {t("aiChat.history.pageTitle", "AI chat history")}

--- a/src/pages/Donate.tsx
+++ b/src/pages/Donate.tsx
@@ -59,7 +59,7 @@ const Donate: React.FC = () => {
       <PageHeader title={t("nav.support")} backTo="/home" backLabel={t("common.back")} />
 
       {/* Content */}
-      <div className="min-h-0 flex-1 overflow-y-auto py-8">
+      <div className="min-h-0 flex-1 py-8">
         <Container>
           <div className="mx-auto max-w-2xl">
             {/* Hero Section */}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -80,7 +80,7 @@ const Home: React.FC = () => {
           </>
         }
       >
-        <div className="min-h-0 flex-1 overflow-y-auto py-6">
+        <div className="min-h-0 flex-1 py-6">
           <Container>
             <div data-tour-id="tour-home-page-grid" className="min-h-[200px]">
               <PageGrid isSeeding={isSeeding} />

--- a/src/pages/IndexPage.tsx
+++ b/src/pages/IndexPage.tsx
@@ -161,7 +161,7 @@ const IndexPage: React.FC = () => {
         }
       />
 
-      <div className="min-h-0 flex-1 overflow-y-auto py-6">
+      <div className="min-h-0 flex-1 py-6">
         <Container>
           <div className="mx-auto max-w-2xl space-y-6">
             <p className="text-muted-foreground text-sm">

--- a/src/pages/NoteMembers/index.tsx
+++ b/src/pages/NoteMembers/index.tsx
@@ -43,7 +43,7 @@ const NoteMembers: React.FC = () => {
   }
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto py-8">
+    <div className="min-h-0 flex-1 py-8">
       <Container>
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -179,9 +179,18 @@ const NotePageView: React.FC = () => {
         </Container>
       </div>
 
-      {/* モバイルは `ContentWithAIChat` が独自のスクロール領域を持たないため、ここをスクロールコンテナにする。
-          On mobile, `ContentWithAIChat` lacks its own scroll viewport, so this div must scroll. */}
-      <div className="min-h-0 flex-1 overflow-y-auto md:overflow-hidden">
+      {/* 編集時は `ContentWithAIChat` 側がスクロールを管理するため、このラッパーでは
+          二重スクロールを避ける。閲覧専用時は従来どおりここで本文をスクロールさせる。
+          When editing, `ContentWithAIChat` owns the scroll container, so keep
+          this wrapper non-scrollable to avoid nested scroll regions. In
+          read-only mode, this wrapper still scrolls the page body. */}
+      <div
+        className={
+          canEdit
+            ? "min-h-0 flex-1 md:overflow-hidden"
+            : "min-h-0 flex-1 overflow-y-auto md:overflow-hidden"
+        }
+      >
         <NoteWorkspaceProvider key={note.id} noteId={note.id}>
           {canEdit ? (
             <NotePageEditorEditable

--- a/src/pages/NoteSettings/index.tsx
+++ b/src/pages/NoteSettings/index.tsx
@@ -112,7 +112,7 @@ const NoteSettings: React.FC = () => {
   }
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto py-8">
+    <div className="min-h-0 flex-1 py-8">
       <Container>
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">

--- a/src/pages/NoteView/index.tsx
+++ b/src/pages/NoteView/index.tsx
@@ -138,7 +138,7 @@ const NoteView: React.FC = () => {
         ) : null
       }
     >
-      <div className="min-h-0 flex-1 overflow-y-auto py-6">
+      <div className="min-h-0 flex-1 py-6">
         <Container>
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div className="min-w-0">

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -102,7 +102,7 @@ const Pricing: React.FC = () => {
     <div className="flex min-h-0 flex-1 flex-col">
       <PageHeader title={t("pricing.pageTitle")} backTo="/home" backLabel={t("common.back")} />
 
-      <div className="min-h-0 flex-1 overflow-y-auto py-8">
+      <div className="min-h-0 flex-1 py-8">
         <Container>
           {showPlanStatusCard && (
             <section className="mx-auto mb-10">

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -111,7 +111,7 @@ export default function SearchResults() {
     item.noteId ? `shared-${item.noteId}-${item.pageId}` : `personal-${item.pageId}`;
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto py-6">
+    <div className="min-h-0 flex-1 py-6">
       <Container>
         <div className="mb-6">
           {searchQuery ? (

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -51,7 +51,7 @@ const Settings: React.FC = () => {
         actions={<SettingsHeaderNav value={currentSection} onChange={setSection} />}
       />
 
-      <div className="min-h-0 flex-1 overflow-y-auto py-6">
+      <div className="min-h-0 flex-1 py-6">
         <Container>
           <div className="mx-auto max-w-2xl space-y-6">
             <div>

--- a/src/pages/WikiSchemaPage.tsx
+++ b/src/pages/WikiSchemaPage.tsx
@@ -71,7 +71,7 @@ const WikiSchemaPage: React.FC = () => {
         }
       />
 
-      <div className="min-h-0 flex-1 overflow-y-auto py-6">
+      <div className="min-h-0 flex-1 py-6">
         <Container>
           <div className="mx-auto max-w-2xl space-y-6">
             {isLoading ? (


### PR DESCRIPTION
## 概要

`develop` → `main` のリリース PR #702 に付いたレビューコメントへ対応するフォローアップです。スクロール責務の競合を減らし、ナビゲーションとページエディタのアクセシビリティを補強しつつ、`note_members` migration の安全性と運用時の可観測性を高めます。

## 変更点

- **レイアウト / スクロール**
  - `AppLayout` / `ContentWithAIChat` 配下ページのラッパーから不要な `overflow-y-auto` を外し、二重スクロールを抑制
  - `PageLoadingOrDenied` も外側レイアウトにスクロール責務を委譲
  - `NotePageView` は編集時のみ `ContentWithAIChat` 側をスクロールコンテナにし、閲覧専用時は従来どおり本文側でスクロール
- **a11y / ナビゲーション**
  - `PageEditorHeader` のアイコンボタンに `aria-label` を追加
  - `PrimaryNavItem.icon` 型を SVG/ARIA props に対応させ、ヘッダーナビの `aria-hidden` 利用と整合
  - `/notes/discover` を Notes タブの active 判定に含める
- **DB migration / テスト**
  - 0015 migration で lowercase email 重複がある場合は fail loudly するガードを追加
  - 既存カラム環境で backfill をスキップした際に `RAISE WARNING` を出すよう変更
  - `navigationItems` / `PageLoadingOrDenied` のテストを更新し、unsafe cast も解消

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run lint`
2. `bunx vitest run src/components/layout/navigationItems.test.ts src/components/layout/PageLoadingOrDenied.test.tsx src/components/editor/PageEditor/PageEditorHeader.test.tsx src/pages/AIChatHistory.test.tsx src/pages/NoteView/NoteView.test.tsx src/pages/NotePageView.test.tsx`
3. モバイル幅で `/home`, `/notes`, `/note/:noteId/page/:pageId` を確認し、二重スクロールせず操作できることを確認する

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

必要に応じて、モバイルでのスクロール挙動と PageEditor ヘッダー操作の Before/After を追加してください。

## 関連 Issue

<!-- なし -->

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added aria-labels to icon buttons for improved screen reader support

* **Navigation**
  * Notes navigation item now correctly identifies sub-routes like `/notes/discover` as active

* **Layout**
  * Refined vertical scroll behavior across multiple pages for improved parent-level scroll handling

* **Data Integrity**
  * Enhanced validation during migration to detect and prevent duplicate user mappings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->