### PR TITLE
feat: ノート配下ページの URL を短縮しタイトル編集を修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,13 +80,23 @@ function LegacyNoteRedirect({ suffix }: { suffix?: "settings" | "members" }) {
 }
 
 /**
- * Redirect `/note/:noteId/page/:pageId` to `/notes/:noteId/pages/:pageId`.
- * 旧パス `/note/:noteId/page/:pageId` を複数形ルートへリダイレクト。
+ * Redirect `/note/:noteId/page/:pageId` to `/notes/:noteId/:pageId`.
+ * 旧パス `/note/:noteId/page/:pageId` を新ルートへリダイレクト。
  */
 function LegacyNotePageRedirect() {
   const { noteId, pageId } = useParams<{ noteId: string; pageId: string }>();
   const { search, hash } = useLocation();
-  return <Navigate to={`/notes/${noteId}/pages/${pageId}${search}${hash}`} replace />;
+  return <Navigate to={`/notes/${noteId}/${pageId}${search}${hash}`} replace />;
+}
+
+/**
+ * Redirect `/notes/:noteId/pages/:pageId` to `/notes/:noteId/:pageId`.
+ * 旧パス `/notes/:noteId/pages/:pageId` を新しい短縮パスへリダイレクト。
+ */
+function LegacyNotePagesRedirect() {
+  const { noteId, pageId } = useParams<{ noteId: string; pageId: string }>();
+  const { search, hash } = useLocation();
+  return <Navigate to={`/notes/${noteId}/${pageId}${search}${hash}`} replace />;
 }
 
 /**
@@ -187,7 +197,14 @@ const App = () => (
                       <Route path="/notes/:noteId" element={<NoteView />} />
                       <Route path="/notes/:noteId/settings" element={<NoteSettings />} />
                       <Route path="/notes/:noteId/members" element={<NoteMembers />} />
-                      <Route path="/notes/:noteId/pages/:pageId" element={<NotePageView />} />
+                      <Route path="/notes/:noteId/:pageId" element={<NotePageView />} />
+                      {/* Legacy path — redirect `/notes/:noteId/pages/:pageId` to
+                          the shorter `/notes/:noteId/:pageId`.
+                          旧パス `/notes/:noteId/pages/:pageId` を短縮形にリダイレクト。 */}
+                      <Route
+                        path="/notes/:noteId/pages/:pageId"
+                        element={<LegacyNotePagesRedirect />}
+                      />
                       {/* Legacy singular paths — redirect to plural.
                           旧単数形パス — 複数形にリダイレクト。 */}
                       <Route path="/note/:noteId" element={<LegacyNoteRedirect />} />

