### PR TITLE
fix: address PR #719 review comments

### DIFF
--- a/server/api/src/__tests__/routes/pages.test.ts
+++ b/server/api/src/__tests__/routes/pages.test.ts
@@ -214,6 +214,26 @@ describe("GET /api/pages", () => {
     expect(res.status).toBe(200);
   });
 
+  it("selects p.note_id so callers can distinguish personal vs note-native pages in mixed listings", async () => {
+    const { app, chains } = createPagesAppWithChains([{ rows: [] }]);
+
+    const res = await app.request("/api/pages?scope=shared", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    // `scope=shared` は note-native ページも返すため、`zedi_list_pages` MCP ツールや
+    // クライアントは行ごとに `note_id` を見て個人 / ノートネイティブを判別する。
+    // SELECT に `p.note_id` が残っていることを保証する（PR #727 / #719 リグレッション）。
+    // The mixed `scope=shared` listing must surface `note_id` so callers (e.g. the
+    // `zedi_list_pages` MCP tool) can bucket personal vs note-native rows.
+    const executeChain = chains.find((chain) => chain.startMethod === "execute");
+    expect(executeChain).toBeDefined();
+    const serialised = JSON.stringify(executeChain?.startArgs);
+    expect(serialised).toContain("p.note_id");
+  });
+
   it("filters out internal special pages (special_kind, is_schema) by default", async () => {
     const { app, chains } = createPagesAppWithChains([{ rows: [] }]);
 

--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -134,8 +134,13 @@ app.get("/", authRequired, async (c) => {
     ? sql`TRUE`
     : sql`p.special_kind IS NULL AND p.is_schema = false`;
 
+  // `note_id` を返すことで、`scope=shared` で混在 listing を受け取った
+  // クライアントが個人ページ（`note_id IS NULL`）とノートネイティブページを
+  // 区別できる。MCP の `zedi_list_pages` ツールはこれに依存している。
+  // Surface `note_id` so callers receiving mixed `scope=shared` results (e.g.
+  // the `zedi_list_pages` MCP tool) can distinguish personal vs note-native.
   const result = await db.execute(sql`
-    SELECT p.id, p.title, p.content_preview, p.updated_at
+    SELECT p.id, p.title, p.content_preview, p.updated_at, p.note_id
     FROM pages p
     WHERE p.is_deleted = false
       AND ${specialKindFilter}

--- a/server/mcp/src/__tests__/client/httpClient.test.ts
+++ b/server/mcp/src/__tests__/client/httpClient.test.ts
@@ -68,6 +68,7 @@ describe("HttpZediClient request shaping", () => {
             title: "Hello",
             content_preview: null,
             updated_at: "2026-01-01T00:00:00Z",
+            note_id: null,
           },
         ],
       }),

--- a/server/mcp/src/__tests__/server.test.ts
+++ b/server/mcp/src/__tests__/server.test.ts
@@ -89,6 +89,7 @@ describe("createMcpServer", () => {
         title: "Hello",
         content_preview: null,
         updated_at: "2026-01-01T00:00:00Z",
+        note_id: null,
       },
     ]);
     const result = await mcpClient.callTool({

--- a/server/mcp/src/client/ZediClient.ts
+++ b/server/mcp/src/client/ZediClient.ts
@@ -49,6 +49,13 @@ export interface PageListItem {
   title: string | null;
   content_preview: string | null;
   updated_at: string;
+  /**
+   * スコープ判別用。`null` は個人ページ、文字列ならノートネイティブページのノート ID。
+   * `scope: shared` 経由で混在 listing を受け取ったクライアントはこれで仕分けする。
+   * Scope discriminator: `null` for personal pages, string for note-native pages.
+   * Callers receiving the mixed `scope: shared` listing rely on this to bucket rows.
+   */
+  note_id: string | null;
 }
 
 /** `listPages` の入力 / Input for {@link ZediClient.listPages}. */

--- a/server/mcp/src/tools/index.ts
+++ b/server/mcp/src/tools/index.ts
@@ -42,7 +42,7 @@ export function registerAllTools(server: McpServer, client: ZediClient): void {
     {
       title: "List pages",
       description:
-        "Lists the caller's personal pages (note_id IS NULL), paginated and ordered by `updated_at` DESC. `scope: own` returns personal pages only; `scope: shared` additionally includes pages attached to notes the caller is a member of (mixed scope — inspect each row's `note_id` to distinguish personal vs note-native). To list pages of a specific note, use `zedi_list_note_pages` instead. Returns `{ id, title, content_preview, updated_at }`.",
+        "Lists the caller's personal pages (note_id IS NULL), paginated and ordered by `updated_at` DESC. `scope: own` returns personal pages only; `scope: shared` additionally includes pages attached to notes the caller is a member of (mixed scope — inspect each row's `note_id` to distinguish personal vs note-native). To list pages of a specific note, use `zedi_list_note_pages` instead. Returns `{ id, title, content_preview, updated_at, note_id }`.",
       inputSchema: {
         limit: z.number().int().min(1).max(100).optional(),
         offset: z.number().int().min(0).optional(),

--- a/src/components/editor/TiptapEditor/useWikiLinkStatusSync.test.tsx
+++ b/src/components/editor/TiptapEditor/useWikiLinkStatusSync.test.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { useWikiLinkStatusSync } from "./useWikiLinkStatusSync";
+
+type MockNotePage = { id: string; title: string };
+
+let mockNotePagesData: MockNotePage[] | undefined;
+
+vi.mock("@/hooks/useNoteQueries", () => ({
+  useNotePages: vi.fn(() => ({
+    data: mockNotePagesData,
+  })),
+}));
+
+vi.mock("@/hooks/usePageQueries", () => ({
+  useWikiLinkExistsChecker: vi.fn(
+    (options?: { notePages?: MockNotePage[]; pageNoteId?: string | null }) => ({
+      checkExistence: vi.fn(async (titles: string[]) => {
+        const pageTitles = new Set(
+          (options?.pageNoteId ? (options.notePages ?? []) : []).map((page) =>
+            page.title.toLowerCase().trim(),
+          ),
+        );
+        return {
+          pageTitles,
+          referencedTitles: new Set<string>(),
+        };
+      }),
+    }),
+  ),
+}));
+
+function createMockEditor() {
+  const wikiLinkMark = {
+    type: { name: "wikiLink" },
+    attrs: { title: "Beta", exists: false, referenced: false },
+  };
+
+  const chainApi = {
+    setTextSelection: vi.fn(() => chainApi),
+    extendMarkRange: vi.fn(() => chainApi),
+    updateAttributes: vi.fn((_name: string, attrs: { exists: boolean; referenced: boolean }) => {
+      wikiLinkMark.attrs = { ...wikiLinkMark.attrs, ...attrs };
+      return chainApi;
+    }),
+    run: vi.fn(() => true),
+  };
+
+  return {
+    editor: {
+      state: {
+        doc: {
+          descendants: (
+            visitor: (
+              node: { isText: boolean; marks: (typeof wikiLinkMark)[]; nodeSize: number },
+              pos: number,
+            ) => void,
+          ) => {
+            visitor(
+              {
+                isText: true,
+                marks: [wikiLinkMark],
+                nodeSize: 4,
+              },
+              1,
+            );
+          },
+        },
+      },
+      chain: vi.fn(() => chainApi),
+      getJSON: vi.fn(() => ({ type: "doc", content: [] })),
+    },
+    wikiLinkMark,
+    chainApi,
+  };
+}
+
+function Harness({
+  editor,
+  onChange,
+}: {
+  editor: ReturnType<typeof createMockEditor>["editor"];
+  onChange: (content: string) => void;
+}) {
+  useWikiLinkStatusSync({
+    editor: editor as never,
+    content: JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "Beta",
+              marks: [
+                {
+                  type: "wikiLink",
+                  attrs: { title: "Beta", exists: false, referenced: false },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+    pageId: "page-1",
+    onChange,
+    pageNoteId: "note-1",
+  });
+
+  return null;
+}
+
+describe("useWikiLinkStatusSync", () => {
+  beforeEach(() => {
+    mockNotePagesData = [];
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("re-runs status sync when the note-scoped page set changes", async () => {
+    const { editor, wikiLinkMark, chainApi } = createMockEditor();
+    const onChange = vi.fn();
+
+    const view = render(<Harness editor={editor} onChange={onChange} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(wikiLinkMark.attrs.exists).toBe(false);
+
+    mockNotePagesData = [{ id: "page-beta", title: "Beta" }];
+    view.rerender(<Harness editor={editor} onChange={onChange} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    expect(chainApi.updateAttributes).toHaveBeenCalledWith("wikiLink", {
+      exists: true,
+      referenced: false,
+    });
+    expect(wikiLinkMark.attrs.exists).toBe(true);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/editor/TiptapEditor/useWikiLinkStatusSync.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkStatusSync.ts
@@ -53,12 +53,22 @@ export function useWikiLinkStatusSync({
     pageNoteId,
     notePages: pageNoteId ? notePagesQuery.data : undefined,
   });
+  const pageScopeSignature =
+    pageNoteId === null
+      ? "personal"
+      : notePagesQuery.data === undefined
+        ? `note:${pageNoteId}:loading`
+        : `note:${pageNoteId}:${notePagesQuery.data
+            .map((page) => `${page.id}:${page.title.trim().toLowerCase()}`)
+            .sort()
+            .join("|")}`;
 
   // 最後にチェックした状態を追跡
   const lastCheckedRef = useRef<{
     pageId: string | null;
     wikiLinkCount: number;
-  }>({ pageId: null, wikiLinkCount: 0 });
+    pageScopeSignature: string | null;
+  }>({ pageId: null, wikiLinkCount: 0, pageScopeSignature: null });
 
   useEffect(() => {
     if (skipSync || !editor || !content || !pageId) {
@@ -72,15 +82,17 @@ export function useWikiLinkStatusSync({
     // チェックが必要かどうかを判定
     const isNewPage = lastCheckedRef.current.pageId !== pageId;
     const hasMoreWikiLinks = currentCount > lastCheckedRef.current.wikiLinkCount;
+    const hasScopeChanged = lastCheckedRef.current.pageScopeSignature !== pageScopeSignature;
 
-    // ページが変わった場合、またはWikiLinkが増えた場合のみ再チェック
-    if (!isNewPage && !hasMoreWikiLinks) {
+    // ページ/リンク数/解決スコープのいずれも変わらないときだけスキップする。
+    // Re-run when the resolution scope changes, even if the page id and count stay the same.
+    if (!isNewPage && !hasMoreWikiLinks && !hasScopeChanged) {
       return;
     }
 
     const updateWikiLinkStatus = async () => {
       if (currentWikiLinks.length === 0) {
-        lastCheckedRef.current = { pageId, wikiLinkCount: 0 };
+        lastCheckedRef.current = { pageId, wikiLinkCount: 0, pageScopeSignature };
         return;
       }
 
@@ -99,7 +111,7 @@ export function useWikiLinkStatusSync({
       const updates = collectWikiLinkUpdates(editor, pageTitles, referencedTitles);
 
       // チェック完了を記録
-      lastCheckedRef.current = { pageId, wikiLinkCount: currentCount };
+      lastCheckedRef.current = { pageId, wikiLinkCount: currentCount, pageScopeSignature };
 
       // 更新を適用
       if (updates.length > 0) {
@@ -114,7 +126,7 @@ export function useWikiLinkStatusSync({
     // コンテンツ反映を待ってから実行
     const timer = setTimeout(updateWikiLinkStatus, 150);
     return () => clearTimeout(timer);
-  }, [skipSync, editor, content, checkExistence, pageId, onChange]);
+  }, [skipSync, editor, content, checkExistence, pageId, onChange, pageScopeSignature]);
 }
 
 // --- ヘルパー関数 ---

--- a/src/components/editor/TiptapEditor/useWikiLinkStatusSync.ts
+++ b/src/components/editor/TiptapEditor/useWikiLinkStatusSync.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { Editor } from "@tiptap/react";
 import { extractWikiLinksFromContent, getUniqueWikiLinkTitles } from "@/lib/wikiLinkUtils";
 import { useWikiLinkExistsChecker } from "@/hooks/usePageQueries";
@@ -53,15 +53,21 @@ export function useWikiLinkStatusSync({
     pageNoteId,
     notePages: pageNoteId ? notePagesQuery.data : undefined,
   });
-  const pageScopeSignature =
-    pageNoteId === null
-      ? "personal"
-      : notePagesQuery.data === undefined
-        ? `note:${pageNoteId}:loading`
-        : `note:${pageNoteId}:${notePagesQuery.data
-            .map((page) => `${page.id}:${page.title.trim().toLowerCase()}`)
-            .sort()
-            .join("|")}`;
+  // editor の content 変更で頻繁に再レンダーされるため、map+sort+join の O(n log n)
+  // をメモ化して打鍵時のコストを抑える。`notePagesQuery.data` の参照が変わったときのみ
+  // 再計算される（React Query は同一データなら参照を保つ）。
+  // Memoize the signature so keystroke-driven re-renders don't repeat the
+  // O(n log n) map/sort/join over the note's page list. React Query keeps a
+  // stable reference for unchanged data, so this only re-computes on real changes.
+  const notePagesData = notePagesQuery.data;
+  const pageScopeSignature = useMemo(() => {
+    if (pageNoteId === null) return "personal";
+    if (notePagesData === undefined) return `note:${pageNoteId}:loading`;
+    return `note:${pageNoteId}:${notePagesData
+      .map((page) => `${page.id}:${page.title.trim().toLowerCase()}`)
+      .sort()
+      .join("|")}`;
+  }, [pageNoteId, notePagesData]);
 
   // 最後にチェックした状態を追跡
   const lastCheckedRef = useRef<{

--- a/src/hooks/useAIChatActions.ts
+++ b/src/hooks/useAIChatActions.ts
@@ -56,15 +56,18 @@ export function useAIChatActions({ pageContext }: UseAIChatActionsOptions) {
    *
    */
   const updatePageMutation = useUpdatePage();
-  // 編集対象ページが所属するノート（`pageContext.noteId`）に応じて WikiLink
+  // 編集対象ページ自身の所属ノート（`pageContext.noteId`）に応じて WikiLink
   // 同期のスコープを切り替える（Issue #713 Phase 4）。ノート内のページ一覧は
   // `useNotePages` から取得し、`syncLinks` が同一ノート内のタイトルを正しく
-  // 解決できるようにする。`noteId` が空のときは fetch しない。
+  // 解決できるようにする。linked personal page は `noteId` を持たないので、
+  // 個人スコープのまま処理する。`noteId` が空のときは fetch しない。
   //
   // Switch WikiLink sync scope based on the current page's owning note
-  // (`pageContext.noteId`, issue #713 Phase 4). The note's page list is
-  // fetched via `useNotePages` and fed into `useSyncWikiLinks` so same-note
-  // references resolve to real links instead of ghost entries.
+  // (`pageContext.noteId`, issue #713 Phase 4). Linked personal pages keep
+  // this unset even when rendered inside a note, so they continue to use the
+  // personal scope. The note's page list is fetched via `useNotePages` and
+  // fed into `useSyncWikiLinks` so same-note references resolve to real links
+  // instead of ghost entries.
   const scopeNoteId = pageContext?.noteId ?? null;
   const notePagesQuery = useNotePages(scopeNoteId ?? "", undefined, Boolean(scopeNoteId));
   const { syncLinks } = useSyncWikiLinks({

--- a/src/hooks/useNoteQueries.ts
+++ b/src/hooks/useNoteQueries.ts
@@ -536,6 +536,7 @@ export function useCopyNotePageToPersonal() {
       if (userId) {
         queryClient.invalidateQueries({ queryKey: pageKeys.list(userId) });
         queryClient.invalidateQueries({ queryKey: pageKeys.summary(userId) });
+        queryClient.invalidateQueries({ queryKey: pageKeys.byTitles(userId) });
       } else {
         queryClient.invalidateQueries({ queryKey: pageKeys.all });
       }

--- a/src/pages/NotePageView.test.tsx
+++ b/src/pages/NotePageView.test.tsx
@@ -20,13 +20,14 @@ import { AIChatProvider } from "@/contexts/AIChatContext";
 // can see them. Required because `vi.mock` hoists above normal `const`s. The
 // shared `mockToast` lets tests inspect what `toast({...})` was called with
 // — in particular whether the `action` (toast CTA) was supplied.
-const { mockToast, mockUpdatePageMutateAsync, mockApi } = vi.hoisted(() => ({
+const { mockToast, mockUpdatePageMutateAsync, mockApi, mockSetPageContext } = vi.hoisted(() => ({
   mockToast: vi.fn(),
   mockUpdatePageMutateAsync: vi.fn().mockResolvedValue({ skipped: false }),
   mockApi: {
     getPageContent: vi.fn(),
     putPageContent: vi.fn(),
   },
+  mockSetPageContext: vi.fn(),
 }));
 
 vi.mock("react-router-dom", async (importOriginal) => {
@@ -85,6 +86,15 @@ vi.mock("@tanstack/react-query", async (importOriginal) => {
 
 vi.mock("@/hooks/useAuth", () => ({
   useAuth: vi.fn(),
+}));
+
+vi.mock("@/contexts/AIChatContext", () => ({
+  AIChatProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useAIChatContext: () => ({
+    setPageContext: mockSetPageContext,
+    contentAppendHandlerRef: { current: null },
+    insertAtCursorRef: { current: null },
+  }),
 }));
 
 vi.mock("@/hooks/useCollaboration", () => ({
@@ -169,6 +179,7 @@ describe("NotePageView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockToast.mockReset();
+    mockSetPageContext.mockReset();
     mockUpdatePageMutateAsync.mockResolvedValue({ skipped: false });
     mockApi.getPageContent.mockReset();
     mockApi.putPageContent.mockReset();
@@ -351,6 +362,91 @@ describe("NotePageView", () => {
     expect(screen.getByTestId("page-title")).toHaveTextContent("Original title");
     expect(mockApi.putPageContent).not.toHaveBeenCalled();
     expect(mockUpdatePageMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("keeps note-native pages read-only for owners without note edit permission", async () => {
+    vi.mocked(useNote).mockReturnValue({
+      note: { id: "note-1" },
+      access: { canView: true, canEdit: false },
+      source: "local",
+      isLoading: false,
+    } as never);
+    vi.mocked(useNotePage).mockReturnValue({
+      data: {
+        id: "page-1",
+        title: "Original title",
+        content: "{}",
+        ownerUserId: "user-1",
+        noteId: "note-1",
+      },
+      isLoading: false,
+    } as never);
+
+    renderNotePageView();
+    fireEvent.click(screen.getByText("change-title"));
+    vi.advanceTimersByTime(500);
+    await Promise.resolve();
+
+    expect(screen.getByText("閲覧専用")).toBeInTheDocument();
+    expect(screen.getByTestId("page-title")).toHaveTextContent("Original title");
+    expect(mockApi.putPageContent).not.toHaveBeenCalled();
+    expect(mockUpdatePageMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("passes the owning note id to AI chat for note-native pages", () => {
+    vi.mocked(useNote).mockReturnValue({
+      note: { id: "note-1" },
+      access: { canView: true, canEdit: true },
+      source: "local",
+      isLoading: false,
+    } as never);
+    vi.mocked(useNotePage).mockReturnValue({
+      data: {
+        id: "page-1",
+        title: "Note-native",
+        content: "{}",
+        ownerUserId: "user-1",
+        noteId: "note-1",
+      },
+      isLoading: false,
+    } as never);
+
+    renderNotePageView();
+
+    expect(mockSetPageContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageId: "page-1",
+        noteId: "note-1",
+      }),
+    );
+  });
+
+  it("keeps AI chat on personal scope for linked personal pages", () => {
+    vi.mocked(useNote).mockReturnValue({
+      note: { id: "note-1" },
+      access: { canView: true, canEdit: true },
+      source: "local",
+      isLoading: false,
+    } as never);
+    vi.mocked(useNotePage).mockReturnValue({
+      data: {
+        id: "page-1",
+        title: "Linked personal",
+        content: "{}",
+        ownerUserId: "user-1",
+        noteId: null,
+      },
+      isLoading: false,
+    } as never);
+
+    renderNotePageView();
+
+    expect(mockSetPageContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageId: "page-1",
+        noteId: undefined,
+      }),
+    );
   });
 
   it("shows copy-to-personal action for note-native pages (issue #713 Phase 3)", () => {

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -37,9 +37,12 @@ const TITLE_SAVE_DEBOUNCE_MS = 500;
 function canEditPage(
   access: { canEdit?: boolean; canView?: boolean } | undefined,
   userId: string | undefined,
-  page: { ownerUserId?: string } | null | undefined,
+  page: { ownerUserId?: string; noteId?: string | null } | null | undefined,
 ): boolean {
-  if (!access?.canView) return false;
+  if (!access?.canView || !page) return false;
+  if (page.noteId !== null && page.noteId !== undefined) {
+    return Boolean(access.canEdit);
+  }
   if (access.canEdit) return true;
   return Boolean(userId && page?.ownerUserId && page.ownerUserId === userId);
 }
@@ -95,13 +98,13 @@ function NotePageEditorEditable({
     setPageContext({
       type: "editor",
       pageId: page.id,
-      noteId,
+      noteId: page.noteId ?? undefined,
       claudeWorkspaceRoot: workspaceRoot ?? undefined,
       pageTitle: title,
       pageContent: editorContent.slice(0, 3000),
       pageFullContent: editorContent,
     });
-  }, [page.id, title, editorContent, setPageContext, noteId, workspaceRoot]);
+  }, [page.id, page.noteId, title, editorContent, setPageContext, workspaceRoot]);
 
   useEffect(() => {
     return () => setPageContext(null);
@@ -294,7 +297,8 @@ const NotePageView: React.FC = () => {
   }, [navigate, noteId]);
 
   const canEdit = canEditPage(access, userId, page);
-  const isTitleEditable = canEdit && (page?.noteId != null || canEditTitle(userId, page));
+  const isTitleEditable =
+    page?.noteId != null ? Boolean(access?.canEdit) : canEdit && canEditTitle(userId, page);
   const collaborationPageId = page?.id ?? "";
   const isCollaborationEnabled = Boolean(collaborationPageId && isSignedIn && canEdit);
   const collaboration = useCollaboration({

--- a/src/types/aiChat.ts
+++ b/src/types/aiChat.ts
@@ -161,8 +161,10 @@ export interface PageContext {
   type: "editor" | "home" | "search" | "other";
   pageId?: string;
   /**
-   * Parent note id when editing a page inside a note (local metadata only).
-   * ノート内ページ編集中の親ノート ID（ローカルメタデータのみ）。
+   * Owning note id of the page being edited (local metadata only).
+   * Linked personal pages inside a note keep this undefined.
+   * 編集中ページ自身の所属ノート ID（ローカルメタデータのみ）。
+   * ノート内に表示している linked personal page は `undefined` のままにする。
    */
   noteId?: string;
   /**


### PR DESCRIPTION
## 概要

PR #719 に付いた未対応レビューコメントへのフォローアップです。WikiLink の note-scoped 再同期条件、note-native ページの編集権限、AI chat の note scope 伝播、copy-to-personal 後の title キャッシュ無効化、MCP ツール説明の整合性を修正しました。

## 変更点

- `src/pages/NotePageView.tsx` / `src/hooks/useAIChatActions.ts` / `src/types/aiChat.ts`
  - note-native ページはノート権限がある場合のみ編集可能に修正
  - AI chat に渡す `noteId` を親ノートではなくページ自身の owning note に変更
  - linked personal page は personal scope のまま WikiLink sync するよう整理
- `src/components/editor/TiptapEditor/useWikiLinkStatusSync.ts`
  - `pageId` や WikiLink 数が同じでも、note-scoped の候補ページ集合が変わった場合に再同期するよう修正
- `src/hooks/useNoteQueries.ts`
  - copy-to-personal 後に `pageKeys.byTitles(userId)` も無効化して title ベース miss cache を解消
- `server/mcp/src/tools/index.ts`
  - `zedi_list_pages` の説明文に `note_id` を含め、返却 shape の説明を実装に合わせて明確化
- テスト
  - `src/pages/NotePageView.test.tsx` に権限制御と AI chat scope の回帰テストを追加
  - `src/components/editor/TiptapEditor/useWikiLinkStatusSync.test.tsx` を追加

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bunx vitest run src/pages/NotePageView.test.tsx src/components/editor/TiptapEditor/useWikiLinkStatusSync.test.tsx`
2. `bun run lint`
3. `bun run format:check` はリポジトリ全体の既存未整形ファイルにより失敗することを確認済み（今回変更したファイルは pre-commit の Prettier を通過）

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

- なし

## 関連 Issue

- なし

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Page listings now include an owning-note indicator so personal vs note-native pages are distinguishable.

* **Bug Fixes**
  * Wiki-link synchronization reliably re-evaluates when page-scope or page data changes.
  * Page edit and title-edit permissions correctly respect whether a page is note-owned.
  * Title-based page queries refresh after copying a page to personal workspace.

* **Tests**
  * Added/updated tests covering page listing shape, wiki-link sync, and page-scoping behavior.

* **Documentation**
  * Clarified semantics for the page context noteId field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->