### PR TITLE
feat: Add note-scoped search endpoint (Issue #718 Phase 5-2)

### DIFF
--- a/server/api/src/__tests__/routes/notes/search.test.ts
+++ b/server/api/src/__tests__/routes/notes/search.test.ts
@@ -1,0 +1,268 @@
+/**
+ * GET /api/notes/:noteId/search のテスト (Issue #718 Phase 5-2)。
+ * Tests for the note-scoped search endpoint (Issue #718 Phase 5-2).
+ *
+ * Phase 1〜4 で個人 / ノートネイティブページの分離が入り、Phase 5-1 で
+ * `/api/search?scope=own` に `p.note_id IS NULL` を強制した。Phase 5-2 では
+ * 逆向きに「このノート内だけを検索する」エンドポイントを追加し、閲覧権限は
+ * 既存 `getNoteRole` / `note_members` / `visibility` で解決する。
+ *
+ * Phase 5-2 introduces a note-scoped search counterpart so agents and the UI
+ * can ask "only search this note" without leaking across scopes. Permissions
+ * reuse `getNoteRole`, which already consults `note_members`, domain rules and
+ * visibility.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Context, Next } from "hono";
+import type { AppEnv } from "../../../types/index.js";
+
+vi.mock("../../../middleware/auth.js", () => ({
+  authRequired: async (c: Context<AppEnv>, next: Next) => {
+    const userId = c.req.header("x-test-user-id");
+    const userEmail = c.req.header("x-test-user-email");
+    if (!userId) return c.json({ message: "Unauthorized" }, 401);
+    c.set("userId", userId);
+    if (userEmail) c.set("userEmail", userEmail);
+    await next();
+  },
+  authOptional: async (c: Context<AppEnv>, next: Next) => {
+    const userId = c.req.header("x-test-user-id");
+    const userEmail = c.req.header("x-test-user-email");
+    if (userId) c.set("userId", userId);
+    if (userEmail) c.set("userEmail", userEmail);
+    await next();
+  },
+}));
+
+import {
+  TEST_USER_ID,
+  OTHER_USER_ID,
+  createMockNote,
+  createTestApp,
+  authHeaders,
+} from "./setup.js";
+
+const NOTE_ID = "note-test-001";
+
+describe("GET /api/notes/:noteId/search", () => {
+  it("returns 401 without auth header", async () => {
+    const { app } = createTestApp([]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/search?q=hello`, { method: "GET" });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty results when q is missing (no search executed)", async () => {
+    // q が無いときはロール解決も検索 SQL も走らせない（安価なガード）。
+    // Cheap guard: skip role resolution and the search SQL when q is absent.
+    const { app, chains } = createTestApp([]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/search`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: unknown[] };
+    expect(body.results).toEqual([]);
+    // 空クエリでは DB を一切叩かない。
+    // No DB hits at all for an empty query.
+    expect(chains).toHaveLength(0);
+  });
+
+  it("returns 404 when the note does not exist", async () => {
+    const { app } = createTestApp([
+      [], // findActiveNoteById → empty
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/search?q=hello`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when caller has no role on a private note", async () => {
+    // 非公開ノート + メンバーでもドメイン一致でもない → `role = null` で 403。
+    // Private note, no member / domain match → `role = null`, hence 403.
+    const privateNote = createMockNote({ ownerId: OTHER_USER_ID, visibility: "private" });
+    const { app, chains } = createTestApp([
+      [privateNote], // findActiveNoteById
+      [], // member check
+      [], // domain access
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/search?q=hello`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(403);
+    // 403 では検索 SQL を実行してはならない（情報漏洩防止）。
+    // The search SQL must not run on a 403 (avoid side-channel leaks).
+    expect(chains.some((c) => c.startMethod === "execute")).toBe(false);
+  });
+
+  it("restricts SQL to pages joined via note_pages for this noteId", async () => {
+    // ノートスコープ: `note_pages.note_id = :noteId` の inner join で絞り込み、
+    // 他ノートや個人 /home のページが混ざらないことを SQL レベルで担保する。
+    // Scope guard at the SQL layer: inner join through `note_pages` with
+    // `note_id = :noteId` so pages from other notes (or personal /home) cannot
+    // leak into the results.
+    const mockNote = createMockNote();
+    const { app, chains } = createTestApp([
+      [mockNote], // getNoteRole → owner
+      { rows: [] }, // execute search
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/search?q=hello`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    expect(executeChain).toBeDefined();
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).toContain("note_pages");
+    expect(serialised).toContain("np.note_id");
+    // SELECT 句に p.note_id を含め、呼び出し側がネイティブ / リンク済み個人ページを
+    // 見分けられるようにする (Phase 5 契約)。
+    // Expose `p.note_id` so callers can tell note-native vs linked personal.
+    expect(serialised).toContain("p.note_id");
+    // ILIKE による全文検索パターンが使われていること。
+    // ILIKE search uses the escaped pattern.
+    expect(serialised).toContain("ILIKE");
+  });
+
+  it("allows search for a viewer member of a private note", async () => {
+    // メンバーシップが解決できれば private ノートでも検索可能。
+    // Any resolved member role allows searching, even on a private note.
+    const privateNote = createMockNote({ ownerId: OTHER_USER_ID, visibility: "private" });
+    const { app, chains } = createTestApp([
+      [privateNote], // findActiveNoteById
+      [{ role: "viewer" }], // member check matches
+      { rows: [] }, // execute search
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/search?q=hello`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: unknown[] };
+    expect(body.results).toEqual([]);
+    expect(chains.some((c) => c.startMethod === "execute")).toBe(true);
+  });
+
+  it("allows guest search on a public note", async () => {
+    // 公開ノートは `guest` ロールとして解決されるため、認証済みの非メンバーでも
+    // 検索できる（閲覧できる以上、検索も許可する）。
+    // Public notes resolve the caller to `guest`; since they can already read,
+    // they are allowed to search. Mirrors `GET /:noteId/pages` semantics.
+    const publicNote = createMockNote({ ownerId: OTHER_USER_ID, visibility: "public" });
+    const { app } = createTestApp([
+      [publicNote], // findActiveNoteById
+      [], // member check
+      [], // domain access → empty, falls through to visibility=public → guest
+      { rows: [] }, // execute search
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/search?q=hello`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("response rows carry note_id so callers can verify scope", async () => {
+    // ノートスコープ検索でも `note_id` を露出させる (Phase 5 契約)。リンクされた
+    // 個人ページ（`note_id IS NULL`）と、このノートのネイティブページ（`note_id`
+    // = :noteId）を UI 側で見分けるための判定材料。
+    //
+    // Expose `note_id` on every row even for the note-scoped endpoint, so UI and
+    // MCP callers can still tell a linked personal page (`note_id: null`) apart
+    // from a note-native page (`note_id: NOTE_ID`). This matches the Phase 5
+    // scope contract shared with `/api/search`.
+    const mockNote = createMockNote();
+    const { app } = createTestApp([
+      [mockNote], // getNoteRole → owner
+      {
+        rows: [
+          {
+            id: "page-native",
+            title: "Native Page",
+            content_preview: null,
+            updated_at: new Date("2026-04-01T00:00:00Z").toISOString(),
+            note_id: NOTE_ID,
+          },
+          {
+            id: "page-linked-personal",
+            title: "Linked Personal",
+            content_preview: null,
+            updated_at: new Date("2026-04-01T00:00:00Z").toISOString(),
+            note_id: null,
+          },
+        ],
+      },
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/search?q=hello`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: Array<Record<string, unknown>> };
+    expect(body.results).toHaveLength(2);
+    expect(body.results[0]).toHaveProperty("note_id", NOTE_ID);
+    expect(body.results[1]).toHaveProperty("note_id", null);
+  });
+
+  it("honors limit query parameter (clamped between 1 and 100)", async () => {
+    const mockNote = createMockNote();
+    const { app, chains } = createTestApp([
+      [mockNote], // getNoteRole → owner
+      { rows: [] }, // execute search
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/search?q=hello&limit=500`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    // 500 を渡しても最大 100 にクランプされる。
+    // Request for 500 is clamped to the 100 upper bound.
+    expect(serialised).toContain("100");
+    expect(serialised).not.toContain("500");
+  });
+
+  it("passes noteId into the WHERE clause so the scope cannot be bypassed", async () => {
+    // URL に入ってきた noteId が SQL パラメータとして渡され、別ノートの
+    // ページが混ざるような自由なクエリビルドになっていないことを確認する。
+    // Confirm the URL `noteId` flows into the SQL parameters so the scope
+    // cannot be flipped via query rewriting.
+    const mockNote = createMockNote({ id: NOTE_ID });
+    const { app, chains } = createTestApp([
+      [mockNote], // getNoteRole → owner
+      { rows: [] }, // execute search
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/search?q=hello`, {
+      method: "GET",
+      headers: authHeaders(TEST_USER_ID),
+    });
+
+    expect(res.status).toBe(200);
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).toContain(NOTE_ID);
+  });
+});

--- a/server/api/src/__tests__/routes/notes/search.test.ts
+++ b/server/api/src/__tests__/routes/notes/search.test.ts
@@ -271,18 +271,22 @@ describe("GET /api/notes/:noteId/search", () => {
   });
 
   it("truncates fractional limits to an integer before clamping", async () => {
-    // 小数（`?limit=1.5`）がバインドされると Postgres の LIMIT は整数必須で
+    // 小数（`?limit=99.7`）がバインドされると Postgres の LIMIT は整数必須で
     // クエリが落ちる可能性がある。`Math.trunc` で整数化してから範囲に収める。
+    // 既定値 20 への安易なフォールバックにすり替わっても検出できるよう、
+    // 結果側に truncate 後の値 (99) が確かに出ていることまで検証する。
     //
     // Postgres `LIMIT` requires an integer, so a fractional value could error
     // out at the DB layer. Truncate before clamping to keep it a safe integer.
+    // Positively assert the truncated value (99) lands in the query so a
+    // silent fallback to the default 20 would be caught.
     const mockNote = createMockNote();
     const { app, chains } = createTestApp([
       [mockNote], // getNoteRole → owner
       { rows: [] }, // execute search
     ]);
 
-    const res = await app.request(`/api/notes/${NOTE_ID}/search?q=hello&limit=1.9`, {
+    const res = await app.request(`/api/notes/${NOTE_ID}/search?q=hello&limit=99.7`, {
       method: "GET",
       headers: authHeaders(),
     });
@@ -290,7 +294,13 @@ describe("GET /api/notes/:noteId/search", () => {
     expect(res.status).toBe(200);
     const executeChain = chains.find((chain) => chain.startMethod === "execute");
     const serialised = JSON.stringify(executeChain?.startArgs);
-    expect(serialised).not.toContain("1.9");
+    // 小数部は破棄され、整数の 99 が LIMIT に渡る。
+    // Fractional part is dropped; integer 99 lands in LIMIT.
+    expect(serialised).toContain("99");
+    expect(serialised).not.toContain("99.7");
+    // 既定値 20 へのフォールバックになっていないことも併せて確認する。
+    // Also assert no silent fallback to the default 20.
+    expect(serialised).not.toContain("20");
   });
 
   it("passes noteId into the WHERE clause so the scope cannot be bypassed", async () => {

--- a/server/api/src/__tests__/routes/notes/search.test.ts
+++ b/server/api/src/__tests__/routes/notes/search.test.ts
@@ -244,6 +244,55 @@ describe("GET /api/notes/:noteId/search", () => {
     expect(serialised).not.toContain("500");
   });
 
+  it("falls back to the default limit when the value is non-numeric", async () => {
+    // `?limit=abc` → `Number("abc") = NaN` を素通しすると `LIMIT NaN` で
+    // SQL が 500 になる。非数値は黙って既定値 20 に落として、クエリが壊れた
+    // クライアントでもエラーにならないようにする。
+    //
+    // `?limit=abc` would previously flow through as `NaN`, breaking the SQL
+    // with `LIMIT NaN` and 500-ing the request. Non-numeric input must fall
+    // back to the default 20 so a malformed client query stays safe.
+    const mockNote = createMockNote();
+    const { app, chains } = createTestApp([
+      [mockNote], // getNoteRole → owner
+      { rows: [] }, // execute search
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/search?q=hello&limit=abc`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).not.toContain("NaN");
+    expect(serialised).toContain("20");
+  });
+
+  it("truncates fractional limits to an integer before clamping", async () => {
+    // 小数（`?limit=1.5`）がバインドされると Postgres の LIMIT は整数必須で
+    // クエリが落ちる可能性がある。`Math.trunc` で整数化してから範囲に収める。
+    //
+    // Postgres `LIMIT` requires an integer, so a fractional value could error
+    // out at the DB layer. Truncate before clamping to keep it a safe integer.
+    const mockNote = createMockNote();
+    const { app, chains } = createTestApp([
+      [mockNote], // getNoteRole → owner
+      { rows: [] }, // execute search
+    ]);
+
+    const res = await app.request(`/api/notes/${NOTE_ID}/search?q=hello&limit=1.9`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).not.toContain("1.9");
+  });
+
   it("passes noteId into the WHERE clause so the scope cannot be bypassed", async () => {
     // URL に入ってきた noteId が SQL パラメータとして渡され、別ノートの
     // ページが混ざるような自由なクエリビルドになっていないことを確認する。

--- a/server/api/src/routes/notes/index.ts
+++ b/server/api/src/routes/notes/index.ts
@@ -8,6 +8,7 @@ import pageRoutes from "./pages.js";
 import memberRoutes from "./members.js";
 import inviteLinkRoutes from "./inviteLinks.js";
 import domainAccessRoutes from "./domainAccess.js";
+import searchRoutes from "./search.js";
 
 const app = new Hono<AppEnv>();
 
@@ -16,5 +17,6 @@ app.route("/", pageRoutes);
 app.route("/", memberRoutes);
 app.route("/", inviteLinkRoutes);
 app.route("/", domainAccessRoutes);
+app.route("/", searchRoutes);
 
 export default app;

--- a/server/api/src/routes/notes/search.ts
+++ b/server/api/src/routes/notes/search.ts
@@ -1,0 +1,99 @@
+/**
+ * /api/notes/:noteId/search — ノートスコープ全文検索 (Issue #718 Phase 5-2)
+ *
+ * GET /:noteId/search?q=&limit= — 指定ノート内のページに限定した ILIKE 検索。
+ *
+ * スコープ契約 (Issue #713 / #718):
+ * - 結果は `note_pages` で当該ノートにひも付くページのみ。ノートネイティブ
+ *   (`pages.note_id = :noteId`) もリンク済み個人ページ (`note_pages` で結ばれた
+ *   `note_id IS NULL` の個人ページ) も両方含む。`p.note_id` を必ず返すので
+ *   呼び出し側は両者を区別できる。
+ * - 閲覧権限は `getNoteRole` で解決し、任意のロール（owner / editor / viewer /
+ *   guest）が解決できれば検索を許可する。private ノートの非メンバーは 403。
+ * - クロススコープ検索（他ノート・個人 /home を横断）はこのエンドポイントでは
+ *   扱わない（混在グローバル検索は従来どおり `/api/search?scope=shared`）。
+ *
+ * Scope contract (Issue #713 / #718):
+ * - Results are restricted to pages linked to this note via `note_pages` —
+ *   both note-native pages (`pages.note_id = :noteId`) and linked personal
+ *   pages show up through that table, since every "add to note" path writes a
+ *   `note_pages` row. `p.note_id` is always included so callers can tell the
+ *   two apart.
+ * - Read permission is resolved through `getNoteRole`; any resolved role
+ *   (owner / editor / viewer / guest) allows searching. Non-members of a
+ *   private note get 403.
+ * - Cross-scope lookups (spanning other notes or personal /home) are out of
+ *   scope here; mixed global search still lives at `/api/search?scope=shared`.
+ */
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { sql } from "drizzle-orm";
+import { authRequired } from "../../middleware/auth.js";
+import type { AppEnv } from "../../types/index.js";
+import { getNoteRole } from "./helpers.js";
+
+/**
+ * ILIKE に渡すユーザー入力のメタ文字をエスケープする。
+ * Escapes ILIKE meta characters in user-supplied search text.
+ */
+function escapeLike(input: string): string {
+  return input.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
+const app = new Hono<AppEnv>();
+
+app.get("/:noteId/search", authRequired, async (c) => {
+  const noteId = c.req.param("noteId");
+  const userId = c.get("userId");
+  const userEmail = c.get("userEmail");
+  const db = c.get("db");
+
+  const query = c.req.query("q")?.trim();
+  // クエリが空なら DB を一切叩かずに即レスポンス。ノートの存在確認より前に
+  // 短絡するのは `/api/search` と同じ挙動で、フォーカスのたびに撃たれる検索が
+  // 無駄な権限解決で詰まらないようにするため。
+  // Short-circuit before any DB work when q is empty, mirroring /api/search.
+  // Autocomplete-style UI hits this on every keystroke, so skipping even role
+  // resolution keeps the cost at zero.
+  if (!query) {
+    return c.json({ results: [] });
+  }
+
+  const { role, note } = await getNoteRole(noteId, userId, userEmail, db);
+  if (!note) throw new HTTPException(404, { message: "Note not found" });
+  if (!role) throw new HTTPException(403, { message: "Forbidden" });
+
+  const limit = Math.min(Math.max(Number(c.req.query("limit") || 20), 1), 100);
+  const pattern = `%${escapeLike(query)}%`;
+
+  // `note_pages` に書かれている = このノートで表示対象のページ。ノートネイティブ
+  // ページも、リンクされた個人ページも同じ経路で現れるので inner join で十分。
+  // 返り値に `p.note_id` を含めて、呼び出し側が両者を判別できるようにする
+  // （Phase 5 契約）。
+  //
+  // `note_pages` is the authoritative list of pages visible in a note, covering
+  // both note-native pages and linked personal pages. An inner join is enough;
+  // `p.note_id` is included so callers can still distinguish scope per row
+  // (Phase 5 contract).
+  const results = await db.execute(sql`
+    SELECT p.id, p.title, p.content_preview, p.updated_at, p.note_id,
+           pc.content_text
+    FROM pages p
+    INNER JOIN note_pages np
+      ON np.page_id = p.id
+     AND np.note_id = ${noteId}
+     AND np.is_deleted = false
+    LEFT JOIN page_contents pc ON pc.page_id = p.id
+    WHERE p.is_deleted = false
+      AND (
+        p.title ILIKE ${pattern}
+        OR pc.content_text ILIKE ${pattern}
+      )
+    ORDER BY p.updated_at DESC
+    LIMIT ${limit}
+  `);
+
+  return c.json({ results: results.rows });
+});
+
+export default app;

--- a/server/api/src/routes/notes/search.ts
+++ b/server/api/src/routes/notes/search.ts
@@ -40,6 +40,22 @@ function escapeLike(input: string): string {
   return input.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
 
+/**
+ * クエリ文字列の `limit` を有限の整数に正規化し、1〜100 の範囲へクランプする。
+ * 非数値（`?limit=abc`）や `NaN` / 小数は既定値 20 にフォールバックさせて
+ * `LIMIT NaN` による SQL エラーを防ぐ。
+ *
+ * Normalizes the `limit` query param to a finite integer clamped to 1..100.
+ * Non-numeric inputs (`?limit=abc`) and non-finite / fractional values fall
+ * back to the default 20 so a malformed query can't emit `LIMIT NaN` and 500
+ * the request.
+ */
+function clampLimit(raw: string | undefined): number {
+  const parsed = raw === undefined ? 20 : Number(raw);
+  const safe = Number.isFinite(parsed) ? Math.trunc(parsed) : 20;
+  return Math.min(Math.max(safe, 1), 100);
+}
+
 const app = new Hono<AppEnv>();
 
 app.get("/:noteId/search", authRequired, async (c) => {
@@ -63,7 +79,7 @@ app.get("/:noteId/search", authRequired, async (c) => {
   if (!note) throw new HTTPException(404, { message: "Note not found" });
   if (!role) throw new HTTPException(403, { message: "Forbidden" });
 
-  const limit = Math.min(Math.max(Number(c.req.query("limit") || 20), 1), 100);
+  const limit = clampLimit(c.req.query("limit"));
   const pattern = `%${escapeLike(query)}%`;
 
   // `note_pages` に書かれている = このノートで表示対象のページ。ノートネイティブ


### PR DESCRIPTION
## 概要

ノート内に限定した全文検索エンドポイント `GET /api/notes/:noteId/search` を追加します。このエンドポイントは、指定されたノートに属するページのみを検索対象とし、権限解決は既存の `getNoteRole` を再利用します。Phase 5-2 の実装により、エージェントと UI が「このノート内だけを検索する」という明確なスコープを持つ検索を実行できるようになります。

## 変更点

- **新規ファイル: `server/api/src/routes/notes/search.ts`**
  - `GET /:noteId/search?q=&limit=` エンドポイントを実装
  - `note_pages` テーブルを使用してスコープを SQL レベルで強制
  - ノートネイティブページとリンク済み個人ページの両方に対応
  - `p.note_id` を結果に含めて、呼び出し側が両者を区別可能に
  - ILIKE による全文検索（タイトルと本文内容）
  - `limit` パラメータは 1～100 の範囲にクランプ

- **新規ファイル: `server/api/src/__tests__/routes/notes/search.test.ts`**
  - 認証なしでのアクセス拒否（401）
  - クエリ空時の最適化（DB アクセスなし）
  - ノート不在時の 404 応答
  - 権限なしの private ノートへの 403 応答
  - メンバーシップによる private ノート検索許可
  - 公開ノートへのゲストアクセス許可
  - SQL スコープ検証（`note_pages` inner join）
  - `note_id` フィールドの露出確認
  - `limit` パラメータのクランプ動作
  - URL パラメータの SQL インジェクション対策確認

- **修正: `server/api/src/routes/notes/index.ts`**
  - 新しい `search.ts` ルートをインポートして登録

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm test -- search.test.ts` で新規テストスイートを実行
2. すべてのテストケース（11 個）がパスすることを確認
3. 既存の `/api/search` テストが引き続きパスすることを確認

## チェックリスト

- [x] テストがすべてパスする（11 個の新規テストケース）
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #718 (Phase 5-2)

https://claude.ai/code/session_0141JNd7VW3a1vQ8g1E31QYR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Note-scoped search endpoint to search titles and page content within a specific note; results include note_id to distinguish native vs linked pages.
  * Returns empty results for blank queries without executing a search; enforces auth and note permissions (401/403/404).
  * Query limit normalized (default 20, fractional truncated, max 100).

* **Tests**
  * Added test suite validating auth, permission handling, scoping, limit behavior, and result payload. 

* **Chores**
  * Mounted the new search routes into the notes routing surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->