### PR TITLE
feat(routing): plural page/note paths + scope FAB page creation to note

### DIFF
--- a/e2e/auth-mock.ts
+++ b/e2e/auth-mock.ts
@@ -28,7 +28,7 @@ const helpers = {
 
   /**
    * Create a new page and return its ID.
-   * Uses the home FAB (「新規作成」): `/page/new` is no longer a creation entry (editor redirects to /home).
+   * Uses the home FAB (「新規作成」): `/pages/new` is no longer a creation entry (editor redirects to /home).
    */
   async createNewPage(page: Page): Promise<string> {
     await page.goto("/home");
@@ -37,10 +37,10 @@ const helpers = {
     await page.locator('[data-tour-id="tour-fab"]').click();
     await page.getByRole("button", { name: "新規作成" }).click();
 
-    await page.waitForURL(/\/page\/(?!new).+/, { timeout: 15000 });
+    await page.waitForURL(/\/pages\/(?!new).+/, { timeout: 15000 });
 
     const url = page.url();
-    const match = url.match(/\/page\/([^/]+)/);
+    const match = url.match(/\/pages\/([^/]+)/);
     if (!match) {
       throw new Error(`Failed to extract page ID from URL: ${url}`);
     }

--- a/e2e/auth-mock.ts
+++ b/e2e/auth-mock.ts
@@ -37,12 +37,18 @@ const helpers = {
     await page.locator('[data-tour-id="tour-fab"]').click();
     await page.getByRole("button", { name: "新規作成" }).click();
 
-    await page.waitForURL(/\/pages\/(?!new).+/, { timeout: 15000 });
+    // `^/pages/<id>$` のみを許容し、`/notes/.../pages/<id>` のようなノート配下ルートに
+    // 誤遷移した場合はリグレッションとして検知できるように pathname 完全一致で判定する。
+    // Match only the top-level `/pages/:id` route; a regression that accidentally
+    // creates a note-scoped page should fail this helper instead of silently passing.
+    await page.waitForURL((url) => /^\/pages\/(?!new$)[^/]+$/.test(url.pathname), {
+      timeout: 15000,
+    });
 
-    const url = page.url();
-    const match = url.match(/\/pages\/([^/]+)/);
+    const { pathname } = new URL(page.url());
+    const match = pathname.match(/^\/pages\/([^/]+)$/);
     if (!match) {
-      throw new Error(`Failed to extract page ID from URL: ${url}`);
+      throw new Error(`Failed to extract page ID from URL: ${page.url()}`);
     }
 
     return match[1];

--- a/e2e/page-editor.spec.ts
+++ b/e2e/page-editor.spec.ts
@@ -16,10 +16,10 @@ test.describe("Page Editor", () => {
       await expect(page.getByPlaceholder("タイトル")).toBeVisible();
     });
 
-    test("redirects /page/new to home (direct /page/new is not a creation entry)", async ({
+    test("redirects /pages/new to home (direct /pages/new is not a creation entry)", async ({
       page,
     }) => {
-      await page.goto("/page/new");
+      await page.goto("/pages/new");
       await expect(page).toHaveURL(/\/home/, { timeout: 10000 });
     });
   });

--- a/e2e/wikilink-create-dialog.spec.ts
+++ b/e2e/wikilink-create-dialog.spec.ts
@@ -83,7 +83,7 @@ async function seedBlankPage(page: Page, title: string) {
 
 async function createPageWithGhostWikiLink(page: Page, sourceTitle: string) {
   const pageId = await seedBlankPage(page, sourceTitle);
-  await page.goto(`/page/${pageId}`);
+  await page.goto(`/pages/${pageId}`);
   await page.waitForLoadState("networkidle");
   await expect(page.getByRole("textbox", { name: "タイトル" })).toHaveValue(sourceTitle);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,15 @@ import { Toaster as Sonner } from "@zedi/ui/components/sonner";
 import { TooltipProvider } from "@zedi/ui";
 import { ThemeProvider } from "next-themes";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route, Navigate, Outlet, useParams } from "react-router-dom";
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  Navigate,
+  Outlet,
+  useLocation,
+  useParams,
+} from "react-router-dom";
 import Landing from "./pages/Landing";
 import Home from "./pages/Home";
 import Notes from "./pages/Notes";
@@ -48,6 +56,37 @@ const queryClient = new QueryClient();
 function LegacyAIChatConversationRedirect() {
   const { conversationId } = useParams<{ conversationId: string }>();
   return <Navigate to={`/ai/${conversationId}`} replace />;
+}
+
+/**
+ * Redirect singular `/page/:id` to plural `/pages/:id` while preserving search/hash.
+ * 旧パス `/page/:id` を複数形 `/pages/:id` にリダイレクト（search/hash は保持）。
+ */
+function LegacyPageRedirect() {
+  const { id } = useParams<{ id: string }>();
+  const { search, hash } = useLocation();
+  return <Navigate to={`/pages/${id}${search}${hash}`} replace />;
+}
+
+/**
+ * Redirect singular `/note/:noteId` (and sub-routes) to plural `/notes/:noteId/...`.
+ * 旧パス `/note/:noteId` 系を複数形 `/notes/:noteId/...` にリダイレクト。
+ */
+function LegacyNoteRedirect({ suffix }: { suffix?: "settings" | "members" }) {
+  const { noteId } = useParams<{ noteId: string }>();
+  const { search, hash } = useLocation();
+  const tail = suffix ? `/${suffix}` : "";
+  return <Navigate to={`/notes/${noteId}${tail}${search}${hash}`} replace />;
+}
+
+/**
+ * Redirect `/note/:noteId/page/:pageId` to `/notes/:noteId/pages/:pageId`.
+ * 旧パス `/note/:noteId/page/:pageId` を複数形ルートへリダイレクト。
+ */
+function LegacyNotePageRedirect() {
+  const { noteId, pageId } = useParams<{ noteId: string; pageId: string }>();
+  const { search, hash } = useLocation();
+  return <Navigate to={`/notes/${noteId}/pages/${pageId}${search}${hash}`} replace />;
 }
 
 /**
@@ -127,7 +166,10 @@ const App = () => (
                       <Route path="/search" element={<SearchResults />} />
                       <Route path="/notes/discover" element={<NotesDiscover />} />
                       <Route path="/notes" element={<Notes />} />
-                      <Route path="/page/:id" element={<PageEditorPage />} />
+                      <Route path="/pages/:id" element={<PageEditorPage />} />
+                      {/* Legacy singular path — redirect to plural.
+                          旧単数形パス — 複数形にリダイレクト。 */}
+                      <Route path="/page/:id" element={<LegacyPageRedirect />} />
                       <Route path="/settings" element={<Settings />} />
                       <Route path="/wiki-schema" element={<WikiSchemaPage />} />
                       <Route path="/index" element={<IndexPage />} />
@@ -142,10 +184,25 @@ const App = () => (
                         element={<Navigate to="/pricing#manage" replace />}
                       />
                       <Route path="/donate" element={<Donate />} />
-                      <Route path="/note/:noteId" element={<NoteView />} />
-                      <Route path="/note/:noteId/settings" element={<NoteSettings />} />
-                      <Route path="/note/:noteId/members" element={<NoteMembers />} />
-                      <Route path="/note/:noteId/page/:pageId" element={<NotePageView />} />
+                      <Route path="/notes/:noteId" element={<NoteView />} />
+                      <Route path="/notes/:noteId/settings" element={<NoteSettings />} />
+                      <Route path="/notes/:noteId/members" element={<NoteMembers />} />
+                      <Route path="/notes/:noteId/pages/:pageId" element={<NotePageView />} />
+                      {/* Legacy singular paths — redirect to plural.
+                          旧単数形パス — 複数形にリダイレクト。 */}
+                      <Route path="/note/:noteId" element={<LegacyNoteRedirect />} />
+                      <Route
+                        path="/note/:noteId/settings"
+                        element={<LegacyNoteRedirect suffix="settings" />}
+                      />
+                      <Route
+                        path="/note/:noteId/members"
+                        element={<LegacyNoteRedirect suffix="members" />}
+                      />
+                      <Route
+                        path="/note/:noteId/page/:pageId"
+                        element={<LegacyNotePageRedirect />}
+                      />
                     </Route>
 
                     {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/ai-chat/AIChatWikiLink.tsx
+++ b/src/components/ai-chat/AIChatWikiLink.tsx
@@ -21,7 +21,7 @@ const LONG_PRESS_MS = 500;
  * モバイルでは長押しでプレビューを表示する。
  *
  * Renders a clickable WikiLink in AI chat with hover preview.
- * Existing pages link to /page/:id, missing pages render as ghost style.
+ * Existing pages link to /pages/:id, missing pages render as ghost style.
  * Supports long-press preview on mobile.
  */
 export function AIChatWikiLink({ title }: AIChatWikiLinkProps) {
@@ -140,7 +140,7 @@ export function AIChatWikiLink({ title }: AIChatWikiLinkProps) {
       <HoverCardTrigger asChild>
         {page ? (
           <Link
-            to={`/page/${page.id}`}
+            to={`/pages/${page.id}`}
             className="text-primary decoration-primary/50 hover:decoration-primary rounded px-0.5 font-medium underline underline-offset-2 transition-colors"
             onClick={handleAnchorClick}
             {...touchProps}

--- a/src/components/ai-chat/PromoteToWikiDialog.tsx
+++ b/src/components/ai-chat/PromoteToWikiDialog.tsx
@@ -257,7 +257,7 @@ function PromoteToWikiDialogBody({
       };
       toast({ title: t("aiChat.notifications.promoteSuccess") });
       onClose();
-      navigate(`/page/${firstCreated.id}`, {
+      navigate(`/pages/${firstCreated.id}`, {
         state: { pendingChatPageGeneration: pending },
       });
     } catch {

--- a/src/components/editor/PageEditor/usePageDeletion.test.ts
+++ b/src/components/editor/PageEditor/usePageDeletion.test.ts
@@ -58,7 +58,7 @@ describe("usePageDeletion.handleOpenDuplicatePage", () => {
     act(() => result.current.handleOpenDuplicatePage("target-id"));
 
     expect(mockMutate).not.toHaveBeenCalled();
-    expect(mockNavigate).toHaveBeenCalledWith("/page/target-id");
+    expect(mockNavigate).toHaveBeenCalledWith("/pages/target-id");
     expect(result.current.deleteConfirmOpen).toBe(false);
   });
 
@@ -75,7 +75,7 @@ describe("usePageDeletion.handleOpenDuplicatePage", () => {
     act(() => result.current.handleOpenDuplicatePage("target-id"));
 
     expect(mockMutate).toHaveBeenCalledWith("dup-id");
-    expect(mockNavigate).toHaveBeenCalledWith("/page/target-id");
+    expect(mockNavigate).toHaveBeenCalledWith("/pages/target-id");
     expect(mockToast).toHaveBeenCalledWith({
       title: "重複するタイトルのため、ページを削除しました",
     });
@@ -117,7 +117,7 @@ describe("usePageDeletion.handleOpenDuplicatePage", () => {
     expect(mockToast).toHaveBeenCalledWith({
       title: "重複するタイトルのページを削除しました",
     });
-    expect(mockNavigate).toHaveBeenCalledWith("/page/target-id");
+    expect(mockNavigate).toHaveBeenCalledWith("/pages/target-id");
     expect(result.current.deleteConfirmOpen).toBe(false);
   });
 

--- a/src/components/editor/PageEditor/usePageDeletion.ts
+++ b/src/components/editor/PageEditor/usePageDeletion.ts
@@ -129,7 +129,7 @@ export function usePageDeletion({
 
   const handleOpenDuplicatePage = useCallback(
     (targetPageId: string) => {
-      const targetPath = `/page/${targetPageId}`;
+      const targetPath = `/pages/${targetPageId}`;
 
       // 現在のページがまだ作成されていない場合は削除不要でそのまま遷移
       // No current page persisted yet — just navigate.

--- a/src/components/editor/PageEditor/usePageEditorEffects.test.tsx
+++ b/src/components/editor/PageEditor/usePageEditorEffects.test.tsx
@@ -60,7 +60,7 @@ function createBaseOptions(
     wikiStatus: "idle",
     throttledTiptapContent: null,
     navigate: vi.fn(),
-    location: mockLocation("/page/page-1", null),
+    location: mockLocation("/pages/page-1", null),
     initialize: vi.fn(),
     setContent: vi.fn(),
     setWikiContentForCollab: vi.fn(),
@@ -96,7 +96,7 @@ describe("usePageEditorEffects", () => {
               page: null,
               title: "",
               navigate: mockNavigate,
-              location: mockLocation("/page/new", null),
+              location: mockLocation("/pages/new", null),
               setContent: mockSetContent,
               toast: mockToast,
             }),
@@ -135,7 +135,7 @@ describe("usePageEditorEffects", () => {
               isInitialized: false,
               page,
               title: "Test",
-              location: mockLocation("/page/1", null),
+              location: mockLocation("/pages/1", null),
               initialize,
               navigate: mockNavigate,
               setContent: mockSetContent,
@@ -252,7 +252,7 @@ describe("usePageEditorEffects", () => {
             createBaseOptions({
               currentPageId: "page-1",
               isInitialized: true,
-              location: mockLocation("/page/page-1", { initialContent: "<p>from-url</p>" }),
+              location: mockLocation("/pages/page-1", { initialContent: "<p>from-url</p>" }),
               setPendingInitialContent,
               navigate,
               setContent: mockSetContent,
@@ -263,7 +263,7 @@ describe("usePageEditorEffects", () => {
       );
 
       expect(setPendingInitialContent).toHaveBeenCalledWith("<p>from-url</p>");
-      expect(navigate).toHaveBeenCalledWith("/page/page-1", { replace: true, state: null });
+      expect(navigate).toHaveBeenCalledWith("/pages/page-1", { replace: true, state: null });
     });
 
     it("does not apply location.state when not initialized", () => {
@@ -275,7 +275,7 @@ describe("usePageEditorEffects", () => {
           usePageEditorEffects(
             createBaseOptions({
               isInitialized: false,
-              location: mockLocation("/page/page-1", { initialContent: "x" }),
+              location: mockLocation("/pages/page-1", { initialContent: "x" }),
               setPendingInitialContent,
               navigate,
               setContent: mockSetContent,
@@ -298,7 +298,7 @@ describe("usePageEditorEffects", () => {
             createBaseOptions({
               currentPageId: null,
               isInitialized: true,
-              location: mockLocation("/page/new", { initialContent: "x" }),
+              location: mockLocation("/pages/new", { initialContent: "x" }),
               setPendingInitialContent,
               navigate: mockNavigate,
               setContent: mockSetContent,
@@ -321,7 +321,7 @@ describe("usePageEditorEffects", () => {
           usePageEditorEffects(
             createBaseOptions({
               isInitialized: true,
-              location: mockLocation("/page/page-1", {
+              location: mockLocation("/pages/page-1", {
                 sourceUrl: "https://example.com",
                 thumbnailUrl: "https://cdn.example.com/t.png",
               }),
@@ -343,7 +343,7 @@ describe("usePageEditorEffects", () => {
           thumbnailUrl: "https://cdn.example.com/t.png",
         },
       });
-      expect(navigate).toHaveBeenCalledWith("/page/page-1", { replace: true, state: null });
+      expect(navigate).toHaveBeenCalledWith("/pages/page-1", { replace: true, state: null });
     });
 
     it("handles thumbnail-only state with empty sourceUrl passed to setSourceUrl", () => {
@@ -355,7 +355,7 @@ describe("usePageEditorEffects", () => {
           usePageEditorEffects(
             createBaseOptions({
               isInitialized: true,
-              location: mockLocation("/page/page-1", { thumbnailUrl: "https://img/t.png" }),
+              location: mockLocation("/pages/page-1", { thumbnailUrl: "https://img/t.png" }),
               setSourceUrl,
               navigate: mockNavigate,
               updatePageMutation: { mutate, mutateAsync: vi.fn() } as never,
@@ -385,7 +385,7 @@ describe("usePageEditorEffects", () => {
           usePageEditorEffects(
             createBaseOptions({
               isInitialized: true,
-              location: mockLocation("/page/page-1", {}),
+              location: mockLocation("/pages/page-1", {}),
               setSourceUrl,
               navigate: mockNavigate,
               updatePageMutation: { mutate, mutateAsync: vi.fn() } as never,
@@ -419,18 +419,18 @@ describe("usePageEditorEffects", () => {
           ),
         {
           wrapper,
-          initialProps: { loc: mockLocation("/page/page-1", null) },
+          initialProps: { loc: mockLocation("/pages/page-1", null) },
         },
       );
 
       expect(setPendingInitialContent).not.toHaveBeenCalled();
 
       rerender({
-        loc: mockLocation("/page/page-1", { initialContent: "<p>deferred</p>" }),
+        loc: mockLocation("/pages/page-1", { initialContent: "<p>deferred</p>" }),
       });
 
       expect(setPendingInitialContent).toHaveBeenCalledWith("<p>deferred</p>");
-      expect(navigate).toHaveBeenCalledWith("/page/page-1", { replace: true, state: null });
+      expect(navigate).toHaveBeenCalledWith("/pages/page-1", { replace: true, state: null });
     });
   });
 

--- a/src/components/editor/PageEditor/usePageEditorEffects.ts
+++ b/src/components/editor/PageEditor/usePageEditorEffects.ts
@@ -76,7 +76,7 @@ export function usePageEditorEffects(options: UsePageEditorEffectsOptions) {
 
   const { setPageContext, contentAppendHandlerRef } = useAIChatContext();
 
-  // /page/new への直接アクセスはホームへリダイレクト
+  // /pages/new への直接アクセスはホームへリダイレクト
   useEffect(() => {
     if (isNewPage) {
       navigate("/home", { replace: true });

--- a/src/components/editor/PageEditor/usePendingChatPageGeneration.test.tsx
+++ b/src/components/editor/PageEditor/usePendingChatPageGeneration.test.tsx
@@ -78,7 +78,7 @@ describe("usePendingChatPageGeneration", () => {
         <MemoryRouter
           initialEntries={[
             {
-              pathname: "/page/page-1",
+              pathname: "/pages/page-1",
               state: { pendingChatPageGeneration: defaultPending },
             },
           ]}
@@ -100,7 +100,7 @@ describe("usePendingChatPageGeneration", () => {
         <MemoryRouter
           initialEntries={[
             {
-              pathname: "/page/page-1",
+              pathname: "/pages/page-1",
               state: { pendingChatPageGeneration: defaultPending },
             },
           ]}
@@ -125,7 +125,7 @@ describe("usePendingChatPageGeneration", () => {
         }),
       );
       return (
-        <button type="button" data-testid="go-p2" onClick={() => navigate("/page/page-2")}>
+        <button type="button" data-testid="go-p2" onClick={() => navigate("/pages/page-2")}>
           go
         </button>
       );
@@ -137,13 +137,13 @@ describe("usePendingChatPageGeneration", () => {
       <MemoryRouter
         initialEntries={[
           {
-            pathname: "/page/page-1",
+            pathname: "/pages/page-1",
             state: { pendingChatPageGeneration: defaultPending },
           },
         ]}
       >
         <Routes>
-          <Route path="/page/:id" element={<Subject />} />
+          <Route path="/pages/:id" element={<Subject />} />
         </Routes>
       </MemoryRouter>,
     );
@@ -180,7 +180,7 @@ describe("usePendingChatPageGeneration", () => {
           <MemoryRouter
             initialEntries={[
               {
-                pathname: "/page/page-1",
+                pathname: "/pages/page-1",
                 state: { pendingChatPageGeneration: defaultPending },
               },
             ]}
@@ -223,7 +223,7 @@ describe("usePendingChatPageGeneration", () => {
         <MemoryRouter
           initialEntries={[
             {
-              pathname: "/page/page-1",
+              pathname: "/pages/page-1",
               state: { pendingChatPageGeneration: defaultPending },
             },
           ]}
@@ -265,7 +265,7 @@ describe("usePendingChatPageGeneration", () => {
         <MemoryRouter
           initialEntries={[
             {
-              pathname: "/page/page-1",
+              pathname: "/pages/page-1",
               state: { pendingChatPageGeneration: defaultPending },
             },
           ]}
@@ -292,7 +292,7 @@ describe("usePendingChatPageGeneration", () => {
           <MemoryRouter
             initialEntries={[
               {
-                pathname: "/page/page-1",
+                pathname: "/pages/page-1",
                 state: { pendingChatPageGeneration: defaultPending },
               },
             ]}
@@ -321,7 +321,7 @@ describe("usePendingChatPageGeneration", () => {
         <MemoryRouter
           initialEntries={[
             {
-              pathname: "/page/page-1",
+              pathname: "/pages/page-1",
               state: { pendingChatPageGeneration: defaultPending },
             },
           ]}
@@ -368,7 +368,7 @@ describe("usePendingChatPageGeneration", () => {
           <MemoryRouter
             initialEntries={[
               {
-                pathname: "/page/page-1",
+                pathname: "/pages/page-1",
                 state: { pendingChatPageGeneration: defaultPending },
               },
             ]}

--- a/src/components/editor/TiptapEditor/useWikiLinkNavigation.test.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkNavigation.test.ts
@@ -81,7 +81,7 @@ describe("useWikiLinkNavigation", () => {
     });
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/page/existing-id", {
+      expect(mockNavigate).toHaveBeenCalledWith("/pages/existing-id", {
         replace: false,
         flushSync: true,
       });
@@ -150,7 +150,7 @@ describe("useWikiLinkNavigation", () => {
       title: "New Page Title",
       content: "",
     });
-    expect(mockNavigate).toHaveBeenCalledWith("/page/new-page-id", {
+    expect(mockNavigate).toHaveBeenCalledWith("/pages/new-page-id", {
       replace: false,
       flushSync: true,
     });
@@ -194,7 +194,7 @@ describe("useWikiLinkNavigation", () => {
     });
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/page/new-page-id", {
+      expect(mockNavigate).toHaveBeenCalledWith("/pages/new-page-id", {
         replace: false,
         flushSync: true,
       });

--- a/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
@@ -54,7 +54,7 @@ export function useWikiLinkNavigation(): UseWikiLinkNavigationReturn {
 
       if (foundPage) {
         // 既存ページが見つかった場合はそのページに移動
-        navigate(`/page/${foundPage.id}`, { replace: false, flushSync: true });
+        navigate(`/pages/${foundPage.id}`, { replace: false, flushSync: true });
       } else {
         // ページが見つからなかった場合は確認ダイアログを表示
         setPendingCreatePageTitle(title);
@@ -80,7 +80,7 @@ export function useWikiLinkNavigation(): UseWikiLinkNavigationReturn {
       });
       setCreatePageDialogOpen(false);
       setPendingCreatePageTitle(null);
-      navigate(`/page/${newPage.id}`, { replace: false, flushSync: true });
+      navigate(`/pages/${newPage.id}`, { replace: false, flushSync: true });
     } catch (error) {
       console.error("Failed to create page:", error);
     }

--- a/src/components/layout/FloatingActionButton.tsx
+++ b/src/components/layout/FloatingActionButton.tsx
@@ -11,8 +11,16 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@zedi/
 import { useAuth } from "@/hooks/useAuth";
 import { useFloatingActionButtonHandlers } from "./useFloatingActionButtonHandlers";
 
-/** When initialClipUrl is provided, onClipDialogClosedWithInitialUrl is required so the dialog can be closed and URL cleared. */
-type FloatingActionButtonProps =
+/**
+ * FAB 共通プロパティ。`noteId` が指定されるとノート配下ページとして作成・遷移する。
+ * Common FAB props. When `noteId` is supplied the FAB creates pages scoped to
+ * that note and routes to `/notes/:noteId/pages/:pageId` instead of the
+ * standalone `/pages/:id`.
+ *
+ * When initialClipUrl is provided, onClipDialogClosedWithInitialUrl is required
+ * so the dialog can be closed and URL cleared.
+ */
+type FloatingActionButtonProps = { noteId?: string } & (
   | {
       initialClipUrl?: null;
       onClipDialogClosedWithInitialUrl?: never;
@@ -20,18 +28,21 @@ type FloatingActionButtonProps =
   | {
       initialClipUrl: string;
       onClipDialogClosedWithInitialUrl: () => void;
-    };
+    }
+);
 
 /**
- * ホーム用フローティングアクションボタン。新規・URL・画像作成メニューを表示する。
- * FAB for home: shows menu for new page, URL clip, image create.
+ * ホーム／ノート詳細用フローティングアクションボタン。新規・URL・画像作成メニューを表示する。
+ * FAB for home and note detail: shows menu for new page, URL clip, image create.
+ * When `noteId` is supplied the created page is linked to that note.
  */
 const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({
   initialClipUrl,
   onClipDialogClosedWithInitialUrl,
+  noteId,
 }) => {
   const { t } = useTranslation();
-  const { createNewPage, isCreating } = useCreateNewPage();
+  const { createNewPage, isCreating } = useCreateNewPage({ noteId });
   const { isSignedIn } = useAuth();
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -50,6 +61,7 @@ const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({
     createNewPage,
     setIsWebClipperOpen,
     setIsImageDialogOpen,
+    noteId,
   });
 
   const fabButton = (

--- a/src/components/layout/useFloatingActionButtonHandlers.ts
+++ b/src/components/layout/useFloatingActionButtonHandlers.ts
@@ -6,6 +6,7 @@ import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useCreatePage } from "@/hooks/usePageQueries";
+import { useAddPageToNote } from "@/hooks/useNoteQueries";
 import { useToast } from "@zedi/ui";
 import type { FABMenuOption } from "./FABMenu";
 
@@ -14,6 +15,12 @@ export interface UseFloatingActionButtonHandlersOptions {
   createNewPage: () => Promise<void>;
   setIsWebClipperOpen: (open: boolean) => void;
   setIsImageDialogOpen: (open: boolean) => void;
+  /**
+   * 指定したノート配下でページを作成する場合のノート ID。
+   * When set, newly created pages are linked to this note and routed to
+   * `/notes/:noteId/pages/:pageId` instead of the standalone `/pages/:id`.
+   */
+  noteId?: string;
 }
 
 /** FAB ハンドラ hook の戻り値。Return type of useFloatingActionButtonHandlers. */
@@ -39,11 +46,37 @@ export interface UseFloatingActionButtonHandlersResult {
 export function useFloatingActionButtonHandlers(
   options: UseFloatingActionButtonHandlersOptions,
 ): UseFloatingActionButtonHandlersResult {
-  const { createNewPage, setIsWebClipperOpen, setIsImageDialogOpen } = options;
+  const { createNewPage, setIsWebClipperOpen, setIsImageDialogOpen, noteId } = options;
   const { t } = useTranslation();
   const navigate = useNavigate();
   const createPageMutation = useCreatePage();
+  const addPageToNoteMutation = useAddPageToNote();
   const { toast } = useToast();
+
+  /**
+   * 作成済みページをノートに紐づけ、ノート配下のパスに遷移する。
+   * Link the created page to the current note (if any) and navigate into it.
+   */
+  const linkAndNavigate = useCallback(
+    async (pageId: string, navState?: Record<string, unknown>): Promise<void> => {
+      if (noteId) {
+        try {
+          await addPageToNoteMutation.mutateAsync({ noteId, pageId });
+        } catch (error) {
+          // 紐づけ失敗時はスタンドアロンページとして遷移させ、ユーザー操作を止めない。
+          // If linking fails, fall back to the standalone page so the user
+          // can still see and edit their newly created page.
+          console.error("Failed to attach page to note:", error);
+          navigate(`/pages/${pageId}`, navState ? { state: navState } : undefined);
+          return;
+        }
+        navigate(`/notes/${noteId}/pages/${pageId}`, navState ? { state: navState } : undefined);
+        return;
+      }
+      navigate(`/pages/${pageId}`, navState ? { state: navState } : undefined);
+    },
+    [addPageToNoteMutation, navigate, noteId],
+  );
 
   const handleMenuSelect = useCallback(
     async (option: FABMenuOption) => {
@@ -83,9 +116,7 @@ export function useFloatingActionButtonHandlers(
           sourceUrl,
           thumbnailUrl,
         });
-        navigate(`/page/${newPage.id}`, {
-          state: { initialContent: content },
-        });
+        await linkAndNavigate(newPage.id, { initialContent: content });
       } catch (error) {
         console.error("Failed to create page from URL:", error);
         toast({
@@ -94,7 +125,7 @@ export function useFloatingActionButtonHandlers(
         });
       }
     },
-    [createPageMutation, navigate, toast, t],
+    [createPageMutation, linkAndNavigate, toast, t],
   );
 
   const handleImageCreated = useCallback(
@@ -121,7 +152,7 @@ export function useFloatingActionButtonHandlers(
           title: "",
           content,
         });
-        navigate(`/page/${newPage.id}`);
+        await linkAndNavigate(newPage.id);
       } catch (error) {
         console.error("Failed to create page from image:", error);
         toast({
@@ -130,7 +161,7 @@ export function useFloatingActionButtonHandlers(
         });
       }
     },
-    [createPageMutation, navigate, toast, t],
+    [createPageMutation, linkAndNavigate, toast, t],
   );
 
   return {

--- a/src/components/note/NoteCard.tsx
+++ b/src/components/note/NoteCard.tsx
@@ -40,7 +40,7 @@ const NoteCard: React.FC<NoteCardProps> = ({ note, index = 0 }) => {
    *
    */
   const handleClick = () => {
-    navigate(`/note/${note.id}`);
+    navigate(`/notes/${note.id}`);
   };
 
   return (

--- a/src/components/note/NotePageCard.tsx
+++ b/src/components/note/NotePageCard.tsx
@@ -41,7 +41,7 @@ const NotePageCard: React.FC<NotePageCardProps> = ({ noteId, page }) => {
    *
    */
   const handleClick = () => {
-    navigate(`/note/${noteId}/page/${page.id}`);
+    navigate(`/notes/${noteId}/pages/${page.id}`);
   };
 
   return (

--- a/src/components/page/LinkedPagesSection.test.tsx
+++ b/src/components/page/LinkedPagesSection.test.tsx
@@ -145,7 +145,7 @@ describe("LinkedPagesSection", () => {
 
     await user.click(screen.getByText("Target Page"));
 
-    expect(mockNavigate).toHaveBeenCalledWith("/page/target-page");
+    expect(mockNavigate).toHaveBeenCalledWith("/pages/target-page");
   });
 
   it("should navigate to source page when link group source is clicked", async () => {
@@ -173,7 +173,7 @@ describe("LinkedPagesSection", () => {
 
     await user.click(screen.getByText("Source Page"));
 
-    expect(mockNavigate).toHaveBeenCalledWith("/page/source-page");
+    expect(mockNavigate).toHaveBeenCalledWith("/pages/source-page");
   });
 
   it("should navigate to child page when child card is clicked", async () => {
@@ -201,7 +201,7 @@ describe("LinkedPagesSection", () => {
 
     await user.click(screen.getByText("Child Page"));
 
-    expect(mockNavigate).toHaveBeenCalledWith("/page/child-page");
+    expect(mockNavigate).toHaveBeenCalledWith("/pages/child-page");
   });
 
   it("should create page and navigate when ghost link is clicked", async () => {
@@ -218,7 +218,7 @@ describe("LinkedPagesSection", () => {
     });
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/page/new-page-id", {
+      expect(mockNavigate).toHaveBeenCalledWith("/pages/new-page-id", {
         flushSync: true,
       });
     });

--- a/src/components/page/LinkedPagesSection.tsx
+++ b/src/components/page/LinkedPagesSection.tsx
@@ -74,7 +74,7 @@ export function LinkedPagesSection({ pageId, isSyncingLinks = false }: LinkedPag
    *
    */
   const handlePageClick = (id: string) => {
-    navigate(`/page/${id}`);
+    navigate(`/pages/${id}`);
   };
 
   /**
@@ -87,7 +87,7 @@ export function LinkedPagesSection({ pageId, isSyncingLinks = false }: LinkedPag
        *
        */
       const newPage = await createPageMutation.mutateAsync({ title });
-      navigate(`/page/${newPage.id}`, { flushSync: true });
+      navigate(`/pages/${newPage.id}`, { flushSync: true });
     } catch (error) {
       console.error("Failed to create page:", error);
     }

--- a/src/components/page/PageCard.tsx
+++ b/src/components/page/PageCard.tsx
@@ -58,7 +58,7 @@ const PageCard: React.FC<PageCardProps> = ({ page, index = 0 }) => {
       isDraggingRef.current = false;
       return;
     }
-    navigate(`/page/${page.id}`);
+    navigate(`/pages/${page.id}`);
   };
 
   const handleDragStart = useCallback(
@@ -100,7 +100,7 @@ const PageCard: React.FC<PageCardProps> = ({ page, index = 0 }) => {
         title: "複製しました",
         description: `「${newTitle}」を作成しました`,
       });
-      navigate(`/page/${newPage.id}`);
+      navigate(`/pages/${newPage.id}`);
     } catch (error) {
       console.error("Failed to duplicate page:", error);
       toast({

--- a/src/contexts/GlobalSearchContext.tsx
+++ b/src/contexts/GlobalSearchContext.tsx
@@ -21,32 +21,65 @@ interface GlobalSearchContextValue {
 
 const GlobalSearchContext = createContext<GlobalSearchContextValue | null>(null);
 
+/**
+ *
+ */
 export function GlobalSearchProvider({ children }: { children: ReactNode }) {
+  /**
+   *
+   */
   const navigate = useNavigate();
+  /**
+   *
+   */
   const { query, setQuery, searchResults, hasQuery } = useGlobalSearch();
+  /**
+   *
+   */
   const [isOpen, setOpen] = useState(false);
+  /**
+   *
+   */
   const open = useCallback(() => setOpen(true), []);
+  /**
+   *
+   */
   const close = useCallback(() => setOpen(false), []);
 
+  /**
+   *
+   */
   const handleSelect = useCallback(
     (pageId: string, noteId?: string) => {
       if (noteId) {
-        navigate(`/note/${noteId}/page/${pageId}`);
+        navigate(`/notes/${noteId}/pages/${pageId}`);
       } else {
-        navigate(`/page/${pageId}`);
+        navigate(`/pages/${pageId}`);
       }
     },
     [navigate],
   );
 
+  /**
+   *
+   */
   const handleSearchSubmit = useCallback(() => {
+    /**
+     *
+     */
     const q = query.trim();
     if (q) {
       navigate(`/search?q=${encodeURIComponent(q)}`);
     }
   }, [query, navigate]);
 
+  /**
+   *
+   */
   const focusSearchInput = useCallback(() => {
+    /**
+     *
+     */
     const el = document.getElementById("header-search-input") as HTMLInputElement | null;
     if (el) {
       el.focus();
@@ -54,6 +87,9 @@ export function GlobalSearchProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  /**
+   *
+   */
   const value: GlobalSearchContextValue = {
     query,
     setQuery,
@@ -70,7 +106,13 @@ export function GlobalSearchProvider({ children }: { children: ReactNode }) {
   return <GlobalSearchContext.Provider value={value}>{children}</GlobalSearchContext.Provider>;
 }
 
+/**
+ *
+ */
 export function useGlobalSearchContext(): GlobalSearchContextValue {
+  /**
+   *
+   */
   const ctx = useContext(GlobalSearchContext);
   if (!ctx) {
     throw new Error("useGlobalSearchContext must be used within GlobalSearchProvider");
@@ -78,6 +120,9 @@ export function useGlobalSearchContext(): GlobalSearchContextValue {
   return ctx;
 }
 
+/**
+ *
+ */
 export function useGlobalSearchContextOptional(): GlobalSearchContextValue | null {
   return useContext(GlobalSearchContext);
 }

--- a/src/hooks/runAIChatAction.test.ts
+++ b/src/hooks/runAIChatAction.test.ts
@@ -64,7 +64,7 @@ describe("runAIChatAction — create", () => {
       title: "Wiki Topic",
       content: "",
     });
-    expect(navigate).toHaveBeenCalledWith("/page/new-page-1", {
+    expect(navigate).toHaveBeenCalledWith("/pages/new-page-1", {
       state: {
         pendingChatPageGeneration: {
           outline: "- A\n- B",
@@ -97,7 +97,7 @@ describe("runAIChatAction — create", () => {
     });
 
     expect(createPageMutateAsync).toHaveBeenCalledTimes(2);
-    expect(navigate).toHaveBeenCalledWith("/page/p1", {
+    expect(navigate).toHaveBeenCalledWith("/pages/p1", {
       state: {
         pendingChatPageGeneration: {
           outline: "- o1",
@@ -129,7 +129,7 @@ describe("runAIChatAction — create", () => {
       reason: "multi",
     });
 
-    expect(navigate).toHaveBeenCalledWith("/page/p1", {
+    expect(navigate).toHaveBeenCalledWith("/pages/p1", {
       state: {
         pendingChatPageGeneration: {
           outline: "- from-second",

--- a/src/hooks/runAIChatAction.ts
+++ b/src/hooks/runAIChatAction.ts
@@ -59,7 +59,7 @@ async function handleCreatePage(
     content: "",
   });
   if (result?.id) {
-    deps.navigate(`/page/${result.id}`, {
+    deps.navigate(`/pages/${result.id}`, {
       state: { pendingChatPageGeneration: pending },
     });
   }
@@ -96,7 +96,7 @@ async function handleCreateMultiplePages(
       outline: firstOutline,
       conversationText,
     };
-    deps.navigate(`/page/${firstCreatedId}`, {
+    deps.navigate(`/pages/${firstCreatedId}`, {
       state: { pendingChatPageGeneration: pending },
     });
   }

--- a/src/hooks/useAIChatActions.test.ts
+++ b/src/hooks/useAIChatActions.test.ts
@@ -110,7 +110,7 @@ describe("useAIChatActions", () => {
       title: "New Page",
       content: "Content",
     });
-    expect(mockNavigate).toHaveBeenCalledWith("/page/new-page-id");
+    expect(mockNavigate).toHaveBeenCalledWith("/pages/new-page-id");
   });
 
   it("append-to-page without pageContext shows pageContextRequired toast", async () => {

--- a/src/hooks/useAIChatActions.ts
+++ b/src/hooks/useAIChatActions.ts
@@ -20,31 +20,73 @@ import {
 } from "@/lib/aiChatActionHelpers";
 import { extractWikiLinksFromContent } from "@/lib/wikiLinkUtils";
 
+/**
+ *
+ */
 export interface UseAIChatActionsOptions {
   pageContext: PageContext | null;
 }
 
+/**
+ *
+ */
 export function useAIChatActions({ pageContext }: UseAIChatActionsOptions) {
+  /**
+   *
+   */
   const { t } = useTranslation();
+  /**
+   *
+   */
   const { toast } = useToast();
+  /**
+   *
+   */
   const navigate = useNavigate();
+  /**
+   *
+   */
   const { contentAppendHandlerRef } = useAIChatContext();
+  /**
+   *
+   */
   const createPageMutation = useCreatePage();
+  /**
+   *
+   */
   const updatePageMutation = useUpdatePage();
+  /**
+   *
+   */
   const { syncLinks } = useSyncWikiLinks();
 
+  /**
+   *
+   */
   const latestPageContentRef = useRef(pageContext?.pageFullContent ?? "");
 
   useEffect(() => {
     latestPageContentRef.current = pageContext?.pageFullContent ?? "";
   }, [pageContext?.pageFullContent]);
 
+  /**
+   *
+   */
   const appendContentToCurrentPage = useCallback(
     async (markdown: string): Promise<boolean> => {
+      /**
+       *
+       */
       const currentPageId = pageContext?.pageId;
       if (!currentPageId) return false;
 
+      /**
+       *
+       */
       const previousContent = latestPageContentRef.current;
+      /**
+       *
+       */
       const nextContent = appendMarkdownToTiptapContent(latestPageContentRef.current, markdown);
       await updatePageMutation.mutateAsync({
         pageId: currentPageId,
@@ -78,28 +120,49 @@ export function useAIChatActions({ pageContext }: UseAIChatActionsOptions) {
     [pageContext?.pageId, syncLinks, updatePageMutation, contentAppendHandlerRef],
   );
 
+  /**
+   *
+   */
   const handleExecuteAction = useCallback(
     async (action: ChatAction) => {
       try {
         if (action.type === "create-page") {
+          /**
+           *
+           */
           const pageAction = action as CreatePageAction;
+          /**
+           *
+           */
           const result = await createPageMutation.mutateAsync({
             title: pageAction.title,
             content: pageAction.content,
           });
           if (result?.id) {
-            navigate(`/page/${result.id}`);
+            navigate(`/pages/${result.id}`);
           }
         } else if (action.type === "create-multiple-pages") {
+          /**
+           *
+           */
           const multiAction = action as CreateMultiplePagesAction;
-          for (const page of multiAction.pages) {
+          for (/**
+           *
+           */
+          const page of multiAction.pages) {
             await createPageMutation.mutateAsync({
               title: page.title,
               content: page.content,
             });
           }
         } else if (action.type === "append-to-page") {
+          /**
+           *
+           */
           const appendAction = action as AppendToPageAction;
+          /**
+           *
+           */
           const currentPageTitle = pageContext?.pageTitle ?? "";
 
           if (!pageContext?.pageId) {
@@ -125,6 +188,9 @@ export function useAIChatActions({ pageContext }: UseAIChatActionsOptions) {
             }),
           });
         } else if (action.type === "suggest-wiki-links") {
+          /**
+           *
+           */
           const wikiLinkAction = action as SuggestWikiLinksAction;
 
           if (!pageContext?.pageId) {
@@ -135,10 +201,16 @@ export function useAIChatActions({ pageContext }: UseAIChatActionsOptions) {
             return;
           }
 
+          /**
+           *
+           */
           const targetTitles = wikiLinkAction.links
             .map((link) => link.existingPageTitle ?? link.keyword)
             .map((title) => title.trim())
             .filter(Boolean);
+          /**
+           *
+           */
           const missingTitles = getMissingSuggestedWikiLinkTitles(
             latestPageContentRef.current,
             targetTitles,

--- a/src/hooks/useCreateNewPage.ts
+++ b/src/hooks/useCreateNewPage.ts
@@ -1,16 +1,24 @@
 import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { useCreatePage } from "./usePageQueries";
+import { useAddPageToNote } from "./useNoteQueries";
 import { useToast } from "@zedi/ui";
 
 /**
- * Hook to create a new page and navigate to it
- * This centralizes page creation logic and ensures pages are created
- * before navigation, avoiding race conditions.
+ * 新規ページを作成して対応するエディタへ遷移するフック。
+ * `noteId` が指定された場合はノートに紐づけ、`/notes/:noteId/pages/:pageId` へ遷移する。
+ *
+ * Hook to create a new page and navigate to it. When `noteId` is provided the
+ * page is linked to that note and the caller is routed into the note-scoped
+ * path `/notes/:noteId/pages/:pageId`; otherwise the standalone `/pages/:id`
+ * route is used. Centralizing the create-then-navigate flow avoids race
+ * conditions between page creation and navigation.
  */
-export function useCreateNewPage() {
+export function useCreateNewPage(options?: { noteId?: string }) {
+  const noteId = options?.noteId;
   const navigate = useNavigate();
   const createPageMutation = useCreatePage();
+  const addPageToNoteMutation = useAddPageToNote();
   const { toast } = useToast();
 
   const createNewPage = useCallback(async () => {
@@ -24,7 +32,20 @@ export function useCreateNewPage() {
         title: "",
         content: "",
       });
-      navigate(`/page/${newPage.id}`);
+      if (noteId) {
+        try {
+          await addPageToNoteMutation.mutateAsync({ noteId, pageId: newPage.id });
+        } catch (error) {
+          // 紐づけ失敗時はスタンドアロンページとして表示。
+          // Fallback: navigate to the standalone page when linking fails.
+          console.error("Failed to attach page to note:", error);
+          navigate(`/pages/${newPage.id}`);
+          return;
+        }
+        navigate(`/notes/${noteId}/pages/${newPage.id}`);
+        return;
+      }
+      navigate(`/pages/${newPage.id}`);
     } catch (error) {
       console.error("Failed to create page:", error);
       toast({
@@ -32,7 +53,7 @@ export function useCreateNewPage() {
         variant: "destructive",
       });
     }
-  }, [createPageMutation, navigate, toast]);
+  }, [addPageToNoteMutation, createPageMutation, navigate, noteId, toast]);
 
   return {
     createNewPage,

--- a/src/hooks/useCreateNewPage.ts
+++ b/src/hooks/useCreateNewPage.ts
@@ -21,9 +21,18 @@ export function useCreateNewPage(options?: { noteId?: string }) {
   const addPageToNoteMutation = useAddPageToNote();
   const { toast } = useToast();
 
+  // ページ作成〜ノート紐づけの一連の処理全体を「作成中」として扱う。
+  // どちらかが進行中の間は FAB を再タップしても新規作成を開始しないことで、
+  // 低速回線でノート配下での重複ページ作成が発生するのを防ぐ。
+  //
+  // Treat the whole create-then-link sequence as busy. Guarding on either
+  // mutation being in flight prevents a second tap from starting another
+  // create flow (which would produce duplicate blank pages under a note on
+  // slow networks).
+  const isCreating = createPageMutation.isPending || addPageToNoteMutation.isPending;
+
   const createNewPage = useCallback(async () => {
-    // 既に作成中の場合はスキップ
-    if (createPageMutation.isPending) {
+    if (isCreating) {
       return;
     }
 
@@ -53,10 +62,10 @@ export function useCreateNewPage(options?: { noteId?: string }) {
         variant: "destructive",
       });
     }
-  }, [addPageToNoteMutation, createPageMutation, navigate, noteId, toast]);
+  }, [addPageToNoteMutation, createPageMutation, isCreating, navigate, noteId, toast]);
 
   return {
     createNewPage,
-    isCreating: createPageMutation.isPending,
+    isCreating,
   };
 }

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -12,6 +12,9 @@ import {
 } from "@/lib/searchUtils";
 import type { Page } from "@/types/page";
 
+/**
+ *
+ */
 export interface SearchResult {
   page: Page;
   matchedText: string;
@@ -23,7 +26,7 @@ export interface SearchResult {
 /** Unified item for global search (personal + shared). C3-8. */
 export interface GlobalSearchResultItem {
   pageId: string;
-  /** Set for shared-note results; navigate to /note/:noteId/page/:pageId */
+  /** Set for shared-note results; navigate to /notes/:noteId/pages/:pageId */
   noteId?: string;
   title: string;
   highlightedText: string;

--- a/src/pages/IndexPage.tsx
+++ b/src/pages/IndexPage.tsx
@@ -203,7 +203,7 @@ const IndexPage: React.FC = () => {
                   {data.pageId && (
                     <div className="mt-2">
                       <Link
-                        to={`/page/${data.pageId}`}
+                        to={`/pages/${data.pageId}`}
                         className="text-primary text-sm underline underline-offset-2"
                       >
                         __index__ ページを開く / Open __index__ page

--- a/src/pages/InviteLinkPage.tsx
+++ b/src/pages/InviteLinkPage.tsx
@@ -258,7 +258,7 @@ const InviteLinkPage: React.FC = () => {
     if (!token) return;
     try {
       const result = await redeemMutation.mutateAsync({ token });
-      navigate(`/note/${result.noteId}`);
+      navigate(`/notes/${result.noteId}`);
     } catch {
       // 表示側で redeemMutation.error を描画するため何もしない。
       // Surface the error through redeemMutation.error rather than throwing here.

--- a/src/pages/InvitePage.tsx
+++ b/src/pages/InvitePage.tsx
@@ -312,7 +312,7 @@ const InviteContent: React.FC<{
         <CardContent className="space-y-4">
           <p className="text-muted-foreground">{t("invite.alreadyAccepted")}</p>
           <Button className="w-full" asChild>
-            <Link to={`/note/${invitation.noteId}`}>{t("invite.goToNote")}</Link>
+            <Link to={`/notes/${invitation.noteId}`}>{t("invite.goToNote")}</Link>
           </Button>
         </CardContent>
       </>
@@ -428,7 +428,7 @@ const InvitePage: React.FC = () => {
     if (!token) return;
     try {
       const result = await acceptMutation.mutateAsync({ token });
-      navigate(`/note/${result.noteId}`);
+      navigate(`/notes/${result.noteId}`);
     } catch {
       // Error is handled via acceptMutation.error
     }

--- a/src/pages/NoteMembers/NoteMembers.test.tsx
+++ b/src/pages/NoteMembers/NoteMembers.test.tsx
@@ -49,9 +49,9 @@ vi.mock("./NoteMembersManageSection", () => ({
 
 function renderNoteMembers(noteId: string) {
   return render(
-    <MemoryRouter initialEntries={[`/note/${noteId}/members`]}>
+    <MemoryRouter initialEntries={[`/notes/${noteId}/members`]}>
       <Routes>
-        <Route path="/note/:noteId/members" element={<NoteMembers />} />
+        <Route path="/notes/:noteId/members" element={<NoteMembers />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -102,7 +102,7 @@ describe("NoteMembers", () => {
     expect(screen.getByRole("heading", { name: "notes.members" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "notes.backToNote" })).toHaveAttribute(
       "href",
-      "/note/n1",
+      "/notes/n1",
     );
   });
 

--- a/src/pages/NoteMembers/index.tsx
+++ b/src/pages/NoteMembers/index.tsx
@@ -53,7 +53,7 @@ const NoteMembers: React.FC = () => {
             </p>
           </div>
           <Button asChild variant="outline" size="sm">
-            <Link to={`/note/${note.id}`}>{t("notes.backToNote")}</Link>
+            <Link to={`/notes/${note.id}`}>{t("notes.backToNote")}</Link>
           </Button>
         </div>
 

--- a/src/pages/NotePageView.test.tsx
+++ b/src/pages/NotePageView.test.tsx
@@ -64,10 +64,10 @@ vi.mock("@/components/layout/AppLayout", () => ({
 
 function renderNotePageView() {
   return render(
-    <MemoryRouter initialEntries={[`/note/note-1/page/page-1`]}>
+    <MemoryRouter initialEntries={[`/notes/note-1/pages/page-1`]}>
       <AIChatProvider>
         <Routes>
-          <Route path="/note/:noteId/page/:pageId" element={<NotePageView />} />
+          <Route path="/notes/:noteId/pages/:pageId" element={<NotePageView />} />
         </Routes>
       </AIChatProvider>
     </MemoryRouter>,

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -134,7 +134,7 @@ const NotePageView: React.FC = () => {
 
   const handleBack = useCallback(() => {
     if (noteId) {
-      navigate(`/note/${noteId}`);
+      navigate(`/notes/${noteId}`);
     } else {
       navigate("/home");
     }

--- a/src/pages/NoteSettings/NoteSettings.test.tsx
+++ b/src/pages/NoteSettings/NoteSettings.test.tsx
@@ -54,9 +54,9 @@ vi.mock("./NoteSettingsDeleteSection", () => ({
 
 function renderNoteSettings(noteId: string) {
   return render(
-    <MemoryRouter initialEntries={[`/note/${noteId}/settings`]}>
+    <MemoryRouter initialEntries={[`/notes/${noteId}/settings`]}>
       <Routes>
-        <Route path="/note/:noteId/settings" element={<NoteSettings />} />
+        <Route path="/notes/:noteId/settings" element={<NoteSettings />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -106,7 +106,7 @@ describe("NoteSettings", () => {
     expect(screen.getByRole("heading", { name: "notes.noteSettings" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "notes.backToNote" })).toHaveAttribute(
       "href",
-      "/note/n1",
+      "/notes/n1",
     );
   });
 

--- a/src/pages/NoteSettings/index.tsx
+++ b/src/pages/NoteSettings/index.tsx
@@ -69,7 +69,7 @@ const NoteSettings: React.FC = () => {
 
   const noteUrl = useMemo(() => {
     if (!noteId) return "";
-    return `${window.location.origin}/note/${noteId}`;
+    return `${window.location.origin}/notes/${noteId}`;
   }, [noteId]);
 
   const handleCopyLink = async () => {
@@ -125,7 +125,7 @@ const NoteSettings: React.FC = () => {
             </p>
           </div>
           <Button asChild variant="outline" size="sm">
-            <Link to={`/note/${note.id}`}>{t("notes.backToNote")}</Link>
+            <Link to={`/notes/${note.id}`}>{t("notes.backToNote")}</Link>
           </Button>
         </div>
 

--- a/src/pages/NoteView/NoteView.test.tsx
+++ b/src/pages/NoteView/NoteView.test.tsx
@@ -73,9 +73,9 @@ vi.mock("./NoteViewMainContent", () => ({
 
 function renderNoteView(noteId: string) {
   return render(
-    <MemoryRouter initialEntries={[`/note/${noteId}`]}>
+    <MemoryRouter initialEntries={[`/notes/${noteId}`]}>
       <Routes>
-        <Route path="/note/:noteId" element={<NoteView />} />
+        <Route path="/notes/:noteId" element={<NoteView />} />
       </Routes>
     </MemoryRouter>,
   );

--- a/src/pages/NoteView/NoteViewHeaderActions.tsx
+++ b/src/pages/NoteView/NoteViewHeaderActions.tsx
@@ -60,7 +60,7 @@ export function NoteViewHeaderActions({
         <>
           <ShareButton note={note} canManageMembers={canManageMembers} />
           <Button asChild variant="outline" size="sm">
-            <Link to={`/note/${note.id}/settings`}>{t("notes.settings")}</Link>
+            <Link to={`/notes/${note.id}/settings`}>{t("notes.settings")}</Link>
           </Button>
         </>
       )}

--- a/src/pages/NoteView/ShareModal/NoteShareModal.test.tsx
+++ b/src/pages/NoteView/ShareModal/NoteShareModal.test.tsx
@@ -103,7 +103,7 @@ describe("NoteShareModal", () => {
     renderModal();
     expect(screen.getByRole("link", { name: /notes\.shareOpenMembersPage/ })).toHaveAttribute(
       "href",
-      "/note/note-1/members",
+      "/notes/note-1/members",
     );
   });
 
@@ -113,7 +113,7 @@ describe("NoteShareModal", () => {
     await user.click(screen.getByRole("tab", { name: "notes.shareTabVisibility" }));
     const urlInputs = screen.getAllByLabelText("notes.shareLink");
     expect(urlInputs.length).toBeGreaterThan(0);
-    expect(urlInputs[0]).toHaveValue(`${window.location.origin}/note/note-1`);
+    expect(urlInputs[0]).toHaveValue(`${window.location.origin}/notes/note-1`);
   });
 
   it("does not render the share URL field on visibility tab when note is private", async () => {

--- a/src/pages/NoteView/ShareModal/ShareModalMembersTab.tsx
+++ b/src/pages/NoteView/ShareModal/ShareModalMembersTab.tsx
@@ -41,7 +41,7 @@ export function ShareModalMembersTab({ noteId, enabled, onNavigate }: ShareModal
       />
       <div className="mt-3 flex justify-end">
         <Button asChild variant="link" size="sm" onClick={onNavigate}>
-          <Link to={`/note/${noteId}/members`}>
+          <Link to={`/notes/${noteId}/members`}>
             <ExternalLink className="mr-1 h-3 w-3" />
             {t("notes.shareOpenMembersPage")}
           </Link>

--- a/src/pages/NoteView/ShareModal/ShareModalVisibilityTab.tsx
+++ b/src/pages/NoteView/ShareModal/ShareModalVisibilityTab.tsx
@@ -267,7 +267,7 @@ export function ShareModalVisibilityTab({ note, canEdit }: ShareModalVisibilityT
 
   const noteUrl = useMemo(() => {
     if (typeof window === "undefined") return "";
-    return `${window.location.origin}/note/${note.id}`;
+    return `${window.location.origin}/notes/${note.id}`;
   }, [note.id]);
 
   const handleCopyNoteUrl = async () => {

--- a/src/pages/NoteView/index.tsx
+++ b/src/pages/NoteView/index.tsx
@@ -133,7 +133,7 @@ const NoteView: React.FC = () => {
       floatingAction={
         canEdit ? (
           <div className="mr-4 mb-4">
-            <FloatingActionButton />
+            <FloatingActionButton noteId={note.id} />
           </div>
         ) : null
       }

--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -146,7 +146,7 @@ const Notes: React.FC = () => {
       setTitle("");
       setVisibility("private");
       setEditPermission("owner_only");
-      navigate(`/note/${newNote.id}`);
+      navigate(`/notes/${newNote.id}`);
     } catch (error) {
       console.error("Failed to create note:", error);
       setIsPublicAnyLoggedInCreateConfirmOpen(false);

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -96,9 +96,9 @@ export default function SearchResults() {
    */
   const handleResultClick = (item: SearchResultItem) => {
     if (item.noteId) {
-      navigate(`/note/${item.noteId}/page/${item.pageId}`);
+      navigate(`/notes/${item.noteId}/pages/${item.pageId}`);
     } else {
-      navigate(`/page/${item.pageId}`);
+      navigate(`/pages/${item.pageId}`);
     }
   };
 


### PR DESCRIPTION
## Summary

- `/page/:id` / `/note/:noteId/**` ルートを複数形 `/pages/:id` / `/notes/:noteId/**` に統一し、旧パスは `search` / `hash` を保持したリダイレクトで後方互換を維持。
- ノート詳細ページ (`NoteView`) の FAB が、これまでは `/pages/[id]` にノート未紐づけのページを作成していたのを、`useAddPageToNote` でノートに紐づけた上で `/notes/:noteId/pages/:pageId` へ遷移するように変更（紐づけ失敗時はスタンドアロンページへフォールバック）。
- `FloatingActionButton` / `useCreateNewPage` / `useFloatingActionButtonHandlers` にオプショナルな `noteId` を追加し、URL クリップ・画像作成経路でも同じ挙動に統一。

## What changed

### Route rename (singular → plural)

| Before | After |
|---|---|
| `/page/:id` | `/pages/:id` |
| `/note/:noteId` | `/notes/:noteId` |
| `/note/:noteId/settings` | `/notes/:noteId/settings` |
| `/note/:noteId/members` | `/notes/:noteId/members` |
| `/note/:noteId/page/:pageId` | `/notes/:noteId/pages/:pageId` |

旧パスは `App.tsx` で `LegacyPageRedirect` / `LegacyNoteRedirect` / `LegacyNotePageRedirect` として残置し、`search` と `hash` を保ったまま複数形に `replace` 遷移します。

### FAB note-scoped page creation

`NoteView` 配下で FAB からページを作成したとき、作成したページが自動でそのノートに紐づきます。ノート内部の `useAddPageToNote` と同じ API (`POST /api/notes/:noteId/pages`) を経由して紐づけるため、追加のバックエンド変更は不要。

### Why

ノート詳細画面 (`/notes/[id]`) は構造的に `/home` に近く、FAB から新規ページを作成してそのまま編集に入るのが自然な導線ですが、これまでは作成したページがノートに紐づかず、FAB 経由で作ると必ずノートの外（スタンドアロンページ）に出てしまうという挙動になっていました。本 PR はそのギャップを埋めるとともに、機会に合わせて単数/複数が混在していたルートを複数形に揃えます。

## Test plan

- [x] `bun run lint` — 0 errors（既存 warning のみ）
- [x] `bunx tsc --noEmit -p tsconfig.app.json` — 変更由来のエラーなし
- [x] `bunx vitest run` — 176 files / 1532 tests pass
- [ ] Manual: `/note/:noteId` 系の旧 URL から新 URL へのリダイレクトを確認
- [ ] Manual: ノート詳細で FAB をクリックして新規ページを作成 → URL が `/notes/:noteId/pages/:pageId` になり、ノートのページ一覧にも表示されることを確認
- [ ] Manual: Home (`/home`) からの FAB は従来通り `/pages/:id` に遷移することを確認
- [ ] Manual: 検索結果・Wiki リンク・ページ複製などの既存経路が新しい複数形ルートで動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routes standardized to plural paths (/pages, /notes) with redirects; note-scoped page creation/linking supported; Floating Action Button accepts noteId.
* **UI/Layout Improvements**
  * Sticky, scroll-aware header; header action slots added; mobile header sizing/spacing updated; scroll container structure improved; centralized primary navigation.
* **Database**
  * note_members table extended with status and accepted_user tracking.
* **Chores**
  * Removed Cross-Origin-Embedder-Policy header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->