### PR TITLE
fix: enforce personal page scope in search API (Issue #718 Phase 5-1)

### DIFF
--- a/server/api/src/__tests__/routes/search.test.ts
+++ b/server/api/src/__tests__/routes/search.test.ts
@@ -1,0 +1,172 @@
+/**
+ * GET /api/search のスコープ分離テスト (Issue #718 Phase 5-1)。
+ * Tests for scope separation on GET /api/search (Issue #718 Phase 5-1).
+ *
+ * Phase 1〜4 で `pages.note_id` による個人 / ノートネイティブページのスコープ分離が
+ * 導入されたため、`scope=own` でも SQL レベルで `p.note_id IS NULL` を強制し、
+ * ノートネイティブページがリークしないことを検証する。
+ *
+ * Ensures `scope=own` restricts results to personal pages (note_id IS NULL) at
+ * the SQL layer so note-native pages cannot leak into personal search results,
+ * while `scope=shared` keeps its existing cross-scope behavior.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Context, Next } from "hono";
+import type { AppEnv } from "../../types/index.js";
+
+vi.mock("../../middleware/auth.js", () => ({
+  authRequired: async (c: Context<AppEnv>, next: Next) => {
+    const userId = c.req.header("x-test-user-id");
+    if (!userId) return c.json({ message: "Unauthorized" }, 401);
+    c.set("userId", userId);
+    await next();
+  },
+}));
+
+import { Hono } from "hono";
+import searchRoutes from "../../routes/search.js";
+import { createMockDb } from "../createMockDb.js";
+
+const TEST_USER_ID = "user-search-test-001";
+
+function authHeaders() {
+  return {
+    "x-test-user-id": TEST_USER_ID,
+    "Content-Type": "application/json",
+  };
+}
+
+function createSearchApp(dbResults: unknown[]) {
+  const { db, chains } = createMockDb(dbResults);
+  const app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+    await next();
+  });
+  app.route("/api/search", searchRoutes);
+  return { app, chains };
+}
+
+describe("GET /api/search", () => {
+  it("returns 401 without auth header", async () => {
+    const { app } = createSearchApp([{ rows: [] }]);
+
+    const res = await app.request("/api/search?q=hello", { method: "GET" });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty results when q is missing (no DB call)", async () => {
+    const { app, chains } = createSearchApp([]);
+
+    const res = await app.request("/api/search", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: unknown[] };
+    expect(body.results).toEqual([]);
+    expect(chains).toHaveLength(0);
+  });
+
+  it("scope=own restricts SQL to personal pages (note_id IS NULL) to prevent note-native leakage", async () => {
+    // Phase 5-1 防御的修正: 個人検索結果にノートネイティブページが混ざってはならない。
+    // Phase 5-1 defensive fix: personal search results must never include note-native pages.
+    const { app, chains } = createSearchApp([{ rows: [] }]);
+
+    const res = await app.request("/api/search?q=hello&scope=own", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    expect(executeChain).toBeDefined();
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).toContain("p.note_id IS NULL");
+    expect(serialised).toContain("p.owner_id");
+  });
+
+  it("defaults to scope=own when scope query parameter is omitted", async () => {
+    // scope 未指定時の既定は個人スコープ。省略時にノートネイティブがリークしないよう同じガードを要求する。
+    // Omitted scope defaults to personal, so the same guard must apply.
+    const { app, chains } = createSearchApp([{ rows: [] }]);
+
+    const res = await app.request("/api/search?q=hello", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    expect(executeChain).toBeDefined();
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).toContain("p.note_id IS NULL");
+  });
+
+  it("scope=shared does NOT force p.note_id IS NULL (keeps cross-scope behavior)", async () => {
+    // shared は個人 + 参加ノートの混在検索を維持する。
+    // `shared` retains existing cross-scope behavior and must not restrict to personal pages.
+    const { app, chains } = createSearchApp([{ rows: [] }]);
+
+    const res = await app.request("/api/search?q=hello&scope=shared", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    expect(executeChain).toBeDefined();
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).not.toContain("p.note_id IS NULL");
+  });
+
+  it("response rows include note_id so callers can distinguish personal vs note-native", async () => {
+    // 呼び出し側 (フロント / MCP) がスコープ判定できるよう、レスポンスには必ず note_id を含める。
+    // Callers (frontend / MCP) must be able to tell personal vs note-native, so include note_id.
+    const { app, chains } = createSearchApp([
+      {
+        rows: [
+          {
+            id: "page-personal",
+            title: "Personal",
+            content_preview: null,
+            updated_at: new Date("2026-04-01T00:00:00Z").toISOString(),
+            note_id: null,
+          },
+        ],
+      },
+    ]);
+
+    const res = await app.request("/api/search?q=hello&scope=shared", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: Array<Record<string, unknown>> };
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]).toHaveProperty("note_id");
+
+    // SELECT 句に p.note_id が含まれていることも検証する (両スコープ)。
+    // Verify SELECT list includes p.note_id regardless of scope.
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).toContain("p.note_id");
+  });
+
+  it("scope=own SELECT list also exposes p.note_id", async () => {
+    const { app, chains } = createSearchApp([{ rows: [] }]);
+
+    const res = await app.request("/api/search?q=hello&scope=own", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).toContain("p.note_id");
+  });
+});

--- a/server/api/src/__tests__/routes/search.test.ts
+++ b/server/api/src/__tests__/routes/search.test.ts
@@ -156,8 +156,24 @@ describe("GET /api/search", () => {
     expect(serialised).toContain("p.note_id");
   });
 
-  it("scope=own SELECT list also exposes p.note_id", async () => {
-    const { app, chains } = createSearchApp([{ rows: [] }]);
+  it("scope=own SELECT list exposes p.note_id and response surfaces note_id: null", async () => {
+    // SQL の SELECT に note_id が含まれること、かつ JSON ペイロード上も
+    // note_id (個人ページなので null) が露出することを併せて契約する。
+    // Pin both the SQL projection and the JSON payload contract: scope=own
+    // surfaces note_id (null for personal pages) on each result row.
+    const { app, chains } = createSearchApp([
+      {
+        rows: [
+          {
+            id: "page-own",
+            title: "Own page",
+            content_preview: null,
+            updated_at: new Date("2026-04-01T00:00:00Z").toISOString(),
+            note_id: null,
+          },
+        ],
+      },
+    ]);
 
     const res = await app.request("/api/search?q=hello&scope=own", {
       method: "GET",
@@ -165,6 +181,10 @@ describe("GET /api/search", () => {
     });
 
     expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: Array<Record<string, unknown>> };
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]).toHaveProperty("note_id", null);
+
     const executeChain = chains.find((chain) => chain.startMethod === "execute");
     const serialised = JSON.stringify(executeChain?.startArgs);
     expect(serialised).toContain("p.note_id");

--- a/server/api/src/routes/search.ts
+++ b/server/api/src/routes/search.ts
@@ -2,6 +2,20 @@
  * /api/search — 全文検索
  *
  * GET /api/search?q=&scope= — ILIKE による全文検索 (pg_trgm GIN インデックスで高速化)
+ *
+ * スコープ契約 (Issue #713 / #718 Phase 5-1):
+ * - `scope=own` は個人ページ (`note_id IS NULL`) のみを返す。Phase 1〜4 で導入された
+ *   個人 / ノートネイティブページの分離を検索面にも反映するための防御的ガード。
+ * - `scope=shared` は個人ページ + 自分が参加するノートのページを横断する既存挙動を維持する。
+ * - いずれのスコープでも `note_id` を返し、呼び出し側がスコープ判定できるようにする。
+ *
+ * Scope contract (Issue #713 / #718 Phase 5-1):
+ * - `scope=own` returns personal pages only (`note_id IS NULL`). This is a
+ *   defensive guard that mirrors the personal / note-native split introduced
+ *   in Phase 1〜4 at the search layer.
+ * - `scope=shared` keeps the existing cross-scope behavior (personal pages +
+ *   pages in notes the caller participates in).
+ * - Both scopes expose `note_id` so callers can tell the two apart.
  */
 import { Hono } from "hono";
 import { sql } from "drizzle-orm";
@@ -31,7 +45,7 @@ app.get("/", authRequired, async (c) => {
 
   if (scope === "shared") {
     results = await db.execute(sql`
-      SELECT p.id, p.title, p.content_preview, p.updated_at,
+      SELECT p.id, p.title, p.content_preview, p.updated_at, p.note_id,
              pc.content_text
       FROM pages p
       LEFT JOIN page_contents pc ON pc.page_id = p.id
@@ -57,12 +71,13 @@ app.get("/", authRequired, async (c) => {
     `);
   } else {
     results = await db.execute(sql`
-      SELECT p.id, p.title, p.content_preview, p.updated_at,
+      SELECT p.id, p.title, p.content_preview, p.updated_at, p.note_id,
              pc.content_text
       FROM pages p
       LEFT JOIN page_contents pc ON pc.page_id = p.id
       WHERE p.is_deleted = false
         AND p.owner_id = ${userId}
+        AND p.note_id IS NULL
         AND (
           p.title ILIKE ${pattern}
           OR pc.content_text ILIKE ${pattern}

--- a/server/api/src/routes/search.ts
+++ b/server/api/src/routes/search.ts
@@ -41,12 +41,16 @@ app.get("/", authRequired, async (c) => {
   const limit = Math.min(Math.max(Number(c.req.query("limit") || 20), 1), 100);
   const pattern = `%${escapeLike(query)}%`;
 
+  // 両スコープで返す列は同一なので共有する。`p.note_id` は呼び出し側のスコープ判定用。
+  // Both scopes return the same columns; `p.note_id` lets callers distinguish scopes.
+  const searchColumns = sql`p.id, p.title, p.content_preview, p.updated_at, p.note_id,
+             pc.content_text`;
+
   let results;
 
   if (scope === "shared") {
     results = await db.execute(sql`
-      SELECT p.id, p.title, p.content_preview, p.updated_at, p.note_id,
-             pc.content_text
+      SELECT ${searchColumns}
       FROM pages p
       LEFT JOIN page_contents pc ON pc.page_id = p.id
       WHERE p.is_deleted = false
@@ -71,8 +75,7 @@ app.get("/", authRequired, async (c) => {
     `);
   } else {
     results = await db.execute(sql`
-      SELECT p.id, p.title, p.content_preview, p.updated_at, p.note_id,
-             pc.content_text
+      SELECT ${searchColumns}
       FROM pages p
       LEFT JOIN page_contents pc ON pc.page_id = p.id
       WHERE p.is_deleted = false

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -123,7 +123,9 @@ export function useGlobalSearch() {
       const highlightedText = highlightKeywords(preview, keywords);
       return {
         pageId: r.id,
-        noteId: r.note_id,
+        // `note_id` は個人ページが混ざると null になり得るので undefined に正規化する。
+        // `note_id` may be null when personal pages are mixed into shared results.
+        noteId: r.note_id ?? undefined,
         title: r.title ?? "無題のページ",
         highlightedText: highlightedText || "（共有ノート）",
         matchType: "content" as MatchType,

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -146,11 +146,23 @@ export interface CopyNotePageToPersonalResponse {
   page: SyncPageItem;
 }
 
-/** GET /api/search?q=&scope=shared response. */
+/**
+ * GET /api/search?q=&scope=shared のレスポンス。
+ *
+ * `note_id` は個人ページ (`note_id IS NULL`) も結果に含まれ得るため null になり得る
+ * (Issue #718 Phase 5-1)。呼び出し側はノートネイティブと個人を区別する必要がある場合
+ * このフィールドで判定する。
+ *
+ * Response of GET /api/search?q=&scope=shared.
+ *
+ * `note_id` may be null because personal pages (`note_id IS NULL`) can also
+ * appear in shared search results (Issue #718 Phase 5-1). Callers that need to
+ * distinguish note-native from personal pages should branch on this field.
+ */
 export interface SearchSharedResponse {
   results: Array<{
     id: string;
-    note_id: string;
+    note_id: string | null;
     owner_id: string;
     title: string | null;
     content_preview: string | null;

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -74,7 +74,9 @@ export default function SearchResults() {
       const highlightedSnippet = highlightKeywords(snippet || "（共有ノート）", keywords);
       return {
         pageId: r.id,
-        noteId: r.note_id,
+        // `note_id` は個人ページが混ざると null になり得るので undefined に正規化する。
+        // `note_id` may be null when personal pages are mixed into shared results.
+        noteId: r.note_id ?? undefined,
         title: r.title ?? "無題のページ",
         snippet,
         highlightedSnippet,


### PR DESCRIPTION
## 概要

検索 API (`GET /api/search`) に対して、Phase 1〜4 で導入された個人ページ / ノートネイティブページのスコープ分離を反映させる防御的修正を実施します。`scope=own` 時に SQL レベルで `p.note_id IS NULL` を強制し、ノートネイティブページが個人検索結果にリークしないことを保証します。

## 変更点

- **search.ts**: 
  - `scope=own` (デフォルト) の WHERE 句に `AND p.note_id IS NULL` を追加し、個人ページのみを返すよう制限
  - 両スコープの SELECT 句に `p.note_id` を追加し、呼び出し側がページの種別を判定できるように
  - `scope=shared` は既存の横断検索挙動を維持（`note_id IS NULL` 制限なし）
  - スコープ契約をコメントで明記

- **search.test.ts** (新規):
  - 認証なしアクセスが 401 を返すことを検証
  - `q` パラメータ省略時に DB 呼び出しが発生しないことを検証
  - `scope=own` 時に SQL に `p.note_id IS NULL` が含まれることを検証
  - `scope` 省略時のデフォルト動作が個人スコープ制限を適用することを検証
  - `scope=shared` 時に `p.note_id IS NULL` が含まれ**ない**ことを検証
  - 両スコープでレスポンスに `note_id` が含まれることを検証

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm test -- search.test.ts` で新規テストスイートを実行
2. 既存の検索機能テストがすべてパスすることを確認
3. Lint チェック: `npm run lint`

## チェックリスト

- [x] テストがすべてパスする（新規テスト 7 ケース追加）
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #718 (Phase 5-1)

https://claude.ai/code/session_01A1Ya19RCtRE7SVjM75vxs3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search responses now include note identification (note_id) in results.

* **Improvements**
  * Personal ("own") searches now exclude pages tied to notes; shared searches still include note-linked pages.
  * Client-side normalization treats null note IDs as absent so optional noteId is omitted when not applicable.

* **Types**
  * Search response type updated so note_id can be null.

* **Tests**
  * Added tests covering auth, scope behavior, and response contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
