### PR TITLE
docs(notes): clarify post-delete redirect intent in NoteSettings (PR #719 follow-up)

### DIFF
--- a/src/pages/NoteSettings/index.tsx
+++ b/src/pages/NoteSettings/index.tsx
@@ -88,6 +88,14 @@ const NoteSettings: React.FC = () => {
       await deleteNoteMutation.mutateAsync(noteId);
       toast({ title: t("notes.noteDeleted") });
       setIsDeleteDialogOpen(false);
+      // ノート（コンテナ）削除後はノート一覧 (`/notes`) へ戻す。個人ページ削除
+      // (`usePageDeletion` / `NotePageView`) がホーム (`/home`) へ戻すのは、
+      // 削除対象がページであり個人ホームに属しているため。両者は対象が異なる
+      // ので遷移先も異なる（PR #719 CodeRabbit の指摘への明示）。
+      // After deleting a note (the container), return to the notes index
+      // (`/notes`). Page-level deletes go to `/home` because the deleted
+      // entity belongs to the personal home—different entities, different
+      // landing pages by design (clarified per PR #719 review feedback).
       navigate("/notes");
     } catch (error) {
       console.error("Failed to delete note:", error);


### PR DESCRIPTION
## 概要

PR #719 のレビューコメント対応サイクルを締めくくる小さなドキュメンテーション PR。`NoteSettings` でノートを削除した直後に `/notes` へ戻す遷移について、CodeRabbit から「他の削除フロー（`usePageDeletion` や `NotePageView`）が `/home` に戻すのと不整合」との指摘があったため、設計意図をコメントで明示します。

実際にはコード上の不整合ではなく、削除対象がそれぞれ「ノート（コンテナ）」と「ページ」で、それぞれが属する一覧（`/notes` と `/home`）が異なるという設計です。今後同種のレビューが繰り返されないよう、両方の遷移先の根拠をコメントとして残します。

PR #719 で指摘された他の本質的な問題（byTitle invalidation、note-native title editability、MCP `zedi_list_pages` の説明矛盾、AI chat WikiLink scope、PUT content の title 永続化、`useWikiLinkStatusSync` のスコープ再評価）は既に PR #724 / #727 で対応済みです。

## 変更点

- `src/pages/NoteSettings/index.tsx`: `handleDeleteNote` 内の `navigate("/notes")` の直前に、ノート削除と個別ページ削除でそれぞれ遷移先が異なる理由（削除対象のスケールの違い）を日英バイリンガルコメントで明示。

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [x] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bunx vitest run src/pages/NoteSettings/NoteSettings.test.tsx` が 5 tests とも green であること（実行済み: 5 passed）。
2. `bun run lint` が新規エラーを出さないこと（実行済み: 0 errors）。
3. `bunx prettier --check src/pages/NoteSettings/index.tsx` が pass すること（実行済み）。

## チェックリスト

- [x] テストがすべてパスする（影響範囲: NoteSettings.test.tsx, 5 passed）
- [x] Lint エラーがない（プロジェクト全体: 0 errors / 989 warnings はすべて既存）
- [x] 必要に応じてドキュメントを更新した（コードコメントで意図を明示）
- [x] コミットメッセージが Conventional Commits に従っている（`docs(notes): ...`）

## 関連 Issue / PR

Refs #719

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified routing behavior documentation for note operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->