--- a/src/components/editor/PageEditor/PageTitleBlock.tsx
+++ b/src/components/editor/PageEditor/PageTitleBlock.tsx
@@ -54,7 +54,11 @@ export const PageTitleBlock: React.FC<PageTitleBlockProps> = ({
     [onTitleChange],
   );
 
-  if (isReadOnly) {
+  // ハンドラが渡されない場合は表示専用 `<h1>` にフォールバックし、制御 input の
+  // value 固定で「入力できない」状態にならないようにする。
+  // When no handler is supplied, render a static `<h1>` so the controlled input
+  // does not appear editable while silently dropping keystrokes.
+  if (isReadOnly || !onTitleChange) {
     return (
       <div ref={titleRef} className="pt-6 pb-2">
         <h1 className="text-2xl font-semibold break-words whitespace-normal">

--- a/src/components/layout/FloatingActionButton.tsx
+++ b/src/components/layout/FloatingActionButton.tsx
@@ -14,7 +14,7 @@ import { useFloatingActionButtonHandlers } from "./useFloatingActionButtonHandle
 /**
  * FAB 共通プロパティ。`noteId` が指定されるとノート配下ページとして作成・遷移する。
  * Common FAB props. When `noteId` is supplied the FAB creates pages scoped to
- * that note and routes to `/notes/:noteId/pages/:pageId` instead of the
+ * that note and routes to `/notes/:noteId/:pageId` instead of the
  * standalone `/pages/:id`.
  *
  * When initialClipUrl is provided, onClipDialogClosedWithInitialUrl is required

--- a/src/components/layout/useFloatingActionButtonHandlers.ts
+++ b/src/components/layout/useFloatingActionButtonHandlers.ts
@@ -18,7 +18,7 @@ export interface UseFloatingActionButtonHandlersOptions {
   /**
    * 指定したノート配下でページを作成する場合のノート ID。
    * When set, newly created pages are linked to this note and routed to
-   * `/notes/:noteId/pages/:pageId` instead of the standalone `/pages/:id`.
+   * `/notes/:noteId/:pageId` instead of the standalone `/pages/:id`.
    */
   noteId?: string;
 }
@@ -70,7 +70,7 @@ export function useFloatingActionButtonHandlers(
           navigate(`/pages/${pageId}`, navState ? { state: navState } : undefined);
           return;
         }
-        navigate(`/notes/${noteId}/pages/${pageId}`, navState ? { state: navState } : undefined);
+        navigate(`/notes/${noteId}/${pageId}`, navState ? { state: navState } : undefined);
         return;
       }
       navigate(`/pages/${pageId}`, navState ? { state: navState } : undefined);

--- a/src/components/note/NotePageCard.tsx
+++ b/src/components/note/NotePageCard.tsx
@@ -41,7 +41,7 @@ const NotePageCard: React.FC<NotePageCardProps> = ({ noteId, page }) => {
    *
    */
   const handleClick = () => {
-    navigate(`/notes/${noteId}/pages/${page.id}`);
+    navigate(`/notes/${noteId}/${page.id}`);
   };
 
   return (

--- a/src/contexts/GlobalSearchContext.tsx
+++ b/src/contexts/GlobalSearchContext.tsx
@@ -52,7 +52,7 @@ export function GlobalSearchProvider({ children }: { children: ReactNode }) {
   const handleSelect = useCallback(
     (pageId: string, noteId?: string) => {
       if (noteId) {
-        navigate(`/notes/${noteId}/pages/${pageId}`);
+        navigate(`/notes/${noteId}/${pageId}`);
       } else {
         navigate(`/pages/${pageId}`);
       }

--- a/src/hooks/useCreateNewPage.ts
+++ b/src/hooks/useCreateNewPage.ts
@@ -6,11 +6,11 @@ import { useToast } from "@zedi/ui";
 
 /**
  * 新規ページを作成して対応するエディタへ遷移するフック。
- * `noteId` が指定された場合はノートに紐づけ、`/notes/:noteId/pages/:pageId` へ遷移する。
+ * `noteId` が指定された場合はノートに紐づけ、`/notes/:noteId/:pageId` へ遷移する。
  *
  * Hook to create a new page and navigate to it. When `noteId` is provided the
  * page is linked to that note and the caller is routed into the note-scoped
- * path `/notes/:noteId/pages/:pageId`; otherwise the standalone `/pages/:id`
+ * path `/notes/:noteId/:pageId`; otherwise the standalone `/pages/:id`
  * route is used. Centralizing the create-then-navigate flow avoids race
  * conditions between page creation and navigation.
  */
@@ -51,7 +51,7 @@ export function useCreateNewPage(options?: { noteId?: string }) {
           navigate(`/pages/${newPage.id}`);
           return;
         }
-        navigate(`/notes/${noteId}/pages/${newPage.id}`);
+        navigate(`/notes/${noteId}/${newPage.id}`);
         return;
       }
       navigate(`/pages/${newPage.id}`);

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -26,7 +26,7 @@ export interface SearchResult {
 /** Unified item for global search (personal + shared). C3-8. */
 export interface GlobalSearchResultItem {
   pageId: string;
-  /** Set for shared-note results; navigate to /notes/:noteId/pages/:pageId */
+  /** Set for shared-note results; navigate to /notes/:noteId/:pageId */
   noteId?: string;
   title: string;
   highlightedText: string;

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -26,7 +26,7 @@ export interface SearchResult {
 /** Unified item for global search (personal + shared). C3-8. */
 export interface GlobalSearchResultItem {
   pageId: string;
-  /** Set for shared-note results; navigate to /notes/:noteId/:pageId */
+  /** 共有ノート結果で設定される。Set for shared-note results; navigate to /notes/:noteId/:pageId. */
   noteId?: string;
   title: string;
   highlightedText: string;

--- a/src/pages/NotePageView.test.tsx
+++ b/src/pages/NotePageView.test.tsx
@@ -70,6 +70,7 @@ vi.mock("@zedi/ui", () => ({
       {children}
     </button>
   ),
+  useToast: () => ({ toast: vi.fn() }),
 }));
 
 vi.mock("@/components/layout/AppLayout", () => ({

--- a/src/pages/NotePageView.test.tsx
+++ b/src/pages/NotePageView.test.tsx
@@ -18,7 +18,23 @@ vi.mock("react-router-dom", async (importOriginal) => {
 vi.mock("@/hooks/useNoteQueries", () => ({
   useNote: vi.fn(),
   useNotePage: vi.fn(),
+  noteKeys: {
+    page: (noteId: string, pageId: string) => ["notes", "pages", noteId, pageId],
+    pageList: (noteId: string) => ["notes", "pages", noteId],
+  },
 }));
+
+vi.mock("@/hooks/usePageQueries", () => ({
+  useUpdatePage: vi.fn(() => ({ mutateAsync: vi.fn().mockResolvedValue({ skipped: false }) })),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQueryClient: vi.fn(() => ({ invalidateQueries: vi.fn() })),
+  };
+});
 
 vi.mock("@/hooks/useAuth", () => ({
   useAuth: vi.fn(),
@@ -64,10 +80,10 @@ vi.mock("@/components/layout/AppLayout", () => ({
 
 function renderNotePageView() {
   return render(
-    <MemoryRouter initialEntries={[`/notes/note-1/pages/page-1`]}>
+    <MemoryRouter initialEntries={[`/notes/note-1/page-1`]}>
       <AIChatProvider>
         <Routes>
-          <Route path="/notes/:noteId/pages/:pageId" element={<NotePageView />} />
+          <Route path="/notes/:noteId/:pageId" element={<NotePageView />} />
         </Routes>
       </AIChatProvider>
     </MemoryRouter>,

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -1,11 +1,13 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import Container from "@/components/layout/Container";
 import { PageLoadingOrDenied } from "@/components/layout/PageLoadingOrDenied";
 import { PageEditorContent } from "@/components/editor/PageEditor/PageEditorContent";
 import { Button } from "@zedi/ui";
-import { useNote, useNotePage } from "@/hooks/useNoteQueries";
+import { useNote, useNotePage, noteKeys } from "@/hooks/useNoteQueries";
+import { useUpdatePage } from "@/hooks/usePageQueries";
 import { useAuth } from "@/hooks/useAuth";
 import { useCollaboration } from "@/hooks/useCollaboration";
 import { ContentWithAIChat } from "@/components/ai-chat/ContentWithAIChat";
@@ -15,6 +17,8 @@ import { NoteWorkspaceToolbar } from "@/components/note/NoteWorkspaceToolbar";
 import { convertMarkdownToTiptapContent } from "@/lib/markdownToTiptap";
 import type { UseCollaborationReturn } from "@/lib/collaboration/types";
 import type { Page } from "@/types/page";
+
+const TITLE_SAVE_DEBOUNCE_MS = 500;
 
 function canEditPage(
   access: { canEdit?: boolean; canView?: boolean } | undefined,
@@ -42,10 +46,15 @@ function NotePageEditorEditable({
   isCollaborationEnabled: boolean;
 }): React.JSX.Element {
   const [editorContent, setEditorContent] = useState(page.content ?? "");
+  const [title, setTitle] = useState(page.title);
   const { setPageContext, contentAppendHandlerRef, insertAtCursorRef } = useAIChatContext();
   const noteWorkspace = useNoteWorkspaceOptional();
   const workspaceRoot = noteWorkspace?.workspaceRoot ?? null;
   const editorInsertRef = useRef<((content: unknown) => boolean) | null>(null);
+  const updatePageMutation = useUpdatePage();
+  const queryClient = useQueryClient();
+  const titleSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingTitleRef = useRef<string | null>(null);
 
   useEffect(() => {
     setPageContext({
@@ -53,11 +62,11 @@ function NotePageEditorEditable({
       pageId: page.id,
       noteId,
       claudeWorkspaceRoot: workspaceRoot ?? undefined,
-      pageTitle: page.title,
+      pageTitle: title,
       pageContent: editorContent.slice(0, 3000),
       pageFullContent: editorContent,
     });
-  }, [page.id, page.title, editorContent, setPageContext, noteId, workspaceRoot]);
+  }, [page.id, title, editorContent, setPageContext, noteId, workspaceRoot]);
 
   useEffect(() => {
     return () => setPageContext(null);
@@ -86,12 +95,69 @@ function NotePageEditorEditable({
     };
   }, [insertAtCursorRef]);
 
+  const persistTitle = useCallback(
+    async (nextTitle: string) => {
+      try {
+        await updatePageMutation.mutateAsync({
+          pageId: page.id,
+          updates: { title: nextTitle },
+        });
+        // `useUpdatePage` updates `pageKeys.*` caches, but the note page list and
+        // detail are held under `noteKeys.*`. Invalidate those so the new title
+        // propagates to the note view and sidebar.
+        // `useUpdatePage` は `pageKeys.*` を更新するが、ノート側のキャッシュは
+        // `noteKeys.*` にあるため、タイトル変更をノート表示やサイドバーに反映
+        // させるには明示的に無効化する必要がある。
+        queryClient.invalidateQueries({ queryKey: noteKeys.page(noteId, page.id) });
+        queryClient.invalidateQueries({ queryKey: noteKeys.pageList(noteId) });
+      } catch (error) {
+        console.error("Failed to save page title:", error);
+      }
+    },
+    [noteId, page.id, queryClient, updatePageMutation],
+  );
+
+  const handleTitleChange = useCallback(
+    (newTitle: string) => {
+      setTitle(newTitle);
+      pendingTitleRef.current = newTitle;
+      if (titleSaveTimerRef.current) {
+        clearTimeout(titleSaveTimerRef.current);
+      }
+      titleSaveTimerRef.current = setTimeout(() => {
+        titleSaveTimerRef.current = null;
+        const pending = pendingTitleRef.current;
+        pendingTitleRef.current = null;
+        if (pending !== null) {
+          void persistTitle(pending);
+        }
+      }, TITLE_SAVE_DEBOUNCE_MS);
+    },
+    [persistTitle],
+  );
+
+  // アンマウント時に debounce 中のタイトル保存を即時フラッシュし、遷移で失われないようにする。
+  // Flush any debounced title save on unmount so navigation does not drop it.
+  useEffect(() => {
+    return () => {
+      if (titleSaveTimerRef.current) {
+        clearTimeout(titleSaveTimerRef.current);
+        titleSaveTimerRef.current = null;
+        const pending = pendingTitleRef.current;
+        pendingTitleRef.current = null;
+        if (pending !== null) {
+          void persistTitle(pending);
+        }
+      }
+    };
+  }, [persistTitle]);
+
   return (
     <ContentWithAIChat>
       <NoteWorkspaceToolbar />
       <PageEditorContent
         content={editorContent}
-        title={page.title}
+        title={title}
         sourceUrl={page.sourceUrl}
         currentPageId={page.id}
         pageId={page.id}
@@ -102,6 +168,7 @@ function NotePageEditorEditable({
         showToolbar
         onContentChange={setEditorContent}
         onContentError={() => undefined}
+        onTitleChange={handleTitleChange}
         collaboration={isCollaborationEnabled ? collaboration : undefined}
         insertAtCursorRef={editorInsertRef}
       />

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft } from "lucide-react";
 import Container from "@/components/layout/Container";
 import { PageLoadingOrDenied } from "@/components/layout/PageLoadingOrDenied";
 import { PageEditorContent } from "@/components/editor/PageEditor/PageEditorContent";
-import { Button } from "@zedi/ui";
+import { Button, useToast } from "@zedi/ui";
 import { useNote, useNotePage, noteKeys } from "@/hooks/useNoteQueries";
 import { useUpdatePage } from "@/hooks/usePageQueries";
 import { useAuth } from "@/hooks/useAuth";
@@ -31,6 +31,21 @@ function canEditPage(
 }
 
 /**
+ * タイトル更新 API (`PUT /api/pages/:id/content` 経由) はページ所有者しか
+ * 成功しない。ノート編集権限があってもページ所有者でなければタイトル欄は
+ * 閲覧専用として表示し、サイレントフェイルを避ける。
+ * The title-update path (`PUT /api/pages/:id/content`) only succeeds for the
+ * page owner. Even with note-level edit rights, non-owners get a read-only
+ * title rendering so we do not silently drop their keystrokes.
+ */
+function canEditTitle(
+  userId: string | undefined,
+  page: { ownerUserId?: string } | null | undefined,
+): boolean {
+  return Boolean(userId && page?.ownerUserId && page.ownerUserId === userId);
+}
+
+/**
  * Uses `key` on the parent so page switches reset local editor state.
  * `editorContent` の初期値は `page.content` から。
  */
@@ -39,11 +54,14 @@ function NotePageEditorEditable({
   noteId,
   collaboration,
   isCollaborationEnabled,
+  isTitleEditable,
 }: {
   page: Page;
   noteId: string;
   collaboration: UseCollaborationReturn;
   isCollaborationEnabled: boolean;
+  /** ページ所有者のみタイトル編集可。Only the page owner can edit the title. */
+  isTitleEditable: boolean;
 }): React.JSX.Element {
   const [editorContent, setEditorContent] = useState(page.content ?? "");
   const [title, setTitle] = useState(page.title);
@@ -53,8 +71,10 @@ function NotePageEditorEditable({
   const editorInsertRef = useRef<((content: unknown) => boolean) | null>(null);
   const updatePageMutation = useUpdatePage();
   const queryClient = useQueryClient();
+  const { toast } = useToast();
   const titleSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingTitleRef = useRef<string | null>(null);
+  const isSavingTitleRef = useRef(false);
 
   useEffect(() => {
     setPageContext({
@@ -95,62 +115,94 @@ function NotePageEditorEditable({
     };
   }, [insertAtCursorRef]);
 
-  const persistTitle = useCallback(
-    async (nextTitle: string) => {
-      try {
-        await updatePageMutation.mutateAsync({
-          pageId: page.id,
-          updates: { title: nextTitle },
-        });
-        // `useUpdatePage` updates `pageKeys.*` caches, but the note page list and
-        // detail are held under `noteKeys.*`. Invalidate those so the new title
-        // propagates to the note view and sidebar.
-        // `useUpdatePage` は `pageKeys.*` を更新するが、ノート側のキャッシュは
-        // `noteKeys.*` にあるため、タイトル変更をノート表示やサイドバーに反映
-        // させるには明示的に無効化する必要がある。
-        queryClient.invalidateQueries({ queryKey: noteKeys.page(noteId, page.id) });
-        queryClient.invalidateQueries({ queryKey: noteKeys.pageList(noteId) });
-      } catch (error) {
-        console.error("Failed to save page title:", error);
-      }
-    },
-    [noteId, page.id, queryClient, updatePageMutation],
-  );
+  // 最新の persistTitle をミュータブルな ref に退避する。useMutation の戻り値は
+  // 状態遷移（idle → pending → success）ごとに identity が変わるため、直接
+  // useCallback の依存に入れるとアンマウント用 effect の cleanup が過剰発火し、
+  // 保留中の保存が debounce を待たずに走ってしまう。ref 経由なら effect 側は
+  // 安定した参照だけを見て済む。
+  // Keep the latest persistTitle in a mutable ref. `useMutation()` returns a new
+  // object on every state transition (idle → pending → success), so referencing
+  // the mutation directly in a `useCallback` dep array would cause the unmount
+  // flush effect's cleanup to fire mid-typing and flush the debounce early.
+  const persistTitleRef = useRef<(nextTitle: string) => Promise<void>>(async () => {});
+  persistTitleRef.current = async (nextTitle: string) => {
+    try {
+      await updatePageMutation.mutateAsync({
+        pageId: page.id,
+        updates: { title: nextTitle },
+      });
+      // `useUpdatePage` updates `pageKeys.*` caches, but the note page list and
+      // detail are held under `noteKeys.*`. Invalidate those so the new title
+      // propagates to the note view and sidebar.
+      // `useUpdatePage` は `pageKeys.*` を更新するが、ノート側のキャッシュは
+      // `noteKeys.*` にあるため、タイトル変更をノート表示やサイドバーに反映
+      // させるには明示的に無効化する必要がある。
+      queryClient.invalidateQueries({ queryKey: noteKeys.page(noteId, page.id) });
+      queryClient.invalidateQueries({ queryKey: noteKeys.pageList(noteId) });
+    } catch (error) {
+      console.error("Failed to save page title:", error);
+      toast({
+        title: "タイトルの保存に失敗しました",
+        description: "通信環境を確認し、再度お試しください。",
+        variant: "destructive",
+      });
+      throw error;
+    }
+  };
 
-  const handleTitleChange = useCallback(
-    (newTitle: string) => {
-      setTitle(newTitle);
-      pendingTitleRef.current = newTitle;
-      if (titleSaveTimerRef.current) {
-        clearTimeout(titleSaveTimerRef.current);
-      }
-      titleSaveTimerRef.current = setTimeout(() => {
-        titleSaveTimerRef.current = null;
-        const pending = pendingTitleRef.current;
-        pendingTitleRef.current = null;
-        if (pending !== null) {
-          void persistTitle(pending);
+  // タイトル保存を直列化する。保存中なら何もせず、完了後に pending があれば
+  // 追随保存する。これにより「古いリクエストが遅延完了して新しい値を上書きする」
+  // 先祖返りを防止する。
+  // Serialize title saves: skip while a save is in-flight, and re-run once it
+  // completes if a newer title is pending. This prevents an out-of-order
+  // response from overwriting a more recent edit.
+  const flushPendingTitleRef = useRef<() => void>(() => {});
+  flushPendingTitleRef.current = () => {
+    if (isSavingTitleRef.current) return;
+    const pending = pendingTitleRef.current;
+    if (pending === null) return;
+    pendingTitleRef.current = null;
+    isSavingTitleRef.current = true;
+    void (async () => {
+      try {
+        await persistTitleRef.current(pending);
+      } catch {
+        // persistTitleRef で toast + console.error 済み。ここは coalesce 継続のため握る。
+        // Already logged + toasted inside persistTitleRef; swallow so we keep coalescing.
+      } finally {
+        isSavingTitleRef.current = false;
+        if (pendingTitleRef.current !== null) {
+          flushPendingTitleRef.current();
         }
-      }, TITLE_SAVE_DEBOUNCE_MS);
-    },
-    [persistTitle],
-  );
+      }
+    })();
+  };
+
+  const handleTitleChange = useCallback((newTitle: string) => {
+    setTitle(newTitle);
+    pendingTitleRef.current = newTitle;
+    if (titleSaveTimerRef.current) {
+      clearTimeout(titleSaveTimerRef.current);
+    }
+    titleSaveTimerRef.current = setTimeout(() => {
+      titleSaveTimerRef.current = null;
+      flushPendingTitleRef.current();
+    }, TITLE_SAVE_DEBOUNCE_MS);
+  }, []);
 
   // アンマウント時に debounce 中のタイトル保存を即時フラッシュし、遷移で失われないようにする。
+  // deps は空配列 — ref 経由のみで参照しているため、mutation 状態遷移で cleanup が走らない。
   // Flush any debounced title save on unmount so navigation does not drop it.
+  // Empty deps: we only read refs, so cleanup does not fire on mutation state transitions.
   useEffect(() => {
     return () => {
       if (titleSaveTimerRef.current) {
         clearTimeout(titleSaveTimerRef.current);
         titleSaveTimerRef.current = null;
-        const pending = pendingTitleRef.current;
-        pendingTitleRef.current = null;
-        if (pending !== null) {
-          void persistTitle(pending);
-        }
       }
+      flushPendingTitleRef.current();
     };
-  }, [persistTitle]);
+  }, []);
 
   return (
     <ContentWithAIChat>
@@ -168,7 +220,7 @@ function NotePageEditorEditable({
         showToolbar
         onContentChange={setEditorContent}
         onContentError={() => undefined}
-        onTitleChange={handleTitleChange}
+        onTitleChange={isTitleEditable ? handleTitleChange : undefined}
         collaboration={isCollaborationEnabled ? collaboration : undefined}
         insertAtCursorRef={editorInsertRef}
       />
@@ -208,6 +260,7 @@ const NotePageView: React.FC = () => {
   }, [navigate, noteId]);
 
   const canEdit = canEditPage(access, userId, page);
+  const isTitleEditable = canEdit && canEditTitle(userId, page);
   const collaborationPageId = page?.id ?? "";
   const isCollaborationEnabled = Boolean(collaborationPageId && isSignedIn && canEdit);
   const collaboration = useCollaboration({
@@ -274,6 +327,7 @@ const NotePageView: React.FC = () => {
               page={page}
               collaboration={collaboration}
               isCollaborationEnabled={isCollaborationEnabled}
+              isTitleEditable={isTitleEditable}
             />
           ) : (
             <PageEditorContent

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -96,7 +96,7 @@ export default function SearchResults() {
    */
   const handleResultClick = (item: SearchResultItem) => {
     if (item.noteId) {
-      navigate(`/notes/${item.noteId}/pages/${item.pageId}`);
+      navigate(`/notes/${item.noteId}/${item.pageId}`);
     } else {
       navigate(`/pages/${item.pageId}`);
     }


### PR DESCRIPTION
## 概要

ノート配下ページの URL を `/notes/:noteId/pages/:pageId` から `/notes/:noteId/:pageId` に短縮し、同ルートでタイトルが入力できなかった問題を修正します。

## 変更点

- **ルート変更**: `/notes/:noteId/pages/:pageId` → `/notes/:noteId/:pageId` に短縮。旧パスは互換リダイレクトを追加し、既存のブックマーク・共有リンクは維持。
- **タイトル入力の修正**: `NotePageView` の編集モードで `onTitleChange` ハンドラと `useUpdatePage` ミューテーション（デバウンス 500ms）を追加。保存成功時に `noteKeys.page` / `noteKeys.pageList` キャッシュを無効化してノート画面・サイドバーに反映。アンマウント時は保留中の保存をフラッシュし、画面遷移でタイトルが失われないようにする。
- 関連 navigate 呼び出し（`GlobalSearchContext` / `NotePageCard` / `SearchResults` / `useCreateNewPage` / `useFloatingActionButtonHandlers`）とコメント、およびテストのルート設定を新パスへ更新。

## なぜタイトルが入力できなかったか

`NotePageView` の `NotePageEditorEditable` が `<PageEditorContent>` に `title={page.title}` のみ渡し、`onTitleChange` コールバックも保存処理も渡していませんでした。`<PageTitleBlock>` は `<input value={title} onChange={handleChange}>` の制御コンポーネントなので、`onTitleChange` が未定義だと入力イベントで state が更新されず、`value` が常に元の値に固定されてしまい「入力できない」状態に見えていました。通常の `/pages/:id` では `usePageEditorStateAndSync` → `handleTitleChange` → `saveChanges`（`useUpdatePage` 経由）の流れがありますが、ノート版にはこれが未実装でした。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)（旧パスはリダイレクトで維持）
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. ノートを開き、その中のページを選択 → URL が `/notes/:noteId/:pageId` になることを確認。
2. 旧 URL `/notes/:noteId/pages/:pageId` を直接開き、新 URL へ自動リダイレクトされることを確認。
3. ページのタイトル欄にフォーカスして文字を入力 → 入力が反映され、500ms 後に保存されることを確認。
4. 編集後すぐに戻るなど画面遷移 → 入力したタイトルが失われていないこと、ノート一覧・サイドバーにも新タイトルが反映されていることを確認。
5. `bun x vitest run src/pages src/contexts` → 80 tests 全て pass を確認。

## チェックリスト

- [x] テストがすべてパスする（対象範囲で 80/80 pass）
- [x] Lint エラーがない（`bun run lint` で 0 errors）
- [x] 必要に応じてドキュメントを更新した（関連 TSDoc / コメント内のパスを新パスへ更新）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

<!-- 該当なし -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic title saving with debounced persistence and immediate flush on navigation.

* **Improvements**
  * Shortened note/page URLs for cleaner, concise links.
  * Legacy URLs now redirect to new paths while preserving search params and scroll/hash.

* **Bug Fixes**
  * Title field now renders as read-only when editing is not enabled, preventing dropped edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->