### PR TITLE
fix(layout): NotePageView 編集ラッパーを flex 列にしてモバイルスクロールを復旧

### DIFF
--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -184,10 +184,18 @@ const NotePageView: React.FC = () => {
           When editing, `ContentWithAIChat` owns the scroll container, so keep
           this wrapper non-scrollable to avoid nested scroll regions. In
           read-only mode, this wrapper still scrolls the page body. */}
+      {/* 編集時は ContentWithAIChat 内のモバイルスクロールラッパー（flex-1 +
+          overflow-y-auto）に高さを伝搬させるため、このラッパーも flex 列にする。
+          ブロックレイアウトのままだと子の `flex-1` が効かず、スクロールラッパーが
+          コンテンツ高さに張り付き overflow-y-auto が発火しない。
+          When editing, this wrapper must be a flex column so the bounded height
+          propagates down to ContentWithAIChat's mobile scroll wrapper (which
+          relies on flex-1). Without `flex flex-col`, the child's `flex-1` is a
+          no-op in block layout and `overflow-y-auto` never engages. */}
       <div
         className={
           canEdit
-            ? "min-h-0 flex-1 md:overflow-hidden"
+            ? "flex min-h-0 flex-1 flex-col md:overflow-hidden"
             : "min-h-0 flex-1 overflow-y-auto md:overflow-hidden"
         }
       >


### PR DESCRIPTION
## 概要

PR #702 の Devin Review で指摘された、モバイル環境で `NotePageView` の編集モード時に本文がスクロールできなくなる回帰を修正します。

## 変更点

- `src/pages/NotePageView.tsx`: 編集モード時 (`canEdit === true`) のラッパー div に `flex flex-col` を付与し、子の `ContentWithAIChat` モバイルスクロールラッパー (`flex-1 + overflow-y-auto`) に高さを伝搬させる。
- 意図を説明するコメントを追加。

### 背景

`ContentWithAIChat` のモバイル分岐は内部に `relative min-h-0 flex-1 overflow-y-auto` のスクロールコンテナを持ちます。`NotePageView` の編集モードでは外側ラッパーが block レイアウト (`min-h-0 flex-1 md:overflow-hidden`) のままだったため、子の `flex-1` が効かずスクロールラッパーがコンテンツ高さに張り付き、`overflow-y-auto` が発火しません。先祖の `overflow-hidden` (NotePageView.tsx:172) でクリップされ、モバイル編集時に本文がスクロールできない状態でした。

ラッパーを `flex flex-col` にすることで `ContentWithAIChat` 側がスクロール責務を持つ PR #702 の意図と整合し、ネストスクロールも回避できます。

他の `ContentWithAIChat` 利用箇所 (Home / NoteView / PageEditorLayout) は親が flex コンテナのため影響なし。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. モバイル幅 (DevTools のモバイルエミュレーション等) でノートページを編集モードで開く
2. エディタ本文を縦スクロールできることを確認する
3. デスクトップ幅でも従来どおり挙動することを確認する (md 以上は `overflow-hidden`)
4. 閲覧専用モードでもスクロール可能であることを確認する (`overflow-y-auto md:overflow-hidden` のまま)

## チェックリスト

- [x] テストがすべてパスする (CI で確認)
- [x] Lint エラーがない (`bun run lint`: 0 errors)
- [x] 必要に応じてドキュメントを更新した (該当なし、コード内コメントで意図を補足)
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue / PR

- Addresses Devin Review feedback on #702
- Follow-up to: #702


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout rendering in note editing mode to properly display content and ensure height constraints work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->