### PR TITLE
fix: address PR #719 review comments

### DIFF
--- a/server/api/src/__tests__/routes/pages.test.ts
+++ b/server/api/src/__tests__/routes/pages.test.ts
@@ -158,7 +158,7 @@ describe("GET /api/pages", () => {
     expect(body.pages[0]).toMatchObject({ id: "page-shared" });
   });
 
-  it("scope=shared predicate also includes note-native pages owned by the caller via notes.owner_id", async () => {
+  it("scope=shared predicate includes note-owner access through note_pages for linked personal pages too", async () => {
     const { app, chains } = createPagesAppWithChains([{ rows: [] }]);
 
     const res = await app.request("/api/pages?scope=shared", {
@@ -167,15 +167,16 @@ describe("GET /api/pages", () => {
     });
 
     expect(res.status).toBe(200);
-    // ノートオーナーは通常 note_members 行を持たないため、shared predicate に
-    // `notes.owner_id = userId` 経路を入れて listing と getNoteRole を整合させる
-    // （Issue #713 / PR #714 レビュー対応）。SQL チャンクから直接検証する。
-    // Verify the shared predicate contains the note-owner branch so listing
-    // matches `getNoteRole` for owners who lack a `note_members` row.
+    // ノートオーナーは通常 note_members 行を持たないため、shared predicate には
+    // `note_pages -> notes.owner_id` 経路が必要。これで note-native page だけでなく
+    // linked personal page も listing と `assertPageViewAccess` で整合する。
+    // Verify the shared predicate contains the note-owner branch via note_pages,
+    // so linked personal pages remain visible to note owners too.
     const executeChain = chains.find((chain) => chain.startMethod === "execute");
     expect(executeChain).toBeDefined();
     const serialised = JSON.stringify(executeChain?.startArgs);
-    expect(serialised).toContain("p.note_id IS NOT NULL");
+    expect(serialised).toContain("note_pages");
+    expect(serialised).toContain("np.page_id = p.id");
     expect(serialised).toContain("n.owner_id");
   });
 

--- a/server/api/src/__tests__/routes/search.test.ts
+++ b/server/api/src/__tests__/routes/search.test.ts
@@ -105,9 +105,9 @@ describe("GET /api/search", () => {
     expect(serialised).toContain("p.note_id IS NULL");
   });
 
-  it("scope=shared does NOT force p.note_id IS NULL (keeps cross-scope behavior)", async () => {
-    // shared は個人 + 参加ノートの混在検索を維持する。
-    // `shared` retains existing cross-scope behavior and must not restrict to personal pages.
+  it("scope=shared keeps non-personal access branches alongside the personal ownership guard", async () => {
+    // shared は個人ページの owner 分岐を残しつつ、note_pages 経由の共有アクセスも併せ持つ。
+    // `shared` keeps the personal-owner guard but must still include note-based branches.
     const { app, chains } = createSearchApp([{ rows: [] }]);
 
     const res = await app.request("/api/search?q=hello&scope=shared", {
@@ -119,7 +119,39 @@ describe("GET /api/search", () => {
     const executeChain = chains.find((chain) => chain.startMethod === "execute");
     expect(executeChain).toBeDefined();
     const serialised = JSON.stringify(executeChain?.startArgs);
-    expect(serialised).not.toContain("p.note_id IS NULL");
+    expect(serialised).toContain("p.note_id IS NULL");
+    expect(serialised).toContain("note_pages");
+    expect(serialised).toContain("OR EXISTS");
+  });
+
+  it("falls back to the default limit when the limit query is non-numeric", async () => {
+    const { app } = createSearchApp([{ rows: [] }]);
+
+    const res = await app.request("/api/search?q=hello&scope=shared&limit=abc", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("scope=shared keeps personal ownership limited to personal pages and adds note-owner access via note_pages", async () => {
+    const { app, chains } = createSearchApp([{ rows: [] }]);
+
+    const res = await app.request("/api/search?q=hello&scope=shared", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    expect(executeChain).toBeDefined();
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).toContain("p.owner_id");
+    expect(serialised).toContain("p.note_id IS NULL");
+    expect(serialised).toContain("note_pages");
+    expect(serialised).toContain("np.page_id = p.id");
+    expect(serialised).toContain("n.owner_id");
   });
 
   it("response rows include note_id so callers can distinguish personal vs note-native", async () => {

--- a/server/api/src/__tests__/services/pageAccessService.test.ts
+++ b/server/api/src/__tests__/services/pageAccessService.test.ts
@@ -35,10 +35,21 @@ describe("assertPageViewAccess (issue #713)", () => {
       [{ id: PAGE_ID, ownerId: OTHER_USER_ID, noteId: null }], // getPageOwnership
       [{ email: USER_EMAIL }], // getUserEmailLowercase
       [], // notePages JOIN — no membership
+      [], // note_pages -> notes.owner_id fallback
     ]);
     await expect(assertPageViewAccess(asDb(db), PAGE_ID, USER_ID)).rejects.toMatchObject({
       status: 403,
     });
+  });
+
+  it("allows note owner on a linked personal page even without a note_members row", async () => {
+    const { db } = createMockDb([
+      [{ id: PAGE_ID, ownerId: OTHER_USER_ID, noteId: null }], // getPageOwnership
+      [{ email: USER_EMAIL }], // getUserEmailLowercase
+      [], // notePages JOIN — no membership
+      [{ noteId: NOTE_ID }], // note_pages -> notes.owner_id fallback
+    ]);
+    await expect(assertPageViewAccess(asDb(db), PAGE_ID, USER_ID)).resolves.toBeUndefined();
   });
 
   it("denies note-native page when caller has no role on the note", async () => {

--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -57,9 +57,10 @@ async function applyPagesMetadataUpdate(
 }
 
 // ── GET /pages ──────────────────────────────────────────────────────────────
-// `scope=shared` の場合、`/api/search` と同じ認可ロジック (own + 受諾済みノートメンバー) を流用する。
+// `scope=shared` の場合、`/api/search` と同じ認可ロジック
+// (own + 受諾済みノートメンバー + note owner) を流用する。
 // When `scope=shared`, reuses the same authorization model as `/api/search`
-// (own pages + pages attached to notes the caller is a member of).
+// (own pages + accepted note members + note owners).
 app.get("/", authRequired, async (c) => {
   const userId = c.get("userId");
   const db = c.get("db");
@@ -83,21 +84,17 @@ app.get("/", authRequired, async (c) => {
   // `own` スコープは個人ページ（`pages.note_id IS NULL`）のみを返す。
   // ノートネイティブページ（issue #713）は、ノート画面または `scope=shared`
   // 経由でのみアクセスする。`shared` 経由の場合は (a) note_members 経由の
-  // メンバーシップ、または (b) `notes.owner_id = userId` 経由のオーナーシップで
-  // 含まれる。オーナー経路を明示しておかないと、ノートオーナーは通常 note_members
-  // 行を持たないため、自分が作った note-native page が listing から消える
-  // （閲覧は assertPageViewAccess / getNoteRole 経由で可能だが listing で見えなく
-  // なる）という非対称が起きる。`getNoteRole` の解決順 (owner → member → ...) と
-  // listing predicate を揃える。
+  // メンバーシップ、または (b) `note_pages -> notes.owner_id = userId` 経由の
+  // オーナーシップで含まれる。オーナー経路を note-native page だけに限定すると、
+  // linked personal page が listing から消えて `assertPageViewAccess` と非対称になる。
+  // `getNoteRole` の解決順 (owner → member → ...) と listing predicate を揃える。
   //
   // The `own` scope returns personal pages only (`pages.note_id IS NULL`).
   // Note-native pages (issue #713) are accessed via the note view or
   // `scope=shared`. `shared` includes them either through (a) `note_members`
-  // membership or (b) `notes.owner_id = userId` ownership. The owner branch is
-  // mandatory because note owners typically have no `note_members` row, so
-  // omitting it would let owners view their note-native pages via
-  // `assertPageViewAccess` / `getNoteRole` while hiding them from the listing
-  // — keep the predicate aligned with `getNoteRole`'s resolution order.
+  // membership or (b) note ownership reached through `note_pages`. That owner
+  // branch must cover linked personal pages too; otherwise owners could open
+  // them via `assertPageViewAccess` while the listing hides them.
   const accessFilter =
     scope === "shared"
       ? sql`(
@@ -114,14 +111,13 @@ app.get("/", authRequired, async (c) => {
               AND np.is_deleted = false
               AND n.is_deleted = false
           )
-          OR (
-            p.note_id IS NOT NULL
-            AND EXISTS (
-              SELECT 1 FROM notes n
-              WHERE n.id = p.note_id
-                AND n.owner_id = ${userId}
-                AND n.is_deleted = false
-            )
+          OR EXISTS (
+            SELECT 1 FROM note_pages np
+            JOIN notes n ON n.id = np.note_id
+            WHERE np.page_id = p.id
+              AND np.is_deleted = false
+              AND n.owner_id = ${userId}
+              AND n.is_deleted = false
           )
         )`
       : sql`p.owner_id = ${userId} AND p.note_id IS NULL`;

--- a/server/api/src/routes/search.ts
+++ b/server/api/src/routes/search.ts
@@ -26,6 +26,12 @@ function escapeLike(input: string): string {
   return input.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
 
+function clampLimit(raw: string | undefined): number {
+  const parsed = raw === undefined ? 20 : Number(raw);
+  const safe = Number.isFinite(parsed) ? Math.trunc(parsed) : 20;
+  return Math.min(Math.max(safe, 1), 100);
+}
+
 const app = new Hono<AppEnv>();
 
 app.get("/", authRequired, async (c) => {
@@ -38,7 +44,7 @@ app.get("/", authRequired, async (c) => {
   }
 
   const scope = c.req.query("scope") || "own";
-  const limit = Math.min(Math.max(Number(c.req.query("limit") || 20), 1), 100);
+  const limit = clampLimit(c.req.query("limit"));
   const pattern = `%${escapeLike(query)}%`;
 
   // 両スコープで返す列は同一なので共有する。`p.note_id` は呼び出し側のスコープ判定用。
@@ -55,15 +61,28 @@ app.get("/", authRequired, async (c) => {
       LEFT JOIN page_contents pc ON pc.page_id = p.id
       WHERE p.is_deleted = false
         AND (
-          p.owner_id = ${userId}
-          OR p.id IN (
-            SELECT np.page_id FROM note_pages np
+          (p.owner_id = ${userId} AND p.note_id IS NULL)
+          OR EXISTS (
+            SELECT 1
+            FROM note_pages np
+            JOIN notes n ON n.id = np.note_id
             JOIN note_members nm ON nm.note_id = np.note_id
-            WHERE nm.member_email IN (
-              SELECT email FROM "user" WHERE id = ${userId}
-            )
-            AND nm.is_deleted = false
-            AND np.is_deleted = false
+            JOIN "user" u ON u.email = nm.member_email
+            WHERE np.page_id = p.id
+              AND u.id = ${userId}
+              AND nm.status = 'accepted'
+              AND nm.is_deleted = false
+              AND np.is_deleted = false
+              AND n.is_deleted = false
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM note_pages np
+            JOIN notes n ON n.id = np.note_id
+            WHERE np.page_id = p.id
+              AND np.is_deleted = false
+              AND n.owner_id = ${userId}
+              AND n.is_deleted = false
           )
         )
         AND (

--- a/server/api/src/services/pageAccessService.ts
+++ b/server/api/src/services/pageAccessService.ts
@@ -45,15 +45,16 @@ async function getUserEmailLowercase(db: Database, userId: string): Promise<stri
  * ページへの閲覧権限を確認する。
  *
  * - 個人ページ (`pages.note_id IS NULL`): 所有者本人、または当該ページが
- *   `note_pages` 経由で登録されているノートの受諾済みメンバー
+ *   `note_pages` 経由で登録されているノートの受諾済みメンバー / ノート所有者
  * - ノートネイティブページ (`pages.note_id IS NOT NULL`): そのノートに対する
  *   ロール解決（owner / member / domain / public guest）が成立すれば閲覧可。
  *   `pages.ownerId` の一致では許可しない（脱退後に閲覧権が残るのを防ぐ）
  *
  * Verify the user can view the page.
  *
- * - Personal page (`pages.note_id IS NULL`): owner of the page row, or an
- *   accepted member of any note this page is attached to via `note_pages`
+ * - Personal page (`pages.note_id IS NULL`): owner of the page row, an accepted
+ *   member of any note this page is attached to via `note_pages`, or the owner
+ *   of such a note
  * - Note-native page (`pages.note_id IS NOT NULL`): caller must resolve to a
  *   role (owner / member / domain / public guest) on that note. Owning the
  *   underlying `pages` row is intentionally NOT enough — that would let a
@@ -109,6 +110,22 @@ export async function assertPageViewAccess(
     .limit(1);
 
   if (noteMembership[0]) return;
+
+  // ノートオーナーは通常 `note_members` 行を持たないため、linked personal page でも
+  // `note_pages -> notes.owner_id` 経路で閲覧を許可する。Issue #713 / PR #719 review.
+  // Note owners usually do not have a `note_members` row. Allow linked personal
+  // pages through the `note_pages -> notes.owner_id` path too.
+  const noteOwnership = await db
+    .select({ noteId: notePages.noteId })
+    .from(notePages)
+    .innerJoin(
+      notes,
+      and(eq(notes.id, notePages.noteId), eq(notes.ownerId, userId), eq(notes.isDeleted, false)),
+    )
+    .where(and(eq(notePages.pageId, pageId), eq(notePages.isDeleted, false)))
+    .limit(1);
+
+  if (noteOwnership[0]) return;
 
   throw new HTTPException(403, { message: "Forbidden" });
 }

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -91,13 +91,17 @@ export interface PostSyncPagesResponse {
 export interface PageContentResponse {
   ydoc_state: string; // base64
   version: number;
+  content_text?: string | null;
+  updated_at?: string;
 }
 
 /** PUT /api/pages/:id/content body. */
 export interface PutPageContentBody {
   ydoc_state: string; // base64
   content_text?: string;
-  version?: number;
+  content_preview?: string;
+  title?: string;
+  expected_version?: number;
 }
 
 /** POST /api/pages body. */

--- a/src/pages/NotePageView.test.tsx
+++ b/src/pages/NotePageView.test.tsx
@@ -1,9 +1,14 @@
 import React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useParams } from "react-router-dom";
 import NotePageView from "./NotePageView";
-import { useNote, useNotePage, useCopyNotePageToPersonal } from "@/hooks/useNoteQueries";
+import {
+  useNote,
+  useNotePage,
+  useCopyNotePageToPersonal,
+  useNoteApi,
+} from "@/hooks/useNoteQueries";
 import { useAuth } from "@/hooks/useAuth";
 import { AIChatProvider } from "@/contexts/AIChatContext";
 
@@ -15,8 +20,13 @@ import { AIChatProvider } from "@/contexts/AIChatContext";
 // can see them. Required because `vi.mock` hoists above normal `const`s. The
 // shared `mockToast` lets tests inspect what `toast({...})` was called with
 // — in particular whether the `action` (toast CTA) was supplied.
-const { mockToast } = vi.hoisted(() => ({
+const { mockToast, mockUpdatePageMutateAsync, mockApi } = vi.hoisted(() => ({
   mockToast: vi.fn(),
+  mockUpdatePageMutateAsync: vi.fn().mockResolvedValue({ skipped: false }),
+  mockApi: {
+    getPageContent: vi.fn(),
+    putPageContent: vi.fn(),
+  },
 }));
 
 vi.mock("react-router-dom", async (importOriginal) => {
@@ -42,6 +52,13 @@ vi.mock("react-i18next", () => ({
 vi.mock("@/hooks/useNoteQueries", () => ({
   useNote: vi.fn(),
   useNotePage: vi.fn(),
+  useNoteApi: vi.fn(() => ({
+    api: mockApi,
+    userId: "user-1",
+    userEmail: undefined,
+    isSignedIn: true,
+    isLoaded: true,
+  })),
   useCopyNotePageToPersonal: vi.fn(() => ({
     mutateAsync: vi
       .fn()
@@ -55,7 +72,7 @@ vi.mock("@/hooks/useNoteQueries", () => ({
 }));
 
 vi.mock("@/hooks/usePageQueries", () => ({
-  useUpdatePage: vi.fn(() => ({ mutateAsync: vi.fn().mockResolvedValue({ skipped: false }) })),
+  useUpdatePage: vi.fn(() => ({ mutateAsync: mockUpdatePageMutateAsync })),
 }));
 
 vi.mock("@tanstack/react-query", async (importOriginal) => {
@@ -85,7 +102,20 @@ vi.mock("@/components/layout/Container", () => ({
 }));
 
 vi.mock("@/components/editor/PageEditor/PageEditorContent", () => ({
-  PageEditorContent: () => <div data-testid="page-editor">PageEditorContent</div>,
+  PageEditorContent: ({
+    title,
+    onTitleChange,
+  }: {
+    title: string;
+    onTitleChange?: (title: string) => void;
+  }) => (
+    <div data-testid="page-editor">
+      <div data-testid="page-title">{title}</div>
+      <button type="button" onClick={() => onTitleChange?.("Edited title")}>
+        change-title
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("@/components/ai-chat/ContentWithAIChat", () => ({
@@ -139,8 +169,23 @@ describe("NotePageView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockToast.mockReset();
+    mockUpdatePageMutateAsync.mockResolvedValue({ skipped: false });
+    mockApi.getPageContent.mockReset();
+    mockApi.putPageContent.mockReset();
     vi.mocked(useParams).mockReturnValue({ noteId: "note-1", pageId: "page-1" });
     vi.mocked(useAuth).mockReturnValue({ isSignedIn: true, userId: "user-1" } as never);
+    vi.mocked(useNoteApi).mockReturnValue({
+      api: mockApi,
+      userId: "user-1",
+      userEmail: undefined,
+      isSignedIn: true,
+      isLoaded: true,
+    } as never);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("shows loading state when note or page is loading", () => {
@@ -198,6 +243,114 @@ describe("NotePageView", () => {
 
     expect(screen.getByTestId("content-with-ai-chat")).toBeInTheDocument();
     expect(screen.getByTestId("page-editor")).toBeInTheDocument();
+  });
+
+  it("saves note-native page titles through the page-content API for note editors", async () => {
+    vi.mocked(useNote).mockReturnValue({
+      note: { id: "note-1" },
+      access: { canView: true, canEdit: true },
+      source: "local",
+      isLoading: false,
+    } as never);
+    vi.mocked(useNotePage).mockReturnValue({
+      data: {
+        id: "page-1",
+        title: "Original title",
+        content: "{}",
+        ownerUserId: "user-other",
+        noteId: "note-1",
+      },
+      isLoading: false,
+    } as never);
+    mockApi.getPageContent.mockResolvedValue({
+      ydoc_state: "AQ==",
+      version: 3,
+      content_text: "body",
+    });
+    mockApi.putPageContent.mockResolvedValue({ version: 4 });
+
+    renderNotePageView();
+    fireEvent.click(screen.getByText("change-title"));
+    await vi.advanceTimersByTimeAsync(500);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockApi.putPageContent).toHaveBeenCalledTimes(1);
+    expect(mockApi.putPageContent).toHaveBeenCalledWith("page-1", {
+      ydoc_state: "AQ==",
+      content_text: "body",
+      expected_version: 3,
+      title: "Edited title",
+    });
+    expect(mockUpdatePageMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the visible title when a note-native title save fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(useNote).mockReturnValue({
+      note: { id: "note-1" },
+      access: { canView: true, canEdit: true },
+      source: "local",
+      isLoading: false,
+    } as never);
+    vi.mocked(useNotePage).mockReturnValue({
+      data: {
+        id: "page-1",
+        title: "Original title",
+        content: "{}",
+        ownerUserId: "user-other",
+        noteId: "note-1",
+      },
+      isLoading: false,
+    } as never);
+    mockApi.getPageContent.mockResolvedValue({
+      ydoc_state: "AQ==",
+      version: 3,
+      content_text: "body",
+    });
+    mockApi.putPageContent.mockRejectedValue(new Error("save failed"));
+
+    renderNotePageView();
+    fireEvent.click(screen.getByText("change-title"));
+    expect(screen.getByTestId("page-title")).toHaveTextContent("Edited title");
+
+    await vi.advanceTimersByTimeAsync(500);
+    vi.useRealTimers();
+    await waitFor(() => {
+      expect(screen.getByTestId("page-title")).toHaveTextContent("Original title");
+    });
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "タイトルの保存に失敗しました", variant: "destructive" }),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("keeps linked personal page titles read-only for non-owners", async () => {
+    vi.mocked(useNote).mockReturnValue({
+      note: { id: "note-1" },
+      access: { canView: true, canEdit: true },
+      source: "local",
+      isLoading: false,
+    } as never);
+    vi.mocked(useNotePage).mockReturnValue({
+      data: {
+        id: "page-1",
+        title: "Original title",
+        content: "{}",
+        ownerUserId: "user-other",
+        noteId: null,
+      },
+      isLoading: false,
+    } as never);
+
+    renderNotePageView();
+    fireEvent.click(screen.getByText("change-title"));
+    vi.advanceTimersByTime(500);
+    await Promise.resolve();
+
+    expect(screen.getByTestId("page-title")).toHaveTextContent("Original title");
+    expect(mockApi.putPageContent).not.toHaveBeenCalled();
+    expect(mockUpdatePageMutateAsync).not.toHaveBeenCalled();
   });
 
   it("shows copy-to-personal action for note-native pages (issue #713 Phase 3)", () => {

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -14,7 +14,13 @@ import {
   useToast,
 } from "@zedi/ui";
 import { useTranslation } from "react-i18next";
-import { useNote, useNotePage, noteKeys, useCopyNotePageToPersonal } from "@/hooks/useNoteQueries";
+import {
+  useNote,
+  useNotePage,
+  noteKeys,
+  useCopyNotePageToPersonal,
+  useNoteApi,
+} from "@/hooks/useNoteQueries";
 import { useUpdatePage } from "@/hooks/usePageQueries";
 import { useAuth } from "@/hooks/useAuth";
 import { useCollaboration } from "@/hooks/useCollaboration";
@@ -39,12 +45,11 @@ function canEditPage(
 }
 
 /**
- * タイトル更新 API (`PUT /api/pages/:id/content` 経由) はページ所有者しか
- * 成功しない。ノート編集権限があってもページ所有者でなければタイトル欄は
- * 閲覧専用として表示し、サイレントフェイルを避ける。
- * The title-update path (`PUT /api/pages/:id/content`) only succeeds for the
- * page owner. Even with note-level edit rights, non-owners get a read-only
- * title rendering so we do not silently drop their keystrokes.
+ * リンク済み個人ページ (`noteId === null`) のタイトル更新はページ所有者だけに許す。
+ * ノートネイティブページ (`noteId !== null`) はノート権限 (`canEdit`) 側で別判定する。
+ * For linked personal pages (`noteId === null`), only the page owner may edit
+ * the title. Note-native pages (`noteId !== null`) are gated separately by
+ * note-level edit permission.
  */
 function canEditTitle(
   userId: string | undefined,
@@ -73,6 +78,7 @@ function NotePageEditorEditable({
 }): React.JSX.Element {
   const [editorContent, setEditorContent] = useState(page.content ?? "");
   const [title, setTitle] = useState(page.title);
+  const { api } = useNoteApi();
   const { setPageContext, contentAppendHandlerRef, insertAtCursorRef } = useAIChatContext();
   const noteWorkspace = useNoteWorkspaceOptional();
   const workspaceRoot = noteWorkspace?.workspaceRoot ?? null;
@@ -83,6 +89,7 @@ function NotePageEditorEditable({
   const titleSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingTitleRef = useRef<string | null>(null);
   const isSavingTitleRef = useRef(false);
+  const lastSavedTitleRef = useRef(page.title);
 
   useEffect(() => {
     setPageContext({
@@ -134,11 +141,23 @@ function NotePageEditorEditable({
   // flush effect's cleanup to fire mid-typing and flush the debounce early.
   const persistTitleRef = useRef<(nextTitle: string) => Promise<void>>(async () => {});
   persistTitleRef.current = async (nextTitle: string) => {
+    const previousTitle = lastSavedTitleRef.current;
     try {
-      await updatePageMutation.mutateAsync({
-        pageId: page.id,
-        updates: { title: nextTitle },
-      });
+      if (page.noteId !== null) {
+        const current = await api.getPageContent(page.id);
+        await api.putPageContent(page.id, {
+          ydoc_state: current.ydoc_state,
+          content_text: current.content_text ?? undefined,
+          expected_version: current.version,
+          title: nextTitle,
+        });
+      } else {
+        await updatePageMutation.mutateAsync({
+          pageId: page.id,
+          updates: { title: nextTitle },
+        });
+      }
+      lastSavedTitleRef.current = nextTitle;
       // `useUpdatePage` updates `pageKeys.*` caches, but the note page list and
       // detail are held under `noteKeys.*`. Invalidate those so the new title
       // propagates to the note view and sidebar.
@@ -148,6 +167,9 @@ function NotePageEditorEditable({
       queryClient.invalidateQueries({ queryKey: noteKeys.page(noteId, page.id) });
       queryClient.invalidateQueries({ queryKey: noteKeys.pageList(noteId) });
     } catch (error) {
+      if (pendingTitleRef.current === null) {
+        setTitle(previousTitle);
+      }
       console.error("Failed to save page title:", error);
       toast({
         title: "タイトルの保存に失敗しました",
@@ -272,7 +294,7 @@ const NotePageView: React.FC = () => {
   }, [navigate, noteId]);
 
   const canEdit = canEditPage(access, userId, page);
-  const isTitleEditable = canEdit && canEditTitle(userId, page);
+  const isTitleEditable = canEdit && (page?.noteId != null || canEditTitle(userId, page));
   const collaborationPageId = page?.id ?? "";
   const isCollaborationEnabled = Boolean(collaborationPageId && isSignedIn && canEdit);
   const collaboration = useCollaboration({


### PR DESCRIPTION
## 概要

PR #719 のレビューコメント対応を follow-up PR として切り出しました。
ノート内ページのタイトル編集権限と保存経路をサーバー側の認可モデルに揃え、shared scope の閲覧・検索条件も note owner を含む形へ補正しています。

## 変更点

- `src/`
  - `NotePageView` で note-native page のタイトル編集を note の `canEdit` に合わせて許可
  - note-native page のタイトル保存を IndexedDB 経由から `GET/PUT /api/pages/:id/content` へ切り替え
  - タイトル保存失敗時に、保留中の newer edit が無い場合は保存済みタイトルへロールバック
  - 関連する UI テストと API 型定義を更新
- `server/api/`
  - `assertPageViewAccess` に、`note_members` 行を持たない note owner 向けの linked personal page 閲覧フォールバックを追加
  - `/api/pages?scope=shared` と `/api/search?scope=shared` の predicate を同じ access model に揃え、note ownership を `note_pages` 経由で判定
  - `/api/search` の `limit` を finite integer に正規化して 1..100 に clamp
- `server/api` tests
  - `pageAccessService` / `pages` / `search` / `NotePageView` の回帰テストを追加・更新

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. note-native page で、ページ作成者ではない note editor としてタイトルを変更し、再読込後も変更が保持されることを確認する
2. linked personal page を持つ note の owner としてページを開き、一覧表示と shared search からも到達できることを確認する
3. `/api/search?scope=shared&limit=abc` を呼び、500 ではなく正常応答になることを確認する
4. 自動チェック: `bun run lint`
5. 自動チェック: `bun run test:run`

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている
- [x] `bun run format:check` を実行した（既存の repo-wide な整形崩れ 354 files により fail。今回差分起因ではないことを確認済み）

## スクリーンショット（UI 変更がある場合）

- なし（挙動修正のみ）

## 関連 Issue

- Related to #719

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Note owners can now access and view personal pages linked to their notes.
  * Title editing functionality is now available for note-native pages.

* **Improvements**
  * Search query limit parameter now handles invalid values gracefully with sensible defaults.
  * Enhanced page visibility control for shared notes.

* **API Updates**
  * Page content responses now include updated timestamp and content preview metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->