### PR TITLE
fix(notes): redirect to /notes after note deletion

### DIFF
--- a/src/pages/NoteSettings/index.tsx
+++ b/src/pages/NoteSettings/index.tsx
@@ -88,7 +88,7 @@ const NoteSettings: React.FC = () => {
       await deleteNoteMutation.mutateAsync(noteId);
       toast({ title: t("notes.noteDeleted") });
       setIsDeleteDialogOpen(false);
-      navigate("/home");
+      navigate("/notes");
     } catch (error) {
       console.error("Failed to delete note:", error);
       toast({ title: t("notes.noteDeleteFailed"), variant: "destructive" });


### PR DESCRIPTION
## 概要

ノート設定画面からノートを削除した際のリダイレクト先を `/home` から `/notes` に変更します。削除後はノート一覧に戻り、他のノートの管理を続けられるようにします。

## 変更点

- [src/pages/NoteSettings/index.tsx:91](src/pages/NoteSettings/index.tsx:91) の `handleDeleteNote` で `navigate("/home")` → `navigate("/notes")` に変更

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. ノート設定画面 (`/notes/:noteId/settings`) を開く
2. 「ノートを削除」ボタンから削除を確定する
3. `/notes` にリダイレクトされ、ノート一覧が表示されることを確認する

## チェックリスト

- [x] テストがすべてパスする（既存テストに影響なし。削除後のリダイレクト先を検証するアサーションはもともと無し）
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

N/A（ナビゲーション先のみの変更）

## 関連 Issue

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed note deletion to redirect to the notes list instead of the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->