### PR TITLE
feat: add noteId field to support note-native pages (issue #713 Phase 2)

### DIFF
--- a/src/components/wiki-link/WikiLinkPreviewContent.test.tsx
+++ b/src/components/wiki-link/WikiLinkPreviewContent.test.tsx
@@ -7,6 +7,7 @@ import type { Page } from "@/types/page";
 const createMockPage = (overrides?: Partial<Page>): Page => ({
   id: "page-1",
   ownerUserId: "user-1",
+  noteId: null,
   title: "テストページ",
   content:
     '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"これはテストのプレビューです"}]}]}',

--- a/src/hooks/useGlobalSearch.test.ts
+++ b/src/hooks/useGlobalSearch.test.ts
@@ -9,6 +9,7 @@ function createTestPage(id: string, title: string, content: string, options?: Pa
   return {
     id,
     ownerUserId: "test-user",
+    noteId: null,
     title,
     content,
     createdAt: now,

--- a/src/hooks/useLinkedPages.test.ts
+++ b/src/hooks/useLinkedPages.test.ts
@@ -9,6 +9,7 @@ function createTestPage(id: string, title: string, content: string, options?: Pa
   return {
     id,
     ownerUserId: "test-user-id",
+    noteId: null,
     title,
     content,
     createdAt: now,
@@ -510,6 +511,7 @@ function createTestSummary(id: string, title: string, options?: Partial<PageSumm
   return {
     id,
     ownerUserId: "user-1",
+    noteId: null,
     title,
     contentPreview: undefined,
     thumbnailUrl: undefined,

--- a/src/hooks/useNoteQueries.ts
+++ b/src/hooks/useNoteQueries.ts
@@ -13,10 +13,11 @@ import type { Page, PageSummary } from "@/types/page";
 /** Page in a note with who added it (for canDeletePage). */
 export type NotePageSummary = PageSummary & { addedByUserId: string };
 
-export /**
- *
+/**
+ * Note 関連クエリ・ミューテーションで共有する React Query キー群。
+ * React Query key factory shared by note-related queries and mutations.
  */
-const noteKeys = {
+export const noteKeys = {
   all: ["notes"] as const,
   lists: () => [...noteKeys.all, "list"] as const,
   list: (userId: string, userEmail?: string) =>
@@ -196,23 +197,15 @@ export function useNoteApi() {
 }
 
 /**
- *
+ * 認証済みユーザーが所属する全 Note のサマリ一覧を取得するフック。
+ * React Query hook that fetches the current user's note summaries.
  */
 export function useNotes() {
-  /**
-   *
-   */
   const { api, userId, userEmail, isLoaded, isSignedIn } = useNoteApi();
 
-  /**
-   *
-   */
   const query = useQuery({
     queryKey: noteKeys.list(userId, userEmail),
     queryFn: async () => {
-      /**
-       *
-       */
       const list = await api.getNotes();
       return list.map(apiNoteToNoteSummary);
     },
@@ -229,40 +222,23 @@ export function useNotes() {
 type UseNoteOptions = { allowRemote?: boolean };
 
 /**
- *
+ * 単一の Note とアクセス権情報を取得するフック。
+ * Hook that fetches a single Note alongside the caller's access context.
  */
 export function useNote(noteId: string, _options?: UseNoteOptions) {
-  /**
-   *
-   */
   const { api, userId, userEmail, isLoaded, isSignedIn } = useNoteApi();
 
-  /**
-   *
-   */
   const query = useQuery({
     queryKey: noteKeys.detail(noteId, userId, userEmail),
     queryFn: async (): Promise<NoteWithAccess> => {
-      /**
-       *
-       */
       const res = await api.getNote(noteId);
-      /**
-       *
-       */
       const note = apiNoteToNote(res);
-      /**
-       *
-       */
       const access = buildAccessFromApi(note, res.current_user_role, userId);
       return { note, access };
     },
     enabled: isLoaded && !!noteId,
   });
 
-  /**
-   *
-   */
   const noteWithAccess = query.data ?? null;
 
   return {
@@ -275,12 +251,10 @@ export function useNote(noteId: string, _options?: UseNoteOptions) {
 }
 
 /**
- *
+ * 公開ノートの発見（Discover）向け一覧を取得するフック。
+ * Hook that fetches the public Discover listing of notes.
  */
 export function usePublicNotes(sort: "updated" | "popular" = "updated", limit = 20, offset = 0) {
-  /**
-   *
-   */
   const { api } = useNoteApi();
   return useQuery({
     queryKey: noteKeys.publicList(sort, limit, offset),
@@ -292,24 +266,19 @@ export function usePublicNotes(sort: "updated" | "popular" = "updated", limit = 
 }
 
 /**
- *
+ * 指定ノートに含まれるページ一覧（ノート画面用）を取得するフック。
+ * Hook that fetches pages belonging to the given note for the note view.
  */
 export function useNotePages(
   noteId: string,
   _source?: "local" | "remote",
   enabled: boolean = true,
 ) {
-  /**
-   *
-   */
   const { api, isLoaded } = useNoteApi();
 
   return useQuery({
     queryKey: noteKeys.pageList(noteId),
     queryFn: async (): Promise<NotePageSummary[]> => {
-      /**
-       *
-       */
       const res = await api.getNote(noteId);
       return res.pages.map((p) => ({
         ...apiPageToPageSummary(p),
@@ -321,7 +290,8 @@ export function useNotePages(
 }
 
 /**
- *
+ * ノート内の単一ページ（noteId + pageId）を取得するフック。
+ * Hook that fetches a single page within a note by noteId + pageId.
  */
 export function useNotePage(
   noteId: string,
@@ -329,21 +299,12 @@ export function useNotePage(
   _source?: "local" | "remote",
   enabled: boolean = true,
 ) {
-  /**
-   *
-   */
   const { api, isLoaded, isSignedIn } = useNoteApi();
 
   return useQuery({
     queryKey: noteKeys.page(noteId, pageId),
     queryFn: async (): Promise<Page | null> => {
-      /**
-       *
-       */
       const res = await api.getNote(noteId);
-      /**
-       *
-       */
       const p = res.pages.find((x) => x.id === pageId);
       return p ? apiPageToPage(p) : null;
     },
@@ -352,20 +313,15 @@ export function useNotePage(
 }
 
 /**
- *
+ * ノートの招待済み・参加中メンバー一覧を取得するフック。
+ * Hook that fetches invited / joined members of a note.
  */
 export function useNoteMembers(noteId: string, enabled: boolean = true) {
-  /**
-   *
-   */
   const { api, isLoaded, isSignedIn } = useNoteApi();
 
   return useQuery({
     queryKey: noteKeys.memberList(noteId),
     queryFn: async (): Promise<NoteMember[]> => {
-      /**
-       *
-       */
       const list = await api.getNoteMembers(noteId);
       return list.map((m) => apiMemberToNoteMember(m, noteId));
     },
@@ -374,16 +330,11 @@ export function useNoteMembers(noteId: string, enabled: boolean = true) {
 }
 
 /**
- *
+ * 新規ノート作成のミューテーションフック。成功時にノート系キャッシュを無効化する。
+ * Mutation hook for creating a new note; invalidates note caches on success.
  */
 export function useCreateNote() {
-  /**
-   *
-   */
   const { api } = useNoteApi();
-  /**
-   *
-   */
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -396,9 +347,6 @@ export function useCreateNote() {
       visibility: Note["visibility"];
       editPermission?: Note["editPermission"];
     }) => {
-      /**
-       *
-       */
       const created = await api.createNote({
         title,
         visibility,
@@ -413,16 +361,11 @@ export function useCreateNote() {
 }
 
 /**
- *
+ * ノートの title / visibility / editPermission を更新するミューテーションフック。
+ * Mutation hook for updating a note's title / visibility / editPermission.
  */
 export function useUpdateNote() {
-  /**
-   *
-   */
   const { api } = useNoteApi();
-  /**
-   *
-   */
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -450,16 +393,11 @@ export function useUpdateNote() {
 }
 
 /**
- *
+ * ノートを削除するミューテーションフック。
+ * Mutation hook for deleting a note.
  */
 export function useDeleteNote() {
-  /**
-   *
-   */
   const { api } = useNoteApi();
-  /**
-   *
-   */
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -474,16 +412,11 @@ export function useDeleteNote() {
 }
 
 /**
- *
+ * ノートにページを追加するミューテーションフック（既存ページの参照またはタイトル指定作成）。
+ * Mutation hook for attaching a page to a note (reference or title-based create).
  */
 export function useAddPageToNote() {
-  /**
-   *
-   */
   const { api } = useNoteApi();
-  /**
-   *
-   */
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -506,16 +439,11 @@ export function useAddPageToNote() {
 }
 
 /**
- *
+ * ノートからページを外すミューテーションフック。
+ * Mutation hook for detaching a page from a note.
  */
 export function useRemovePageFromNote() {
-  /**
-   *
-   */
   const { api } = useNoteApi();
-  /**
-   *
-   */
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -530,16 +458,11 @@ export function useRemovePageFromNote() {
 }
 
 /**
- *
+ * ノートにメンバー（viewer / editor）を招待するミューテーションフック。
+ * Mutation hook for inviting a member (viewer / editor) to a note.
  */
 export function useAddNoteMember() {
-  /**
-   *
-   */
   const { api } = useNoteApi();
-  /**
-   *
-   */
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -562,16 +485,11 @@ export function useAddNoteMember() {
 }
 
 /**
- *
+ * 既存メンバーのロールを viewer ↔ editor で更新するミューテーションフック。
+ * Mutation hook for updating an existing member's role (viewer ↔ editor).
  */
 export function useUpdateNoteMemberRole() {
-  /**
-   *
-   */
   const { api } = useNoteApi();
-  /**
-   *
-   */
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -594,16 +512,11 @@ export function useUpdateNoteMemberRole() {
 }
 
 /**
- *
+ * ノートからメンバーを外す（招待取り消し／強制脱退）ミューテーションフック。
+ * Mutation hook for removing a member from a note (revoke invite / kick).
  */
 export function useRemoveNoteMember() {
-  /**
-   *
-   */
   const { api } = useNoteApi();
-  /**
-   *
-   */
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/src/hooks/useNoteQueries.ts
+++ b/src/hooks/useNoteQueries.ts
@@ -128,6 +128,14 @@ function apiPageToPageSummary(p: GetNoteResponse["pages"][0]): PageSummary {
   return {
     id: p.id,
     ownerUserId: p.owner_id,
+    // GET /api/notes/:id は現状 `note_id` を返さない（Phase 1 対象外）。
+    // ノート画面で消費されるため personal /home フィルタには影響しないが、
+    // note-native か個人ページかの厳密区別が必要になる Phase 3 でサーバー
+    // レスポンスを拡張する。Issue #713。
+    // GET /api/notes/:id does not surface `note_id` yet; this consumer is the
+    // note view, so personal /home filtering is unaffected. Phase 3 will
+    // extend the server response when the distinction is needed. Issue #713.
+    noteId: null,
     title: p.title ?? "",
     contentPreview: p.content_preview ?? undefined,
     thumbnailUrl: p.thumbnail_url ?? undefined,

--- a/src/hooks/usePageQueries.ts
+++ b/src/hooks/usePageQueries.ts
@@ -28,7 +28,10 @@ const LOCAL_USER_ID = "local-user";
 const initialSyncRequestedForUser = new Set<string>();
 
 // Query keys
-export const pageKeys = {
+export /**
+ *
+ */
+const pageKeys = {
   all: ["pages"] as const,
   lists: () => [...pageKeys.all, "list"] as const,
   list: (userId: string) => [...pageKeys.lists(), userId] as const,
@@ -228,13 +231,28 @@ type UsePageOptions = {
   enabled?: boolean;
 };
 
+/**
+ *
+ */
 export function usePage(pageId: string, options?: UsePageOptions) {
+  /**
+   *
+   */
   const { getRepository, userId, isLoaded } = useRepository();
+  /**
+   *
+   */
   const isEnabled = (options?.enabled ?? true) && isLoaded && !!pageId;
 
+  /**
+   *
+   */
   const query = useQuery({
     queryKey: pageKeys.detail(userId, pageId),
     queryFn: async () => {
+      /**
+       *
+       */
       const repo = await getRepository();
       return repo.getPage(userId, pageId);
     },
@@ -348,6 +366,9 @@ export function useCreatePage() {
       const newSummary: PageSummary = {
         id: newPage.id,
         ownerUserId: newPage.ownerUserId,
+        // useCreatePage は個人ページ作成しか経由しないので常に `null`。Issue #713。
+        // useCreatePage only creates personal pages, so noteId is always null.
+        noteId: newPage.noteId,
         title: newPage.title,
         contentPreview: newPage.contentPreview,
         thumbnailUrl: newPage.thumbnailUrl,

--- a/src/hooks/usePageQueries.ts
+++ b/src/hooks/usePageQueries.ts
@@ -27,11 +27,11 @@ const LOCAL_USER_ID = "local-user";
  */
 const initialSyncRequestedForUser = new Set<string>();
 
-// Query keys
-export /**
- *
+/**
+ * ページ系クエリ・ミューテーションが共有する React Query キー群。
+ * React Query key factory shared by page-related queries and mutations.
  */
-const pageKeys = {
+export const pageKeys = {
   all: ["pages"] as const,
   lists: () => [...pageKeys.all, "list"] as const,
   list: (userId: string) => [...pageKeys.lists(), userId] as const,
@@ -225,34 +225,24 @@ export function usePagesSummary() {
 }
 
 /**
- * Hook to fetch a single page by ID
+ * `usePage` のオプション。`enabled: false` でリクエストを抑止できる。
+ * Options for {@link usePage}; pass `enabled: false` to suppress the request.
  */
 type UsePageOptions = {
   enabled?: boolean;
 };
 
 /**
- *
+ * ID 指定で単一ページを取得するフック。取得前は `data = undefined`。
+ * Hook that fetches a single page by ID; `data` is `undefined` until loaded.
  */
 export function usePage(pageId: string, options?: UsePageOptions) {
-  /**
-   *
-   */
   const { getRepository, userId, isLoaded } = useRepository();
-  /**
-   *
-   */
   const isEnabled = (options?.enabled ?? true) && isLoaded && !!pageId;
 
-  /**
-   *
-   */
   const query = useQuery({
     queryKey: pageKeys.detail(userId, pageId),
     queryFn: async () => {
-      /**
-       *
-       */
       const repo = await getRepository();
       return repo.getPage(userId, pageId);
     },

--- a/src/hooks/useSyncWikiLinks.test.ts
+++ b/src/hooks/useSyncWikiLinks.test.ts
@@ -47,6 +47,7 @@ describe("syncLinksWithRepo", () => {
         {
           id: "page-a",
           ownerUserId: userId,
+          noteId: null,
           title: "Page A",
           contentPreview: undefined,
           thumbnailUrl: undefined,
@@ -92,6 +93,7 @@ describe("syncLinksWithRepo", () => {
         {
           id: "page-a",
           ownerUserId: userId,
+          noteId: null,
           title: "Page A",
           contentPreview: undefined,
           thumbnailUrl: undefined,
@@ -140,6 +142,7 @@ describe("syncLinksWithRepo", () => {
         {
           id: "page-a",
           ownerUserId: userId,
+          noteId: null,
           title: "Page A",
           contentPreview: undefined,
           thumbnailUrl: undefined,
@@ -151,6 +154,7 @@ describe("syncLinksWithRepo", () => {
         {
           id: "page-b",
           ownerUserId: userId,
+          noteId: null,
           title: "Page B",
           contentPreview: undefined,
           thumbnailUrl: undefined,
@@ -186,6 +190,7 @@ describe("syncLinksWithRepo", () => {
         {
           id: "page-a",
           ownerUserId: userId,
+          noteId: null,
           title: "Page A",
           contentPreview: undefined,
           thumbnailUrl: undefined,
@@ -222,6 +227,7 @@ describe("syncLinksWithRepo", () => {
         {
           id: sourcePageId,
           ownerUserId: userId,
+          noteId: null,
           title: "My Page",
           contentPreview: undefined,
           thumbnailUrl: undefined,

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -12,11 +12,20 @@ export interface SyncPagesResponse {
 }
 
 /**
+ * `/api/sync/pages` etc. が返すページ行。`note_id` が `null` または未指定の場合は
+ * 個人ページ（issue #713）。GET `/api/sync/pages` は個人ページのみを返すため
+ * 実運用では常に `null` だが、新規エンドポイントでも同じ型を再利用できるよう
+ * 任意フィールドとして表現している。
  *
+ * Page row from `/api/sync/pages` and friends. `note_id` `null` or missing
+ * means a personal page (issue #713). GET `/api/sync/pages` only ever returns
+ * personal pages, but the field is optional so the same type can describe
+ * note-native rows from future endpoints.
  */
 export interface SyncPageItem {
   id: string;
   owner_id: string;
+  note_id?: string | null;
   source_page_id: string | null;
   title: string | null;
   content_preview: string | null;

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -37,7 +37,8 @@ export interface SyncPageItem {
 }
 
 /**
- *
+ * WikiLink グラフのリンク行。`/api/sync/pages` 応答内で使われる。
+ * Link row in the wiki-link graph, returned by `/api/sync/pages`.
  */
 export interface SyncLinkItem {
   source_id: string;
@@ -46,7 +47,8 @@ export interface SyncLinkItem {
 }
 
 /**
- *
+ * 未解決 WikiLink（ゴーストリンク）の行。`/api/sync/pages` で同期される。
+ * Ghost-link (unresolved WikiLink) row synced via `/api/sync/pages`.
  */
 export interface SyncGhostLinkItem {
   link_text: string;
@@ -149,7 +151,9 @@ export interface DiscoverResponse {
 }
 
 /**
- *
+ * `GET /api/notes/discover` のノート行。閲覧数・ページ数などの発見用メタ情報を含む。
+ * Row in the `/api/notes/discover` response, carrying discover-oriented
+ * metadata such as view count and page count.
  */
 export interface DiscoverNoteItem {
   id: string;

--- a/src/lib/dateUtils.test.ts
+++ b/src/lib/dateUtils.test.ts
@@ -10,6 +10,7 @@ function makePage(overrides: Partial<Page> = {}): Page {
   return {
     id: overrides.id ?? "p1",
     ownerUserId: "u1",
+    noteId: null,
     title: overrides.title ?? "Test",
     content: "{}",
     createdAt: overrides.createdAt ?? Date.now(),

--- a/src/lib/pageRepository/StorageAdapterPageRepository.test.ts
+++ b/src/lib/pageRepository/StorageAdapterPageRepository.test.ts
@@ -113,6 +113,7 @@ describe("StorageAdapterPageRepository", () => {
       const meta: PageMetadata = {
         id: "page-1",
         ownerId: LOCAL_USER_ID,
+        noteId: null,
         sourcePageId: null,
         title: "Hello",
         contentPreview: "preview",
@@ -144,6 +145,7 @@ describe("StorageAdapterPageRepository", () => {
         {
           id: "p1",
           ownerId: LOCAL_USER_ID,
+          noteId: null,
           sourcePageId: null,
           title: "A",
           contentPreview: null,
@@ -156,6 +158,7 @@ describe("StorageAdapterPageRepository", () => {
         {
           id: "p2",
           ownerId: LOCAL_USER_ID,
+          noteId: null,
           sourcePageId: null,
           title: "B",
           contentPreview: null,
@@ -180,6 +183,7 @@ describe("StorageAdapterPageRepository", () => {
       const existing: PageMetadata = {
         id: "page-1",
         ownerId: LOCAL_USER_ID,
+        noteId: null,
         sourcePageId: null,
         title: "Old Title",
         contentPreview: null,
@@ -283,6 +287,7 @@ describe("StorageAdapterPageRepository", () => {
       {
         id: "p1",
         ownerId: LOCAL_USER_ID,
+        noteId: null,
         sourcePageId: null,
         title: "Unique Title",
         contentPreview: null,
@@ -295,6 +300,7 @@ describe("StorageAdapterPageRepository", () => {
       {
         id: "p2",
         ownerId: LOCAL_USER_ID,
+        noteId: null,
         sourcePageId: null,
         title: "Another Title",
         contentPreview: null,
@@ -323,6 +329,87 @@ describe("StorageAdapterPageRepository", () => {
       (adapter.getAllPages as ReturnType<typeof vi.fn>).mockResolvedValue(pages);
       const dup = await repo.checkDuplicateTitle(LOCAL_USER_ID, "Nonexistent Title");
       expect(dup).toBeNull();
+    });
+  });
+
+  describe("noteId passthrough (issue #713 Phase 2)", () => {
+    // 個人ページ作成 (`createPage`) は常に `noteId = null` のメタデータを書き、
+    // 取得系は adapter から渡された `noteId` をそのまま `Page` / `PageSummary`
+    // に伝播させる。ノートネイティブページは `note-native` の値を保つ。
+    //
+    // `createPage` always writes personal-page metadata (`noteId = null`); read
+    // paths surface whatever `noteId` the adapter returns into `Page` /
+    // `PageSummary` unchanged so callers can scope behaviour without re-querying.
+
+    it("createPage (local) writes noteId: null to the adapter", async () => {
+      await repo.createPage(LOCAL_USER_ID, "Personal", "");
+      const upsertMock = adapter.upsertPage as ReturnType<typeof vi.fn>;
+      expect(upsertMock).toHaveBeenCalledOnce();
+      const stored = upsertMock.mock.calls[0][0] as PageMetadata;
+      expect(stored.noteId).toBeNull();
+    });
+
+    it("createPage (remote) defaults noteId to null when API omits it", async () => {
+      const now = new Date().toISOString();
+      (api.createPage as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: "api-page-1",
+        owner_id: AUTH_USER_ID,
+        title: "API Page",
+        content_preview: null,
+        source_page_id: null,
+        thumbnail_url: null,
+        source_url: null,
+        created_at: now,
+        updated_at: now,
+        is_deleted: false,
+      });
+      const page = await repo.createPage(AUTH_USER_ID, "API Page");
+      expect(page.noteId).toBeNull();
+      const upsertMock = adapter.upsertPage as ReturnType<typeof vi.fn>;
+      const stored = upsertMock.mock.calls[0][0] as PageMetadata;
+      expect(stored.noteId).toBeNull();
+    });
+
+    it("getPage / getPagesSummary forward adapter noteId verbatim", async () => {
+      const personal: PageMetadata = {
+        id: "p1",
+        ownerId: LOCAL_USER_ID,
+        noteId: null,
+        sourcePageId: null,
+        title: "Personal",
+        contentPreview: null,
+        thumbnailUrl: null,
+        sourceUrl: null,
+        createdAt: 1000,
+        updatedAt: 2000,
+        isDeleted: false,
+      };
+      const noteNative: PageMetadata = {
+        id: "p2",
+        ownerId: LOCAL_USER_ID,
+        noteId: "note-1",
+        sourcePageId: null,
+        title: "Note-native",
+        contentPreview: null,
+        thumbnailUrl: null,
+        sourceUrl: null,
+        createdAt: 1000,
+        updatedAt: 2000,
+        isDeleted: false,
+      };
+
+      (adapter.getPage as ReturnType<typeof vi.fn>).mockResolvedValueOnce(noteNative);
+      const fetched = await repo.getPage(LOCAL_USER_ID, "p2");
+      expect(fetched?.noteId).toBe("note-1");
+
+      (adapter.getAllPages as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+        personal,
+        noteNative,
+      ]);
+      const summaries = await repo.getPagesSummary(LOCAL_USER_ID);
+      const byId = new Map(summaries.map((s) => [s.id, s]));
+      expect(byId.get("p1")?.noteId).toBeNull();
+      expect(byId.get("p2")?.noteId).toBe("note-1");
     });
   });
 });

--- a/src/lib/pageRepository/StorageAdapterPageRepository.ts
+++ b/src/lib/pageRepository/StorageAdapterPageRepository.ts
@@ -45,11 +45,18 @@ function metadataToPageSummary(m: PageMetadata): PageSummary {
 }
 
 /**
+ * ローカル IndexedDB (StorageAdapter) と REST API (ApiClient) を束ねる
+ * ページリポジトリ。ゲスト (`LOCAL_USER_ID`) は adapter のみを使い、
+ * 認証済みユーザーは adapter + API の両方を使って CRUD を行う。
  *
+ * Page repository that bridges the local IndexedDB (StorageAdapter) with the
+ * REST API (ApiClient). Guest users (`LOCAL_USER_ID`) go through the adapter
+ * only, while authenticated users read/write via adapter + API.
  */
 export class StorageAdapterPageRepository {
   /**
-   *
+   * @param adapter ローカルストレージ実装 / local storage backend
+   * @param api REST API クライアント / REST API client
    */
   constructor(
     private adapter: StorageAdapter,
@@ -57,7 +64,8 @@ export class StorageAdapterPageRepository {
   ) {}
 
   /**
-   *
+   * 新しいページを作成する。ゲストはローカルのみ、認証済みは API 経由で作成。
+   * Create a new page. Guest users stay local; authenticated users hit the API.
    */
   async createPage(
     userId: string,
@@ -76,21 +84,9 @@ export class StorageAdapterPageRepository {
     content: string,
     options?: CreatePageOptions,
   ): Promise<Page> {
-    /**
-     *
-     */
     const contentPreview = getPageListPreview(content);
-    /**
-     *
-     */
     const now = Date.now();
-    /**
-     *
-     */
     const id = crypto.randomUUID();
-    /**
-     *
-     */
     const meta: PageMetadata = {
       id,
       ownerId: LOCAL_USER_ID,
@@ -115,22 +111,13 @@ export class StorageAdapterPageRepository {
     content: string,
     options?: CreatePageOptions,
   ): Promise<Page> {
-    /**
-     *
-     */
     const contentPreview = getPageListPreview(content);
-    /**
-     *
-     */
     const created = await this.api.createPage({
       title: title || undefined,
       content_preview: contentPreview || undefined,
       source_url: options?.sourceUrl ?? undefined,
       thumbnail_url: options?.thumbnailUrl ?? undefined,
     });
-    /**
-     *
-     */
     const meta: PageMetadata = {
       id: created.id,
       ownerId: created.owner_id,
@@ -155,94 +142,67 @@ export class StorageAdapterPageRepository {
   }
 
   /**
-   *
+   * ID 指定で単一ページを取得する（論理削除済みは `null`）。
+   * Fetch a single page by ID; `null` if missing or soft-deleted.
    */
   async getPage(_userId: string, pageId: string): Promise<Page | null> {
-    /**
-     *
-     */
     const m = await this.adapter.getPage(pageId);
     return m ? metadataToPage(m) : null;
   }
 
   /**
-   *
+   * ユーザーの個人ページ一覧を返す（ノートネイティブページは除外）。
+   * Return all personal pages for the user (note-native pages excluded).
    */
   async getPages(_userId: string): Promise<Page[]> {
-    /**
-     *
-     */
     const list = await this.adapter.getAllPages();
     return list.map(metadataToPage);
   }
 
   /**
-   *
+   * 一覧表示用の軽量ページサマリを返す（本文なし、個人ページのみ）。
+   * Return lightweight page summaries (no content, personal only) for listing.
    */
   async getPagesSummary(_userId: string): Promise<PageSummary[]> {
-    /**
-     *
-     */
     const list = await this.adapter.getAllPages();
     return list.map(metadataToPageSummary);
   }
 
   /**
-   *
+   * 複数 ID のページをまとめて取得する。存在しない ID は結果に含まれない。
+   * Fetch multiple pages by ID; missing IDs are silently dropped.
    */
   async getPagesByIds(_userId: string, pageIds: string[]): Promise<Page[]> {
     if (pageIds.length === 0) return [];
-    /**
-     *
-     */
     const list = await this.adapter.getAllPages();
-    /**
-     *
-     */
     const idSet = new Set(pageIds);
     return list.filter((m) => idSet.has(m.id)).map(metadataToPage);
   }
 
   /**
-   *
+   * タイトル完全一致でページを 1 件検索する。
+   * Find one page by exact title match.
    */
   async getPageByTitle(_userId: string, title: string): Promise<Page | null> {
-    /**
-     *
-     */
     const trimmed = title.trim();
     if (!trimmed) return null;
-    /**
-     *
-     */
     const list = await this.adapter.getAllPages();
-    /**
-     *
-     */
     const m = list.find((p) => (p.title ?? "").trim() === trimmed);
     return m ? metadataToPage(m) : null;
   }
 
   /**
-   *
+   * `excludePageId` 以外で同一タイトルのページが存在するか検査する。
+   * Return a page with the same title (excluding `excludePageId`), or `null`.
    */
   async checkDuplicateTitle(
     _userId: string,
     title: string,
     excludePageId?: string,
   ): Promise<Page | null> {
-    /**
-     *
-     */
     const trimmed = title.trim();
     if (!trimmed) return null;
-    /**
-     *
-     */
     const list = await this.adapter.getAllPages();
-    /**
-     *
-     */
     const m = list.find(
       (p) => (p.title ?? "").trim() === trimmed && (!excludePageId || p.id !== excludePageId),
     );
@@ -250,25 +210,19 @@ export class StorageAdapterPageRepository {
   }
 
   /**
+   * ページメタデータ (title / content / thumbnail / sourceUrl) を更新し、
+   * 検索インデックスもタイトル・本文変更時は更新する。
    *
+   * Update page metadata and refresh the search index when title/content change.
    */
   async updatePage(
     _userId: string,
     pageId: string,
     updates: Partial<Pick<Page, "title" | "content" | "thumbnailUrl" | "sourceUrl">>,
   ): Promise<void> {
-    /**
-     *
-     */
     const existing = await this.adapter.getPage(pageId);
     if (!existing) return;
-    /**
-     *
-     */
     const now = Date.now();
-    /**
-     *
-     */
     const meta: PageMetadata = {
       ...existing,
       title: updates.title !== undefined ? updates.title : existing.title,
@@ -284,24 +238,16 @@ export class StorageAdapterPageRepository {
     await this.adapter.upsertPage(meta);
     // タイトルまたはコンテンツが変更された場合、検索インデックスを更新
     if (updates.title !== undefined || updates.content !== undefined) {
-      /**
-       *
-       */
       const titleText = meta.title ?? "";
-      /**
-       *
-       */
       const contentText = updates.content ? extractPlainText(updates.content) : "";
-      /**
-       *
-       */
       const searchText = [titleText, contentText].filter(Boolean).join(" ");
       await this.adapter.updateSearchIndex(pageId, searchText);
     }
   }
 
   /**
-   *
+   * ページを論理削除する。認証済みユーザーは API 経由でも削除を通知。
+   * Soft-delete a page; authenticated users also notify the API.
    */
   async deletePage(userId: string, pageId: string): Promise<void> {
     await this.adapter.deletePage(pageId);
@@ -311,24 +257,13 @@ export class StorageAdapterPageRepository {
   }
 
   /**
-   *
+   * ローカルの検索インデックス越しにページを全文検索する。
+   * Full-text search over the local search index.
    */
   async searchPages(_userId: string, query: string): Promise<Page[]> {
-    /**
-     *
-     */
     const results = await this.adapter.searchPages(query);
-    /**
-     *
-     */
     const pages: Page[] = [];
-    for (/**
-     *
-     */
-    const r of results) {
-      /**
-       *
-       */
+    for (const r of results) {
       const m = await this.adapter.getPage(r.pageId);
       if (m) pages.push(metadataToPage(m));
     }
@@ -336,28 +271,21 @@ export class StorageAdapterPageRepository {
   }
 
   /**
-   *
+   * 2 ページ間のリンクを追加する（重複追加はスキップ）。
+   * Add a link between two pages; duplicate inserts are a no-op.
    */
   async addLink(sourceId: string, targetId: string): Promise<void> {
-    /**
-     *
-     */
     const links = await this.adapter.getLinks(sourceId);
-    /**
-     *
-     */
     const now = Date.now();
     if (links.some((l) => l.targetId === targetId)) return;
     await this.adapter.saveLinks(sourceId, [...links, { sourceId, targetId, createdAt: now }]);
   }
 
   /**
-   *
+   * 2 ページ間のリンクを削除する。
+   * Remove a link between two pages.
    */
   async removeLink(sourceId: string, targetId: string): Promise<void> {
-    /**
-     *
-     */
     const links = await this.adapter.getLinks(sourceId);
     await this.adapter.saveLinks(
       sourceId,
@@ -366,46 +294,31 @@ export class StorageAdapterPageRepository {
   }
 
   /**
-   *
+   * 指定ページから出ているリンクの target ID 一覧を返す。
+   * Return target IDs of outgoing links for a page.
    */
   async getOutgoingLinks(pageId: string): Promise<string[]> {
-    /**
-     *
-     */
     const links = await this.adapter.getLinks(pageId);
     return links.map((l) => l.targetId);
   }
 
   /**
-   *
+   * 指定ページへの被リンク（バックリンク）の source ID 一覧を返す。
+   * Return source IDs of backlinks pointing at the page.
    */
   async getBacklinks(pageId: string): Promise<string[]> {
-    /**
-     *
-     */
     const links = await this.adapter.getBacklinks(pageId);
     return links.map((l) => l.sourceId);
   }
 
   /**
-   *
+   * ユーザー配下の全ページに対する全リンクを集めて返す。
+   * Collect every link across all pages owned by the user.
    */
   async getLinks(_userId: string): Promise<Link[]> {
-    /**
-     *
-     */
     const pages = await this.adapter.getAllPages();
-    /**
-     *
-     */
     const all: Link[] = [];
-    for (/**
-     *
-     */
-    const p of pages) {
-      /**
-       *
-       */
+    for (const p of pages) {
       const links = await this.adapter.getLinks(p.id);
       all.push(...links);
     }
@@ -413,16 +326,11 @@ export class StorageAdapterPageRepository {
   }
 
   /**
-   *
+   * ゴーストリンク（未解決 WikiLink）を追加する。重複は無視。
+   * Add a ghost link (unresolved WikiLink); duplicates are ignored.
    */
   async addGhostLink(linkText: string, sourcePageId: string): Promise<void> {
-    /**
-     *
-     */
     const ghosts = await this.adapter.getGhostLinks(sourcePageId);
-    /**
-     *
-     */
     const now = Date.now();
     if (ghosts.some((g) => g.linkText === linkText)) return;
     await this.adapter.saveGhostLinks(sourcePageId, [
@@ -432,12 +340,10 @@ export class StorageAdapterPageRepository {
   }
 
   /**
-   *
+   * ゴーストリンクを削除する。
+   * Remove a ghost link from a source page.
    */
   async removeGhostLink(linkText: string, sourcePageId: string): Promise<void> {
-    /**
-     *
-     */
     const ghosts = await this.adapter.getGhostLinks(sourcePageId);
     await this.adapter.saveGhostLinks(
       sourcePageId,
@@ -446,24 +352,13 @@ export class StorageAdapterPageRepository {
   }
 
   /**
-   *
+   * 指定リンクテキストのゴーストを持つページ ID 一覧を返す。
+   * Return IDs of pages that carry a ghost link for the given text.
    */
   async getGhostLinkSources(linkText: string): Promise<string[]> {
-    /**
-     *
-     */
     const pages = await this.adapter.getAllPages();
-    /**
-     *
-     */
     const sources: string[] = [];
-    for (/**
-     *
-     */
-    const p of pages) {
-      /**
-       *
-       */
+    for (const p of pages) {
       const ghosts = await this.adapter.getGhostLinks(p.id);
       if (ghosts.some((g) => g.linkText === linkText)) sources.push(p.id);
     }
@@ -471,24 +366,13 @@ export class StorageAdapterPageRepository {
   }
 
   /**
-   *
+   * ユーザー配下の全ページについてゴーストリンクを集めて返す。
+   * Aggregate every ghost link across all pages owned by the user.
    */
   async getGhostLinks(_userId: string): Promise<GhostLink[]> {
-    /**
-     *
-     */
     const pages = await this.adapter.getAllPages();
-    /**
-     *
-     */
     const all: GhostLink[] = [];
-    for (/**
-     *
-     */
-    const p of pages) {
-      /**
-       *
-       */
+    for (const p of pages) {
       const ghosts = await this.adapter.getGhostLinks(p.id);
       all.push(
         ...ghosts.map((g) => ({
@@ -502,33 +386,26 @@ export class StorageAdapterPageRepository {
   }
 
   /**
-   *
+   * 単一ソースページに属するゴーストリンクのリンクテキスト一覧を返す（差分同期用）。
+   * Return ghost-link texts for a single source page (used by delta sync).
    */
   async getGhostLinksBySourcePage(sourcePageId: string): Promise<string[]> {
-    /**
-     *
-     */
     const ghosts = await this.adapter.getGhostLinks(sourcePageId);
     return ghosts.map((g) => g.linkText);
   }
 
   /**
+   * 2 箇所以上から参照されているゴーストリンクを、実在ページとして昇格させる。
+   * 新規ページを作成し、各ソースからのリンクへ置き換える。
    *
+   * Promote a ghost link referenced by two or more source pages into a real
+   * page, rewiring each source to link into the new page.
    */
   async promoteGhostLink(userId: string, linkText: string): Promise<Page | null> {
-    /**
-     *
-     */
     const sources = await this.getGhostLinkSources(linkText);
     if (sources.length < 2) return null;
-    /**
-     *
-     */
     const newPage = await this.createPage(userId, linkText, "");
-    for (/**
-     *
-     */
-    const sourceId of sources) {
+    for (const sourceId of sources) {
       await this.addLink(sourceId, newPage.id);
       await this.removeGhostLink(linkText, sourceId);
     }

--- a/src/lib/pageRepository/StorageAdapterPageRepository.ts
+++ b/src/lib/pageRepository/StorageAdapterPageRepository.ts
@@ -17,6 +17,7 @@ function metadataToPage(m: PageMetadata): Page {
   return {
     id: m.id,
     ownerUserId: m.ownerId,
+    noteId: m.noteId ?? null,
     title: m.title ?? "",
     content: "", // Y.Doc; load via adapter.getYDocState or API
     contentPreview: m.contentPreview ?? undefined,
@@ -32,6 +33,7 @@ function metadataToPageSummary(m: PageMetadata): PageSummary {
   return {
     id: m.id,
     ownerUserId: m.ownerId,
+    noteId: m.noteId ?? null,
     title: m.title ?? "",
     contentPreview: m.contentPreview ?? undefined,
     thumbnailUrl: m.thumbnailUrl ?? undefined,
@@ -42,12 +44,21 @@ function metadataToPageSummary(m: PageMetadata): PageSummary {
   };
 }
 
+/**
+ *
+ */
 export class StorageAdapterPageRepository {
+  /**
+   *
+   */
   constructor(
     private adapter: StorageAdapter,
     private api: ApiClient,
   ) {}
 
+  /**
+   *
+   */
   async createPage(
     userId: string,
     title: string = "",
@@ -65,12 +76,27 @@ export class StorageAdapterPageRepository {
     content: string,
     options?: CreatePageOptions,
   ): Promise<Page> {
+    /**
+     *
+     */
     const contentPreview = getPageListPreview(content);
+    /**
+     *
+     */
     const now = Date.now();
+    /**
+     *
+     */
     const id = crypto.randomUUID();
+    /**
+     *
+     */
     const meta: PageMetadata = {
       id,
       ownerId: LOCAL_USER_ID,
+      // ローカル (ゲスト) で作るのは個人ページのみ。Issue #713。
+      // Local (guest) creation always produces a personal page. Issue #713.
+      noteId: null,
       sourcePageId: null,
       title: title || null,
       contentPreview: contentPreview || null,
@@ -89,16 +115,32 @@ export class StorageAdapterPageRepository {
     content: string,
     options?: CreatePageOptions,
   ): Promise<Page> {
+    /**
+     *
+     */
     const contentPreview = getPageListPreview(content);
+    /**
+     *
+     */
     const created = await this.api.createPage({
       title: title || undefined,
       content_preview: contentPreview || undefined,
       source_url: options?.sourceUrl ?? undefined,
       thumbnail_url: options?.thumbnailUrl ?? undefined,
     });
+    /**
+     *
+     */
     const meta: PageMetadata = {
       id: created.id,
       ownerId: created.owner_id,
+      // POST /api/pages は個人ページしか作らないので `null`。サーバーが将来
+      // ノート所属を返すようになっても (`note_id` は SyncPageItem で optional)
+      // 値があればそのまま採用する。Issue #713。
+      // POST /api/pages only ever creates personal pages, so default to `null`.
+      // If the server ever surfaces `note_id` (it's optional on `SyncPageItem`)
+      // we honor it. Issue #713.
+      noteId: created.note_id ?? null,
       sourcePageId: created.source_page_id ?? null,
       title: created.title ?? null,
       contentPreview: created.content_preview ?? null,
@@ -112,58 +154,121 @@ export class StorageAdapterPageRepository {
     return metadataToPage(meta);
   }
 
+  /**
+   *
+   */
   async getPage(_userId: string, pageId: string): Promise<Page | null> {
+    /**
+     *
+     */
     const m = await this.adapter.getPage(pageId);
     return m ? metadataToPage(m) : null;
   }
 
+  /**
+   *
+   */
   async getPages(_userId: string): Promise<Page[]> {
+    /**
+     *
+     */
     const list = await this.adapter.getAllPages();
     return list.map(metadataToPage);
   }
 
+  /**
+   *
+   */
   async getPagesSummary(_userId: string): Promise<PageSummary[]> {
+    /**
+     *
+     */
     const list = await this.adapter.getAllPages();
     return list.map(metadataToPageSummary);
   }
 
+  /**
+   *
+   */
   async getPagesByIds(_userId: string, pageIds: string[]): Promise<Page[]> {
     if (pageIds.length === 0) return [];
+    /**
+     *
+     */
     const list = await this.adapter.getAllPages();
+    /**
+     *
+     */
     const idSet = new Set(pageIds);
     return list.filter((m) => idSet.has(m.id)).map(metadataToPage);
   }
 
+  /**
+   *
+   */
   async getPageByTitle(_userId: string, title: string): Promise<Page | null> {
+    /**
+     *
+     */
     const trimmed = title.trim();
     if (!trimmed) return null;
+    /**
+     *
+     */
     const list = await this.adapter.getAllPages();
+    /**
+     *
+     */
     const m = list.find((p) => (p.title ?? "").trim() === trimmed);
     return m ? metadataToPage(m) : null;
   }
 
+  /**
+   *
+   */
   async checkDuplicateTitle(
     _userId: string,
     title: string,
     excludePageId?: string,
   ): Promise<Page | null> {
+    /**
+     *
+     */
     const trimmed = title.trim();
     if (!trimmed) return null;
+    /**
+     *
+     */
     const list = await this.adapter.getAllPages();
+    /**
+     *
+     */
     const m = list.find(
       (p) => (p.title ?? "").trim() === trimmed && (!excludePageId || p.id !== excludePageId),
     );
     return m ? metadataToPage(m) : null;
   }
 
+  /**
+   *
+   */
   async updatePage(
     _userId: string,
     pageId: string,
     updates: Partial<Pick<Page, "title" | "content" | "thumbnailUrl" | "sourceUrl">>,
   ): Promise<void> {
+    /**
+     *
+     */
     const existing = await this.adapter.getPage(pageId);
     if (!existing) return;
+    /**
+     *
+     */
     const now = Date.now();
+    /**
+     *
+     */
     const meta: PageMetadata = {
       ...existing,
       title: updates.title !== undefined ? updates.title : existing.title,
@@ -179,13 +284,25 @@ export class StorageAdapterPageRepository {
     await this.adapter.upsertPage(meta);
     // タイトルまたはコンテンツが変更された場合、検索インデックスを更新
     if (updates.title !== undefined || updates.content !== undefined) {
+      /**
+       *
+       */
       const titleText = meta.title ?? "";
+      /**
+       *
+       */
       const contentText = updates.content ? extractPlainText(updates.content) : "";
+      /**
+       *
+       */
       const searchText = [titleText, contentText].filter(Boolean).join(" ");
       await this.adapter.updateSearchIndex(pageId, searchText);
     }
   }
 
+  /**
+   *
+   */
   async deletePage(userId: string, pageId: string): Promise<void> {
     await this.adapter.deletePage(pageId);
     if (userId !== LOCAL_USER_ID) {
@@ -193,24 +310,54 @@ export class StorageAdapterPageRepository {
     }
   }
 
+  /**
+   *
+   */
   async searchPages(_userId: string, query: string): Promise<Page[]> {
+    /**
+     *
+     */
     const results = await this.adapter.searchPages(query);
+    /**
+     *
+     */
     const pages: Page[] = [];
-    for (const r of results) {
+    for (/**
+     *
+     */
+    const r of results) {
+      /**
+       *
+       */
       const m = await this.adapter.getPage(r.pageId);
       if (m) pages.push(metadataToPage(m));
     }
     return pages;
   }
 
+  /**
+   *
+   */
   async addLink(sourceId: string, targetId: string): Promise<void> {
+    /**
+     *
+     */
     const links = await this.adapter.getLinks(sourceId);
+    /**
+     *
+     */
     const now = Date.now();
     if (links.some((l) => l.targetId === targetId)) return;
     await this.adapter.saveLinks(sourceId, [...links, { sourceId, targetId, createdAt: now }]);
   }
 
+  /**
+   *
+   */
   async removeLink(sourceId: string, targetId: string): Promise<void> {
+    /**
+     *
+     */
     const links = await this.adapter.getLinks(sourceId);
     await this.adapter.saveLinks(
       sourceId,
@@ -218,28 +365,64 @@ export class StorageAdapterPageRepository {
     );
   }
 
+  /**
+   *
+   */
   async getOutgoingLinks(pageId: string): Promise<string[]> {
+    /**
+     *
+     */
     const links = await this.adapter.getLinks(pageId);
     return links.map((l) => l.targetId);
   }
 
+  /**
+   *
+   */
   async getBacklinks(pageId: string): Promise<string[]> {
+    /**
+     *
+     */
     const links = await this.adapter.getBacklinks(pageId);
     return links.map((l) => l.sourceId);
   }
 
+  /**
+   *
+   */
   async getLinks(_userId: string): Promise<Link[]> {
+    /**
+     *
+     */
     const pages = await this.adapter.getAllPages();
+    /**
+     *
+     */
     const all: Link[] = [];
-    for (const p of pages) {
+    for (/**
+     *
+     */
+    const p of pages) {
+      /**
+       *
+       */
       const links = await this.adapter.getLinks(p.id);
       all.push(...links);
     }
     return all;
   }
 
+  /**
+   *
+   */
   async addGhostLink(linkText: string, sourcePageId: string): Promise<void> {
+    /**
+     *
+     */
     const ghosts = await this.adapter.getGhostLinks(sourcePageId);
+    /**
+     *
+     */
     const now = Date.now();
     if (ghosts.some((g) => g.linkText === linkText)) return;
     await this.adapter.saveGhostLinks(sourcePageId, [
@@ -248,7 +431,13 @@ export class StorageAdapterPageRepository {
     ]);
   }
 
+  /**
+   *
+   */
   async removeGhostLink(linkText: string, sourcePageId: string): Promise<void> {
+    /**
+     *
+     */
     const ghosts = await this.adapter.getGhostLinks(sourcePageId);
     await this.adapter.saveGhostLinks(
       sourcePageId,
@@ -256,20 +445,50 @@ export class StorageAdapterPageRepository {
     );
   }
 
+  /**
+   *
+   */
   async getGhostLinkSources(linkText: string): Promise<string[]> {
+    /**
+     *
+     */
     const pages = await this.adapter.getAllPages();
+    /**
+     *
+     */
     const sources: string[] = [];
-    for (const p of pages) {
+    for (/**
+     *
+     */
+    const p of pages) {
+      /**
+       *
+       */
       const ghosts = await this.adapter.getGhostLinks(p.id);
       if (ghosts.some((g) => g.linkText === linkText)) sources.push(p.id);
     }
     return sources;
   }
 
+  /**
+   *
+   */
   async getGhostLinks(_userId: string): Promise<GhostLink[]> {
+    /**
+     *
+     */
     const pages = await this.adapter.getAllPages();
+    /**
+     *
+     */
     const all: GhostLink[] = [];
-    for (const p of pages) {
+    for (/**
+     *
+     */
+    const p of pages) {
+      /**
+       *
+       */
       const ghosts = await this.adapter.getGhostLinks(p.id);
       all.push(
         ...ghosts.map((g) => ({
@@ -282,16 +501,34 @@ export class StorageAdapterPageRepository {
     return all;
   }
 
+  /**
+   *
+   */
   async getGhostLinksBySourcePage(sourcePageId: string): Promise<string[]> {
+    /**
+     *
+     */
     const ghosts = await this.adapter.getGhostLinks(sourcePageId);
     return ghosts.map((g) => g.linkText);
   }
 
+  /**
+   *
+   */
   async promoteGhostLink(userId: string, linkText: string): Promise<Page | null> {
+    /**
+     *
+     */
     const sources = await this.getGhostLinkSources(linkText);
     if (sources.length < 2) return null;
+    /**
+     *
+     */
     const newPage = await this.createPage(userId, linkText, "");
-    for (const sourceId of sources) {
+    for (/**
+     *
+     */
+    const sourceId of sources) {
       await this.addLink(sourceId, newPage.id);
       await this.removeGhostLink(linkText, sourceId);
     }

--- a/src/lib/searchUtils.test.ts
+++ b/src/lib/searchUtils.test.ts
@@ -16,6 +16,7 @@ function createTestPage(id: string, title: string, content: string, options?: Pa
   return {
     id,
     ownerUserId: "test-user",
+    noteId: null,
     title,
     content,
     createdAt: now,

--- a/src/lib/storageAdapter/IndexedDBStorageAdapter.ts
+++ b/src/lib/storageAdapter/IndexedDBStorageAdapter.ts
@@ -405,6 +405,18 @@ export class IndexedDBStorageAdapter implements StorageAdapter {
    * Return all non-deleted personal pages (`noteId === null`), sorted by
    * `updatedAt` descending. Note-native pages (issue #713) are not expected
    * to land in IndexedDB but are filtered defensively if they do.
+   *
+   * NOTE: `by_note` index は `noteId = null` の行をインデックスから除外する
+   * （IndexedDB 仕様: キー値が null の場合レコードは index に含まれない）。
+   * そのため `index("by_note").getAll(IDBKeyRange.only(null))` は 0 件しか
+   * 返せず、ここでは使えない。`by_note` index は将来ノートネイティブページを
+   * 扱う実装（Phase 3 以降）で noteId 指定クエリ側に使う想定。
+   *
+   * NOTE: the `by_note` index excludes rows whose `noteId` is null (per the
+   * IndexedDB spec, records are dropped from an index when the key value is
+   * null). `index("by_note").getAll(IDBKeyRange.only(null))` therefore returns
+   * zero rows and cannot replace this scan. The index is reserved for future
+   * note-scoped queries once note-native pages are fetched into IDB.
    */
   async getAllPages(): Promise<PageMetadata[]> {
     const db = await ensureDb();

--- a/src/lib/storageAdapter/IndexedDBStorageAdapter.ts
+++ b/src/lib/storageAdapter/IndexedDBStorageAdapter.ts
@@ -9,13 +9,29 @@ import type { StorageAdapter } from "./StorageAdapter";
 import type { PageMetadata, Link, GhostLink, SearchResult } from "./types";
 
 const DB_NAME_PREFIX = "zedi-storage-";
-const DB_VERSION = 1;
+// v2: add `noteId` column on `my_pages` to mirror Aurora `pages.note_id`
+//     (issue #713). v1 rows are upgraded in place by `onupgradeneeded` —
+//     existing rows are personal pages, so `noteId = null` is the correct
+//     backfill value.
+//
+// v2: `pages.note_id` (issue #713) を反映するため `my_pages` に `noteId` 列を
+// 追加。v1 の既存行は全て個人ページなので、`onupgradeneeded` で `noteId = null`
+// を埋めれば移行完了。
+const DB_VERSION = 2;
 const YDOC_NAME_PREFIX = "zedi-doc-";
 
 /** Stored page row (camelCase for consistency with PageMetadata). */
 interface StoredPage {
   id: string;
   ownerId: string;
+  /**
+   * 所属ノート ID。`null` は個人ページ、文字列値はノートネイティブページ。
+   * Web 版の同期パスは個人ページしか持ち込まないので、実運用では常に `null`。
+   *
+   * Owning note ID; `null` is a personal page. The web sync path only ever
+   * imports personal pages, so this is always `null` in practice.
+   */
+  noteId: string | null;
   sourcePageId: string | null;
   title: string | null;
   contentPreview: string | null;
@@ -52,6 +68,7 @@ function pageToStored(p: PageMetadata): StoredPage {
   return {
     id: p.id,
     ownerId: p.ownerId,
+    noteId: p.noteId ?? null,
     sourcePageId: p.sourcePageId ?? null,
     title: p.title ?? null,
     contentPreview: p.contentPreview ?? null,
@@ -64,7 +81,11 @@ function pageToStored(p: PageMetadata): StoredPage {
 }
 
 function storedToPage(s: StoredPage): PageMetadata {
-  return { ...s };
+  // v1 で永続化された行は `noteId` を持たない。`null` を返して個人ページ扱いに
+  // 揃える。Issue #713。
+  // Rows persisted under v1 lack `noteId`; coerce to `null` so they read as
+  // personal pages. Issue #713.
+  return { ...s, noteId: s.noteId ?? null };
 }
 
 function ensureDb(): Promise<IDBDatabase> {
@@ -80,6 +101,7 @@ function openDb(userId: string): Promise<IDBDatabase> {
     request.onsuccess = () => resolve(request.result);
     request.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result;
+      const tx = (event.target as IDBOpenDBRequest).transaction;
       if (!db.objectStoreNames.contains("my_pages")) {
         const pages = db.createObjectStore("my_pages", { keyPath: "id" });
         pages.createIndex("updated_at", "updatedAt", { unique: false });
@@ -104,6 +126,29 @@ function openDb(userId: string): Promise<IDBDatabase> {
       }
       if (!db.objectStoreNames.contains("ydoc_versions")) {
         db.createObjectStore("ydoc_versions", { keyPath: "pageId" });
+      }
+
+      // v2 (issue #713): backfill `noteId = null` on existing rows and add a
+      // `by_note` index so future queries can scope by note. v1 only ever
+      // stored personal pages, so `null` is the correct historical value.
+      //
+      // v2 (issue #713): 既存行は全て個人ページなので `noteId = null` を埋め、
+      // 将来のクエリで note 単位に絞れるよう `by_note` index を作る。
+      if (event.oldVersion < 2 && tx) {
+        const pagesStore = tx.objectStore("my_pages");
+        if (!pagesStore.indexNames.contains("by_note")) {
+          pagesStore.createIndex("by_note", "noteId", { unique: false });
+        }
+        const cursorReq = pagesStore.openCursor();
+        cursorReq.onsuccess = () => {
+          const cursor = cursorReq.result;
+          if (!cursor) return;
+          const row = cursor.value as Partial<StoredPage>;
+          if (row.noteId === undefined) {
+            cursor.update({ ...row, noteId: null });
+          }
+          cursor.continue();
+        };
       }
     };
   });
@@ -353,8 +398,13 @@ export class IndexedDBStorageAdapter implements StorageAdapter {
   // ── メタデータ / Page metadata ──
 
   /**
-   * Return all non-deleted pages, sorted by `updatedAt` descending.
-   * 削除されていないページを `updatedAt` 降順で返す。
+   * 削除されていない個人ページ（`noteId === null`）を `updatedAt` 降順で返す。
+   * ノートネイティブページ（issue #713）はサーバー API 経由でのみ表示するため
+   * IndexedDB には基本的に持ち込まれないが、混入時もここで除外する。
+   *
+   * Return all non-deleted personal pages (`noteId === null`), sorted by
+   * `updatedAt` descending. Note-native pages (issue #713) are not expected
+   * to land in IndexedDB but are filtered defensively if they do.
    */
   async getAllPages(): Promise<PageMetadata[]> {
     const db = await ensureDb();
@@ -363,7 +413,9 @@ export class IndexedDBStorageAdapter implements StorageAdapter {
       const req = tx.objectStore("my_pages").getAll();
       req.onsuccess = () => {
         const rows = (req.result as StoredPage[]) || [];
-        const list = rows.filter((r) => !r.isDeleted).map(storedToPage);
+        const list = rows
+          .filter((r) => !r.isDeleted && (r.noteId ?? null) === null)
+          .map(storedToPage);
         list.sort((a, b) => b.updatedAt - a.updatedAt);
         resolve(list);
       };

--- a/src/lib/storageAdapter/types.ts
+++ b/src/lib/storageAdapter/types.ts
@@ -8,6 +8,16 @@
 export interface PageMetadata {
   id: string;
   ownerId: string;
+  /**
+   * 所属ノート ID。`null` は個人ページ、文字列値はそのノートに所属する
+   * ノートネイティブページ。Web の IndexedDB は個人ページのみを保持する
+   * 想定だが、将来の混在に備えてフィールドだけは持たせている。Issue #713 を参照。
+   *
+   * Owning note ID. `null` is a personal page; a string identifies a
+   * note-native page. The web IndexedDB is expected to hold only personal
+   * pages, but the field is carried for forward compatibility. See issue #713.
+   */
+  noteId: string | null;
   sourcePageId: string | null;
   title: string | null;
   contentPreview: string | null;

--- a/src/lib/sync/syncWithApi.test.ts
+++ b/src/lib/sync/syncWithApi.test.ts
@@ -124,6 +124,7 @@ describe("syncWithApi", () => {
       getPage: vi.fn().mockResolvedValue({
         id: "p1",
         ownerId: TEST_USER_ID,
+        noteId: null,
         sourcePageId: null,
         title: "Local Version",
         contentPreview: null,
@@ -218,6 +219,7 @@ describe("syncWithApi", () => {
     const localPage: PageMetadata = {
       id: "p1",
       ownerId: TEST_USER_ID,
+      noteId: null,
       sourcePageId: null,
       title: "Page with thumbnail",
       contentPreview: "preview",
@@ -269,6 +271,7 @@ describe("syncWithApi", () => {
     const localPage: PageMetadata = {
       id: "p1",
       ownerId: TEST_USER_ID,
+      noteId: null,
       sourcePageId: null,
       title: "Page",
       contentPreview: null,
@@ -322,6 +325,7 @@ describe("syncWithApi", () => {
     const localPage: PageMetadata = {
       id: "local-1",
       ownerId: TEST_USER_ID,
+      noteId: null,
       sourcePageId: null,
       title: "Local Page",
       contentPreview: null,
@@ -348,6 +352,7 @@ describe("syncWithApi", () => {
     const manyPages: PageMetadata[] = Array.from({ length: PAGE_PUSH_CHUNK_SIZE + 1 }, (_, i) => ({
       id: `page-${i}`,
       ownerId: TEST_USER_ID,
+      noteId: null,
       sourcePageId: null,
       title: `Page ${i}`,
       contentPreview: null,
@@ -394,6 +399,111 @@ describe("syncWithApi", () => {
     expect(secondCall[0].pages).toHaveLength(1);
     expect(secondCall[0].links).toBeDefined();
     expect(secondCall[0].ghost_links).toBeDefined();
+  });
+
+  it("excludes note-native pages from push (issue #713 Phase 2 defensive filter)", async () => {
+    // ノートネイティブページ（`noteId !== null`）は POST /api/sync/pages の LWW
+    // 対象外。サーバー側でも skip されるが、フロント側でも push 前に除外することで
+    // 余計なリクエストを発生させない。Issue #713 Phase 2。
+    // Note-native rows (`noteId !== null`) are not part of personal-page sync.
+    // Filter them out client-side too so we never put them on the wire even
+    // when the server would skip them. Issue #713 Phase 2.
+    const personalPage: PageMetadata = {
+      id: "personal-1",
+      ownerId: TEST_USER_ID,
+      noteId: null,
+      sourcePageId: null,
+      title: "Personal",
+      contentPreview: null,
+      thumbnailUrl: null,
+      sourceUrl: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isDeleted: false,
+    };
+    const noteNativePage: PageMetadata = {
+      id: "note-native-1",
+      ownerId: TEST_USER_ID,
+      noteId: "note-1",
+      sourcePageId: null,
+      title: "Note-native (should not be pushed)",
+      contentPreview: null,
+      thumbnailUrl: null,
+      sourceUrl: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isDeleted: false,
+    };
+
+    const adapter = createMockAdapter({
+      getLastSyncTime: vi.fn().mockResolvedValue(Date.now() - 60_000),
+      getAllPages: vi.fn().mockResolvedValue([personalPage, noteNativePage]),
+    });
+    const postSyncPages = vi
+      .fn()
+      .mockResolvedValue({ server_time: new Date().toISOString(), conflicts: [] });
+    const api = createMockApi({ postSyncPages });
+
+    await syncWithApi(adapter, api, TEST_USER_ID);
+
+    expect(postSyncPages).toHaveBeenCalledTimes(1);
+    const pushedIds = postSyncPages.mock.calls[0][0].pages.map((p: { id: string }) => p.id);
+    expect(pushedIds).toEqual(["personal-1"]);
+    expect(pushedIds).not.toContain("note-native-1");
+  });
+
+  it("propagates note_id from SyncPageItem into PageMetadata (defensive read)", async () => {
+    // GET /api/sync/pages は現状個人ページしか返さないが、将来 `note_id` が
+    // ワイヤに乗った場合に `PageMetadata.noteId` までそのまま伝わることを保証する。
+    // Issue #713 Phase 2。
+    // GET /api/sync/pages currently only returns personal pages, but if the
+    // wire ever surfaces `note_id` we want it to land on `PageMetadata.noteId`
+    // without further plumbing. Issue #713 Phase 2.
+    const adapter = createMockAdapter();
+    const api = createMockApi({
+      getSyncPages: vi.fn().mockResolvedValue({
+        pages: [
+          {
+            id: "p1",
+            owner_id: TEST_USER_ID,
+            note_id: null,
+            source_page_id: null,
+            title: "Personal",
+            content_preview: null,
+            thumbnail_url: null,
+            source_url: null,
+            created_at: "2025-01-01T00:00:00Z",
+            updated_at: "2025-05-01T00:00:00Z",
+            is_deleted: false,
+          },
+          {
+            id: "p2",
+            owner_id: TEST_USER_ID,
+            note_id: "note-1",
+            source_page_id: null,
+            title: "Note-native (hypothetical)",
+            content_preview: null,
+            thumbnail_url: null,
+            source_url: null,
+            created_at: "2025-01-01T00:00:00Z",
+            updated_at: "2025-05-01T00:00:00Z",
+            is_deleted: false,
+          },
+        ],
+        links: [],
+        ghost_links: [],
+        server_time: new Date().toISOString(),
+      }),
+    });
+
+    await syncWithApi(adapter, api, TEST_USER_ID);
+
+    const upsertMock = adapter.upsertPage as ReturnType<typeof vi.fn>;
+    const upsertedById = new Map<string, PageMetadata>(
+      upsertMock.mock.calls.map(([m]: [PageMetadata]) => [m.id, m]),
+    );
+    expect(upsertedById.get("p1")?.noteId).toBeNull();
+    expect(upsertedById.get("p2")?.noteId).toBe("note-1");
   });
 
   it("skips push on initial sync when local was empty", async () => {

--- a/src/lib/sync/syncWithApi.ts
+++ b/src/lib/sync/syncWithApi.ts
@@ -13,6 +13,13 @@ function syncPageToMetadata(row: SyncPageItem): PageMetadata {
   return {
     id: row.id,
     ownerId: row.owner_id,
+    // GET /api/sync/pages は個人ページ (`note_id IS NULL`) のみを返すため
+    // 実運用では常に `null`。将来 `note_id` がワイヤに乗る場合に備えて値が
+    // 来たらそのまま採用する。Issue #713。
+    // GET /api/sync/pages only returns personal pages (`note_id IS NULL`),
+    // so this is effectively always `null`. We still honor an explicit value
+    // if the wire format ever carries one. Issue #713.
+    noteId: row.note_id ?? null,
     sourcePageId: row.source_page_id ?? null,
     title: row.title ?? null,
     contentPreview: row.content_preview ?? null,
@@ -282,9 +289,15 @@ function getPagesForPush(
   allLocalPages: PageMetadata[],
   pulledPageIds: Set<string>,
 ): PageMetadata[] {
+  // ノートネイティブページ（issue #713）は POST /api/sync/pages では LWW
+  // 対象外。サーバー側でも skip されるが、誤って IndexedDB に入った場合に
+  // 余計なリクエストを発生させないよう、push 前にも除外する。
+  // Drop note-native rows (issue #713) before push — the server skips them
+  // anyway, but filtering here avoids needless wire traffic if any sneak in.
+  const personalOnly = allLocalPages.filter((p) => (p.noteId ?? null) === null);
   return lastSync
-    ? allLocalPages.filter((p) => p.updatedAt > lastSync && !pulledPageIds.has(p.id))
-    : allLocalPages;
+    ? personalOnly.filter((p) => p.updatedAt > lastSync && !pulledPageIds.has(p.id))
+    : personalOnly;
 }
 
 async function finishSyncNoPush(

--- a/src/lib/sync/syncWithApi.ts
+++ b/src/lib/sync/syncWithApi.ts
@@ -67,7 +67,8 @@ let consecutiveFailures = 0;
 const MAX_CONSECUTIVE_FAILURES = 3;
 const PAGE_PUSH_CHUNK_SIZE = 100;
 /**
- *
+ * 同期エンジンの現在ステータス。UI の SyncIndicator などで表示に使う。
+ * Current status of the sync engine; surfaced by the SyncIndicator UI.
  */
 export type SyncStatus = "idle" | "syncing" | "synced" | "error" | "db-resuming";
 let syncStatus: SyncStatus = "idle";
@@ -79,7 +80,8 @@ function setSyncStatus(status: SyncStatus) {
 }
 
 /**
- *
+ * 現在の同期ステータスを返す。
+ * Return the current sync status.
  */
 export function getSyncStatus(): SyncStatus {
   return syncStatus;
@@ -91,7 +93,8 @@ export function hasNeverSynced(): boolean {
 }
 
 /**
- *
+ * 同期ステータスの変化を購読する。返り値は購読解除関数。
+ * Subscribe to sync status changes; returns an unsubscribe function.
  */
 export function subscribeSyncStatus(listener: (status: SyncStatus) => void): () => void {
   syncStatusListeners.add(listener);
@@ -107,7 +110,8 @@ if (typeof window !== "undefined") {
 }
 
 /**
- *
+ * 同期処理が進行中かどうかを返す。
+ * Return whether a sync run is currently in progress.
  */
 export function isSyncInProgress(): boolean {
   return syncInProgress;
@@ -124,7 +128,8 @@ export function resetSyncFailures(): void {
 }
 
 /**
- *
+ * `syncWithApi` / `runApiSync` のオプション。
+ * Options for {@link syncWithApi} and {@link runApiSync}.
  */
 export type SyncWithApiOptions = {
   /** When true and local has 0 pages, do a full pull (since=omit). */
@@ -435,28 +440,20 @@ export async function syncWithApi(
 }
 
 /**
+ * StorageAdapter と ApiClient を組み立てて `syncWithApi` を実行する高レベル API。
+ * アプリ起動時の初回同期や手動再同期から呼ばれる。
  *
+ * High-level wrapper that builds a StorageAdapter + ApiClient and delegates to
+ * {@link syncWithApi}. Used by initial load and manual re-sync paths.
  */
 export async function runApiSync(
   userId: string,
   getToken: () => Promise<string | null>,
   options?: SyncWithApiOptions & { force?: boolean },
 ): Promise<void> {
-  /**
-   *
-   */
   const { createStorageAdapter } = await import("@/lib/storageAdapter");
-  /**
-   *
-   */
   const { createApiClient } = await import("@/lib/api");
-  /**
-   *
-   */
   const adapter = createStorageAdapter();
-  /**
-   *
-   */
   const api = createApiClient({ getToken });
   await syncWithApi(adapter, api, userId, options);
 }

--- a/src/stores/pageStore.ts
+++ b/src/stores/pageStore.ts
@@ -34,7 +34,10 @@ interface PageStore {
   searchPages: (query: string) => Page[];
 }
 
-export const usePageStore = create<PageStore>()(
+export /**
+ *
+ */
+const usePageStore = create<PageStore>()(
   persist(
     (set, get) => ({
       pages: [],
@@ -42,10 +45,19 @@ export const usePageStore = create<PageStore>()(
       ghostLinks: [],
 
       createPage: (title = "", content = "") => {
+        /**
+         *
+         */
         const now = Date.now();
+        /**
+         *
+         */
         const newPage: Page = {
           id: uuidv4(),
           ownerUserId: "local-user",
+          // ローカル zustand ストアは個人ページ専用。Issue #713。
+          // The local zustand store only holds personal pages. Issue #713.
+          noteId: null,
           title,
           content,
           createdAt: now,
@@ -80,6 +92,9 @@ export const usePageStore = create<PageStore>()(
       },
 
       getPageByTitle: (title) => {
+        /**
+         *
+         */
         const normalizedTitle = title.toLowerCase().trim();
         return get().pages.find(
           (page) => page.title.toLowerCase().trim() === normalizedTitle && !page.isDeleted,
@@ -87,6 +102,9 @@ export const usePageStore = create<PageStore>()(
       },
 
       addLink: (sourceId, targetId) => {
+        /**
+         *
+         */
         const exists = get().links.some(
           (link) => link.sourceId === sourceId && link.targetId === targetId,
         );
@@ -118,6 +136,9 @@ export const usePageStore = create<PageStore>()(
       },
 
       addGhostLink: (linkText, sourcePageId) => {
+        /**
+         *
+         */
         const exists = get().ghostLinks.some(
           (gl) => gl.linkText === linkText && gl.sourcePageId === sourcePageId,
         );
@@ -143,9 +164,15 @@ export const usePageStore = create<PageStore>()(
       },
 
       promoteGhostLink: (linkText) => {
+        /**
+         *
+         */
         const sources = get().getGhostLinkSources(linkText);
         if (sources.length >= 2) {
           // Create a new page from the ghost link
+          /**
+           *
+           */
           const newPage = get().createPage(linkText);
 
           // Convert ghost links to real links
@@ -164,13 +191,22 @@ export const usePageStore = create<PageStore>()(
       },
 
       searchPages: (query) => {
+        /**
+         *
+         */
         const normalizedQuery = query.toLowerCase().trim();
         if (!normalizedQuery) return [];
 
         return get().pages.filter((page) => {
           if (page.isDeleted) return false;
 
+          /**
+           *
+           */
           const titleMatch = page.title.toLowerCase().includes(normalizedQuery);
+          /**
+           *
+           */
           const contentMatch = page.content.toLowerCase().includes(normalizedQuery);
 
           return titleMatch || contentMatch;

--- a/src/stores/pageStore.ts
+++ b/src/stores/pageStore.ts
@@ -3,6 +3,13 @@ import { persist } from "zustand/middleware";
 import { v4 as uuidv4 } from "uuid";
 import type { Page, Link, GhostLink } from "@/types/page";
 
+/**
+ * ゲストセッション向けのインメモリページストアのインターフェース。
+ * 認証済みユーザーの正規パスは `StorageAdapterPageRepository` 側。
+ *
+ * Shape of the in-memory page store used by guest sessions. Authenticated
+ * users go through `StorageAdapterPageRepository` instead.
+ */
 interface PageStore {
   pages: Page[];
   links: Link[];
@@ -34,10 +41,14 @@ interface PageStore {
   searchPages: (query: string) => Page[];
 }
 
-export /**
+/**
+ * localStorage に永続化されるゲスト用ページストア。サインイン前後の一時編集や
+ * オンボーディング時のデータ保持に使う（個人ページのみ、Issue #713）。
  *
+ * Guest-mode page store persisted in localStorage. Holds personal pages only
+ * (issue #713) for pre-sign-in drafts and onboarding flows.
  */
-const usePageStore = create<PageStore>()(
+export const usePageStore = create<PageStore>()(
   persist(
     (set, get) => ({
       pages: [],
@@ -45,13 +56,7 @@ const usePageStore = create<PageStore>()(
       ghostLinks: [],
 
       createPage: (title = "", content = "") => {
-        /**
-         *
-         */
         const now = Date.now();
-        /**
-         *
-         */
         const newPage: Page = {
           id: uuidv4(),
           ownerUserId: "local-user",
@@ -92,9 +97,6 @@ const usePageStore = create<PageStore>()(
       },
 
       getPageByTitle: (title) => {
-        /**
-         *
-         */
         const normalizedTitle = title.toLowerCase().trim();
         return get().pages.find(
           (page) => page.title.toLowerCase().trim() === normalizedTitle && !page.isDeleted,
@@ -102,9 +104,6 @@ const usePageStore = create<PageStore>()(
       },
 
       addLink: (sourceId, targetId) => {
-        /**
-         *
-         */
         const exists = get().links.some(
           (link) => link.sourceId === sourceId && link.targetId === targetId,
         );
@@ -136,9 +135,6 @@ const usePageStore = create<PageStore>()(
       },
 
       addGhostLink: (linkText, sourcePageId) => {
-        /**
-         *
-         */
         const exists = get().ghostLinks.some(
           (gl) => gl.linkText === linkText && gl.sourcePageId === sourcePageId,
         );
@@ -164,15 +160,9 @@ const usePageStore = create<PageStore>()(
       },
 
       promoteGhostLink: (linkText) => {
-        /**
-         *
-         */
         const sources = get().getGhostLinkSources(linkText);
         if (sources.length >= 2) {
           // Create a new page from the ghost link
-          /**
-           *
-           */
           const newPage = get().createPage(linkText);
 
           // Convert ghost links to real links
@@ -191,22 +181,13 @@ const usePageStore = create<PageStore>()(
       },
 
       searchPages: (query) => {
-        /**
-         *
-         */
         const normalizedQuery = query.toLowerCase().trim();
         if (!normalizedQuery) return [];
 
         return get().pages.filter((page) => {
           if (page.isDeleted) return false;
 
-          /**
-           *
-           */
           const titleMatch = page.title.toLowerCase().includes(normalizedQuery);
-          /**
-           *
-           */
           const contentMatch = page.content.toLowerCase().includes(normalizedQuery);
 
           return titleMatch || contentMatch;

--- a/src/stores/pageStore.ts
+++ b/src/stores/pageStore.ts
@@ -196,6 +196,29 @@ export const usePageStore = create<PageStore>()(
     }),
     {
       name: "zedi-pages",
+      // v2: `Page.noteId` (Issue #713 / Phase 2) を必須化したため、v1 で
+      // localStorage に保存された `noteId` 未設定のページを `null` に寄せる。
+      // これをしないと deserialize 後 `page.noteId === undefined` となり、
+      // `noteId === null` を期待するコード（個人ページ判定）で取りこぼす。
+      //
+      // v2: persisted pages from v1 (pre-#713) lack `noteId`. Backfill them to
+      // `null` on load so the `Page` type contract (`noteId: string | null`)
+      // holds. Otherwise `page.noteId === undefined` would slip past any
+      // `noteId === null` check intended to identify personal pages.
+      version: 2,
+      migrate: (persistedState: unknown, version: number) => {
+        if (
+          version < 2 &&
+          persistedState &&
+          typeof persistedState === "object" &&
+          "pages" in persistedState &&
+          Array.isArray((persistedState as { pages: unknown }).pages)
+        ) {
+          const state = persistedState as { pages: Array<Record<string, unknown>> };
+          state.pages = state.pages.map((p) => ({ ...p, noteId: p.noteId ?? null }));
+        }
+        return persistedState;
+      },
     },
   ),
 );

--- a/src/types/page.ts
+++ b/src/types/page.ts
@@ -1,5 +1,6 @@
 /**
- *
+ * Wiki ページ本体（エディタで扱う永続化済みコンテンツを含む）。
+ * Wiki page including persisted editor content.
  */
 export interface Page {
   id: string;
@@ -51,7 +52,8 @@ export interface PageSummary {
 }
 
 /**
- *
+ * ページ間のリンク（source → target）。
+ * Link between two pages (source → target).
  */
 export interface Link {
   sourceId: string;
@@ -60,7 +62,8 @@ export interface Link {
 }
 
 /**
- *
+ * 対象ページがまだ存在しない WikiLink（未解決リンク）。
+ * Unresolved WikiLink whose target page does not yet exist.
  */
 export interface GhostLink {
   linkText: string;
@@ -69,7 +72,8 @@ export interface GhostLink {
 }
 
 /**
- *
+ * 前方リンク・被リンク ID を付加したページ（グラフ系 UI 用）。
+ * Page augmented with outgoing/incoming link IDs for graph-style UIs.
  */
 export interface PageWithLinks extends Page {
   outgoingLinks: string[]; // Page IDs
@@ -77,7 +81,8 @@ export interface PageWithLinks extends Page {
 }
 
 /**
- *
+ * 日付ごとにまとめたページグループ（ホーム画面の日付別表示用）。
+ * Pages grouped by date (used by the home date-based view).
  */
 export type DateGroup = {
   date: string; // YYYY-MM-DD

--- a/src/types/page.ts
+++ b/src/types/page.ts
@@ -1,6 +1,19 @@
+/**
+ *
+ */
 export interface Page {
   id: string;
   ownerUserId: string;
+  /**
+   * 所属ノート ID。`null` は個人ページ、文字列値はそのノートに所属する
+   * ノートネイティブページ。個人 `/home` のグリッドには `null` のページのみ
+   * を表示する。Issue #713 を参照。
+   *
+   * Owning note ID. `null` is a personal page; a string identifies a
+   * note-native page. Personal `/home` only renders the `null` ones. See
+   * issue #713.
+   */
+  noteId: string | null;
   title: string;
   content: string; // Tiptap JSON stringified
   contentPreview?: string;
@@ -18,6 +31,16 @@ export interface Page {
 export interface PageSummary {
   id: string;
   ownerUserId: string;
+  /**
+   * 所属ノート ID。`null` は個人ページ、文字列値はそのノートに所属する
+   * ノートネイティブページ。個人 `/home` のグリッドには `null` のページのみ
+   * を表示する。Issue #713 を参照。
+   *
+   * Owning note ID. `null` is a personal page; a string identifies a
+   * note-native page. Personal `/home` only renders the `null` ones. See
+   * issue #713.
+   */
+  noteId: string | null;
   title: string;
   contentPreview?: string;
   thumbnailUrl?: string;
@@ -27,23 +50,35 @@ export interface PageSummary {
   isDeleted: boolean;
 }
 
+/**
+ *
+ */
 export interface Link {
   sourceId: string;
   targetId: string;
   createdAt: number;
 }
 
+/**
+ *
+ */
 export interface GhostLink {
   linkText: string;
   sourcePageId: string;
   createdAt: number;
 }
 
+/**
+ *
+ */
 export interface PageWithLinks extends Page {
   outgoingLinks: string[]; // Page IDs
   incomingLinks: string[]; // Page IDs (backlinks)
 }
 
+/**
+ *
+ */
 export type DateGroup = {
   date: string; // YYYY-MM-DD
   label: string; // "今日", "昨日", "12月15日（日）"


### PR DESCRIPTION
## 概要

ノートネイティブページ対応の Phase 2 として、`noteId` フィールドをページメタデータ全体に追加します。個人ページは `noteId = null`、ノート所属ページは `noteId = "note-id"` となります。Web 版は現在個人ページのみを扱いますが、将来のノート機能拡張に備えてフィールドを先行実装し、サーバーからの値を正しく伝播させます。

## 変更点

- **型定義**: `Page`, `PageSummary`, `PageMetadata`, `SyncPageItem` に `noteId: string | null` フィールドを追加
- **IndexedDB スキーマ**: v1 → v2 へ更新、`my_pages` テーブルに `noteId` 列を追加、既存行は `null` で埋める
- **ページ作成**: `createPage()` は常に `noteId = null` を書き込む（個人ページのみ作成）
- **ページ取得**: adapter から返された `noteId` をそのまま `Page`/`PageSummary` に伝播
- **同期**: `POST /api/sync/pages` 時にノートネイティブページ（`noteId !== null`）を除外してフィルタリング
- **API 応答**: `GET /api/sync/pages` から `note_id` が来た場合、`PageMetadata.noteId` に正しく割り当て
- **テスト**: 個人ページ/ノートネイティブページの分離、フィルタリング、伝播を検証するテストを追加

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

既存の単体テストが全てパスすることで検証：
- `StorageAdapterPageRepository.test.ts`: `noteId` の書き込み・読み込み・伝播
- `syncWithApi.test.ts`: ノートネイティブページの push 除外、API 応答の `note_id` 伝播
- `IndexedDBStorageAdapter`: v1 → v2 マイグレーション、`noteId` の永続化

## チェックリスト

- [x] テストがすべてパスする
- [x] 必要に応じてドキュメント（JSDoc）を更新した
- [x] 既存の個人ページ機能に影響なし（後方互換性を維持）

## 関連 Issue

Closes #713 (Phase 2)

https://claude.ai/code/session_01FeQmmXSWr1LJ62mqGmmoRR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Pages now record an associated note ID (nullable) and local persistence/schema upgraded to store and index it; local data is migrated to include this field.

* **Bug Fixes**
  * Personal views and sync push now exclude note-native pages, preventing non-personal pages from appearing or being sent to the server.

* **Tests**
  * Test fixtures and suites updated to include the new note ID field for consistent coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->