### PR TITLE
feat(notes): scope pages to personal vs note-native via pages.note_id (Phase 1, #713)

### DIFF
--- a/server/api/drizzle/0016_add_pages_note_id.sql
+++ b/server/api/drizzle/0016_add_pages_note_id.sql
@@ -1,0 +1,17 @@
+-- Add `pages.note_id` so pages can be scoped either to an individual user (NULL,
+-- "personal page") or to a specific note (non-null, "note-native page"). Personal
+-- home queries filter on `note_id IS NULL`; note deletion cascades to note-native
+-- pages. See issue #713.
+--
+-- `pages.note_id` を追加してページを「個人ページ（NULL）」と「ノート所属ページ
+-- （値あり）」にスコープ分けできるようにする。個人ホームの一覧は
+-- `note_id IS NULL` で絞り込み、ノート削除時は ON DELETE CASCADE で
+-- ノートネイティブページを一緒に削除する。Issue #713 を参照。
+
+ALTER TABLE "pages" ADD COLUMN "note_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "pages"
+    ADD CONSTRAINT "pages_note_id_notes_id_fk"
+    FOREIGN KEY ("note_id") REFERENCES "notes"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "idx_pages_note_id" ON "pages" ("note_id");

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1777161600000,
       "tag": "0015_add_note_members_status_accepted_user",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1777248000000,
+      "tag": "0016_add_pages_note_id",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/src/__tests__/routes/notes/pages.test.ts
+++ b/server/api/src/__tests__/routes/notes/pages.test.ts
@@ -41,7 +41,7 @@ describe("POST /api/notes/:noteId/pages", () => {
     const mockNote = createMockNote();
     const { app } = createTestApp([
       [mockNote], // getNoteRole → findActiveNoteById (owner)
-      [{ id: "pg-new", ownerId: TEST_USER_ID }], // page exists check
+      [{ id: "pg-new", ownerId: TEST_USER_ID, noteId: null }], // page exists check
       [{ max: 2 }], // maxOrder query
       [], // insert notePages
       [], // update notes.updatedAt
@@ -62,7 +62,7 @@ describe("POST /api/notes/:noteId/pages", () => {
     const mockNote = createMockNote();
     const { app } = createTestApp([
       [mockNote],
-      [{ id: "pg-new", ownerId: TEST_USER_ID }],
+      [{ id: "pg-new", ownerId: TEST_USER_ID, noteId: null }],
       [{ max: 5 }],
       [],
       [],
@@ -82,7 +82,7 @@ describe("POST /api/notes/:noteId/pages", () => {
     const mockNote = createMockNote();
     const { app } = createTestApp([
       [mockNote], // getNoteRole → findActiveNoteById (owner)
-      [{ id: "pg-camel", ownerId: TEST_USER_ID }], // page exists check
+      [{ id: "pg-camel", ownerId: TEST_USER_ID, noteId: null }], // page exists check
       [{ max: 0 }], // maxOrder query
       [], // insert notePages
       [], // update notes.updatedAt
@@ -139,7 +139,7 @@ describe("POST /api/notes/:noteId/pages", () => {
     const mockNote = createMockNote();
     const { app, chains } = createTestApp([
       [mockNote], // getNoteRole → findActiveNoteById (owner)
-      [{ id: "pg-existing", ownerId: TEST_USER_ID }], // page exists check
+      [{ id: "pg-existing", ownerId: TEST_USER_ID, noteId: null }], // page exists check
       [{ max: 0 }], // maxOrder query
       [], // insert notePages
       [], // update notes.updatedAt
@@ -240,6 +240,32 @@ describe("POST /api/notes/:noteId/pages", () => {
     expect(res.status).toBe(404);
   });
 
+  it("should return 400 when page_id refers to a note-native page (issue #713)", async () => {
+    // 別ノートに所属するノートネイティブページを `page_id` 経由で別ノートに
+    // リンクできてしまうと壊れたカード（list には出るが open すると 403）に
+    // なるため拒否する。Phase 1 では個人ページ（`note_id IS NULL`）のみ
+    // リンク可能。Phase 3 のコピーエンドポイントで取り込みを実装する。
+    //
+    // Reject note-native pages on the `page_id` link path (issue #713).
+    // Otherwise a page already scoped to note A would surface in note B but
+    // remain unauthorized for B's members. Only personal pages are linkable.
+    const mockNote = createMockNote();
+    const { app } = createTestApp([
+      [mockNote], // getNoteRole (owner)
+      [{ id: "pg-native", ownerId: TEST_USER_ID, noteId: "another-note-id" }], // page exists, but note-native
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/pages`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ page_id: "pg-native" }),
+    });
+
+    expect(res.status).toBe(400);
+    const text = await res.text();
+    expect(text).toContain("Only personal pages can be linked");
+  });
+
   it("should return 403 when user has no edit permission", async () => {
     const privateNote = createMockNote({
       ownerId: OTHER_USER_ID,
@@ -276,10 +302,11 @@ describe("POST /api/notes/:noteId/pages", () => {
 // ── DELETE /api/notes/:noteId/pages/:pageId ─────────────────────────────────
 
 describe("DELETE /api/notes/:noteId/pages/:pageId", () => {
-  it("should remove a page and return { removed: true }", async () => {
+  it("should detach a personal page (note_id IS NULL) without deleting the pages row", async () => {
     const mockNote = createMockNote();
-    const { app } = createTestApp([
+    const { app, chains } = createTestApp([
       [mockNote], // getNoteRole (owner)
+      [{ id: "pg-001", noteId: null }], // page lookup inside tx
       [], // update notePages (soft delete)
       [], // update notes.updatedAt
     ]);
@@ -292,6 +319,42 @@ describe("DELETE /api/notes/:noteId/pages/:pageId", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).toEqual({ removed: true });
+
+    // 個人ページは `note_pages` リンクと `notes.updatedAt` だけ更新する。
+    // `pages` 自体は所有者の個人 /home に残るので update しない。
+    // Personal page: only `note_pages` and `notes.updatedAt` get updated;
+    // the `pages` row itself stays alive on the owner's /home.
+    const updateCalls = chains.filter((c) => c.startMethod === "update");
+    expect(updateCalls).toHaveLength(2);
+  });
+
+  it("should also tombstone the pages row when removing a note-native page (issue #713)", async () => {
+    // ノートネイティブページ（`pages.note_id = noteId`）を `note_pages` だけ
+    // 論理削除すると `pages` 行が孤児として残り、`/api/pages/:id/content` が
+    // ノートロール経由で引き続き認可してしまう。同じトランザクションで
+    // `pages.is_deleted = true` まで進めることを検証する。
+    //
+    // For note-native pages, tombstoning only `note_pages` would leave the
+    // `pages` row alive and still authorized via the note role. Verify the
+    // route updates `pages.is_deleted = true` in the same transaction.
+    const mockNote = createMockNote();
+    const { app, chains } = createTestApp([
+      [mockNote], // getNoteRole (owner)
+      [{ id: "pg-native", noteId: NOTE_ID }], // page lookup → note-native
+      [], // update notePages (soft delete)
+      [], // update pages (soft delete the orphan)
+      [], // update notes.updatedAt
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/pages/pg-native`, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+
+    const updateCalls = chains.filter((c) => c.startMethod === "update");
+    expect(updateCalls).toHaveLength(3); // note_pages + pages + notes
   });
 
   it("should return 403 when user cannot edit", async () => {

--- a/server/api/src/__tests__/routes/notes/pages.test.ts
+++ b/server/api/src/__tests__/routes/notes/pages.test.ts
@@ -99,7 +99,7 @@ describe("POST /api/notes/:noteId/pages", () => {
     expect(body).toHaveProperty("added", true);
   });
 
-  it("should create a new page when title is provided without page_id", async () => {
+  it("should create a note-native page when title is provided without page_id (issue #713)", async () => {
     const mockNote = createMockNote();
     const { app, chains } = createTestApp([
       [mockNote], // getNoteRole
@@ -124,10 +124,44 @@ describe("POST /api/notes/:noteId/pages", () => {
     const pageInsert = insertCalls[0];
     expect(pageInsert).toBeDefined();
     const valuesOp = pageInsert?.ops.find((op) => op.method === "values");
+    // タイトル経路ではノートネイティブページとして作成されるため `noteId` が
+    // 必ず埋まり、個人 /home（`note_id IS NULL` フィルタ）には現れない。
+    // The title path creates a note-native page; `noteId` must be set so it
+    // never appears on personal /home (which filters `note_id IS NULL`).
     expect(valuesOp?.args[0]).toMatchObject({
       ownerId: TEST_USER_ID,
+      noteId: NOTE_ID,
       title: "New Page",
     });
+  });
+
+  it("should NOT set noteId when linking an existing personal page via page_id (issue #713)", async () => {
+    const mockNote = createMockNote();
+    const { app, chains } = createTestApp([
+      [mockNote], // getNoteRole → findActiveNoteById (owner)
+      [{ id: "pg-existing", ownerId: TEST_USER_ID }], // page exists check
+      [{ max: 0 }], // maxOrder query
+      [], // insert notePages
+      [], // update notes.updatedAt
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/pages`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ page_id: "pg-existing" }),
+    });
+
+    expect(res.status).toBe(200);
+    // `page_id` 経路は既存個人ページをノートに「リンク」するだけで、ページ
+    // 自体のスコープは変わらない。Phase 1 では pages テーブルへの insert は
+    // 走らない（note_pages へのリンクのみ）。Phase 3 で copy エンドポイント
+    // を別途追加する。
+    // The `page_id` path only links an existing personal page into the note;
+    // the page itself stays personal. In Phase 1 there is no insert into the
+    // `pages` table — only the `note_pages` link row is touched. Phase 3
+    // will add a separate copy endpoint.
+    const insertCalls = chains.filter((c) => c.startMethod === "insert");
+    expect(insertCalls).toHaveLength(1); // note_pages link only, no pages insert
   });
 
   it("should return 400 when neither page_id nor title is provided", async () => {

--- a/server/api/src/__tests__/routes/pages.test.ts
+++ b/server/api/src/__tests__/routes/pages.test.ts
@@ -158,6 +158,27 @@ describe("GET /api/pages", () => {
     expect(body.pages[0]).toMatchObject({ id: "page-shared" });
   });
 
+  it("scope=shared predicate also includes note-native pages owned by the caller via notes.owner_id", async () => {
+    const { app, chains } = createPagesAppWithChains([{ rows: [] }]);
+
+    const res = await app.request("/api/pages?scope=shared", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    // ノートオーナーは通常 note_members 行を持たないため、shared predicate に
+    // `notes.owner_id = userId` 経路を入れて listing と getNoteRole を整合させる
+    // （Issue #713 / PR #714 レビュー対応）。SQL チャンクから直接検証する。
+    // Verify the shared predicate contains the note-owner branch so listing
+    // matches `getNoteRole` for owners who lack a `note_members` row.
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    expect(executeChain).toBeDefined();
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).toContain("p.note_id IS NOT NULL");
+    expect(serialised).toContain("n.owner_id");
+  });
+
   it("returns 401 without auth header", async () => {
     const app = createPagesApp([{ rows: [] }]);
 

--- a/server/api/src/__tests__/routes/syncPages.test.ts
+++ b/server/api/src/__tests__/routes/syncPages.test.ts
@@ -141,6 +141,47 @@ describe("POST /api/sync/pages — IDOR protection", () => {
     expect(chains.filter((c) => c.startMethod === "update")).toHaveLength(0);
   });
 
+  it("collapses duplicate page ids in body to a single insert with the latest updated_at (PR #714 review)", async () => {
+    // クライアントのリトライ等で同じ id が複数届いても、bulk-fetch スナップショット
+    // を信じてループに無加工で流すと、新規 id の 2 回目で再 insert → PK 衝突 (500) や
+    // 古い updated_at で順序逆転が起きる。dedupe + マップ更新で防ぐ。
+    //
+    // Duplicate ids in the payload must collapse to a single DML and pick the
+    // latest `updated_at`, otherwise we either crash on PK conflict or
+    // out-of-order LWW updates land on the row.
+    const { app, chains } = createSyncApp([
+      // 1: bulk fetch returns nothing (treat as new id)
+      [],
+      // 2: insert (the deduped occurrence)
+      undefined,
+    ]);
+
+    const res = await app.request("/api/sync/pages", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        pages: [
+          { id: OWNED_PAGE, title: "older", updated_at: "2025-06-01T00:00:00Z" },
+          { id: OWNED_PAGE, title: "newer", updated_at: "2025-06-02T00:00:00Z" },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: { id: string; action: string }[] };
+    // 重複は畳み込まれるため、結果は 1 件のみ。
+    // Duplicates collapse: results contain a single entry.
+    expect(body.results).toEqual([{ id: OWNED_PAGE, action: "created" }]);
+
+    const insertChains = chains.filter((c) => c.startMethod === "insert");
+    expect(insertChains).toHaveLength(1);
+    // 最新の `updated_at` (= "newer") が採用されることを確認する。
+    // Newer payload (`title: "newer"`) wins via dedupe.
+    const valuesOp = (insertChains[0]?.ops ?? []).find((op) => op.method === "values");
+    const inserted = valuesOp?.args?.[0] as { title: string } | undefined;
+    expect(inserted?.title).toBe("newer");
+  });
+
   it("skips both links and ghost_links for non-owned pages in combined request", async () => {
     const oldDate = new Date("2024-01-01T00:00:00Z");
     const { app, chains } = createSyncApp([

--- a/server/api/src/__tests__/routes/syncPages.test.ts
+++ b/server/api/src/__tests__/routes/syncPages.test.ts
@@ -47,8 +47,8 @@ describe("POST /api/sync/pages — IDOR protection", () => {
   it("skips link insertion when source_id is not owned by the user", async () => {
     const oldDate = new Date("2024-01-01T00:00:00Z");
     const { app, chains } = createSyncApp([
-      // 1: page existence check
-      [{ id: OWNED_PAGE, updatedAt: oldDate, ownerId: TEST_USER_ID }],
+      // 1: bulk page fetch (LWW pre-load)
+      [{ id: OWNED_PAGE, ownerId: TEST_USER_ID, noteId: null, updatedAt: oldDate }],
       // 2: page update
       undefined,
       // 3: owned pages query for links
@@ -82,8 +82,8 @@ describe("POST /api/sync/pages — IDOR protection", () => {
   it("skips ghost_link insertion when source_page_id is not owned by the user", async () => {
     const oldDate = new Date("2024-01-01T00:00:00Z");
     const { app, chains } = createSyncApp([
-      // 1: page existence check
-      [{ id: OWNED_PAGE, updatedAt: oldDate, ownerId: TEST_USER_ID }],
+      // 1: bulk page fetch (LWW pre-load)
+      [{ id: OWNED_PAGE, ownerId: TEST_USER_ID, noteId: null, updatedAt: oldDate }],
       // 2: page update
       undefined,
       // 3: owned pages query for ghost_links
@@ -112,11 +112,40 @@ describe("POST /api/sync/pages — IDOR protection", () => {
     expect(insertChains.length).toBe(1);
   });
 
+  it("skips a page id that resolves to a note-native row on the server (issue #713)", async () => {
+    // クライアント側 IndexedDB が個人ページとして持っている ID と同じ ID が、
+    // サーバー側ではノートネイティブページ（`pages.note_id != null`）として
+    // 存在するケースの防御。`update` も `insert` も走らないことを検証する。
+    //
+    // Defensive case: a client tries to LWW-sync an id that on the server is a
+    // note-native page. Neither update nor insert should fire.
+    const oldDate = new Date("2024-01-01T00:00:00Z");
+    const { app, chains } = createSyncApp([
+      // 1: bulk fetch returns a note-native row for the requested id
+      [{ id: OWNED_PAGE, ownerId: TEST_USER_ID, noteId: "some-note", updatedAt: oldDate }],
+    ]);
+
+    const res = await app.request("/api/sync/pages", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        pages: [{ id: OWNED_PAGE, title: "client copy", updated_at: "2025-06-01T00:00:00Z" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: { id: string; action: string }[] };
+    expect(body.results).toEqual([{ id: OWNED_PAGE, action: "skipped" }]);
+
+    expect(chains.filter((c) => c.startMethod === "insert")).toHaveLength(0);
+    expect(chains.filter((c) => c.startMethod === "update")).toHaveLength(0);
+  });
+
   it("skips both links and ghost_links for non-owned pages in combined request", async () => {
     const oldDate = new Date("2024-01-01T00:00:00Z");
     const { app, chains } = createSyncApp([
-      // 1: page existence check
-      [{ id: OWNED_PAGE, updatedAt: oldDate, ownerId: TEST_USER_ID }],
+      // 1: bulk page fetch (LWW pre-load)
+      [{ id: OWNED_PAGE, ownerId: TEST_USER_ID, noteId: null, updatedAt: oldDate }],
       // 2: page update
       undefined,
       // 3: owned pages query for links

--- a/server/api/src/__tests__/services/pageAccessService.test.ts
+++ b/server/api/src/__tests__/services/pageAccessService.test.ts
@@ -1,0 +1,194 @@
+/**
+ * `services/pageAccessService.ts` のテスト。
+ *
+ * Issue #713 で導入した「個人ページ vs ノートネイティブページ」の権限分岐を
+ * 中心に検証する。
+ *
+ * Tests for `services/pageAccessService.ts`. Focused on the personal-page vs.
+ * note-native-page authorization split introduced in issue #713.
+ */
+import { describe, it, expect } from "vitest";
+import type { Database } from "../../types/index.js";
+import { createMockDb } from "../createMockDb.js";
+import { assertPageViewAccess, assertPageEditAccess } from "../../services/pageAccessService.js";
+
+const USER_ID = "user-123";
+const OTHER_USER_ID = "user-other";
+const USER_EMAIL = "user@example.com";
+const PAGE_ID = "page-001";
+const NOTE_ID = "note-001";
+
+function asDb(db: unknown): Database {
+  return db as unknown as Database;
+}
+
+describe("assertPageViewAccess (issue #713)", () => {
+  it("allows personal page owner", async () => {
+    const { db } = createMockDb([
+      [{ id: PAGE_ID, ownerId: USER_ID, noteId: null }], // getPageOwnership
+    ]);
+    await expect(assertPageViewAccess(asDb(db), PAGE_ID, USER_ID)).resolves.toBeUndefined();
+  });
+
+  it("denies non-owner / non-member on personal page", async () => {
+    const { db } = createMockDb([
+      [{ id: PAGE_ID, ownerId: OTHER_USER_ID, noteId: null }], // getPageOwnership
+      [{ email: USER_EMAIL }], // getUserEmailLowercase
+      [], // notePages JOIN — no membership
+    ]);
+    await expect(assertPageViewAccess(asDb(db), PAGE_ID, USER_ID)).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+
+  it("denies note-native page when caller has no role on the note", async () => {
+    // ノートネイティブページは pages.ownerId 一致では許可しない（脱退者対策）。
+    // Note-native: owning the underlying pages row is intentionally not enough.
+    const { db } = createMockDb([
+      [{ id: PAGE_ID, ownerId: USER_ID, noteId: NOTE_ID }], // getPageOwnership
+      [{ email: USER_EMAIL }], // getUserEmailLowercase
+      [], // getNoteRole → findActiveNoteById: note not found by helper path
+    ]);
+    await expect(assertPageViewAccess(asDb(db), PAGE_ID, USER_ID)).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+
+  it("allows note owner on note-native page", async () => {
+    const noteRow = {
+      id: NOTE_ID,
+      ownerId: USER_ID,
+      title: "n",
+      visibility: "private",
+      editPermission: "owner_only",
+      isOfficial: false,
+      viewCount: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      isDeleted: false,
+    };
+    const { db } = createMockDb([
+      [{ id: PAGE_ID, ownerId: OTHER_USER_ID, noteId: NOTE_ID }], // getPageOwnership
+      [{ email: USER_EMAIL }], // getUserEmailLowercase
+      [noteRow], // getNoteRole → findActiveNoteById (owner short-circuits, no further queries)
+    ]);
+    await expect(assertPageViewAccess(asDb(db), PAGE_ID, USER_ID)).resolves.toBeUndefined();
+  });
+
+  it("returns 404 when page is missing", async () => {
+    const { db } = createMockDb([[]]); // getPageOwnership empty
+    await expect(assertPageViewAccess(asDb(db), PAGE_ID, USER_ID)).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+describe("assertPageEditAccess (issue #713)", () => {
+  it("allows personal page owner", async () => {
+    const { db } = createMockDb([[{ id: PAGE_ID, ownerId: USER_ID, noteId: null }]]);
+    await expect(assertPageEditAccess(asDb(db), PAGE_ID, USER_ID)).resolves.toBeUndefined();
+  });
+
+  it("denies non-owner on personal page (note membership doesn't grant edit)", async () => {
+    const { db } = createMockDb([[{ id: PAGE_ID, ownerId: OTHER_USER_ID, noteId: null }]]);
+    await expect(assertPageEditAccess(asDb(db), PAGE_ID, USER_ID)).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+
+  it("allows note owner on note-native page (canEdit=true)", async () => {
+    const noteRow = {
+      id: NOTE_ID,
+      ownerId: USER_ID,
+      title: "n",
+      visibility: "private",
+      editPermission: "owner_only",
+      isOfficial: false,
+      viewCount: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      isDeleted: false,
+    };
+    const { db } = createMockDb([
+      [{ id: PAGE_ID, ownerId: OTHER_USER_ID, noteId: NOTE_ID }],
+      [{ email: USER_EMAIL }],
+      [noteRow], // getNoteRole owner short-circuit
+    ]);
+    await expect(assertPageEditAccess(asDb(db), PAGE_ID, USER_ID)).resolves.toBeUndefined();
+  });
+
+  it("denies viewer member on note-native page when editPermission=members_editors", async () => {
+    const noteRow = {
+      id: NOTE_ID,
+      ownerId: OTHER_USER_ID,
+      title: "n",
+      visibility: "private",
+      editPermission: "members_editors",
+      isOfficial: false,
+      viewCount: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      isDeleted: false,
+    };
+    const { db } = createMockDb([
+      [{ id: PAGE_ID, ownerId: USER_ID, noteId: NOTE_ID }], // getPageOwnership (own underlying row)
+      [{ email: USER_EMAIL }],
+      [noteRow], // findActiveNoteById
+      [{ role: "viewer" }], // member lookup → viewer
+    ]);
+    await expect(assertPageEditAccess(asDb(db), PAGE_ID, USER_ID)).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+
+  it("allows editor member on note-native page when editPermission=members_editors", async () => {
+    const noteRow = {
+      id: NOTE_ID,
+      ownerId: OTHER_USER_ID,
+      title: "n",
+      visibility: "private",
+      editPermission: "members_editors",
+      isOfficial: false,
+      viewCount: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      isDeleted: false,
+    };
+    const { db } = createMockDb([
+      [{ id: PAGE_ID, ownerId: OTHER_USER_ID, noteId: NOTE_ID }],
+      [{ email: USER_EMAIL }],
+      [noteRow],
+      [{ role: "editor" }], // editor passes canEdit when editPermission != owner_only
+    ]);
+    await expect(assertPageEditAccess(asDb(db), PAGE_ID, USER_ID)).resolves.toBeUndefined();
+  });
+
+  it("denies non-owner of underlying row when no note role resolves", async () => {
+    // ノートネイティブページの編集権限は note ロールのみで判定。
+    // Note-native edit permission depends on note role only — owning the
+    // underlying pages row (e.g. created the page then was removed) is NOT
+    // enough. See issue #713.
+    const noteRow = {
+      id: NOTE_ID,
+      ownerId: OTHER_USER_ID,
+      title: "n",
+      visibility: "private",
+      editPermission: "owner_only",
+      isOfficial: false,
+      viewCount: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      isDeleted: false,
+    };
+    const { db } = createMockDb([
+      [{ id: PAGE_ID, ownerId: USER_ID, noteId: NOTE_ID }],
+      [{ email: USER_EMAIL }],
+      [noteRow],
+      [], // member lookup empty
+      [], // domain access lookup empty
+    ]);
+    await expect(assertPageEditAccess(asDb(db), PAGE_ID, USER_ID)).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+});

--- a/server/api/src/routes/notes/pages.ts
+++ b/server/api/src/routes/notes/pages.ts
@@ -55,7 +55,7 @@ app.post("/:noteId/pages", authRequired, async (c) => {
   if (pageId) {
     const result = await db.transaction(async (tx) => {
       const page = await tx
-        .select({ id: pages.id, ownerId: pages.ownerId })
+        .select({ id: pages.id, ownerId: pages.ownerId, noteId: pages.noteId })
         .from(pages)
         .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
         .limit(1);
@@ -63,6 +63,23 @@ app.post("/:noteId/pages", authRequired, async (c) => {
       const firstPage = page[0];
       if (!firstPage) throw new HTTPException(404, { message: "Page not found" });
       if (firstPage.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
+      // 既にノートネイティブのページ（別ノートに所属）を `page_id` 経由で別ノートに
+      // リンクできてしまうと、`/api/pages/:id/content` の認可は元ノート側のロールで
+      // 解決されるため、リンク先メンバーから見ると「リストには出るが開けない」
+      // 壊れたカードになる。Phase 1 では個人ページ（`note_id IS NULL`）のみリンク可。
+      // ノート間の取り込みは Phase 3 で導入予定の copy エンドポイントで扱う。
+      //
+      // Reject note-native pages in the `page_id` linking path. If we let a page
+      // already scoped to note A be linked into note B, then `/api/pages/:id/content`
+      // still authorizes via the original `pages.note_id` → note B members would see
+      // a tile they cannot open (403). In Phase 1 only personal pages
+      // (`note_id IS NULL`) are linkable; cross-note adoption arrives with the
+      // Phase 3 copy endpoint. See issue #713.
+      if (firstPage.noteId !== null) {
+        throw new HTTPException(400, {
+          message: "Only personal pages can be linked via page_id",
+        });
+      }
       const resolvedPageId = firstPage.id;
 
       const maxOrder = await tx
@@ -163,12 +180,42 @@ app.delete("/:noteId/pages/:pageId", authRequired, async (c) => {
     throw new HTTPException(403, { message: "Forbidden" });
   }
 
-  await db
-    .update(notePages)
-    .set({ isDeleted: true, updatedAt: new Date() })
-    .where(and(eq(notePages.noteId, noteId), eq(notePages.pageId, pageId)));
+  // ノートからページを外す。ノートネイティブページ（`pages.note_id = noteId`）の場合は
+  // `note_pages` の論理削除だけだと `pages` 行が残り、`/api/pages/:id/content` などが
+  // ノートロール経由で引き続き認可してしまう（孤児化）。同一トランザクション内で
+  // `pages` 自体も論理削除して整合性を保つ。
+  // 個人ページ（`pages.note_id IS NULL`）のリンク解除は従来どおり `note_pages` だけを
+  // 落とし、ページ自体は所有者の個人 /home に残す。
+  //
+  // Detach a page from a note. For note-native pages
+  // (`pages.note_id = noteId`), tombstoning only `note_pages` would leave the
+  // `pages` row alive and still authorized via the note role on
+  // `/api/pages/:id/content`, etc. Soft-delete the `pages` row in the same
+  // transaction so the orphan goes away. For personal pages (`note_id IS NULL`)
+  // we still only drop the link row so the page stays on the owner's /home.
+  // See issue #713.
+  await db.transaction(async (tx) => {
+    const pageRow = await tx
+      .select({ id: pages.id, noteId: pages.noteId })
+      .from(pages)
+      .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
+      .limit(1);
 
-  await db.update(notes).set({ updatedAt: new Date() }).where(eq(notes.id, noteId));
+    await tx
+      .update(notePages)
+      .set({ isDeleted: true, updatedAt: new Date() })
+      .where(and(eq(notePages.noteId, noteId), eq(notePages.pageId, pageId)));
+
+    const page = pageRow[0];
+    if (page && page.noteId === noteId) {
+      await tx
+        .update(pages)
+        .set({ isDeleted: true, updatedAt: new Date() })
+        .where(eq(pages.id, pageId));
+    }
+
+    await tx.update(notes).set({ updatedAt: new Date() }).where(eq(notes.id, noteId));
+  });
 
   return c.json({ removed: true });
 });

--- a/server/api/src/routes/notes/pages.ts
+++ b/server/api/src/routes/notes/pages.ts
@@ -95,10 +95,19 @@ app.post("/:noteId/pages", authRequired, async (c) => {
     sortOrder = result.sortOrder;
   } else {
     const result = await db.transaction(async (tx) => {
+      // 「タイトルだけで新規作成」経路はノートネイティブページを直接作る。
+      // `note_id` を埋めることで個人ホーム (note_id IS NULL フィルタ) には現れず、
+      // ノート削除時に ON DELETE CASCADE で一緒に消える。Issue #713 を参照。
+      //
+      // The "create from title" path generates a note-native page directly.
+      // Setting `note_id` keeps it out of the personal-home listing
+      // (`note_id IS NULL` filter) and lets ON DELETE CASCADE remove it
+      // alongside the note. See issue #713.
       const created = await tx
         .insert(pages)
         .values({
           ownerId: userId,
+          noteId,
           title: title ?? null,
         })
         .returning();

--- a/server/api/src/routes/pageSnapshots.ts
+++ b/server/api/src/routes/pageSnapshots.ts
@@ -12,7 +12,7 @@ import { eq, and, desc, sql, inArray } from "drizzle-orm";
 import { pages, pageContents, pageSnapshots, users } from "../schema/index.js";
 import { authRequired } from "../middleware/auth.js";
 import type { AppEnv } from "../types/index.js";
-import { assertPageViewAccess } from "../services/pageAccessService.js";
+import { assertPageViewAccess, assertPageEditAccess } from "../services/pageAccessService.js";
 import { pruneSnapshotsExceedingLimitSql } from "../services/snapshotService.js";
 
 const app = new Hono<AppEnv>();
@@ -174,13 +174,24 @@ app.get("/:id/snapshots/:snapshotId", authRequired, async (c) => {
 /**
  * POST /:id/snapshots/:snapshotId/restore
  *
- * スナップショットを復元する。復元はページオーナーのみが実行可能。
- * 共同編集者（ノートメンバー）には復元権限がない。これは意図的な仕様制限であり、
- * オーナーが明示的に承認した状態のみが復元されることを保証する。
+ * スナップショットを復元する。編集権限を持つユーザーのみが実行可能で、判定は
+ * 他のページ書き込み系エンドポイント（`PUT /api/pages/:id/content` など）と
+ * 同じく `assertPageEditAccess` に委譲する。
  *
- * Restore a snapshot. Only the page owner can perform a restore.
- * Note members (collaborators) are intentionally excluded from this operation
- * to ensure only owner-approved states are restored.
+ * - 個人ページ（`pages.note_id IS NULL`）: `pages.ownerId` 一致のみ
+ * - ノートネイティブページ（`pages.note_id IS NOT NULL`）: ノートロール +
+ *   `editPermission` の `canEdit` 評価（issue #713）。これにより、ノートを抜けた
+ *   元作成者が restore を継続できてしまう問題と、ノートオーナーが他メンバー作成
+ *   ページを restore できない問題の両方が解消される。
+ *
+ * Restore a snapshot. Edit permission is required and is now delegated to
+ * `assertPageEditAccess`, the same helper used by `PUT /api/pages/:id/content`.
+ *
+ * - Personal page (`pages.note_id IS NULL`): only the `pages.ownerId` user.
+ * - Note-native page (`pages.note_id IS NOT NULL`): the caller's note role
+ *   must satisfy `canEdit` against the note's `editPermission` (issue #713).
+ *   This both prevents removed members from continuing to restore and lets
+ *   note owners restore snapshots on pages created by other editors.
  *
  * **Collaboration / コラボレーション**: This endpoint acquires a DB row lock for `page_contents`
  * and then asks Hocuspocus to invalidate the live document after commit. Configure
@@ -194,16 +205,9 @@ app.post("/:id/snapshots/:snapshotId/restore", authRequired, async (c) => {
   const userId = c.get("userId");
   const db = c.get("db");
 
-  // 復元は編集権限が必要（所有者のみ） / Restore requires owner permission
-  const page = await db
-    .select({ id: pages.id, ownerId: pages.ownerId })
-    .from(pages)
-    .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
-    .limit(1);
-
-  const pageRow = page[0];
-  if (!pageRow) throw new HTTPException(404, { message: "Page not found" });
-  if (pageRow.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
+  // 編集権限チェック（個人ページは所有者のみ、ノートネイティブはノートロール経由）
+  // Edit-permission check (owner for personal pages, note-role aware for note-native).
+  await assertPageEditAccess(db, pageId, userId);
 
   // 復元対象のスナップショットを取得
   const snapRows = await db

--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -16,6 +16,7 @@ import { pages, pageContents } from "../schema/index.js";
 import { authRequired } from "../middleware/auth.js";
 import type { AppEnv, Database } from "../types/index.js";
 import { maybeCreateSnapshot } from "../services/snapshotService.js";
+import { assertPageViewAccess, assertPageEditAccess } from "../services/pageAccessService.js";
 
 /**
  * ベストエフォートで自動スナップショットを作成する。失敗してもメイン処理には影響しない。
@@ -79,10 +80,18 @@ app.get("/", authRequired, async (c) => {
   // `shared` mirrors the canonical authorization model from `services/pageAccessService.ts`:
   //   the linked note must be active, the membership must be accepted, and the join rows
   //   must not be soft-deleted. EXISTS + JOIN keeps the planner happy on large datasets.
+  // `own` スコープは個人ページ（`pages.note_id IS NULL`）のみを返す。
+  // ノートネイティブページ（issue #713）は、ノート画面または `scope=shared`
+  // 経由でのみアクセスする。`shared` 経由の場合は note メンバーシップで
+  // ノートネイティブページが含まれる。
+  //
+  // The `own` scope returns personal pages only (`pages.note_id IS NULL`).
+  // Note-native pages (issue #713) are accessed via the note view or
+  // `scope=shared` (which already includes them through note membership).
   const accessFilter =
     scope === "shared"
       ? sql`(
-          p.owner_id = ${userId}
+          (p.owner_id = ${userId} AND p.note_id IS NULL)
           OR EXISTS (
             SELECT 1 FROM note_pages np
             JOIN notes n ON n.id = np.note_id
@@ -96,7 +105,7 @@ app.get("/", authRequired, async (c) => {
               AND n.is_deleted = false
           )
         )`
-      : sql`p.owner_id = ${userId}`;
+      : sql`p.owner_id = ${userId} AND p.note_id IS NULL`;
 
   // Wiki の内部システムページ（`special_kind` が `__index__` / `__log__`、
   // および `is_schema = true` のスキーマページ）は通常一覧から除外する。
@@ -130,16 +139,11 @@ app.get("/:id/content", authRequired, async (c) => {
   const userId = c.get("userId");
   const db = c.get("db");
 
-  // ページ所有者確認
-  const page = await db
-    .select({ id: pages.id, ownerId: pages.ownerId })
-    .from(pages)
-    .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
-    .limit(1);
-
-  const pageRow = page[0];
-  if (!pageRow) throw new HTTPException(404, { message: "Page not found" });
-  if (pageRow.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
+  // 個人ページは所有者のみ、ノートネイティブページはノートのロール解決
+  // （member / domain / public guest）が成立すれば閲覧可。Issue #713 を参照。
+  // Personal pages: owner only. Note-native pages: any resolved note role
+  // (member / domain / public guest) may view. See issue #713.
+  await assertPageViewAccess(db, pageId, userId);
 
   // コンテンツ取得
   const content = await db
@@ -191,16 +195,11 @@ app.put("/:id/content", authRequired, async (c) => {
     throw new HTTPException(400, { message: "ydoc_state is required" });
   }
 
-  // ページ所有者確認
-  const page = await db
-    .select({ id: pages.id, ownerId: pages.ownerId })
-    .from(pages)
-    .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
-    .limit(1);
-
-  const pageRow = page[0];
-  if (!pageRow) throw new HTTPException(404, { message: "Page not found" });
-  if (pageRow.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
+  // 個人ページは所有者のみ、ノートネイティブページは note ロール / editPermission
+  // で判定する。Issue #713 を参照。
+  // Personal pages: owner only. Note-native pages: note role + editPermission
+  // (`canEdit`). See issue #713.
+  await assertPageEditAccess(db, pageId, userId);
 
   const ydocBuffer = Buffer.from(body.ydoc_state, "base64");
 
@@ -375,15 +374,10 @@ app.delete("/:id", authRequired, async (c) => {
   const userId = c.get("userId");
   const db = c.get("db");
 
-  const page = await db
-    .select({ id: pages.id, ownerId: pages.ownerId })
-    .from(pages)
-    .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
-    .limit(1);
-
-  const pageRow = page[0];
-  if (!pageRow) throw new HTTPException(404, { message: "Page not found" });
-  if (pageRow.ownerId !== userId) throw new HTTPException(403, { message: "Forbidden" });
+  // ノートネイティブページの削除はノート編集権限で判定する。
+  // Note-native page deletion is governed by the note's edit permission.
+  // See issue #713.
+  await assertPageEditAccess(db, pageId, userId);
 
   await db
     .update(pages)

--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -82,12 +82,22 @@ app.get("/", authRequired, async (c) => {
   //   must not be soft-deleted. EXISTS + JOIN keeps the planner happy on large datasets.
   // `own` スコープは個人ページ（`pages.note_id IS NULL`）のみを返す。
   // ノートネイティブページ（issue #713）は、ノート画面または `scope=shared`
-  // 経由でのみアクセスする。`shared` 経由の場合は note メンバーシップで
-  // ノートネイティブページが含まれる。
+  // 経由でのみアクセスする。`shared` 経由の場合は (a) note_members 経由の
+  // メンバーシップ、または (b) `notes.owner_id = userId` 経由のオーナーシップで
+  // 含まれる。オーナー経路を明示しておかないと、ノートオーナーは通常 note_members
+  // 行を持たないため、自分が作った note-native page が listing から消える
+  // （閲覧は assertPageViewAccess / getNoteRole 経由で可能だが listing で見えなく
+  // なる）という非対称が起きる。`getNoteRole` の解決順 (owner → member → ...) と
+  // listing predicate を揃える。
   //
   // The `own` scope returns personal pages only (`pages.note_id IS NULL`).
   // Note-native pages (issue #713) are accessed via the note view or
-  // `scope=shared` (which already includes them through note membership).
+  // `scope=shared`. `shared` includes them either through (a) `note_members`
+  // membership or (b) `notes.owner_id = userId` ownership. The owner branch is
+  // mandatory because note owners typically have no `note_members` row, so
+  // omitting it would let owners view their note-native pages via
+  // `assertPageViewAccess` / `getNoteRole` while hiding them from the listing
+  // — keep the predicate aligned with `getNoteRole`'s resolution order.
   const accessFilter =
     scope === "shared"
       ? sql`(
@@ -103,6 +113,15 @@ app.get("/", authRequired, async (c) => {
               AND nm.is_deleted = false
               AND np.is_deleted = false
               AND n.is_deleted = false
+          )
+          OR (
+            p.note_id IS NOT NULL
+            AND EXISTS (
+              SELECT 1 FROM notes n
+              WHERE n.id = p.note_id
+                AND n.owner_id = ${userId}
+                AND n.is_deleted = false
+            )
           )
         )`
       : sql`p.owner_id = ${userId} AND p.note_id IS NULL`;

--- a/server/api/src/routes/syncPages.ts
+++ b/server/api/src/routes/syncPages.ts
@@ -6,7 +6,7 @@
  */
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { eq, and, gt, inArray, isNull, sql } from "drizzle-orm";
+import { eq, and, gt, inArray, isNull } from "drizzle-orm";
 import { pages, links, ghostLinks } from "../schema/index.js";
 import { authRequired } from "../middleware/auth.js";
 import type { AppEnv } from "../types/index.js";
@@ -122,36 +122,39 @@ app.post("/", authRequired, async (c) => {
 
   // ページごとに LWW (Last Write Wins) 同期。
   // 同期対象は個人ページ（`pages.note_id IS NULL`）のみ。ノートネイティブ
-  // ページ（issue #713）は対象外で、もし同 ID の行がノートに存在する場合は
-  // ガードのため skipped 扱いとする（クライアント側 IndexedDB が note 行を
-  // 持っているはずがないが防御）。
+  // ページ（issue #713）や他人の個人ページは衝突回避のため `skipped` 扱い。
+  //
+  // バルク取得で N+1 を避ける: クライアントから来た全 ID を一括で引き、
+  // メモリ上で「未存在 / 自分の個人ページ / それ以外（ノートネイティブ or
+  // 他人）」に振り分けてから個別の DML を発行する。
   //
   // LWW sync runs only against personal pages (`pages.note_id IS NULL`).
-  // Note-native pages (issue #713) are excluded — if a row with the same id
-  // happens to be note-native, it is skipped defensively (clients should not
-  // hold note-native rows in IndexedDB).
-  for (const p of body.pages) {
-    const existing = await db
-      .select({ id: pages.id, updatedAt: pages.updatedAt, ownerId: pages.ownerId })
-      .from(pages)
-      .where(and(eq(pages.id, p.id), eq(pages.ownerId, userId), isNull(pages.noteId)))
-      .limit(1);
+  // Note-native pages (issue #713) and other users' personal pages are skipped
+  // to avoid ID collisions and IDOR.
+  //
+  // Bulk-load to avoid N+1: fetch every incoming id in one query, then classify
+  // in memory as "missing", "owned personal", or "other (note-native or
+  // someone else's)". Only after that do we issue per-row DML.
+  const incomingIds = [...new Set(body.pages.map((p) => p.id))];
+  const existingRows =
+    incomingIds.length > 0
+      ? await db
+          .select({
+            id: pages.id,
+            ownerId: pages.ownerId,
+            noteId: pages.noteId,
+            updatedAt: pages.updatedAt,
+          })
+          .from(pages)
+          .where(inArray(pages.id, incomingIds))
+      : [];
+  const existingMap = new Map(existingRows.map((row) => [row.id, row]));
 
+  for (const p of body.pages) {
+    const existing = existingMap.get(p.id);
     const clientTime = new Date(p.updated_at);
 
-    if (existing.length === 0) {
-      // 既存の同 ID ページがノートネイティブだった場合は無視する
-      // Skip if a same-id page exists but is note-native
-      const noteNativeCheck = await db
-        .select({ id: pages.id })
-        .from(pages)
-        .where(and(eq(pages.id, p.id), sql`${pages.noteId} IS NOT NULL`))
-        .limit(1);
-      if (noteNativeCheck.length > 0) {
-        results.push({ id: p.id, action: "skipped" });
-        continue;
-      }
-
+    if (!existing) {
       await db.insert(pages).values({
         id: p.id,
         ownerId: userId,
@@ -165,26 +168,32 @@ app.post("/", authRequired, async (c) => {
         updatedAt: clientTime,
       });
       results.push({ id: p.id, action: "created" });
+      continue;
+    }
+
+    // ノートネイティブ or 他人の個人ページは触らない
+    // Skip note-native rows or rows owned by another user
+    if (existing.noteId !== null || existing.ownerId !== userId) {
+      results.push({ id: p.id, action: "skipped" });
+      continue;
+    }
+
+    if (clientTime > existing.updatedAt) {
+      await db
+        .update(pages)
+        .set({
+          title: p.title ?? null,
+          contentPreview: p.content_preview ?? null,
+          thumbnailUrl: p.thumbnail_url ?? null,
+          sourceUrl: p.source_url ?? null,
+          sourcePageId: p.source_page_id ?? null,
+          isDeleted: p.is_deleted ?? false,
+          updatedAt: clientTime,
+        })
+        .where(and(eq(pages.id, p.id), eq(pages.ownerId, userId), isNull(pages.noteId)));
+      results.push({ id: p.id, action: "updated" });
     } else {
-      const existingRow = existing[0];
-      if (existingRow && clientTime > existingRow.updatedAt) {
-        // クライアント側が新しい: 更新
-        await db
-          .update(pages)
-          .set({
-            title: p.title ?? null,
-            contentPreview: p.content_preview ?? null,
-            thumbnailUrl: p.thumbnail_url ?? null,
-            sourceUrl: p.source_url ?? null,
-            sourcePageId: p.source_page_id ?? null,
-            isDeleted: p.is_deleted ?? false,
-            updatedAt: clientTime,
-          })
-          .where(and(eq(pages.id, p.id), eq(pages.ownerId, userId), isNull(pages.noteId)));
-        results.push({ id: p.id, action: "updated" });
-      } else {
-        results.push({ id: p.id, action: "skipped" });
-      }
+      results.push({ id: p.id, action: "skipped" });
     }
   }
 

--- a/server/api/src/routes/syncPages.ts
+++ b/server/api/src/routes/syncPages.ts
@@ -135,8 +135,36 @@ app.post("/", authRequired, async (c) => {
   // Bulk-load to avoid N+1: fetch every incoming id in one query, then classify
   // in memory as "missing", "owned personal", or "other (note-native or
   // someone else's)". Only after that do we issue per-row DML.
-  const incomingIds = [...new Set(body.pages.map((p) => p.id))];
-  const existingRows =
+  // クライアント側のリトライや誤ったペイロードで `body.pages` に同じ id が
+  // 複数入る場合がある。bulk-fetch で得たスナップショットは「リクエスト到着前
+  // の DB 状態」なので、ループ内で更新せず無加工に流すと:
+  //   - 新規 id の 2 回目の occurrence で再度 insert → PK 衝突 (500)
+  //   - 既存 id の 2 回目以降は古い updatedAt と比較 → LWW の順序が崩れる
+  // 対策として (1) 入力を id ごとに updated_at 最新のものへ畳み込み、
+  // (2) DML を発行するたび existingMap も更新して in-request の状態を保つ。
+  //
+  // Duplicate ids in `body.pages` (client retries / bad payloads) would break
+  // the bulk-prefetched snapshot: a new id would re-insert and collide on PK
+  // (500), and an existing id would be compared against a stale `updatedAt`,
+  // breaking LWW ordering. Defend by (1) collapsing duplicates to the newest
+  // `updated_at` per id, and (2) updating `existingMap` after every DML so the
+  // in-request state stays consistent.
+  const latestIncomingById = new Map<string, (typeof body.pages)[number]>();
+  for (const p of body.pages) {
+    const prev = latestIncomingById.get(p.id);
+    if (!prev || new Date(p.updated_at) > new Date(prev.updated_at)) {
+      latestIncomingById.set(p.id, p);
+    }
+  }
+
+  const incomingIds = [...latestIncomingById.keys()];
+  type ExistingRow = {
+    id: string;
+    ownerId: string;
+    noteId: string | null;
+    updatedAt: Date;
+  };
+  const existingRows: ExistingRow[] =
     incomingIds.length > 0
       ? await db
           .select({
@@ -148,9 +176,9 @@ app.post("/", authRequired, async (c) => {
           .from(pages)
           .where(inArray(pages.id, incomingIds))
       : [];
-  const existingMap = new Map(existingRows.map((row) => [row.id, row]));
+  const existingMap = new Map<string, ExistingRow>(existingRows.map((row) => [row.id, row]));
 
-  for (const p of body.pages) {
+  for (const p of latestIncomingById.values()) {
     const existing = existingMap.get(p.id);
     const clientTime = new Date(p.updated_at);
 
@@ -165,6 +193,15 @@ app.post("/", authRequired, async (c) => {
         sourcePageId: p.source_page_id ?? null,
         isDeleted: p.is_deleted ?? false,
         createdAt: clientTime,
+        updatedAt: clientTime,
+      });
+      // 後続イテレーション（同 id の重複が dedupe をすり抜けた場合の保険）が
+      // 再 insert に走らないようマップを更新しておく。
+      // Track the just-inserted row so any later iteration sees current state.
+      existingMap.set(p.id, {
+        id: p.id,
+        ownerId: userId,
+        noteId: null,
         updatedAt: clientTime,
       });
       results.push({ id: p.id, action: "created" });
@@ -191,6 +228,7 @@ app.post("/", authRequired, async (c) => {
           updatedAt: clientTime,
         })
         .where(and(eq(pages.id, p.id), eq(pages.ownerId, userId), isNull(pages.noteId)));
+      existingMap.set(p.id, { ...existing, updatedAt: clientTime });
       results.push({ id: p.id, action: "updated" });
     } else {
       results.push({ id: p.id, action: "skipped" });

--- a/server/api/src/routes/syncPages.ts
+++ b/server/api/src/routes/syncPages.ts
@@ -6,7 +6,7 @@
  */
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { eq, and, gt, inArray } from "drizzle-orm";
+import { eq, and, gt, inArray, isNull, sql } from "drizzle-orm";
 import { pages, links, ghostLinks } from "../schema/index.js";
 import { authRequired } from "../middleware/auth.js";
 import type { AppEnv } from "../types/index.js";
@@ -14,10 +14,19 @@ import type { AppEnv } from "../types/index.js";
 const app = new Hono<AppEnv>();
 
 // ── GET /sync/pages ─────────────────────────────────────────────────────────
+// 個人ページ同期はクライアントの IndexedDB と個人ページ (`pages.note_id IS
+// NULL`) のみを対象にする。ノートネイティブページ（issue #713）はサーバー側
+// で管理され、ノート画面/共同編集経由でのみアクセスする。
+//
+// Personal-page sync only mirrors personal pages (`pages.note_id IS NULL`)
+// into the client's IndexedDB. Note-native pages (issue #713) live solely on
+// the server and are accessed through the note view / collaborative editor.
 app.get("/", authRequired, async (c) => {
   const userId = c.get("userId");
   const db = c.get("db");
   const since = c.req.query("since");
+
+  const personalPageFilter = and(eq(pages.ownerId, userId), isNull(pages.noteId));
 
   let query = db
     .select({
@@ -33,11 +42,11 @@ app.get("/", authRequired, async (c) => {
       updated_at: pages.updatedAt,
     })
     .from(pages)
-    .where(eq(pages.ownerId, userId))
+    .where(personalPageFilter)
     .$dynamic();
 
   if (since) {
-    query = query.where(and(eq(pages.ownerId, userId), gt(pages.updatedAt, new Date(since))));
+    query = query.where(and(personalPageFilter, gt(pages.updatedAt, new Date(since))));
   }
 
   const rows = await query.orderBy(pages.updatedAt);
@@ -111,18 +120,38 @@ app.post("/", authRequired, async (c) => {
 
   const results: Array<{ id: string; action: string }> = [];
 
-  // ページごとに LWW (Last Write Wins) 同期
+  // ページごとに LWW (Last Write Wins) 同期。
+  // 同期対象は個人ページ（`pages.note_id IS NULL`）のみ。ノートネイティブ
+  // ページ（issue #713）は対象外で、もし同 ID の行がノートに存在する場合は
+  // ガードのため skipped 扱いとする（クライアント側 IndexedDB が note 行を
+  // 持っているはずがないが防御）。
+  //
+  // LWW sync runs only against personal pages (`pages.note_id IS NULL`).
+  // Note-native pages (issue #713) are excluded — if a row with the same id
+  // happens to be note-native, it is skipped defensively (clients should not
+  // hold note-native rows in IndexedDB).
   for (const p of body.pages) {
     const existing = await db
       .select({ id: pages.id, updatedAt: pages.updatedAt, ownerId: pages.ownerId })
       .from(pages)
-      .where(and(eq(pages.id, p.id), eq(pages.ownerId, userId)))
+      .where(and(eq(pages.id, p.id), eq(pages.ownerId, userId), isNull(pages.noteId)))
       .limit(1);
 
     const clientTime = new Date(p.updated_at);
 
     if (existing.length === 0) {
-      // 新規作成
+      // 既存の同 ID ページがノートネイティブだった場合は無視する
+      // Skip if a same-id page exists but is note-native
+      const noteNativeCheck = await db
+        .select({ id: pages.id })
+        .from(pages)
+        .where(and(eq(pages.id, p.id), sql`${pages.noteId} IS NOT NULL`))
+        .limit(1);
+      if (noteNativeCheck.length > 0) {
+        results.push({ id: p.id, action: "skipped" });
+        continue;
+      }
+
       await db.insert(pages).values({
         id: p.id,
         ownerId: userId,
@@ -151,7 +180,7 @@ app.post("/", authRequired, async (c) => {
             isDeleted: p.is_deleted ?? false,
             updatedAt: clientTime,
           })
-          .where(and(eq(pages.id, p.id), eq(pages.ownerId, userId)));
+          .where(and(eq(pages.id, p.id), eq(pages.ownerId, userId), isNull(pages.noteId)));
         results.push({ id: p.id, action: "updated" });
       } else {
         results.push({ id: p.id, action: "skipped" });
@@ -159,13 +188,14 @@ app.post("/", authRequired, async (c) => {
     }
   }
 
-  // リンク同期
+  // リンク同期 — 個人ページ間のみ
+  // Link sync — personal pages only
   if (body.links?.length) {
     const sourceIds = [...new Set(body.links.map((l) => l.source_id))];
     const ownedPages = await db
       .select({ id: pages.id })
       .from(pages)
-      .where(and(eq(pages.ownerId, userId), inArray(pages.id, sourceIds)));
+      .where(and(eq(pages.ownerId, userId), isNull(pages.noteId), inArray(pages.id, sourceIds)));
     const ownedIds = new Set(ownedPages.map((r) => r.id));
     for (const sourceId of sourceIds) {
       if (!ownedIds.has(sourceId)) continue;
@@ -184,13 +214,14 @@ app.post("/", authRequired, async (c) => {
     }
   }
 
-  // ゴーストリンク同期
+  // ゴーストリンク同期 — 個人ページ間のみ
+  // Ghost link sync — personal pages only
   if (body.ghost_links?.length) {
     const sourceIds = [...new Set(body.ghost_links.map((g) => g.source_page_id))];
     const ownedGhostPages = await db
       .select({ id: pages.id })
       .from(pages)
-      .where(and(eq(pages.ownerId, userId), inArray(pages.id, sourceIds)));
+      .where(and(eq(pages.ownerId, userId), isNull(pages.noteId), inArray(pages.id, sourceIds)));
     const ownedGhostIds = new Set(ownedGhostPages.map((r) => r.id));
     for (const sourceId of sourceIds) {
       if (!ownedGhostIds.has(sourceId)) continue;

--- a/server/api/src/schema/pages.ts
+++ b/server/api/src/schema/pages.ts
@@ -1,6 +1,7 @@
 import { pgTable, uuid, text, timestamp, boolean, index } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import { users } from "./users.js";
+import { notes } from "./notes.js";
 
 /**
  * Special page kinds that stand apart from normal wiki entries.
@@ -26,6 +27,18 @@ export const pages = pgTable(
     ownerId: text("owner_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
+    /**
+     * 所属ノート ID。NULL は個人ページ、値ありはそのノートに所属するノート
+     * ネイティブページ。ノートネイティブページは個人ホーム（`note_id IS NULL`
+     * フィルタ）には現れず、ノート削除時に `ON DELETE CASCADE` で一緒に消える。
+     * Issue #713 を参照。
+     *
+     * Owning note ID. NULL means a personal page; a non-null value identifies
+     * a note-native page that lives only inside that note. Personal-home
+     * queries filter on `note_id IS NULL`, and note deletion cascades to
+     * note-native pages. See issue #713.
+     */
+    noteId: uuid("note_id").references(() => notes.id, { onDelete: "cascade" }),
     sourcePageId: uuid("source_page_id"),
     title: text("title"),
     contentPreview: text("content_preview"),
@@ -56,6 +69,13 @@ export const pages = pgTable(
       .on(table.ownerId)
       .where(sql`NOT ${table.isDeleted}`),
     index("idx_pages_owner_special_kind").on(table.ownerId, table.specialKind),
+    /**
+     * Lookup of pages owned by a particular note (and an efficient predicate
+     * for "personal pages only" via `note_id IS NULL` / `IS NOT NULL`).
+     * 特定のノートに所属するページの引きと、`note_id IS NULL`/`IS NOT NULL` の
+     * 部分述語に効くインデックス。
+     */
+    index("idx_pages_note_id").on(table.noteId),
   ],
 );
 

--- a/server/api/src/services/pageAccessService.ts
+++ b/server/api/src/services/pageAccessService.ts
@@ -3,7 +3,7 @@
  * Shared page access authorization service.
  */
 import { HTTPException } from "hono/http-exception";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { pages, users, notes, notePages, noteMembers } from "../schema/index.js";
 import type { Database } from "../types/index.js";
 import { getNoteRole, canEdit } from "../routes/notes/helpers.js";
@@ -91,7 +91,16 @@ export async function assertPageViewAccess(
       noteMembers,
       and(
         eq(noteMembers.noteId, notePages.noteId),
-        eq(noteMembers.memberEmail, userEmail),
+        // 大文字小文字を区別せずに突合する。`getUserEmailLowercase` で正規化済み
+        // のメールに対し、DB 側でも `LOWER(...)` を適用して旧来データや手動挿入
+        // で大文字混じりの行を取りこぼさない。`helpers.ts` の `getNoteRole` と
+        // 同じ慣用に揃える。
+        //
+        // Match case-insensitively. `getUserEmailLowercase` already lower-cases
+        // the input; apply `LOWER(...)` on the column too so legacy or manually
+        // inserted mixed-case rows still match. Mirrors `getNoteRole` in
+        // `helpers.ts`.
+        sql`LOWER(${noteMembers.memberEmail}) = ${userEmail}`,
         eq(noteMembers.isDeleted, false),
         eq(noteMembers.status, "accepted"),
       ),

--- a/server/api/src/services/pageAccessService.ts
+++ b/server/api/src/services/pageAccessService.ts
@@ -6,45 +6,80 @@ import { HTTPException } from "hono/http-exception";
 import { eq, and } from "drizzle-orm";
 import { pages, users, notes, notePages, noteMembers } from "../schema/index.js";
 import type { Database } from "../types/index.js";
+import { getNoteRole, canEdit } from "../routes/notes/helpers.js";
 
 /**
- * ページへの閲覧権限を確認する。所有者またはノートメンバーであればアクセス可能。
- * Verify the user can view the page (owner or note member).
+ * ページの種別と所有情報。`noteId` が非 null の場合はノートネイティブページ
+ * （`pages.note_id` がそのノートを指している）。
  *
- * Hocuspocus の `canEditNotePage` に準拠し、`note_members` を JOIN して
- * 現在のユーザーが当該ノートのメンバーであることを検証する。
- * Mirrors the Hocuspocus `canEditNotePage` logic: JOINs `notes` with
- * `is_deleted = FALSE` and `note_members` to verify membership.
+ * Page kind and ownership info. `noteId !== null` means a note-native page
+ * whose `pages.note_id` references that note. See issue #713.
  */
-export async function assertPageViewAccess(
-  db: Database,
-  pageId: string,
-  userId: string,
-): Promise<void> {
+type PageOwnership = { id: string; ownerId: string; noteId: string | null };
+
+async function getPageOwnership(db: Database, pageId: string): Promise<PageOwnership> {
   const page = await db
-    .select({ id: pages.id, ownerId: pages.ownerId })
+    .select({ id: pages.id, ownerId: pages.ownerId, noteId: pages.noteId })
     .from(pages)
     .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
     .limit(1);
 
   const pageRow = page[0];
   if (!pageRow) throw new HTTPException(404, { message: "Page not found" });
+  return pageRow;
+}
 
-  // オーナーはアクセス可 / Owner always has access
-  if (pageRow.ownerId === userId) return;
-
-  // ユーザーの email を取得 / Get user email for note_members lookup
+async function getUserEmailLowercase(db: Database, userId: string): Promise<string> {
   const userRow = await db
     .select({ email: users.email })
     .from(users)
     .where(eq(users.id, userId))
     .limit(1);
 
-  if (!userRow[0]) {
-    throw new HTTPException(403, { message: "Forbidden" });
+  const email = userRow[0]?.email;
+  if (!email) throw new HTTPException(403, { message: "Forbidden" });
+  return email.trim().toLowerCase();
+}
+
+/**
+ * ページへの閲覧権限を確認する。
+ *
+ * - 個人ページ (`pages.note_id IS NULL`): 所有者本人、または当該ページが
+ *   `note_pages` 経由で登録されているノートの受諾済みメンバー
+ * - ノートネイティブページ (`pages.note_id IS NOT NULL`): そのノートに対する
+ *   ロール解決（owner / member / domain / public guest）が成立すれば閲覧可。
+ *   `pages.ownerId` の一致では許可しない（脱退後に閲覧権が残るのを防ぐ）
+ *
+ * Verify the user can view the page.
+ *
+ * - Personal page (`pages.note_id IS NULL`): owner of the page row, or an
+ *   accepted member of any note this page is attached to via `note_pages`
+ * - Note-native page (`pages.note_id IS NOT NULL`): caller must resolve to a
+ *   role (owner / member / domain / public guest) on that note. Owning the
+ *   underlying `pages` row is intentionally NOT enough — that would let a
+ *   removed member keep reading after leaving the note.
+ *
+ * See issue #713.
+ */
+export async function assertPageViewAccess(
+  db: Database,
+  pageId: string,
+  userId: string,
+): Promise<void> {
+  const pageRow = await getPageOwnership(db, pageId);
+
+  if (pageRow.noteId) {
+    const userEmail = await getUserEmailLowercase(db, userId);
+    const { role } = await getNoteRole(pageRow.noteId, userId, userEmail, db);
+    if (!role) throw new HTTPException(403, { message: "Forbidden" });
+    return;
   }
 
-  const userEmail = userRow[0].email.trim().toLowerCase();
+  // 個人ページ：オーナーは常にアクセス可
+  // Personal page: owner always has access
+  if (pageRow.ownerId === userId) return;
+
+  const userEmail = await getUserEmailLowercase(db, userId);
 
   // ページが属するノートを取得し、そのノートのメンバーかチェック
   // Find notes this page belongs to and verify user is a member
@@ -67,4 +102,42 @@ export async function assertPageViewAccess(
   if (noteMembership[0]) return;
 
   throw new HTTPException(403, { message: "Forbidden" });
+}
+
+/**
+ * ページへの編集権限を確認する。
+ *
+ * - 個人ページ (`pages.note_id IS NULL`): 所有者本人のみ
+ * - ノートネイティブページ (`pages.note_id IS NOT NULL`): そのノートに対する
+ *   ロールと `note.editPermission` を `canEdit` で評価
+ *
+ * Verify the user can edit the page.
+ *
+ * - Personal page (`pages.note_id IS NULL`): owner only
+ * - Note-native page (`pages.note_id IS NOT NULL`): role on that note must
+ *   pass `canEdit(role, note)` (owner / editor with note permissions / public
+ *   guest under `any_logged_in` rules)
+ *
+ * See issue #713.
+ */
+export async function assertPageEditAccess(
+  db: Database,
+  pageId: string,
+  userId: string,
+): Promise<void> {
+  const pageRow = await getPageOwnership(db, pageId);
+
+  if (pageRow.noteId) {
+    const userEmail = await getUserEmailLowercase(db, userId);
+    const { role, note } = await getNoteRole(pageRow.noteId, userId, userEmail, db);
+    if (!note) throw new HTTPException(404, { message: "Note not found" });
+    if (!role || !canEdit(role, note)) {
+      throw new HTTPException(403, { message: "Forbidden" });
+    }
+    return;
+  }
+
+  if (pageRow.ownerId !== userId) {
+    throw new HTTPException(403, { message: "Forbidden" });
+  }
 }


### PR DESCRIPTION
## 概要

Issue #713 の Phase 1。`pages.note_id` カラムを追加してページを「個人ページ（`note_id IS NULL`）」と「ノートネイティブページ（`note_id = <noteId>`）」に明示スコープし、サーバ API 側の挙動を新仕様に揃える。フロントは無変更でも互換動作する（個人ページ作成 → ノートにリンク、というフローは現状維持）。

Phase 2（フロントの pageRepository / storageAdapter / syncWithApi に noteId を流す）と Phase 3（コピー API + 「ノートに登録 / 個人に取り込み」UI）は別 PR で続ける。

## 変更点

### `server/api/drizzle/`

- `0016_add_pages_note_id.sql`: `pages.note_id uuid NULL`、`notes.id` への FK（`ON DELETE CASCADE`）、`idx_pages_note_id` を追加
- `meta/_journal.json`: 0016 を追記

### `server/api/src/schema/pages.ts`

- `noteId` フィールド + 用途を説明する TSDoc + 部分述語に効くインデックスを追加

### `server/api/src/services/pageAccessService.ts`

- `assertPageViewAccess` をノートネイティブ対応に書き直し（個人ページ: 所有者 or note_pages 経由のメンバー / ノートネイティブ: `getNoteRole` で解決可能なロール）
- `assertPageEditAccess` を新設（個人: ownerId 一致 / ノートネイティブ: `canEdit(role, note)`）
- ノートネイティブページでは `pages.ownerId` 一致を編集権限として認めない（ノートから外された元作成者が編集権を持ち続けないように）

### `server/api/src/routes/notes/pages.ts`

- `POST /:noteId/pages` の **title 経路** で `noteId` を `pages` へ INSERT し、ノートネイティブページとして作成
- `page_id` 経路（既存個人ページのリンク）は無変更（既存データフロー保護）

### `server/api/src/routes/pages.ts`

- `GET /api/pages` の `scope=own` に `note_id IS NULL` フィルタを追加。`scope=shared` も「自分の個人ページ + 受諾済みノートメンバーのページ」に揃える
- `GET/PUT /api/pages/:id/content` と `DELETE /api/pages/:id` を新ヘルパー（`assertPageViewAccess` / `assertPageEditAccess`）経由に置き換え

### `server/api/src/routes/syncPages.ts`

- `GET /api/sync/pages`（クライアント IndexedDB への sync）と `POST /api/sync/pages`（LWW）を `pages.note_id IS NULL` に絞り込み、ノートネイティブページがクライアントに漏れないようにする
- 念のため、同 ID の行がノートネイティブだった場合の POST は `skipped` として扱う防御コード追加
- リンク / ゴーストリンク同期も個人ページ間のみに限定

### `server/api/src/__tests__/`

- `services/pageAccessService.test.ts`: 個人 × ノートネイティブ × view × edit の 11 ケース
- `routes/notes/pages.test.ts`: title 経路で `noteId: NOTE_ID` がセットされること / `page_id` 経路で `pages` テーブルへの INSERT が走らないこと（note_pages リンクのみ）

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [ ] 🐛 バグ修正
- [ ] 💥 破壊的変更
- [x] 🧪 テスト
- [ ] 📝 ドキュメント
- [ ] 🎨 リファクタ
- [ ] 🔧 ビルド/CI

## テスト方法

### 1. マイグレーション適用

```bash
cd server/api
bun run drizzle:migrate
```

`pages` に `note_id` カラム / `idx_pages_note_id` / `pages_note_id_notes_id_fk` が追加されることを確認する。既存の `pages` 行は全部 `note_id NULL`。

### 2. 自動テスト

```bash
cd server/api
bun run test
```

→ 686 tests / 50 files が pass することを確認（うち本 PR で追加された 13 ケースを含む）。

### 3. 手動確認: ノートネイティブページの作成

1. 任意のノートを開き、`NoteAddPageDialog` の「タイトルを入力して新規作成」フローでページを作る
2. 作成されたページがそのノートには表示され、**個人 /home には現れない** ことを確認
3. DB で当該 `pages.note_id` がそのノート id と一致していることを確認

### 4. 手動確認: 既存「個人ページをノートに登録」フローの後方互換

1. `/home` で個人ページを作成
2. ノートで `NoteAddPageDialog` の「既存ページを追加」フローでそのページを選択
3. ノートにも個人 /home にも両方表示される（= Phase 1 では既存挙動を変えない）

### 5. 手動確認: ノートネイティブページの編集権限

1. ノート A をオーナー X で作成、`editPermission = members_editors`、Y を viewer ロールで招待
2. X として note-native ページを作成
3. Y として `PUT /api/pages/:id/content` を叩くと **403** になること
4. Y のロールを editor に上げると **200** で更新できること

### 6. 手動確認: ノート削除カスケード

1. note-native ページを 1 件以上含むノートを論理削除（`is_deleted = true`）するのではなく、物理削除（`DELETE FROM notes WHERE id = ...`）を実行
2. 該当 `pages` 行も CASCADE で消えていることを確認（論理削除の挙動は別途検討）

## チェックリスト

- [x] テストがすべてパスする (server/api: 686/686)
- [x] Lint エラーがない（warnings は既存のみ）
- [x] フォーマット (prettier) を変更ファイルに適用済み
- [x] コミットメッセージが Conventional Commits に従っている
- [ ] 必要に応じてドキュメントを更新した（issue 本文に詳細仕様を記載済み。フロント仕様は Phase 2/3 で更新）

## スクリーンショット

UI 変更なし。

## 関連 Issue

Refs #713（Phase 2 / Phase 3 の PR でこの issue を Close する予定）


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pages can be created as note-associated (note-native) and are tied to the note lifecycle.

* **Changes**
  * Listings now separate personal vs note-associated pages; access and sync behavior differ by type.
  * Sync will no longer modify note-associated pages; such items are skipped.
  * Removing a page from a note will soft-delete the note-associated page when applicable.
  * Restore and content write actions use unified role-based permission checks.

* **Tests**
  * Added and updated tests covering linking, access rules, sync skipping, and deletion behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->