### PR TITLE
fix: prevent hidden page editor header from staying focusable

### DIFF
--- a/src/components/editor/PageEditor/PageEditorHeader.test.tsx
+++ b/src/components/editor/PageEditor/PageEditorHeader.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PageEditorHeader } from "./PageEditorHeader";
 
@@ -162,6 +162,37 @@ describe("PageEditorHeader", () => {
       });
       await user.click(screen.getByTestId("connection-indicator"));
       expect(onReconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("スクロールで非表示になったヘッダーはフォーカス対象から外れる", async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <div style={{ overflowY: "auto" }}>
+          <PageEditorHeader {...defaultProps} />
+        </div>,
+      );
+
+      const backButton = screen.getByRole("button", { name: /back|common\.back/i });
+      const scrollContainer = container.firstElementChild as HTMLElement | null;
+      const header = scrollContainer?.firstElementChild as HTMLElement | null;
+      expect(scrollContainer).not.toBeNull();
+      expect(header).not.toBeNull();
+
+      backButton.focus();
+      expect(backButton).toHaveFocus();
+
+      if (!scrollContainer) {
+        throw new Error("scroll container not found");
+      }
+      await act(async () => {
+        scrollContainer.scrollTop = 24;
+        scrollContainer.dispatchEvent(new Event("scroll"));
+      });
+
+      await waitFor(() => {
+        expect(header).toHaveAttribute("aria-hidden", "true");
+      });
+      expect(backButton).not.toHaveFocus();
     });
   });
 });

--- a/src/components/editor/PageEditor/PageEditorHeader.tsx
+++ b/src/components/editor/PageEditor/PageEditorHeader.tsx
@@ -145,12 +145,26 @@ export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
     };
   }, []);
 
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+
+    el.inert = hidden;
+    if (!hidden) return;
+
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLElement && el.contains(activeElement)) {
+      activeElement.blur();
+    }
+  }, [hidden]);
+
   return (
     <div
       ref={wrapperRef}
+      aria-hidden={hidden || undefined}
       className={cn(
-        "bg-background/70 supports-[backdrop-filter]:bg-background/50 sticky top-0 z-20 backdrop-blur transition-transform duration-300 ease-in-out",
-        hidden ? "-translate-y-full" : "translate-y-0",
+        "bg-background/70 supports-backdrop-filter:bg-background/50 sticky top-0 z-20 backdrop-blur transition-transform duration-300 ease-in-out",
+        hidden ? "pointer-events-none -translate-y-full" : "translate-y-0",
       )}
     >
       <Container className="flex items-center justify-between gap-4 py-2">

--- a/src/components/editor/PageEditor/PageEditorHeader.tsx
+++ b/src/components/editor/PageEditor/PageEditorHeader.tsx
@@ -163,7 +163,7 @@ export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
       ref={wrapperRef}
       aria-hidden={hidden || undefined}
       className={cn(
-        "bg-background/70 supports-backdrop-filter:bg-background/50 sticky top-0 z-20 backdrop-blur transition-transform duration-300 ease-in-out",
+        "bg-background/70 supports-[backdrop-filter]:bg-background/50 sticky top-0 z-20 backdrop-blur transition-transform duration-300 ease-in-out",
         hidden ? "pointer-events-none -translate-y-full" : "translate-y-0",
       )}
     >


### PR DESCRIPTION
## 概要

`PageEditorHeader` がスクロールで画面外へ退避した後も、内部のアイコンボタンがキーボードフォーカス対象に残り続ける問題を修正します。見えない操作に tab 移動できてしまう状態を防ぎ、ヘッダー非表示時のアクセシビリティを改善します。

## 変更点

- `PageEditorHeader` が非表示状態になったときに `inert` と `aria-hidden` を付け、内部操作をフォーカス対象から外すよう修正
- 非表示中のヘッダーに対して `pointer-events-none` を追加し、見えない UI への操作を防止
- スクロールでヘッダーが隠れた際にフォーカスが外れることを確認する回帰テストを追加

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run lint`
2. `bunx vitest run src/components/editor/PageEditor/PageEditorHeader.test.tsx`
3. ノート編集画面でスクロールしてヘッダーを隠し、キーボード操作で見えない戻るボタンやメニューボタンに移動しないことを確認する

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

必要に応じて、ヘッダー表示中 / 非表示中のキーボード操作差分を追記してください。

## 関連 Issue

<!-- なし -->

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Header now updates ARIA to reflect visibility, disables pointer interactions when hidden, and ensures keyboard focus is moved away when scrolled out of view.
  * Visual transition behavior for showing/hiding the header refined.

* **Tests**
  * New test coverage verifying header focus handling and visibility/ARIA synchronization during scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->