### PR TITLE
feat: scope WikiLink resolution to note-native pages (Issue #713 Phase 4)

### DIFF
--- a/src/components/editor/PageEditor/PageEditorContent.tsx
+++ b/src/components/editor/PageEditor/PageEditorContent.tsx
@@ -71,6 +71,16 @@ interface PageEditorContentProps {
    * Ref to insert content at the editor's cursor. Forwarded to TiptapEditor.
    */
   insertAtCursorRef?: MutableRefObject<((content: unknown) => boolean) | null>;
+  /**
+   * 編集中ページの noteId。WikiLink 候補・解決のスコープを決定する。
+   * `null` は個人ページ、文字列値はそのノートに所属するノートネイティブ
+   * ページ。Issue #713 Phase 4 を参照。
+   *
+   * Owning note ID of the page being edited. Determines WikiLink scope:
+   * `null` limits candidates to personal pages, a string limits them to the
+   * same note. See issue #713 Phase 4.
+   */
+  pageNoteId?: string | null;
 }
 
 /**
@@ -101,6 +111,7 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
   wikiContentForCollab = null,
   onWikiContentApplied,
   insertAtCursorRef,
+  pageNoteId = null,
 }) => {
   const isEditorReadOnly = isReadOnly ?? isWikiGenerating;
   const hasContent = useMemo(() => isContentNotEmpty(content), [content]);
@@ -171,6 +182,7 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
                 onInitialContentApplied={onInitialContentApplied}
                 wikiContentForCollab={wikiContentForCollab ?? undefined}
                 onWikiContentApplied={onWikiContentApplied}
+                pageNoteId={pageNoteId}
               />
             </>
           )}

--- a/src/components/editor/PageEditor/PageEditorLayout.tsx
+++ b/src/components/editor/PageEditor/PageEditorLayout.tsx
@@ -168,6 +168,16 @@ export const PageEditorLayout: React.FC<PageEditorLayoutProps> = (props) => {
           }}
           wikiContentForCollab={wikiContentForCollab}
           onWikiContentApplied={onWikiContentApplied}
+          /*
+           * `/pages/:id` は個人ページ専用のルート（IndexedDB には
+           * `note_id IS NULL` のページしか入らない）。そのため WikiLink の
+           * スコープは常に個人 (`null`)。Issue #713 Phase 4 を参照。
+           *
+           * `/pages/:id` only serves personal pages (IndexedDB only stores
+           * rows with `note_id IS NULL`), so the WikiLink scope is always
+           * personal (`null`). See issue #713 Phase 4.
+           */
+          pageNoteId={null}
         />
       </ContentWithAIChat>
 

--- a/src/components/editor/TiptapEditor.tsx
+++ b/src/components/editor/TiptapEditor.tsx
@@ -43,6 +43,7 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
   isWikiGenerating = false,
   wikiContentForCollab,
   onWikiContentApplied,
+  pageNoteId = null,
 }) => {
   const { t } = useTranslation();
   const {
@@ -83,6 +84,7 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
     onSlashAgentBusyChange,
     claudeWorkspaceRoot,
     claudeWorkspaceNoteId,
+    pageNoteId: resolvedPageNoteId,
   } = useTiptapEditorController({
     content,
     onChange,
@@ -100,6 +102,7 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
     isWikiGenerating,
     wikiContentForCollab,
     onWikiContentApplied,
+    pageNoteId,
   });
 
   return (
@@ -142,6 +145,7 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
         suggestionRef={suggestionRef}
         onSelect={handleSuggestionSelect}
         onClose={handleSuggestionClose}
+        pageNoteId={resolvedPageNoteId}
       />
       <WikiLinkHoverCardLayer
         editor={editor}

--- a/src/components/editor/TiptapEditor/WikiLinkSuggestionLayer.tsx
+++ b/src/components/editor/TiptapEditor/WikiLinkSuggestionLayer.tsx
@@ -27,12 +27,15 @@ interface WikiLinkSuggestionLayerProps {
 }
 
 /**
+ * WikiLink サジェスト UI のフローティング層。`useWikiLinkCandidates` で
+ * スコープ（個人 / ノート）に応じた候補ページを取得し、`WikiLinkSuggestion`
+ * に渡す。Issue #713 Phase 4。
  *
+ * Floating layer for the WikiLink suggestion popup. Fetches scope-aware
+ * candidate pages via `useWikiLinkCandidates` and forwards them to
+ * `WikiLinkSuggestion`. See issue #713 Phase 4.
  */
-export /**
- *
- */
-const WikiLinkSuggestionLayer: React.FC<WikiLinkSuggestionLayerProps> = ({
+export const WikiLinkSuggestionLayer: React.FC<WikiLinkSuggestionLayerProps> = ({
   editor,
   suggestionState,
   position,
@@ -41,9 +44,6 @@ const WikiLinkSuggestionLayer: React.FC<WikiLinkSuggestionLayerProps> = ({
   onClose,
   pageNoteId,
 }) => {
-  /**
-   *
-   */
   const { pages } = useWikiLinkCandidates(pageNoteId);
 
   if (!suggestionState?.active || !suggestionState.range || !position || !editor) return null;

--- a/src/components/editor/TiptapEditor/WikiLinkSuggestionLayer.tsx
+++ b/src/components/editor/TiptapEditor/WikiLinkSuggestionLayer.tsx
@@ -6,6 +6,7 @@ import {
   type SuggestionItem,
   type WikiLinkSuggestionHandle,
 } from "../extensions/WikiLinkSuggestion";
+import { useWikiLinkCandidates } from "@/hooks/useWikiLinkCandidates";
 
 interface WikiLinkSuggestionLayerProps {
   editor: Editor | null;
@@ -14,16 +15,37 @@ interface WikiLinkSuggestionLayerProps {
   suggestionRef: React.RefObject<WikiLinkSuggestionHandle>;
   onSelect: (item: SuggestionItem) => void;
   onClose: () => void;
+  /**
+   * 編集中ページの noteId。候補スコープを個人 (`null`) / 同一ノート
+   * (`string`) に絞り込むために使用する。Issue #713 Phase 4。
+   *
+   * Owning note ID of the page being edited. Used to scope suggestion
+   * candidates to personal (`null`) or same-note (`string`). See issue #713
+   * Phase 4.
+   */
+  pageNoteId: string | null;
 }
 
-export const WikiLinkSuggestionLayer: React.FC<WikiLinkSuggestionLayerProps> = ({
+/**
+ *
+ */
+export /**
+ *
+ */
+const WikiLinkSuggestionLayer: React.FC<WikiLinkSuggestionLayerProps> = ({
   editor,
   suggestionState,
   position,
   suggestionRef,
   onSelect,
   onClose,
+  pageNoteId,
 }) => {
+  /**
+   *
+   */
+  const { pages } = useWikiLinkCandidates(pageNoteId);
+
   if (!suggestionState?.active || !suggestionState.range || !position || !editor) return null;
 
   return (
@@ -41,6 +63,7 @@ export const WikiLinkSuggestionLayer: React.FC<WikiLinkSuggestionLayerProps> = (
         range={suggestionState.range}
         onSelect={onSelect}
         onClose={onClose}
+        pages={pages}
       />
     </div>
   );

--- a/src/components/editor/TiptapEditor/types.ts
+++ b/src/components/editor/TiptapEditor/types.ts
@@ -52,6 +52,17 @@ export interface TiptapEditorProps {
   /** コラボモード時、Wiki生成内容を Y.Doc に反映する用。反映後に onWikiContentApplied を呼ぶ */
   wikiContentForCollab?: string | null;
   onWikiContentApplied?: () => void;
+  /**
+   * 編集中ページが所属するノート ID。`null` は個人ページ、文字列値はノート
+   * ネイティブページ。WikiLink のサジェスト・解決候補をノート／個人スコープに
+   * 絞るために使用する。Issue #713 Phase 4 を参照。
+   *
+   * Owning note ID of the page being edited. `null` is a personal page; a
+   * string identifies a note-native page. Used to scope WikiLink suggestions
+   * and resolution to the same note (or personal pages). See issue #713
+   * Phase 4.
+   */
+  pageNoteId?: string | null;
 }
 
 /**

--- a/src/components/editor/TiptapEditor/useEditorLifecycle.ts
+++ b/src/components/editor/TiptapEditor/useEditorLifecycle.ts
@@ -25,6 +25,13 @@ interface UseEditorLifecycleOptions {
   onWikiContentApplied: TiptapEditorProps["onWikiContentApplied"];
   handleImageUpload: (files: FileList | File[]) => void;
   isEditorInitializedRef: React.MutableRefObject<boolean>;
+  /**
+   * 編集中ページの noteId。WikiLink 存在確認のスコープを切り替える
+   * （Issue #713 Phase 4）。
+   * Owning note ID of the page being edited; scopes WikiLink existence
+   * checks (issue #713 Phase 4).
+   */
+  pageNoteId: TiptapEditorProps["pageNoteId"];
 }
 
 /**
@@ -50,6 +57,7 @@ export function useEditorLifecycle({
   onWikiContentApplied,
   handleImageUpload,
   isEditorInitializedRef,
+  pageNoteId,
 }: UseEditorLifecycleOptions) {
   const initialContentAppliedRef = useRef(false);
 
@@ -151,5 +159,6 @@ export function useEditorLifecycle({
     pageId: pageId || undefined,
     onChange,
     skipSync: isWikiGenerating,
+    pageNoteId: pageNoteId ?? null,
   });
 }

--- a/src/components/editor/TiptapEditor/useTiptapEditorController.ts
+++ b/src/components/editor/TiptapEditor/useTiptapEditorController.ts
@@ -56,6 +56,13 @@ function useEditorControllers(args: {
   workspaceRoot: string | null;
   /** Note id for Tauri workspace registry (Issue #461). */
   noteId: string | null;
+  /**
+   * 編集中ページの noteId。WikiLink 存在確認のスコープに使用する
+   * （Issue #713 Phase 4）。
+   * Owning note ID of the page being edited; scopes WikiLink existence
+   * checks (issue #713 Phase 4).
+   */
+  pageNoteId: string | null;
 }) {
   const { editor, handleInsertMermaid, isEditorInitializedRef } = useEditorSetup({
     content: args.content,
@@ -112,6 +119,7 @@ function useEditorControllers(args: {
     onWikiContentApplied: args.onWikiContentApplied,
     handleImageUpload: args.handleImageUpload,
     isEditorInitializedRef,
+    pageNoteId: args.pageNoteId,
   });
 
   return { editor, handleInsertMermaid, ...suggestionUi };
@@ -221,6 +229,7 @@ export function useTiptapEditorController({
     handleImageUpload: imageUpload.handleImageUpload,
     workspaceRoot,
     noteId: noteIdForWorkspace,
+    pageNoteId,
   });
   const { handleInsertThumbnailImage } = useThumbnailController(
     editorRef,

--- a/src/components/editor/TiptapEditor/useTiptapEditorController.ts
+++ b/src/components/editor/TiptapEditor/useTiptapEditorController.ts
@@ -138,6 +138,7 @@ export function useTiptapEditorController({
   isWikiGenerating = false,
   wikiContentForCollab,
   onWikiContentApplied,
+  pageNoteId = null,
 }: TiptapEditorProps) {
   const { editorFontSizePx } = useGeneralSettings();
   const noteWorkspace = useNoteWorkspaceOptional();
@@ -152,7 +153,7 @@ export function useTiptapEditorController({
     pendingCreatePageTitle,
     handleConfirmCreate,
     handleCancelCreate,
-  } = useWikiLinkNavigation();
+  } = useWikiLinkNavigation({ pageNoteId });
   const [mermaidDialogOpen, setMermaidDialogOpen] = useState(false);
   const {
     storageSettings,
@@ -265,5 +266,6 @@ export function useTiptapEditorController({
     onSlashAgentBusyChange: setSlashAgentBusy,
     claudeWorkspaceRoot: noteWorkspace?.workspaceRoot ?? null,
     claudeWorkspaceNoteId: noteWorkspace?.noteId ?? null,
+    pageNoteId,
   };
 }

--- a/src/components/editor/TiptapEditor/useWikiLinkNavigation.test.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkNavigation.test.ts
@@ -209,15 +209,16 @@ describe("useWikiLinkNavigation", () => {
   });
 
   // Issue #713 Phase 4: `pageNoteId` を指定したときは同一ノートのページを
-  // 解決候補にし、遷移先は `/notes/:noteId/pages/:id`。個人ページの検索
-  // (`usePageByTitle`) は呼ばれないため、ここではモック応答の有無にかかわらず
-  // 同一ノート内のマッチだけが採用される。
-  // Note-scoped branch (issue #713 Phase 4): navigation targets the note
-  // URL and personal lookups must not leak into the resolved page.
+  // 解決候補にし、遷移先は canonical ルート `/notes/:noteId/:pageId`。
+  // 個人ページの検索 (`usePageByTitle`) は呼ばれないため、ここではモック応答の
+  // 有無にかかわらず同一ノート内のマッチだけが採用される。
+  // Note-scoped branch (issue #713 Phase 4): navigation targets the
+  // canonical `/notes/:noteId/:pageId` route and personal lookups must
+  // not leak into the resolved page.
   describe("ノートスコープ (pageNoteId 指定)", () => {
     const noteId = "note-42";
 
-    it("同一ノート内のページにマッチしたら /notes/:noteId/pages/:id に遷移する", async () => {
+    it("同一ノート内のページにマッチしたら /notes/:noteId/:pageId に遷移する", async () => {
       vi.mocked(useNotePages).mockReturnValue({
         data: [
           {

--- a/src/components/editor/TiptapEditor/useWikiLinkNavigation.test.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkNavigation.test.ts
@@ -16,9 +16,14 @@ vi.mock("react-router-dom", async () => {
 
 vi.mock("@/hooks/usePageQueries", () => ({
   usePageByTitle: vi.fn(),
+  usePagesSummary: vi.fn(() => ({ data: [], isLoading: false, isFetched: true })),
   useCreatePage: () => ({
     mutateAsync: mockMutateAsync,
   }),
+}));
+
+vi.mock("@/hooks/useNoteQueries", () => ({
+  useNotePages: vi.fn(() => ({ data: [], isLoading: false, isFetched: true })),
 }));
 
 import { usePageByTitle } from "@/hooks/usePageQueries";

--- a/src/components/editor/TiptapEditor/useWikiLinkNavigation.test.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkNavigation.test.ts
@@ -27,6 +27,7 @@ vi.mock("@/hooks/useNoteQueries", () => ({
 }));
 
 import { usePageByTitle } from "@/hooks/usePageQueries";
+import { useNotePages } from "@/hooks/useNoteQueries";
 
 describe("useWikiLinkNavigation", () => {
   beforeEach(() => {
@@ -205,5 +206,120 @@ describe("useWikiLinkNavigation", () => {
       });
     });
     expect(result.current.createPageDialogOpen).toBe(false);
+  });
+
+  // Issue #713 Phase 4: `pageNoteId` を指定したときは同一ノートのページを
+  // 解決候補にし、遷移先は `/notes/:noteId/pages/:id`。個人ページの検索
+  // (`usePageByTitle`) は呼ばれないため、ここではモック応答の有無にかかわらず
+  // 同一ノート内のマッチだけが採用される。
+  // Note-scoped branch (issue #713 Phase 4): navigation targets the note
+  // URL and personal lookups must not leak into the resolved page.
+  describe("ノートスコープ (pageNoteId 指定)", () => {
+    const noteId = "note-42";
+
+    it("同一ノート内のページにマッチしたら /notes/:noteId/pages/:id に遷移する", async () => {
+      vi.mocked(useNotePages).mockReturnValue({
+        data: [
+          {
+            id: "note-page-1",
+            ownerUserId: "user-1",
+            noteId,
+            title: "Note Page A",
+            contentPreview: undefined,
+            thumbnailUrl: undefined,
+            sourceUrl: undefined,
+            createdAt: 0,
+            updatedAt: 0,
+            isDeleted: false,
+            addedByUserId: "user-1",
+          },
+        ],
+        isFetched: true,
+        isLoading: false,
+      } as unknown as ReturnType<typeof useNotePages>);
+
+      const { result } = renderHook(() => useWikiLinkNavigation({ pageNoteId: noteId }), {
+        wrapper: createHookWrapper(),
+      });
+
+      act(() => {
+        result.current.handleLinkClick("Note Page A");
+      });
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(`/notes/${noteId}/pages/note-page-1`, {
+          replace: false,
+          flushSync: true,
+        });
+      });
+      expect(result.current.createPageDialogOpen).toBe(false);
+    });
+
+    it("ノート内で一致しないタイトルをクリックするとダイアログを開き、handleConfirmCreate は新規作成 API を呼ばずに閉じる", async () => {
+      vi.mocked(useNotePages).mockReturnValue({
+        data: [],
+        isFetched: true,
+        isLoading: false,
+      } as unknown as ReturnType<typeof useNotePages>);
+
+      const { result } = renderHook(() => useWikiLinkNavigation({ pageNoteId: noteId }), {
+        wrapper: createHookWrapper(),
+      });
+
+      act(() => {
+        result.current.handleLinkClick("Nonexistent");
+      });
+
+      await waitFor(() => {
+        expect(result.current.createPageDialogOpen).toBe(true);
+        expect(result.current.pendingCreatePageTitle).toBe("Nonexistent");
+      });
+
+      await act(async () => {
+        await result.current.handleConfirmCreate();
+      });
+
+      // 個人用作成ミューテーションはノートスコープでは呼ばない（別フロー）。
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(result.current.createPageDialogOpen).toBe(false);
+      expect(result.current.pendingCreatePageTitle).toBe(null);
+    });
+
+    it("削除済みノートページと同一タイトルのクリックでは、ダイアログを開いて新規作成フローに入る", async () => {
+      vi.mocked(useNotePages).mockReturnValue({
+        data: [
+          {
+            id: "tombstone",
+            ownerUserId: "user-1",
+            noteId,
+            title: "Archived",
+            contentPreview: undefined,
+            thumbnailUrl: undefined,
+            sourceUrl: undefined,
+            createdAt: 0,
+            updatedAt: 0,
+            isDeleted: true,
+            addedByUserId: "user-1",
+          },
+        ],
+        isFetched: true,
+        isLoading: false,
+      } as unknown as ReturnType<typeof useNotePages>);
+
+      const { result } = renderHook(() => useWikiLinkNavigation({ pageNoteId: noteId }), {
+        wrapper: createHookWrapper(),
+      });
+
+      act(() => {
+        result.current.handleLinkClick("Archived");
+      });
+
+      await waitFor(() => {
+        expect(result.current.createPageDialogOpen).toBe(true);
+        expect(result.current.pendingCreatePageTitle).toBe("Archived");
+      });
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/editor/TiptapEditor/useWikiLinkNavigation.test.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkNavigation.test.ts
@@ -247,7 +247,10 @@ describe("useWikiLinkNavigation", () => {
       });
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith(`/notes/${noteId}/pages/note-page-1`, {
+        // 旧パス `/notes/:noteId/pages/:pageId` はリダイレクト用に残って
+        // いるが、canonical ルート（App.tsx）は `/notes/:noteId/:pageId`。
+        // Use the canonical short route to avoid the legacy redirect hop.
+        expect(mockNavigate).toHaveBeenCalledWith(`/notes/${noteId}/note-page-1`, {
           replace: false,
           flushSync: true,
         });

--- a/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { usePageByTitle, useCreatePage } from "@/hooks/usePageQueries";
+import { usePageByTitle, usePagesSummary, useCreatePage } from "@/hooks/usePageQueries";
 import { useNotePages } from "@/hooks/useNoteQueries";
 
 interface UseWikiLinkNavigationOptions {
@@ -45,13 +45,51 @@ export function useWikiLinkNavigation(
   const createPageMutation = useCreatePage();
   const [linkTitleToFind, setLinkTitleToFind] = useState<string | null>(null);
 
-  // 個人スコープ: IndexedDB / 個人ページに対するタイトル検索
-  // Personal scope: title lookup against IndexedDB / personal pages.
+  // 個人スコープ: 個人ページに対する大小文字を無視したタイトル検索。
+  // `usePageByTitle` は完全一致 (`trim` のみ) しか返さないため、既存キャッシュ
+  // ヒット時はそれを使い、そうでなければ `usePagesSummary` の結果を大小文字
+  // 無視で走査する。`syncLinksWithRepo` と `WikiLinkSuggestion` が `toLowerCase`
+  // で解決しているので、ナビゲーションもスコープ間で揃える。Issue #713 Phase 4。
+  //
+  // Personal scope: case-insensitive title lookup over personal pages.
+  // `usePageByTitle` is case-sensitive, so we prefer its cache when it hits
+  // and otherwise fall back to a case-insensitive scan of `usePagesSummary`
+  // to mirror the normalization already used by `syncLinksWithRepo` and the
+  // suggestion UI. See issue #713 Phase 4.
   const shouldQueryPersonal = pageNoteId === null && !!linkTitleToFind;
   const personalLookup = usePageByTitle(shouldQueryPersonal ? linkTitleToFind || "" : "");
+  const personalSummary = usePagesSummary({ enabled: shouldQueryPersonal });
 
-  // ノートスコープ: そのノートに所属するページ一覧に対する完全一致検索
-  // Note scope: title lookup against the note's page list.
+  const personalResolved = useMemo(() => {
+    if (!shouldQueryPersonal || !linkTitleToFind) {
+      return { data: null as { id: string; title: string } | null, isFetched: true };
+    }
+    if (personalLookup.data) {
+      return {
+        data: { id: personalLookup.data.id, title: personalLookup.data.title },
+        isFetched: personalLookup.isFetched,
+      };
+    }
+    const normalized = linkTitleToFind.trim().toLowerCase();
+    const list = personalSummary.data ?? [];
+    const found = list.find(
+      (p) => !p.isDeleted && (p.title ?? "").trim().toLowerCase() === normalized,
+    );
+    return {
+      data: found ? { id: found.id, title: found.title } : null,
+      isFetched: personalLookup.isFetched && !personalSummary.isLoading,
+    };
+  }, [
+    shouldQueryPersonal,
+    linkTitleToFind,
+    personalLookup.data,
+    personalLookup.isFetched,
+    personalSummary.data,
+    personalSummary.isLoading,
+  ]);
+
+  // ノートスコープ: そのノートに所属するページ一覧に対する大小文字無視の検索。
+  // Note scope: case-insensitive title lookup against the note's page list.
   const shouldQueryNote = pageNoteId !== null && !!linkTitleToFind;
   const notePagesQuery = useNotePages(pageNoteId ?? "", undefined, Boolean(pageNoteId));
 
@@ -68,8 +106,8 @@ export function useWikiLinkNavigation(
     };
   }, [shouldQueryNote, linkTitleToFind, notePagesQuery.data, notePagesQuery.isFetched]);
 
-  const foundPage = pageNoteId === null ? personalLookup.data : noteLookup.data;
-  const isFetched = pageNoteId === null ? personalLookup.isFetched : noteLookup.isFetched;
+  const foundPage = pageNoteId === null ? personalResolved.data : noteLookup.data;
+  const isFetched = pageNoteId === null ? personalResolved.isFetched : noteLookup.isFetched;
 
   // Pending link action
   const pendingLinkActionRef = useRef<{ title: string } | null>(null);

--- a/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
@@ -1,6 +1,21 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { usePageByTitle, useCreatePage } from "@/hooks/usePageQueries";
+import { useNotePages } from "@/hooks/useNoteQueries";
+
+interface UseWikiLinkNavigationOptions {
+  /**
+   * 編集中ページの noteId。`null` は個人ページ、文字列値はノートネイティブ
+   * ページ。リンク先の検索スコープと遷移先 URL を切り替えるために使用する。
+   * Issue #713 Phase 4。
+   *
+   * Owning note ID of the page being edited. `null` scopes resolution to
+   * personal pages and navigates to `/pages/:id`; a string scopes resolution
+   * to same-note pages and navigates to `/notes/:noteId/pages/:id`. See
+   * issue #713 Phase 4.
+   */
+  pageNoteId: string | null;
+}
 
 interface UseWikiLinkNavigationReturn {
   handleLinkClick: (title: string) => void;
@@ -13,13 +28,48 @@ interface UseWikiLinkNavigationReturn {
 /**
  * Hook to handle WikiLink navigation
  * When a WikiLink is clicked, it checks if the page exists and either navigates to it
- * or shows a dialog to create a new page
+ * or shows a dialog to create a new page.
+ *
+ * WikiLink クリック時、`pageNoteId` に応じて候補スコープを切り替える。
+ * - `pageNoteId === null` → 個人ページのみを検索し、`/pages/:id` に遷移。
+ * - `pageNoteId !== null` → そのノート内のページのみを検索し、
+ *   `/notes/:pageNoteId/pages/:id` に遷移。
+ *
+ * Issue #713 Phase 4。
  */
-export function useWikiLinkNavigation(): UseWikiLinkNavigationReturn {
+export function useWikiLinkNavigation(
+  options: UseWikiLinkNavigationOptions = { pageNoteId: null },
+): UseWikiLinkNavigationReturn {
+  const { pageNoteId } = options;
   const navigate = useNavigate();
   const createPageMutation = useCreatePage();
   const [linkTitleToFind, setLinkTitleToFind] = useState<string | null>(null);
-  const { data: foundPage, isFetched } = usePageByTitle(linkTitleToFind || "");
+
+  // 個人スコープ: IndexedDB / 個人ページに対するタイトル検索
+  // Personal scope: title lookup against IndexedDB / personal pages.
+  const shouldQueryPersonal = pageNoteId === null && !!linkTitleToFind;
+  const personalLookup = usePageByTitle(shouldQueryPersonal ? linkTitleToFind || "" : "");
+
+  // ノートスコープ: そのノートに所属するページ一覧に対する完全一致検索
+  // Note scope: title lookup against the note's page list.
+  const shouldQueryNote = pageNoteId !== null && !!linkTitleToFind;
+  const notePagesQuery = useNotePages(pageNoteId ?? "", undefined, Boolean(pageNoteId));
+
+  const noteLookup = useMemo(() => {
+    if (!shouldQueryNote || !linkTitleToFind) {
+      return { data: null as { id: string; title: string } | null, isFetched: true };
+    }
+    const normalized = linkTitleToFind.trim().toLowerCase();
+    const list = notePagesQuery.data ?? [];
+    const found = list.find((p) => (p.title ?? "").trim().toLowerCase() === normalized);
+    return {
+      data: found ? { id: found.id, title: found.title } : null,
+      isFetched: notePagesQuery.isFetched,
+    };
+  }, [shouldQueryNote, linkTitleToFind, notePagesQuery.data, notePagesQuery.isFetched]);
+
+  const foundPage = pageNoteId === null ? personalLookup.data : noteLookup.data;
+  const isFetched = pageNoteId === null ? personalLookup.isFetched : noteLookup.isFetched;
 
   // Pending link action
   const pendingLinkActionRef = useRef<{ title: string } | null>(null);
@@ -53,8 +103,14 @@ export function useWikiLinkNavigation(): UseWikiLinkNavigationReturn {
       if (!title.trim()) return;
 
       if (foundPage) {
-        // 既存ページが見つかった場合はそのページに移動
-        navigate(`/pages/${foundPage.id}`, { replace: false, flushSync: true });
+        // 既存ページが見つかった場合はそのページに移動。ノートスコープ時は
+        // ノート URL へ、個人スコープ時は従来どおり `/pages/:id` へ遷移する。
+        // Existing page: route to `/notes/:noteId/pages/:id` under a note
+        // scope, otherwise to `/pages/:id`.
+        const target = pageNoteId
+          ? `/notes/${pageNoteId}/pages/${foundPage.id}`
+          : `/pages/${foundPage.id}`;
+        navigate(target, { replace: false, flushSync: true });
       } else {
         // ページが見つからなかった場合は確認ダイアログを表示
         setPendingCreatePageTitle(title);
@@ -67,11 +123,23 @@ export function useWikiLinkNavigation(): UseWikiLinkNavigationReturn {
     };
 
     handleNavigation();
-  }, [foundPage, isFetched, linkTitleToFind, navigate]);
+  }, [foundPage, isFetched, linkTitleToFind, navigate, pageNoteId]);
 
   // Handle create page confirmation
+  // 新規ページ作成パスは個人スコープでのみ有効。ノートネイティブページの
+  // 作成はノート配下の別フロー（`POST /api/notes/:noteId/pages`）で行うため、
+  // ここでは個人ページとして作成し `/pages/:id` へ遷移する。Issue #713 Phase 4。
+  //
+  // Page creation from a WikiLink is only supported in personal scope; note
+  // scope is handled by a separate flow (`POST /api/notes/:noteId/pages`).
   const handleConfirmCreate = useCallback(async () => {
     if (!pendingCreatePageTitle) return;
+    if (pageNoteId) {
+      // ノートスコープ内での新規作成は未対応。今は何もせずダイアログを閉じる。
+      setCreatePageDialogOpen(false);
+      setPendingCreatePageTitle(null);
+      return;
+    }
 
     try {
       const newPage = await createPageMutation.mutateAsync({
@@ -84,7 +152,7 @@ export function useWikiLinkNavigation(): UseWikiLinkNavigationReturn {
     } catch (error) {
       console.error("Failed to create page:", error);
     }
-  }, [pendingCreatePageTitle, createPageMutation, navigate]);
+  }, [pendingCreatePageTitle, createPageMutation, navigate, pageNoteId]);
 
   const handleCancelCreate = useCallback(() => {
     setCreatePageDialogOpen(false);

--- a/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
@@ -99,7 +99,13 @@ export function useWikiLinkNavigation(
     }
     const normalized = linkTitleToFind.trim().toLowerCase();
     const list = notePagesQuery.data ?? [];
-    const found = list.find((p) => (p.title ?? "").trim().toLowerCase() === normalized);
+    // 削除済みページは候補から外す（個人スコープのフォールバックが
+    // `!p.isDeleted` を見ているので挙動を揃える。Issue #713 Phase 4）。
+    // Exclude deleted pages to match the personal fallback and avoid
+    // navigating to a tombstone instead of showing the create dialog.
+    const found = list.find(
+      (p) => !p.isDeleted && (p.title ?? "").trim().toLowerCase() === normalized,
+    );
     return {
       data: found ? { id: found.id, title: found.title } : null,
       isFetched: notePagesQuery.isFetched,

--- a/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
@@ -11,7 +11,7 @@ interface UseWikiLinkNavigationOptions {
    *
    * Owning note ID of the page being edited. `null` scopes resolution to
    * personal pages and navigates to `/pages/:id`; a string scopes resolution
-   * to same-note pages and navigates to `/notes/:noteId/pages/:id`. See
+   * to same-note pages and navigates to `/notes/:noteId/:pageId`. See
    * issue #713 Phase 4.
    */
   pageNoteId: string | null;
@@ -33,7 +33,7 @@ interface UseWikiLinkNavigationReturn {
  * WikiLink クリック時、`pageNoteId` に応じて候補スコープを切り替える。
  * - `pageNoteId === null` → 個人ページのみを検索し、`/pages/:id` に遷移。
  * - `pageNoteId !== null` → そのノート内のページのみを検索し、
- *   `/notes/:pageNoteId/pages/:id` に遷移。
+ *   canonical ルート `/notes/:pageNoteId/:id` に遷移。
  *
  * Issue #713 Phase 4。
  */

--- a/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkNavigation.ts
@@ -148,11 +148,16 @@ export function useWikiLinkNavigation(
 
       if (foundPage) {
         // 既存ページが見つかった場合はそのページに移動。ノートスコープ時は
-        // ノート URL へ、個人スコープ時は従来どおり `/pages/:id` へ遷移する。
-        // Existing page: route to `/notes/:noteId/pages/:id` under a note
-        // scope, otherwise to `/pages/:id`.
+        // 短縮形の `/notes/:noteId/:pageId`（App.tsx の canonical ルート）に
+        // 直接遷移して、旧パス `/notes/:noteId/pages/:pageId` のリダイレクトを
+        // 踏まないようにする。個人スコープ時は従来どおり `/pages/:id`。
+        //
+        // Existing page: route to `/notes/:noteId/:pageId` (the canonical
+        // note page route defined in `App.tsx`) to avoid the legacy
+        // `/notes/:noteId/pages/:pageId` redirect hop. Personal scope uses
+        // `/pages/:id` as before.
         const target = pageNoteId
-          ? `/notes/${pageNoteId}/pages/${foundPage.id}`
+          ? `/notes/${pageNoteId}/${foundPage.id}`
           : `/pages/${foundPage.id}`;
         navigate(target, { replace: false, flushSync: true });
       } else {

--- a/src/components/editor/TiptapEditor/useWikiLinkStatusSync.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkStatusSync.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { Editor } from "@tiptap/react";
 import { extractWikiLinksFromContent, getUniqueWikiLinkTitles } from "@/lib/wikiLinkUtils";
 import { useWikiLinkExistsChecker } from "@/hooks/usePageQueries";
+import { useNotePages } from "@/hooks/useNoteQueries";
 
 interface UseWikiLinkStatusSyncOptions {
   editor: Editor | null;
@@ -10,6 +11,16 @@ interface UseWikiLinkStatusSyncOptions {
   onChange: (content: string) => void;
   /** true の間は同期をスキップ（Wiki生成中のリンクスタイルちらつき防止） */
   skipSync?: boolean;
+  /**
+   * 編集中ページの noteId。`null`（既定）は個人ページ、文字列値なら
+   * ノートネイティブページ。存在確認のスコープを切り替えるために使う。
+   * Issue #713 Phase 4。
+   *
+   * Owning note ID of the page being edited. `null` (default) scopes
+   * existence checks to personal pages; a string scopes them to the given
+   * note's pages (fetched via `useNotePages`). See issue #713 Phase 4.
+   */
+  pageNoteId?: string | null;
 }
 
 /**
@@ -18,6 +29,16 @@ interface UseWikiLinkStatusSyncOptions {
  * 以下のタイミングでWikiLinkのexists/referenced属性を更新する:
  * 1. ページ読み込み時（pageIdの変更）
  * 2. WikiLinkの数が増加した時（Wiki生成後など）
+ *
+ * `pageNoteId` が指定された場合は、`useNotePages` から取得したノート配下の
+ * ページ一覧を存在判定の候補にする（Issue #713 Phase 4）。これにより、
+ * ノートネイティブページ内で同じノートの WikiLink が「存在しない」と
+ * 誤判定されて壊れた表示に倒れる問題を防ぐ。
+ *
+ * When `pageNoteId` is provided, note-scoped existence checks use the
+ * `useNotePages(pageNoteId)` result instead of personal-only IndexedDB
+ * summaries. This keeps same-note WikiLinks rendering as existing after
+ * subsequent sync passes (issue #713 Phase 4).
  */
 export function useWikiLinkStatusSync({
   editor,
@@ -25,8 +46,13 @@ export function useWikiLinkStatusSync({
   pageId,
   onChange,
   skipSync = false,
+  pageNoteId = null,
 }: UseWikiLinkStatusSyncOptions): void {
-  const { checkExistence } = useWikiLinkExistsChecker();
+  const notePagesQuery = useNotePages(pageNoteId ?? "", undefined, Boolean(pageNoteId));
+  const { checkExistence } = useWikiLinkExistsChecker({
+    pageNoteId,
+    notePages: pageNoteId ? notePagesQuery.data : undefined,
+  });
 
   // 最後にチェックした状態を追跡
   const lastCheckedRef = useRef<{

--- a/src/components/editor/extensions/WikiLinkSuggestion.tsx
+++ b/src/components/editor/extensions/WikiLinkSuggestion.tsx
@@ -1,16 +1,28 @@
 import { forwardRef, useEffect, useImperativeHandle, useState, useCallback } from "react";
 import { Editor } from "@tiptap/core";
-import { usePageStore } from "@/stores/pageStore";
 import { cn } from "@zedi/ui";
 import { FileText, Plus } from "lucide-react";
 
 /**
- *
+ * WikiLink サジェストに表示する 1 アイテム。`exists=true` は既存ページ、
+ * `exists=false` は「このタイトルで新規作成」オプションを示す。
+ * One item rendered in the WikiLink suggestion dropdown; `exists=false` marks
+ * the "create new" option.
  */
 export interface SuggestionItem {
   id: string;
   title: string;
   exists: boolean;
+}
+
+/**
+ * `WikiLinkSuggestion` が候補リストの組み立てに使う最小ページ情報。
+ * Minimal page shape consumed by `WikiLinkSuggestion`.
+ */
+export interface WikiLinkSuggestionPage {
+  id: string;
+  title: string;
+  isDeleted?: boolean;
 }
 
 interface WikiLinkSuggestionProps {
@@ -19,6 +31,16 @@ interface WikiLinkSuggestionProps {
   range: { from: number; to: number };
   onSelect: (item: SuggestionItem) => void;
   onClose: () => void;
+  /**
+   * サジェスト候補として渡されるページ一覧。呼び出し側で WikiLink のスコープ
+   * （個人ページ / 同じノート内のページ）に合わせて絞り込んで渡す。
+   * Issue #713 Phase 4。
+   *
+   * Candidate pages supplied by the caller. The caller is responsible for
+   * scoping (personal-only vs. same-note) so this component can stay a pure
+   * presentation layer. See issue #713 Phase 4.
+   */
+  pages: WikiLinkSuggestionPage[];
 }
 
 /**
@@ -32,15 +54,11 @@ export /**
  *
  */
 const WikiLinkSuggestion = forwardRef<WikiLinkSuggestionHandle, WikiLinkSuggestionProps>(
-  ({ query, onSelect, onClose }, ref) => {
+  ({ query, onSelect, onClose, pages }, ref) => {
     /**
      *
      */
     const [selectedIndex, setSelectedIndex] = useState(0);
-    /**
-     *
-     */
-    const { pages } = usePageStore();
 
     // Get matching pages
     /**

--- a/src/components/editor/extensions/WikiLinkSuggestion.tsx
+++ b/src/components/editor/extensions/WikiLinkSuggestion.tsx
@@ -44,36 +44,33 @@ interface WikiLinkSuggestionProps {
 }
 
 /**
- *
+ * `onKeyDown` が `true` を返すと呼び出し元は既定のキーハンドラを抑止する。
+ * Imperative handle exposing `onKeyDown`; returning `true` tells the caller
+ * to suppress the default key handling.
  */
 export interface WikiLinkSuggestionHandle {
   onKeyDown: (event: KeyboardEvent) => boolean;
 }
 
-export /**
+/**
+ * WikiLink サジェストポップアップ。`pages` で受け取った候補のうちクエリに
+ * マッチするものを最大 5 件表示し、完全一致が無ければ「新規作成」項目も出す。
+ * Issue #713 Phase 4（スコープは呼び出し側で事前に絞る）。
  *
+ * WikiLink suggestion popup. Renders up to five candidates matching the
+ * query and, when there is no exact match, a "create new" option. Scope
+ * filtering (personal vs. same-note) is expected to happen in the caller
+ * before pages are passed in (see issue #713 Phase 4).
  */
-const WikiLinkSuggestion = forwardRef<WikiLinkSuggestionHandle, WikiLinkSuggestionProps>(
+export const WikiLinkSuggestion = forwardRef<WikiLinkSuggestionHandle, WikiLinkSuggestionProps>(
   ({ query, onSelect, onClose, pages }, ref) => {
-    /**
-     *
-     */
     const [selectedIndex, setSelectedIndex] = useState(0);
 
     // Get matching pages
-    /**
-     *
-     */
     const getItems = useCallback((): SuggestionItem[] => {
-      /**
-       *
-       */
       const normalizedQuery = query.toLowerCase().trim();
 
       // Get existing pages that match
-      /**
-       *
-       */
       const matchingPages = pages
         .filter((p) => !p.isDeleted && p.title.toLowerCase().includes(normalizedQuery))
         .slice(0, 5)
@@ -84,16 +81,10 @@ const WikiLinkSuggestion = forwardRef<WikiLinkSuggestionHandle, WikiLinkSuggesti
         }));
 
       // If query doesn't match any existing page exactly, add create option
-      /**
-       *
-       */
       const exactMatch = pages.find(
         (p) => !p.isDeleted && p.title.toLowerCase() === normalizedQuery,
       );
 
-      /**
-       *
-       */
       const items: SuggestionItem[] = [...matchingPages];
 
       if (query.trim() && !exactMatch) {
@@ -107,9 +98,6 @@ const WikiLinkSuggestion = forwardRef<WikiLinkSuggestionHandle, WikiLinkSuggesti
       return items;
     }, [query, pages]);
 
-    /**
-     *
-     */
     const items = getItems();
 
     // Reset selection when items change
@@ -117,14 +105,8 @@ const WikiLinkSuggestion = forwardRef<WikiLinkSuggestionHandle, WikiLinkSuggesti
       queueMicrotask(() => setSelectedIndex(0));
     }, [query]);
 
-    /**
-     *
-     */
     const selectItem = useCallback(
       (index: number) => {
-        /**
-         *
-         */
         const item = items[index];
         if (item) {
           onSelect(item);

--- a/src/hooks/useAIChatActions.ts
+++ b/src/hooks/useAIChatActions.ts
@@ -12,6 +12,7 @@ import type {
 } from "@/types/aiChat";
 import type { PageContext } from "@/types/aiChat";
 import { useCreatePage, useUpdatePage, useSyncWikiLinks } from "@/hooks/usePageQueries";
+import { useNotePages } from "@/hooks/useNoteQueries";
 import {
   appendMarkdownToTiptapContent,
   buildSuggestedWikiLinksMarkdown,
@@ -55,10 +56,21 @@ export function useAIChatActions({ pageContext }: UseAIChatActionsOptions) {
    *
    */
   const updatePageMutation = useUpdatePage();
-  /**
-   *
-   */
-  const { syncLinks } = useSyncWikiLinks();
+  // 編集対象ページが所属するノート（`pageContext.noteId`）に応じて WikiLink
+  // 同期のスコープを切り替える（Issue #713 Phase 4）。ノート内のページ一覧は
+  // `useNotePages` から取得し、`syncLinks` が同一ノート内のタイトルを正しく
+  // 解決できるようにする。`noteId` が空のときは fetch しない。
+  //
+  // Switch WikiLink sync scope based on the current page's owning note
+  // (`pageContext.noteId`, issue #713 Phase 4). The note's page list is
+  // fetched via `useNotePages` and fed into `useSyncWikiLinks` so same-note
+  // references resolve to real links instead of ghost entries.
+  const scopeNoteId = pageContext?.noteId ?? null;
+  const notePagesQuery = useNotePages(scopeNoteId ?? "", undefined, Boolean(scopeNoteId));
+  const { syncLinks } = useSyncWikiLinks({
+    pageNoteId: scopeNoteId,
+    notePages: scopeNoteId ? notePagesQuery.data : undefined,
+  });
 
   /**
    *

--- a/src/hooks/usePageQueries.ts
+++ b/src/hooks/usePageQueries.ts
@@ -809,6 +809,10 @@ export function useWikiLinkExistsChecker(options: UseWikiLinkExistsCheckerOption
       // リンク追跡は未整備（backend 側の管轄）のため、v1 では個人ゴーストのみ
       // を参照する。Note-scope ghost links are handled by the server for now;
       // only personal ghost links contribute to `referencedTitles` in v1.
+      // TODO(issue #713 Phase 5+): クライアント側でもノートスコープのゴースト
+      // リンクを扱えるようにする（検索・MCP の整備と合わせて別 issue で対応）。
+      // TODO(issue #713 Phase 5+): surface note-scope ghost links on the
+      // client (tracked with the search / MCP scoping work in a follow-up).
       const ghostLinks = pageNoteId === null ? await repo.getGhostLinks(userId) : [];
       const referencedTitles = new Set<string>();
 

--- a/src/hooks/usePageQueries.ts
+++ b/src/hooks/usePageQueries.ts
@@ -201,11 +201,25 @@ export function usePages() {
 }
 
 /**
+ * `usePagesSummary` のオプション。`enabled: false` を渡すと IndexedDB への
+ * 問い合わせをスキップできる（ノートスコープ編集時に個人ページを取りに
+ * 行かないように抑止するなど。Issue #713 Phase 4）。
+ * Options for {@link usePagesSummary}; pass `enabled: false` to skip the
+ * IndexedDB lookup (e.g. in note scope where personal pages are irrelevant,
+ * see issue #713 Phase 4).
+ */
+type UsePagesSummaryOptions = {
+  enabled?: boolean;
+};
+
+/**
  * Hook to fetch page summaries for the current user (without content)
  * Use this for list views to minimize data transfer
  */
-export function usePagesSummary() {
+export function usePagesSummary(options?: UsePagesSummaryOptions) {
   const { getRepository, userId, isLoaded } = useRepository();
+  const callerEnabled = options?.enabled ?? true;
+  const isEnabled = callerEnabled && isLoaded;
 
   const query = useQuery({
     queryKey: pageKeys.summary(userId),
@@ -213,13 +227,13 @@ export function usePagesSummary() {
       const repo = await getRepository();
       return repo.getPagesSummary(userId);
     },
-    enabled: isLoaded,
+    enabled: isEnabled,
     staleTime: 1000 * 60, // 1 minute
   });
 
   return {
     ...query,
-    isLoading: query.isLoading || !isLoaded,
+    isLoading: callerEnabled && (query.isLoading || !isLoaded),
     isRepositoryReady: isLoaded,
   };
 }
@@ -689,13 +703,46 @@ export function useSyncWikiLinks() {
 }
 
 /**
+ * `useWikiLinkExistsChecker` のオプション。WikiLink の解決スコープを
+ * 個人ページとノートネイティブページで切り替える（Issue #713 Phase 4）。
+ *
+ * Options for {@link useWikiLinkExistsChecker}. Switches WikiLink resolution
+ * scope between personal pages and note-native pages. See issue #713 Phase 4.
+ */
+export type UseWikiLinkExistsCheckerOptions = {
+  /**
+   * 編集中ページの noteId。`null`（既定）は個人ページ、文字列は
+   * ノートネイティブページ。
+   *
+   * Owning note ID. `null` (default) → personal scope; string → note scope.
+   */
+  pageNoteId?: string | null;
+  /**
+   * `pageNoteId !== null` のときに使う候補ページ一覧。IndexedDB には
+   * ノートネイティブページが載らないため、API 経由で取得したノート配下の
+   * ページ一覧を呼び出し側が渡す。
+   *
+   * Candidate pages used when `pageNoteId` is a string. IndexedDB does not
+   * hold note-native pages, so callers must supply the note's page list
+   * (typically from `useNotePages`).
+   */
+  notePages?: Array<Pick<PageSummary, "id" | "title">>;
+};
+
+/**
  * Hook to get data needed to update WikiLink exists status
  * Returns a function that checks if pages exist by their titles
  *
+ * スコープ（個人 / ノート）に応じて候補ソースを切り替える。Issue #713 Phase 4：
+ * - `pageNoteId === null` / 省略: `repo.getPagesSummary()`（個人ページ）
+ * - `pageNoteId !== null`: `notePages`（呼び出し側が `useNotePages` から渡す）
+ *
  * OPTIMIZED: Uses getPagesSummary() instead of getPages() to reduce Rows Read
  */
-export function useWikiLinkExistsChecker() {
+export function useWikiLinkExistsChecker(options: UseWikiLinkExistsCheckerOptions = {}) {
   const { getRepository, userId, isLoaded } = useRepository();
+  const pageNoteId = options.pageNoteId ?? null;
+  const notePages = options.notePages;
 
   const checkExistence = useCallback(
     async (
@@ -711,12 +758,29 @@ export function useWikiLinkExistsChecker() {
 
       const repo = await getRepository();
 
-      // OPTIMIZED: Use summary (no content) to check existence
-      const pages = await repo.getPagesSummary(userId);
-      const pageTitles = new Set(pages.map((p) => p.title.toLowerCase().trim()));
+      // スコープに応じて候補ソースを切り替える（Issue #713 Phase 4）。
+      // ノートスコープで `notePages` が未到着のときは空集合で返し、誤って
+      // 「存在しない」と判定して WikiLink を壊さないようにする。
+      //
+      // Select the candidate source based on scope (issue #713 Phase 4).
+      // If note-scope candidates have not loaded yet, return empty sets so
+      // we do not mis-classify valid same-note links as missing on this pass.
+      let pageTitles: Set<string>;
+      if (pageNoteId !== null) {
+        if (notePages === undefined) {
+          return { pageTitles: new Set(), referencedTitles: new Set() };
+        }
+        pageTitles = new Set(notePages.map((p) => p.title.toLowerCase().trim()));
+      } else {
+        const pages = await repo.getPagesSummary(userId);
+        pageTitles = new Set(pages.map((p) => p.title.toLowerCase().trim()));
+      }
 
-      // Get ghost links to check referenced status
-      const ghostLinks = await repo.getGhostLinks(userId);
+      // Get ghost links to check referenced status. ノートスコープのゴースト
+      // リンク追跡は未整備（backend 側の管轄）のため、v1 では個人ゴーストのみ
+      // を参照する。Note-scope ghost links are handled by the server for now;
+      // only personal ghost links contribute to `referencedTitles` in v1.
+      const ghostLinks = pageNoteId === null ? await repo.getGhostLinks(userId) : [];
       const referencedTitles = new Set<string>();
 
       // Group ghost links by link_text
@@ -740,7 +804,7 @@ export function useWikiLinkExistsChecker() {
 
       return { pageTitles, referencedTitles };
     },
-    [getRepository, userId, isLoaded],
+    [getRepository, userId, isLoaded, pageNoteId, notePages],
   );
 
   return { checkExistence, isLoaded };

--- a/src/hooks/usePageQueries.ts
+++ b/src/hooks/usePageQueries.ts
@@ -678,15 +678,41 @@ export function usePromoteGhostLink() {
 }
 
 /**
+ * `useSyncWikiLinks` のオプション。WikiLink 同期のスコープを個人ページと
+ * ノートネイティブページで切り替える（Issue #713 Phase 4）。
+ *
+ * - `pageNoteId === null` / 省略: 個人スコープ。`repo.getPagesSummary()`
+ *   が返す個人ページのみを解決候補にする。
+ * - `pageNoteId !== null`: ノートスコープ。呼び出し側は同じノートに所属する
+ *   ページ一覧（`useNotePages` で取得）を `notePages` に渡す。
+ *
+ * Options for {@link useSyncWikiLinks}. Switches sync scope between personal
+ * and note-native pages. When `pageNoteId` is set, callers must supply
+ * `notePages` (typically from `useNotePages`) because the repository does
+ * not hold note-native page summaries locally. See issue #713 Phase 4.
+ */
+export type UseSyncWikiLinksOptions = {
+  pageNoteId?: string | null;
+  notePages?: Array<Pick<PageSummary, "id" | "title">>;
+};
+
+/**
  * Hook to sync WikiLinks when saving a page (delta update).
  * - Removes links/ghost_links that are no longer in content.
  * - Adds or updates links for current content (existing pages → links, others → ghost_links).
  *
  * Only touches the saved page; no full-scan of all pages.
  * OPTIMIZED: Uses getPagesSummary() for title↔id resolution (no content).
+ *
+ * `options.pageNoteId` を文字列で渡すとノートスコープで同期する。ノート内の
+ * ページ一覧 (`options.notePages`) を呼び出し側が用意する必要がある。
+ * 個人ページ（既定）では従来どおり `repo.getPagesSummary(userId)` を使う。
+ * Issue #713 Phase 4。
  */
-export function useSyncWikiLinks() {
+export function useSyncWikiLinks(options: UseSyncWikiLinksOptions = {}) {
   const { getRepository, userId } = useRepository();
+  const pageNoteId = options.pageNoteId ?? null;
+  const notePages = options.notePages;
 
   const syncLinks = useCallback(
     async (
@@ -694,9 +720,12 @@ export function useSyncWikiLinks() {
       wikiLinks: Array<{ title: string; exists: boolean }>,
     ): Promise<void> => {
       const repo = await getRepository();
-      await syncLinksWithRepo(repo, userId, sourcePageId, wikiLinks);
+      await syncLinksWithRepo(repo, userId, sourcePageId, wikiLinks, {
+        pageNoteId,
+        notePages,
+      });
     },
-    [getRepository, userId],
+    [getRepository, userId, pageNoteId, notePages],
   );
 
   return { syncLinks };

--- a/src/hooks/useSyncWikiLinks.test.ts
+++ b/src/hooks/useSyncWikiLinks.test.ts
@@ -359,5 +359,30 @@ describe("syncLinksWithRepo", () => {
       expect(addGhostLink).toHaveBeenCalledTimes(1);
       expect(addGhostLink).toHaveBeenCalledWith("Unknown", sourcePageId);
     });
+
+    // CodeRabbit / Codex が指摘: ノートスコープで `notePages` が空のとき、
+    // 旧 outgoing link が候補マップに乗らず削除されないとグラフに残骸が残る。
+    // 候補マップに無い targetId は「スコープから外れた」として常に removeLink
+    // されることを担保する（Issue #713 Phase 4 リグレッションガード）。
+    // Regression guard for issue #713 Phase 4: when note scope is active but
+    // `notePages` is empty/unavailable, any stale outgoing link targetId
+    // should still be treated as out-of-scope and removed, otherwise the
+    // link graph would accumulate dangling edges.
+    it("pageNoteId 指定で notePages が空でも、既存の outgoing link は removeLink で掃除される", async () => {
+      const removeLink = vi.fn().mockResolvedValue(undefined);
+
+      const repo = createMockRepo({
+        getOutgoingLinks: vi.fn().mockResolvedValue(["stale-target-id"]),
+        getGhostLinksBySourcePage: vi.fn().mockResolvedValue([]),
+        removeLink,
+      });
+
+      await syncLinksWithRepo(repo, userId, sourcePageId, [], {
+        pageNoteId: noteId,
+      });
+
+      expect(removeLink).toHaveBeenCalledTimes(1);
+      expect(removeLink).toHaveBeenCalledWith(sourcePageId, "stale-target-id");
+    });
   });
 });

--- a/src/hooks/useSyncWikiLinks.test.ts
+++ b/src/hooks/useSyncWikiLinks.test.ts
@@ -254,4 +254,110 @@ describe("syncLinksWithRepo", () => {
       expect(addGhostLink).not.toHaveBeenCalled();
     });
   });
+
+  // Issue #713 Phase 4: ノートネイティブページを source にする場合は
+  // `repo.getPagesSummary` を使わず、呼び出し側が `options.notePages` で
+  // 渡したノート内ページだけを解決候補にする。個人ページは候補に入らない。
+  // Note-native scope: `syncLinksWithRepo` must skip `repo.getPagesSummary`
+  // and only use `options.notePages` as candidates so personal pages never
+  // bleed into note-native resolution.
+  describe("スコープ: ノートネイティブページ（pageNoteId 指定）", () => {
+    const noteId = "note-1";
+
+    it("pageNoteId を渡すと repo.getPagesSummary は呼ばれず、notePages のみを解決候補にする", async () => {
+      const getPagesSummary = vi.fn().mockResolvedValue([
+        {
+          id: "personal-a",
+          ownerUserId: userId,
+          noteId: null,
+          title: "Personal A",
+          contentPreview: undefined,
+          thumbnailUrl: undefined,
+          sourceUrl: undefined,
+          createdAt: 0,
+          updatedAt: 0,
+          isDeleted: false,
+        } satisfies PageSummary,
+      ]);
+      const addLink = vi.fn().mockResolvedValue(undefined);
+      const addGhostLink = vi.fn().mockResolvedValue(undefined);
+
+      const repo = createMockRepo({
+        getPagesSummary,
+        getOutgoingLinks: vi.fn().mockResolvedValue([]),
+        getGhostLinksBySourcePage: vi.fn().mockResolvedValue([]),
+        addLink,
+        addGhostLink,
+      });
+
+      // 同じタイトル "Personal A" でも、notePages に含まれていないのでゴースト扱いになる
+      await syncLinksWithRepo(
+        repo,
+        userId,
+        sourcePageId,
+        [{ title: "Personal A", exists: false }],
+        {
+          pageNoteId: noteId,
+          notePages: [{ id: "note-page-1", title: "Note Page 1" }],
+        },
+      );
+
+      expect(getPagesSummary).not.toHaveBeenCalled();
+      expect(addLink).not.toHaveBeenCalled();
+      expect(addGhostLink).toHaveBeenCalledTimes(1);
+      expect(addGhostLink).toHaveBeenCalledWith("Personal A", sourcePageId);
+    });
+
+    it("pageNoteId + notePages 指定時、同じノート内のページへのリンクは addLink で解決される", async () => {
+      const addLink = vi.fn().mockResolvedValue(undefined);
+      const addGhostLink = vi.fn().mockResolvedValue(undefined);
+      const removeGhostLink = vi.fn().mockResolvedValue(undefined);
+
+      const repo = createMockRepo({
+        getOutgoingLinks: vi.fn().mockResolvedValue([]),
+        getGhostLinksBySourcePage: vi.fn().mockResolvedValue([]),
+        addLink,
+        addGhostLink,
+        removeGhostLink,
+      });
+
+      await syncLinksWithRepo(
+        repo,
+        userId,
+        sourcePageId,
+        [{ title: "Note Page 1", exists: true }],
+        {
+          pageNoteId: noteId,
+          notePages: [
+            { id: "note-page-1", title: "Note Page 1" },
+            { id: "note-page-2", title: "Note Page 2" },
+          ],
+        },
+      );
+
+      expect(addLink).toHaveBeenCalledTimes(1);
+      expect(addLink).toHaveBeenCalledWith(sourcePageId, "note-page-1");
+      expect(addGhostLink).not.toHaveBeenCalled();
+    });
+
+    it("pageNoteId 指定で notePages を渡さないと、全てゴーストリンクになる", async () => {
+      const addLink = vi.fn().mockResolvedValue(undefined);
+      const addGhostLink = vi.fn().mockResolvedValue(undefined);
+
+      const repo = createMockRepo({
+        getOutgoingLinks: vi.fn().mockResolvedValue([]),
+        getGhostLinksBySourcePage: vi.fn().mockResolvedValue([]),
+        addLink,
+        addGhostLink,
+      });
+
+      await syncLinksWithRepo(repo, userId, sourcePageId, [{ title: "Unknown", exists: false }], {
+        pageNoteId: noteId,
+      });
+
+      expect(addLink).not.toHaveBeenCalled();
+      expect(addGhostLink).toHaveBeenCalledTimes(1);
+      expect(addGhostLink).toHaveBeenCalledWith("Unknown", sourcePageId);
+    });
+  });
 });

--- a/src/hooks/useWikiLinkCandidates.test.ts
+++ b/src/hooks/useWikiLinkCandidates.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useWikiLinkCandidates } from "./useWikiLinkCandidates";
+import type { PageSummary } from "@/types/page";
+
+// usePagesSummary と useNotePages は、個人 / ノートスコープに応じた候補
+// リストの出し分けの仕様を検証するため、返す内容を固定でモックする。
+// Mock `usePagesSummary` / `useNotePages` so we can verify that the scope
+// chosen by `useWikiLinkCandidates` selects the correct backing source.
+const mockUsePagesSummary = vi.fn();
+const mockUseNotePages = vi.fn();
+
+vi.mock("@/hooks/usePageQueries", () => ({
+  usePagesSummary: (...args: unknown[]) => mockUsePagesSummary(...args),
+}));
+
+vi.mock("@/hooks/useNoteQueries", () => ({
+  useNotePages: (...args: unknown[]) => mockUseNotePages(...args),
+}));
+
+function makePersonalSummary(overrides: Partial<PageSummary> = {}): PageSummary {
+  return {
+    id: overrides.id ?? "p-1",
+    ownerUserId: overrides.ownerUserId ?? "user-1",
+    noteId: null,
+    title: overrides.title ?? "Personal",
+    contentPreview: undefined,
+    thumbnailUrl: undefined,
+    sourceUrl: undefined,
+    createdAt: 0,
+    updatedAt: 0,
+    isDeleted: overrides.isDeleted ?? false,
+  };
+}
+
+function makeNoteSummary(noteId: string, overrides: Partial<PageSummary> = {}): PageSummary {
+  return {
+    id: overrides.id ?? "n-1",
+    ownerUserId: overrides.ownerUserId ?? "user-1",
+    noteId,
+    title: overrides.title ?? "Note Page",
+    contentPreview: undefined,
+    thumbnailUrl: undefined,
+    sourceUrl: undefined,
+    createdAt: 0,
+    updatedAt: 0,
+    isDeleted: overrides.isDeleted ?? false,
+  };
+}
+
+beforeEach(() => {
+  mockUsePagesSummary.mockReset();
+  mockUseNotePages.mockReset();
+});
+
+describe("useWikiLinkCandidates", () => {
+  it("pageNoteId が null のとき、個人ページサマリを返し、useNotePages は無効化して呼ばれる（enabled=false）", () => {
+    const personal = [makePersonalSummary({ id: "p-1", title: "Alpha" })];
+    mockUsePagesSummary.mockReturnValue({ data: personal, isLoading: false });
+    mockUseNotePages.mockReturnValue({ data: undefined, isLoading: false });
+
+    const { result } = renderHook(() => useWikiLinkCandidates(null));
+
+    expect(result.current.pages).toEqual([{ id: "p-1", title: "Alpha", isDeleted: false }]);
+    // useNotePages は noteId が空 + enabled=false で呼ばれる（実データは取りに行かない）。
+    expect(mockUseNotePages).toHaveBeenCalledWith("", undefined, false);
+  });
+
+  it("pageNoteId 指定時、ノートのページサマリを返し、個人ページは候補に入らない", () => {
+    const noteId = "note-x";
+    const notePages = [
+      makeNoteSummary(noteId, { id: "n-1", title: "Spec" }),
+      makeNoteSummary(noteId, { id: "n-2", title: "Design" }),
+    ];
+    mockUsePagesSummary.mockReturnValue({
+      data: [makePersonalSummary({ id: "p-1", title: "Leaked Personal" })],
+      isLoading: false,
+    });
+    mockUseNotePages.mockReturnValue({ data: notePages, isLoading: false });
+
+    const { result } = renderHook(() => useWikiLinkCandidates(noteId));
+
+    expect(result.current.pages).toEqual([
+      { id: "n-1", title: "Spec", isDeleted: false },
+      { id: "n-2", title: "Design", isDeleted: false },
+    ]);
+    expect(mockUseNotePages).toHaveBeenCalledWith(noteId, undefined, true);
+    // 個人ページがスコープを越えて紛れ込まないこと。
+    expect(result.current.pages.find((p) => p.id === "p-1")).toBeUndefined();
+  });
+
+  it("useNotePages の data が undefined のとき、pages は空配列で返る（null 安全）", () => {
+    mockUsePagesSummary.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseNotePages.mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() => useWikiLinkCandidates("note-y"));
+
+    expect(result.current.pages).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/src/hooks/useWikiLinkCandidates.test.ts
+++ b/src/hooks/useWikiLinkCandidates.test.ts
@@ -62,6 +62,8 @@ describe("useWikiLinkCandidates", () => {
     const { result } = renderHook(() => useWikiLinkCandidates(null));
 
     expect(result.current.pages).toEqual([{ id: "p-1", title: "Alpha", isDeleted: false }]);
+    // 個人スコープでは個人ページ取得を有効化する。
+    expect(mockUsePagesSummary).toHaveBeenCalledWith({ enabled: true });
     // useNotePages は noteId が空 + enabled=false で呼ばれる（実データは取りに行かない）。
     expect(mockUseNotePages).toHaveBeenCalledWith("", undefined, false);
   });
@@ -85,6 +87,8 @@ describe("useWikiLinkCandidates", () => {
       { id: "n-2", title: "Design", isDeleted: false },
     ]);
     expect(mockUseNotePages).toHaveBeenCalledWith(noteId, undefined, true);
+    // ノートスコープでは個人ページ取得を抑止して IndexedDB アクセスを避ける。
+    expect(mockUsePagesSummary).toHaveBeenCalledWith({ enabled: false });
     // 個人ページがスコープを越えて紛れ込まないこと。
     expect(result.current.pages.find((p) => p.id === "p-1")).toBeUndefined();
   });

--- a/src/hooks/useWikiLinkCandidates.ts
+++ b/src/hooks/useWikiLinkCandidates.ts
@@ -31,7 +31,11 @@ export function useWikiLinkCandidates(
   pageNoteId: string | null | undefined,
 ): WikiLinkCandidatesResult {
   const noteId = pageNoteId ?? null;
-  const personal = usePagesSummary();
+  // ノートスコープでは個人ページを取りに行かない（IndexedDB への不要な
+  // アクセスを避ける）。`enabled` は react-query で queryFn を抑止する。
+  // In note scope, skip the personal pages lookup to avoid unnecessary
+  // IndexedDB access; `enabled` suppresses the react-query queryFn.
+  const personal = usePagesSummary({ enabled: noteId === null });
   const notePages = useNotePages(noteId ?? "", undefined, Boolean(noteId));
 
   return useMemo<WikiLinkCandidatesResult>(() => {

--- a/src/hooks/useWikiLinkCandidates.ts
+++ b/src/hooks/useWikiLinkCandidates.ts
@@ -1,0 +1,51 @@
+import { useMemo } from "react";
+import { usePagesSummary } from "@/hooks/usePageQueries";
+import { useNotePages } from "@/hooks/useNoteQueries";
+import type { PageSummary } from "@/types/page";
+
+/**
+ * WikiLink のサジェスト・タイトル検索に使う候補ページのスコープ。
+ * Scope of candidate pages used by WikiLink suggestion / title lookups.
+ *
+ * - `pageNoteId === null` → 個人ページのみ（`note_id IS NULL`）
+ * - `pageNoteId !== null` → そのノートに所属するページのみ
+ *
+ * ノートを跨いだ参照、ノート↔個人を跨いだ参照は v1 では非対応
+ * （Issue #713 Phase 4）。
+ */
+export interface WikiLinkCandidatesResult {
+  pages: Array<Pick<PageSummary, "id" | "title" | "isDeleted">>;
+  isLoading: boolean;
+}
+
+/**
+ * 現在編集中のページ所属（個人 or ノート）に基づく WikiLink 候補を返す。
+ * 呼び出し側は `WikiLinkSuggestion` や `getPageByTitle` などスコープを尊重
+ * したい処理で利用する。
+ *
+ * Returns WikiLink candidate pages scoped to the current editor context
+ * (personal pages when `pageNoteId === null`, same-note pages otherwise).
+ * See issue #713 Phase 4.
+ */
+export function useWikiLinkCandidates(
+  pageNoteId: string | null | undefined,
+): WikiLinkCandidatesResult {
+  const noteId = pageNoteId ?? null;
+  const personal = usePagesSummary();
+  const notePages = useNotePages(noteId ?? "", undefined, Boolean(noteId));
+
+  return useMemo<WikiLinkCandidatesResult>(() => {
+    if (noteId) {
+      const data = notePages.data ?? [];
+      return {
+        pages: data.map((p) => ({ id: p.id, title: p.title, isDeleted: p.isDeleted })),
+        isLoading: notePages.isLoading,
+      };
+    }
+    const data = personal.data ?? [];
+    return {
+      pages: data.map((p) => ({ id: p.id, title: p.title, isDeleted: p.isDeleted })),
+      isLoading: personal.isLoading,
+    };
+  }, [noteId, personal.data, personal.isLoading, notePages.data, notePages.isLoading]);
+}

--- a/src/lib/syncWikiLinks.ts
+++ b/src/lib/syncWikiLinks.ts
@@ -74,10 +74,17 @@ export async function syncLinksWithRepo(
   wikiLinks: WikiLinkForSync[],
   options: SyncLinksOptions = {},
 ): Promise<void> {
+  // `pageNoteId` は `null` / 文字列の 2 値契約。`pageNoteId ? ... : ...` は
+  // 空文字列 ("") の場合も個人スコープに倒れるため、明示的に `!== null` で
+  // 判別する。`null` なら個人 (`repo.getPagesSummary`)、文字列なら
+  // `options.notePages` を使う。
+  //
+  // `pageNoteId` is a null | string contract. Using truthiness would treat
+  // an empty string as personal scope; compare to `null` explicitly so the
+  // scope switch follows the documented contract.
   const pageNoteId = options.pageNoteId ?? null;
-  const candidateSource: Array<Pick<PageSummary, "id" | "title">> = pageNoteId
-    ? (options.notePages ?? [])
-    : await repo.getPagesSummary(userId);
+  const candidateSource: Array<Pick<PageSummary, "id" | "title">> =
+    pageNoteId !== null ? (options.notePages ?? []) : await repo.getPagesSummary(userId);
 
   const pageTitleToId = new Map(candidateSource.map((p) => [p.title.toLowerCase().trim(), p.id]));
   const idToNormalizedTitle = new Map(
@@ -85,14 +92,21 @@ export async function syncLinksWithRepo(
   );
   const currentNormalizedTitles = new Set(wikiLinks.map((l) => l.title.toLowerCase().trim()));
 
-  // Delta: remove links that are no longer in content
+  // Delta: remove links that are no longer in content.
+  // 候補ソースにマッピングが無い `targetId` は「現在のスコープから外れた」
+  // リンクとして古いエッジを削除する。`idToNormalizedTitle` が空（ノート
+  // スコープで `notePages` 未提供など）でも古い links を残さないようにする。
+  //
+  // If the candidate source does not know the `targetId`, the link is out of
+  // the current scope: remove the stale edge so we do not accumulate dangling
+  // graph entries when `notePages` is empty.
   const [oldOutgoingTargetIds, oldGhostTexts] = await Promise.all([
     repo.getOutgoingLinks(sourcePageId),
     repo.getGhostLinksBySourcePage(sourcePageId),
   ]);
   for (const targetId of oldOutgoingTargetIds) {
     const norm = idToNormalizedTitle.get(targetId);
-    if (norm !== undefined && !currentNormalizedTitles.has(norm)) {
+    if (norm === undefined || !currentNormalizedTitles.has(norm)) {
       await repo.removeLink(sourcePageId, targetId);
     }
   }

--- a/src/lib/syncWikiLinks.ts
+++ b/src/lib/syncWikiLinks.ts
@@ -1,8 +1,50 @@
 import type { IPageRepository } from "@/lib/pageRepository";
+import type { PageSummary } from "@/types/page";
 
+/**
+ * `syncLinksWithRepo` が受け取る WikiLink の最小情報。
+ * Minimal shape of a WikiLink passed to `syncLinksWithRepo`.
+ */
 export interface WikiLinkForSync {
   title: string;
   exists?: boolean;
+}
+
+/**
+ * `syncLinksWithRepo` の拡張オプション。WikiLink のスコープ絞り込み
+ * （Issue #713 Phase 4）のために `pageNoteId` と、ノートネイティブページ用
+ * の外部候補リスト `notePages` を受け取る。
+ *
+ * Extra options for `syncLinksWithRepo`. Used to scope WikiLink resolution
+ * (issue #713 Phase 4). `pageNoteId` identifies whether the source page is
+ * personal (`null`) or note-native (`string`); `notePages` supplies an
+ * external candidate list when the repository does not hold note-native
+ * pages locally (IndexedDB holds only personal pages).
+ */
+export interface SyncLinksOptions {
+  /**
+   * リンク元ページの所属ノート ID。`null` なら個人ページとして同期し、
+   * `repo.getPagesSummary()` が返す個人ページのみを解決候補にする。
+   * 文字列値なら `notePages` に渡された候補リストだけを使う。
+   *
+   * Note id that owns the source page. `null` → personal; the repo's
+   * personal page summaries are used. A string → note-native; callers must
+   * supply `notePages` with the note's page list.
+   */
+  pageNoteId?: string | null;
+  /**
+   * `pageNoteId !== null` のときに使われる、ノートネイティブページの候補
+   * リスト。IndexedDB にはノート配下のページが入らない前提のため、API
+   * から取得したリストを呼び出し側が渡す必要がある。渡されない場合は
+   * ノートスコープでの解決候補が空になり、すべてゴーストリンクとして
+   * 扱われる。
+   *
+   * External candidate list used when `pageNoteId` is a string. The
+   * repository does not store note-native pages locally, so callers pass
+   * pages fetched from the API. If omitted, note-scoped resolution has no
+   * candidates and every WikiLink becomes a ghost link.
+   */
+  notePages?: Array<Pick<PageSummary, "id" | "title">>;
 }
 
 /**
@@ -11,16 +53,36 @@ export interface WikiLinkForSync {
  * - Adds links for current content (existing pages → links, others → ghost_links).
  *
  * Extracted for unit testing with a mock repo.
+ *
+ * Scope (Issue #713 Phase 4):
+ * - `options.pageNoteId === null`（既定）: 個人ページに対する同期。解決候補
+ *   は `repo.getPagesSummary(userId)` が返す個人ページのみ。
+ * - `options.pageNoteId === string`: ノートネイティブページに対する同期。
+ *   解決候補は `options.notePages` のみ（呼び出し側が API から取得した
+ *   ノート配下のページ一覧を渡す）。
+ *
+ * - `options.pageNoteId === null` (default): sync for a personal page.
+ *   Candidates come from `repo.getPagesSummary(userId)`.
+ * - `options.pageNoteId === string`: sync for a note-native page. Candidates
+ *   come from `options.notePages` only (caller must pre-fetch the note's
+ *   pages from the API).
  */
 export async function syncLinksWithRepo(
   repo: IPageRepository,
   userId: string,
   sourcePageId: string,
   wikiLinks: WikiLinkForSync[],
+  options: SyncLinksOptions = {},
 ): Promise<void> {
-  const pages = await repo.getPagesSummary(userId);
-  const pageTitleToId = new Map(pages.map((p) => [p.title.toLowerCase().trim(), p.id]));
-  const idToNormalizedTitle = new Map(pages.map((p) => [p.id, p.title.toLowerCase().trim()]));
+  const pageNoteId = options.pageNoteId ?? null;
+  const candidateSource: Array<Pick<PageSummary, "id" | "title">> = pageNoteId
+    ? (options.notePages ?? [])
+    : await repo.getPagesSummary(userId);
+
+  const pageTitleToId = new Map(candidateSource.map((p) => [p.title.toLowerCase().trim(), p.id]));
+  const idToNormalizedTitle = new Map(
+    candidateSource.map((p) => [p.id, p.title.toLowerCase().trim()]),
+  );
   const currentNormalizedTitles = new Set(wikiLinks.map((l) => l.title.toLowerCase().trim()));
 
   // Delta: remove links that are no longer in content

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -231,6 +231,7 @@ function NotePageEditorEditable({
         onTitleChange={isTitleEditable ? handleTitleChange : undefined}
         collaboration={isCollaborationEnabled ? collaboration : undefined}
         insertAtCursorRef={editorInsertRef}
+        pageNoteId={page.noteId ?? null}
       />
     </ContentWithAIChat>
   );
@@ -430,6 +431,7 @@ const NotePageView: React.FC = () => {
               showToolbar={false}
               onContentChange={() => undefined}
               onContentError={() => undefined}
+              pageNoteId={page.noteId ?? null}
             />
           )}
         </NoteWorkspaceProvider>


### PR DESCRIPTION
## 概要

WikiLink のスコープを個人ページとノートネイティブページで分離し、ノート内のページ編集時に個人ページが候補に混入しないようにします。Issue #713 Phase 4 の実装です。

## 変更点

- **`syncLinksWithRepo` の拡張**: `SyncLinksOptions` を追加し、`pageNoteId` と `notePages` パラメータでスコープを制御。ノートネイティブページ編集時は `repo.getPagesSummary()` を呼ばず、呼び出し側が渡した `notePages` のみを解決候補にする
- **`useWikiLinkCandidates` フック新規作成**: 編集中ページの所属（個人 or ノート）に基づいて候補ページを返す。個人ページ時は `usePagesSummary()`、ノート時は `useNotePages()` を使い分ける
- **`useWikiLinkNavigation` の拡張**: `pageNoteId` オプションを受け取り、個人スコープ時は `/pages/:id` へ、ノートスコープ時は `/notes/:noteId/pages/:id` へ遷移。ノートスコープでの新規作成は未対応として処理をスキップ
- **`WikiLinkSuggestion` の責務分離**: 候補ページリストを props で受け取り、呼び出し側でスコープ絞り込みを行う設計に変更
- **`WikiLinkSuggestionLayer` の更新**: `useWikiLinkCandidates` を使用して `pageNoteId` に応じた候補を取得し、`WikiLinkSuggestion` に渡す
- **エディタコンポーネントの連鎖更新**: `TiptapEditor`、`PageEditorContent`、`NotePageView` に `pageNoteId` prop を追加し、ツリー全体でスコープ情報を伝播

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)

## テスト方法

- 新規テストケース 3 件を `useSyncWikiLinks.test.ts` に追加（ノートネイティブページのスコープ検証）
- 新規テストファイル `useWikiLinkCandidates.test.ts` を作成（個人/ノートスコープの切り替え検証）
- 既存テストはすべてパス

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #713 (Phase 4)

https://claude.ai/code/session_01Ei21HcGn7LtKQmcHiaXB5j
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WikiLink autocomplete, suggestion layer, navigation and sync now respect page context (personal vs note-scoped) via a propagated pageNoteId; note-scoped routing uses /notes/:noteId/:pageId and suggestions come from note pages when applicable.
  * Editor forwards page context in both edit and read-only views.

* **Bug Fixes**
  * Disables WikiLink-driven page creation in note-scoped contexts; stale/out-of-scope links are removed.

* **Tests**
  * Added tests for note-scoped resolution, candidate selection, sync behavior, and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->