### PR TITLE
test: expand test coverage with mutation-killing assertions

### DIFF
--- a/src/hooks/useImageUpload.test.ts
+++ b/src/hooks/useImageUpload.test.ts
@@ -85,8 +85,12 @@ describe("useImageUpload", () => {
         await result.current.uploadImage(file, { signal: controller.signal });
       });
 
+      // PNG は convertToWebP を経由するが、既定モックは入力 File をそのまま返すため、
+      // provider に渡るのは元の `file` インスタンスそのもの（参照同一性で検証）。
+      // PNG goes through convertToWebP, but the default mock returns the input
+      // unchanged, so the provider receives the very same `file` instance.
       expect(mocks.providerUploadImage).toHaveBeenCalledWith(
-        expect.any(File),
+        file,
         expect.objectContaining({ signal: controller.signal }),
       );
     });
@@ -193,27 +197,40 @@ describe("useImageUpload", () => {
       expect(mocks.providerUploadImage).toHaveBeenCalledWith(original, expect.any(Object));
     });
 
-    it("invokes provider with onProgress that updates hook progress state", async () => {
-      // provider に渡される onProgress を介して state.progress が更新されること。
-      // Pin the wiring of provider.onProgress → setState.progress.
-      let capturedOnProgress:
-        | ((p: { loaded: number; total: number; percentage: number }) => void)
-        | undefined;
-      mocks.providerUploadImage.mockImplementationOnce((_file, options) => {
+    it("provider's onProgress callback writes its arg through to state.progress", async () => {
+      // provider に渡される onProgress クロージャはアップロード完了後も有効で、
+      // 呼び出すと `setState((prev) => ({ ...prev, progress }))` が実行され、
+      // 引数オブジェクトがそのまま state.progress に反映されることを検証する。
+      // Capture the closure, finish the upload, then fire onProgress manually
+      // and observe the state. This avoids nested-act issues with deferred
+      // promises while still proving the wiring (closure → setState).
+      // Kills mutations that (a) drop the `progress` arg from setState or
+      // (b) replace it with a different value.
+      type ProgressArg = { loaded: number; total: number; percentage: number };
+      let capturedOnProgress: ((p: ProgressArg) => void) | undefined;
+      mocks.providerUploadImage.mockImplementationOnce(async (_file, options) => {
         capturedOnProgress = options.onProgress;
-        return Promise.resolve("https://cdn.example.com/x.webp");
+        return "https://cdn.example.com/x.webp";
       });
       const { result } = renderHook(() => useImageUpload());
 
-      const promise = act(async () => {
+      await act(async () => {
         await result.current.uploadImage(makeFile());
       });
 
-      // 進捗コールバックを擬似的に発火する（resolve 前に呼べたかは実装上難しいため、
-      // ここでは provider 呼び出しが受け取った onProgress 関数の存在のみ検証する）。
-      // We at least pin that provider received an `onProgress` function.
-      await promise;
+      // provider が onProgress を受け取った（関数として配線されている）。
+      // Pin that the provider received a callable onProgress.
       expect(capturedOnProgress).toBeTypeOf("function");
+
+      // クロージャを発火し、引数オブジェクトが state.progress に反映されることを検証する。
+      // Fire the captured callback and observe the resulting state.progress.
+      const observed: ProgressArg = { loaded: 50, total: 100, percentage: 50 };
+      if (!capturedOnProgress) throw new Error("capturedOnProgress was not set by provider mock");
+      const fire = capturedOnProgress;
+      act(() => {
+        fire(observed);
+      });
+      expect(result.current.progress).toEqual(observed);
     });
 
     it("reports the provider error message in error state and re-throws", async () => {
@@ -337,6 +354,11 @@ describe("useImageUpload", () => {
 
       expect(urls).toHaveLength(2);
       expect(mocks.providerUploadImage).toHaveBeenCalledTimes(2);
+      // 通った 2 件が画像エントリ (b.png, d.jpg) であることを参照同一性で固定する。
+      // Pin that the two calls are exactly the image entries (not text/pdf),
+      // so a swapped-filter mutation that lets non-image files through fails.
+      expect(mocks.providerUploadImage).toHaveBeenCalledWith(files[1], expect.any(Object));
+      expect(mocks.providerUploadImage).toHaveBeenCalledWith(files[3], expect.any(Object));
     });
 
     it("throws when no image files remain after filtering", async () => {
@@ -443,9 +465,13 @@ describe("useImageUpload", () => {
   });
 
   describe("clearError", () => {
-    it("resets error state to null without touching isUploading or progress", async () => {
-      // 直近のエラーを null に戻すが、他の state は不変であることを検証する。
-      // Pin that clearError ONLY resets `error`, not `isUploading` or `progress`.
+    it("resets error state to null and leaves the rest of state untouched", async () => {
+      // `setState((prev) => ({ ...prev, error: null }))` の意味論を検証する。
+      // 失敗した uploadImage の後に clearError を呼び、`error` だけが null に戻り、
+      // `isUploading` と `progress` は失敗時の値（false / null）のままであることを固定する。
+      // Pin both: (1) error → null, (2) the spread keeps `isUploading` / `progress`
+      // at the values the failed upload left them at (false / null), so a buggy
+      // clearError that resets the whole state would also surface here.
       mocks.providerUploadImage.mockRejectedValueOnce(new Error("oops"));
       const { result } = renderHook(() => useImageUpload());
 
@@ -458,12 +484,16 @@ describe("useImageUpload", () => {
       });
 
       expect(result.current.error).toBe("oops");
+      const isUploadingBefore = result.current.isUploading;
+      const progressBefore = result.current.progress;
 
       act(() => {
         result.current.clearError();
       });
 
       expect(result.current.error).toBeNull();
+      expect(result.current.isUploading).toBe(isUploadingBefore);
+      expect(result.current.progress).toBe(progressBefore);
     });
   });
 });

--- a/src/hooks/useImageUpload.test.ts
+++ b/src/hooks/useImageUpload.test.ts
@@ -1,21 +1,34 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 
+/**
+ * Hoisted mock state for `useImageUpload`. Each test mutates these
+ * containers (instead of redefining the modules) to vary settings, configured
+ * status, WebP conversion, and provider behavior.
+ *
+ * フック `useImageUpload` 用のホイスト済みモック。各テストはモジュール再定義
+ * ではなくこれらのコンテナを書き換えて、設定・configured 判定・WebP 変換・
+ * プロバイダの挙動を変える。
+ */
 const mocks = vi.hoisted(() => ({
   providerUploadImage: vi.fn(),
   getToken: vi.fn().mockResolvedValue("test-token"),
-}));
-
-vi.mock("./useStorageSettings", () => ({
-  useStorageSettings: () => ({
+  isStorageConfiguredForUpload: vi.fn(() => true),
+  getSettingsForUpload: vi.fn((settings: unknown) => settings),
+  convertToWebP: vi.fn(async (file: File) => file),
+  storageSettings: {
     settings: {
       provider: "s3",
       preferDefaultStorage: true,
       config: {},
       isConfigured: true,
-    },
+    } as unknown,
     isLoading: false,
-  }),
+  },
+}));
+
+vi.mock("./useStorageSettings", () => ({
+  useStorageSettings: () => mocks.storageSettings,
 }));
 
 vi.mock("./useAuth", () => ({
@@ -28,31 +41,429 @@ vi.mock("@/lib/storage", () => ({
   getStorageProvider: vi.fn(() => ({
     uploadImage: mocks.providerUploadImage,
   })),
-  getSettingsForUpload: vi.fn((settings) => settings),
-  isStorageConfiguredForUpload: vi.fn(() => true),
-  convertToWebP: vi.fn(async (file: File) => file),
+  getSettingsForUpload: (settings: unknown) => mocks.getSettingsForUpload(settings),
+  isStorageConfiguredForUpload: () => mocks.isStorageConfiguredForUpload(),
+  convertToWebP: (file: File) => mocks.convertToWebP(file),
 }));
 
 import { useImageUpload } from "./useImageUpload";
+
+/**
+ * Build a test image File succinctly. Defaults to PNG (subject to WebP conversion).
+ * テスト用の画像 File を簡潔に生成する。既定は PNG（WebP 変換対象）。
+ */
+function makeFile(type: string = "image/png", name = "sample.png"): File {
+  return new File([new Uint8Array([1, 2, 3, 4])], name, { type });
+}
 
 describe("useImageUpload", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.providerUploadImage.mockResolvedValue("https://cdn.example.com/image.webp");
+    mocks.isStorageConfiguredForUpload.mockReturnValue(true);
+    mocks.convertToWebP.mockImplementation(async (file: File) => file);
+    mocks.storageSettings = {
+      settings: {
+        provider: "s3",
+        preferDefaultStorage: true,
+        config: {},
+        isConfigured: true,
+      } as unknown,
+      isLoading: false,
+    };
   });
 
-  it("forwards AbortSignal to the storage provider uploadImage call", async () => {
-    const { result } = renderHook(() => useImageUpload());
-    const controller = new AbortController();
-    const file = new File([new Uint8Array([1, 2, 3])], "sample.png", { type: "image/png" });
+  describe("uploadImage", () => {
+    it("forwards AbortSignal to the storage provider uploadImage call", async () => {
+      // signal を provider に渡し、外部からのキャンセル要求を伝播させる契約を固定する。
+      // Pin the contract that the abort signal reaches the provider.
+      const { result } = renderHook(() => useImageUpload());
+      const controller = new AbortController();
+      const file = makeFile();
 
-    await act(async () => {
-      await result.current.uploadImage(file, { signal: controller.signal });
+      await act(async () => {
+        await result.current.uploadImage(file, { signal: controller.signal });
+      });
+
+      expect(mocks.providerUploadImage).toHaveBeenCalledWith(
+        expect.any(File),
+        expect.objectContaining({ signal: controller.signal }),
+      );
     });
 
-    expect(mocks.providerUploadImage).toHaveBeenCalledWith(
-      file,
-      expect.objectContaining({ signal: controller.signal }),
-    );
+    it("returns the URL produced by the provider", async () => {
+      // 戻り値が provider.uploadImage の解決値そのままであること。
+      // Pin that the hook returns the provider URL verbatim (no rewriting).
+      mocks.providerUploadImage.mockResolvedValueOnce("https://cdn.example.com/foo.webp");
+      const { result } = renderHook(() => useImageUpload());
+
+      let url = "";
+      await act(async () => {
+        url = await result.current.uploadImage(makeFile());
+      });
+
+      expect(url).toBe("https://cdn.example.com/foo.webp");
+    });
+
+    it("throws AbortError synchronously when signal is already aborted", async () => {
+      // 開始時点で abort 済みなら provider 呼び出しの前に DOMException("AbortError") を投げる。
+      // Pin the early-abort guard: provider must not be called when already aborted.
+      const { result } = renderHook(() => useImageUpload());
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        act(async () => {
+          await result.current.uploadImage(makeFile(), { signal: controller.signal });
+        }),
+      ).rejects.toMatchObject({ name: "AbortError" });
+      expect(mocks.providerUploadImage).not.toHaveBeenCalled();
+      expect(mocks.convertToWebP).not.toHaveBeenCalled();
+    });
+
+    it("throws the configured-storage error when storage is not configured", async () => {
+      // 未設定時は固定文言の Error を投げ、provider を呼ばない。
+      // Pin both the error message and that provider is not invoked when not configured.
+      mocks.isStorageConfiguredForUpload.mockReturnValue(false);
+      const { result } = renderHook(() => useImageUpload());
+
+      await expect(
+        act(async () => {
+          await result.current.uploadImage(makeFile());
+        }),
+      ).rejects.toThrow("ストレージが設定されていません。設定画面でストレージを設定してください。");
+      expect(mocks.providerUploadImage).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { type: "text/plain", name: "note.txt" },
+      { type: "application/pdf", name: "doc.pdf" },
+      { type: "video/mp4", name: "clip.mp4" },
+    ])("throws when file type is non-image ($type)", async ({ type, name }) => {
+      // `image/` 以外は明示文言で拒否し、provider は呼ばない。startsWith の比較変異を殺す。
+      // Pin the non-image rejection message and kill `startsWith("image/")` mutations.
+      const { result } = renderHook(() => useImageUpload());
+      await expect(
+        act(async () => {
+          await result.current.uploadImage(makeFile(type, name));
+        }),
+      ).rejects.toThrow("画像ファイルのみアップロードできます");
+      expect(mocks.providerUploadImage).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { type: "image/jpeg", name: "photo.jpg" },
+      { type: "image/png", name: "photo.png" },
+    ])("converts $type to WebP before upload", async ({ type, name }) => {
+      // 静止画は WebP 変換を経由する。`||` の両辺（jpeg, png）を個別に検証する。
+      // Pin WebP conversion for both branches of the static-image OR.
+      const original = makeFile(type, name);
+      const converted = new File([new Uint8Array([9, 9, 9])], "converted.webp", {
+        type: "image/webp",
+      });
+      mocks.convertToWebP.mockResolvedValueOnce(converted);
+      const { result } = renderHook(() => useImageUpload());
+
+      await act(async () => {
+        await result.current.uploadImage(original);
+      });
+
+      expect(mocks.convertToWebP).toHaveBeenCalledTimes(1);
+      expect(mocks.convertToWebP).toHaveBeenCalledWith(original);
+      // provider に渡るのは変換後ファイル。
+      // Provider receives the converted file, not the original.
+      expect(mocks.providerUploadImage).toHaveBeenCalledWith(converted, expect.any(Object));
+    });
+
+    it.each([
+      { type: "image/gif", name: "anim.gif" },
+      { type: "image/webp", name: "already.webp" },
+      { type: "image/svg+xml", name: "icon.svg" },
+    ])("does NOT convert $type to WebP", async ({ type, name }) => {
+      // GIF/WebP/SVG は変換対象外。`isStaticImage` 条件のロジック反転変異を殺す。
+      // Kill the `isStaticImage` boolean mutation by ensuring conversion is skipped here.
+      const original = makeFile(type, name);
+      const { result } = renderHook(() => useImageUpload());
+
+      await act(async () => {
+        await result.current.uploadImage(original);
+      });
+
+      expect(mocks.convertToWebP).not.toHaveBeenCalled();
+      expect(mocks.providerUploadImage).toHaveBeenCalledWith(original, expect.any(Object));
+    });
+
+    it("invokes provider with onProgress that updates hook progress state", async () => {
+      // provider に渡される onProgress を介して state.progress が更新されること。
+      // Pin the wiring of provider.onProgress → setState.progress.
+      let capturedOnProgress:
+        | ((p: { loaded: number; total: number; percentage: number }) => void)
+        | undefined;
+      mocks.providerUploadImage.mockImplementationOnce((_file, options) => {
+        capturedOnProgress = options.onProgress;
+        return Promise.resolve("https://cdn.example.com/x.webp");
+      });
+      const { result } = renderHook(() => useImageUpload());
+
+      const promise = act(async () => {
+        await result.current.uploadImage(makeFile());
+      });
+
+      // 進捗コールバックを擬似的に発火する（resolve 前に呼べたかは実装上難しいため、
+      // ここでは provider 呼び出しが受け取った onProgress 関数の存在のみ検証する）。
+      // We at least pin that provider received an `onProgress` function.
+      await promise;
+      expect(capturedOnProgress).toBeTypeOf("function");
+    });
+
+    it("reports the provider error message in error state and re-throws", async () => {
+      // 失敗時は state.error にメッセージを格納し、エラーを再 throw する。
+      // Pin both the propagated throw and that error state captures the message.
+      mocks.providerUploadImage.mockRejectedValueOnce(new Error("network down"));
+      const { result } = renderHook(() => useImageUpload());
+
+      let thrown: unknown;
+      await act(async () => {
+        try {
+          await result.current.uploadImage(makeFile());
+        } catch (e) {
+          thrown = e;
+        }
+      });
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).message).toBe("network down");
+      expect(result.current.error).toBe("network down");
+      expect(result.current.isUploading).toBe(false);
+      expect(result.current.progress).toBeNull();
+    });
+
+    it("uses the fallback error string for non-Error throwables", async () => {
+      // Error 以外（文字列 throw など）の場合は固定の日本語フォールバック文言を入れる。
+      // Pin the fallback "アップロードに失敗しました" branch when the thrown value is not an Error.
+      mocks.providerUploadImage.mockRejectedValueOnce("just a string");
+      const { result } = renderHook(() => useImageUpload());
+
+      let thrown: unknown;
+      await act(async () => {
+        try {
+          await result.current.uploadImage(makeFile());
+        } catch (e) {
+          thrown = e;
+        }
+      });
+
+      expect(thrown).toBe("just a string");
+      expect(result.current.error).toBe("アップロードに失敗しました");
+    });
+
+    it("does NOT set error state when failure is due to caller-side abort", async () => {
+      // signal.aborted の場合は state.error を null のまま、progress を null に戻す。
+      // Pin the abort branch: error stays null, progress is cleared, error is re-thrown.
+      const controller = new AbortController();
+      mocks.providerUploadImage.mockImplementationOnce(async () => {
+        controller.abort();
+        throw new DOMException("aborted", "AbortError");
+      });
+      const { result } = renderHook(() => useImageUpload());
+
+      await expect(
+        act(async () => {
+          await result.current.uploadImage(makeFile(), { signal: controller.signal });
+        }),
+      ).rejects.toMatchObject({ name: "AbortError" });
+
+      await waitFor(() => expect(result.current.isUploading).toBe(false));
+      expect(result.current.error).toBeNull();
+      expect(result.current.progress).toBeNull();
+    });
+
+    it("returns successfully even if the signal aborts AFTER the provider resolves", async () => {
+      // provider が成功裏に解決した後の throwIfAborted は呼ばない（孤児化防止）。
+      // Pin the post-resolve invariant: do not throw after a successful upload.
+      const controller = new AbortController();
+      mocks.providerUploadImage.mockImplementationOnce(async () => {
+        // 解決直前に signal を abort する。実装が誤って throwIfAborted を再度呼ぶと失敗する。
+        // Aborting just before resolve would trip a buggy post-resolve abort check.
+        controller.abort();
+        return "https://cdn.example.com/late.webp";
+      });
+      const { result } = renderHook(() => useImageUpload());
+
+      let url: string | undefined;
+      await act(async () => {
+        url = await result.current.uploadImage(makeFile(), { signal: controller.signal });
+      });
+
+      expect(url).toBe("https://cdn.example.com/late.webp");
+    });
+
+    it("sets isUploading=false and progress=100% on success", async () => {
+      // 成功後は isUploading が false に戻り、進捗 100% で締めくくられる。
+      // Pin the terminal state of a successful upload.
+      const { result } = renderHook(() => useImageUpload());
+
+      await act(async () => {
+        await result.current.uploadImage(makeFile());
+      });
+
+      expect(result.current.isUploading).toBe(false);
+      expect(result.current.progress).toEqual({
+        loaded: expect.any(Number),
+        total: expect.any(Number),
+        percentage: 100,
+      });
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("uploadImages", () => {
+    it("filters non-image files and uploads only image entries", async () => {
+      // image/* 以外は事前に除外し、画像だけを並列でアップロードする。
+      // Pin the prefilter and that only image files reach the provider.
+      const files = [
+        makeFile("text/plain", "a.txt"),
+        makeFile("image/png", "b.png"),
+        makeFile("application/pdf", "c.pdf"),
+        makeFile("image/jpeg", "d.jpg"),
+      ];
+      mocks.providerUploadImage.mockResolvedValue("https://cdn.example.com/x.webp");
+      const { result } = renderHook(() => useImageUpload());
+
+      let urls: string[] = [];
+      await act(async () => {
+        urls = await result.current.uploadImages(files);
+      });
+
+      expect(urls).toHaveLength(2);
+      expect(mocks.providerUploadImage).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws when no image files remain after filtering", async () => {
+      // フィルタ後に画像が 0 件なら固定文言で throw、provider は呼ばない。
+      // Pin the empty-after-filter branch and its message.
+      const { result } = renderHook(() => useImageUpload());
+
+      await expect(
+        act(async () => {
+          await result.current.uploadImages([
+            makeFile("text/plain", "a.txt"),
+            makeFile("application/pdf", "b.pdf"),
+          ]);
+        }),
+      ).rejects.toThrow("画像ファイルが選択されていません");
+      expect(mocks.providerUploadImage).not.toHaveBeenCalled();
+    });
+
+    it("returns URLs in input order (Promise.all preserves order)", async () => {
+      // 戻り値は入力順を保つ（Promise.all のセマンティクスに依存）。
+      // Pin in-order URL return so a `.map` → `.reverse` mutation is caught.
+      mocks.providerUploadImage
+        .mockResolvedValueOnce("https://cdn.example.com/1.webp")
+        .mockResolvedValueOnce("https://cdn.example.com/2.webp");
+      const { result } = renderHook(() => useImageUpload());
+
+      let urls: string[] = [];
+      await act(async () => {
+        urls = await result.current.uploadImages([
+          makeFile("image/png", "first.png"),
+          makeFile("image/jpeg", "second.jpg"),
+        ]);
+      });
+
+      expect(urls).toEqual(["https://cdn.example.com/1.webp", "https://cdn.example.com/2.webp"]);
+    });
+
+    it("captures error message in state and re-throws on batch failure", async () => {
+      // バッチで失敗した場合も error 文言を state に格納し、再 throw する。
+      // Pin the batch error path: state.error and re-throw both fire.
+      mocks.providerUploadImage.mockRejectedValue(new Error("batch boom"));
+      const { result } = renderHook(() => useImageUpload());
+
+      let thrown: unknown;
+      await act(async () => {
+        try {
+          await result.current.uploadImages([makeFile("image/png", "x.png")]);
+        } catch (e) {
+          thrown = e;
+        }
+      });
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).message).toBe("batch boom");
+      expect(result.current.error).toBe("batch boom");
+      expect(result.current.isUploading).toBe(false);
+    });
+
+    it("uses the fallback error string for non-Error rejections in batch", async () => {
+      // 非 Error 例外時のフォールバック文言を固定する。
+      // Pin the fallback message branch in `uploadImages`.
+      mocks.providerUploadImage.mockRejectedValue({ weird: true });
+      const { result } = renderHook(() => useImageUpload());
+
+      let thrown: unknown;
+      await act(async () => {
+        try {
+          await result.current.uploadImages([makeFile("image/png", "x.png")]);
+        } catch (e) {
+          thrown = e;
+        }
+      });
+
+      expect(thrown).toEqual({ weird: true });
+      expect(result.current.error).toBe("アップロードに失敗しました");
+    });
+  });
+
+  describe("isConfigured", () => {
+    it("is true when not loading and storage is configured", () => {
+      mocks.storageSettings = { settings: { isConfigured: true } as unknown, isLoading: false };
+      mocks.isStorageConfiguredForUpload.mockReturnValue(true);
+      const { result } = renderHook(() => useImageUpload());
+      expect(result.current.isConfigured).toBe(true);
+    });
+
+    it("is false while storage settings are still loading", () => {
+      // ロード中は configured とみなさない（`!isLoading` のロジック反転を殺す）。
+      // Pin that `isLoading=true` forces `isConfigured=false`.
+      mocks.storageSettings = { settings: { isConfigured: true } as unknown, isLoading: true };
+      mocks.isStorageConfiguredForUpload.mockReturnValue(true);
+      const { result } = renderHook(() => useImageUpload());
+      expect(result.current.isConfigured).toBe(false);
+    });
+
+    it("is false when storage is not configured", () => {
+      // `isStorageConfiguredForUpload` が false の場合は configured=false。
+      // Pin the right side of the `&&` in `isConfigured`.
+      mocks.storageSettings = { settings: { isConfigured: false } as unknown, isLoading: false };
+      mocks.isStorageConfiguredForUpload.mockReturnValue(false);
+      const { result } = renderHook(() => useImageUpload());
+      expect(result.current.isConfigured).toBe(false);
+    });
+  });
+
+  describe("clearError", () => {
+    it("resets error state to null without touching isUploading or progress", async () => {
+      // 直近のエラーを null に戻すが、他の state は不変であることを検証する。
+      // Pin that clearError ONLY resets `error`, not `isUploading` or `progress`.
+      mocks.providerUploadImage.mockRejectedValueOnce(new Error("oops"));
+      const { result } = renderHook(() => useImageUpload());
+
+      await act(async () => {
+        try {
+          await result.current.uploadImage(makeFile());
+        } catch {
+          /* expected */
+        }
+      });
+
+      expect(result.current.error).toBe("oops");
+
+      act(() => {
+        result.current.clearError();
+      });
+
+      expect(result.current.error).toBeNull();
+    });
   });
 });

--- a/src/lib/aiChatConversationTitle.test.ts
+++ b/src/lib/aiChatConversationTitle.test.ts
@@ -1,52 +1,136 @@
 import { describe, it, expect } from "vitest";
 import { generateConversationTitleFromTree } from "./aiChatConversationTitle";
+import type { TreeChatMessage } from "../types/aiChat";
+
+/**
+ * Build a small message-map with the given ordered chain (root → ... → leaf).
+ * 親子チェーンを 1 行で組み立てるユーティリティ。
+ */
+function chain(
+  ...nodes: Array<
+    Partial<TreeChatMessage> & { id: string; role: TreeChatMessage["role"]; content: string }
+  >
+): {
+  map: Record<string, TreeChatMessage>;
+  leafId: string;
+} {
+  const map: Record<string, TreeChatMessage> = {};
+  let parentId: string | null = null;
+  let ts = 1;
+  for (const n of nodes) {
+    map[n.id] = {
+      id: n.id,
+      role: n.role,
+      content: n.content,
+      timestamp: n.timestamp ?? ts++,
+      parentId: n.parentId ?? parentId,
+    };
+    parentId = n.id;
+  }
+  return { map, leafId: nodes[nodes.length - 1].id };
+}
 
 describe("generateConversationTitleFromTree", () => {
-  it("returns empty string when no user message on path (caller localizes)", () => {
-    const map = {
-      a: {
-        id: "a",
-        role: "assistant" as const,
-        content: "hi",
-        timestamp: 1,
-        parentId: null as string | null,
-      },
-    };
-    expect(generateConversationTitleFromTree(map, "a")).toBe("");
+  describe("empty / no-user-message branch", () => {
+    it("returns empty string when no user message exists on the active path", () => {
+      // ユーザーメッセージが無ければ空文字（呼び出し側が未設定ラベルを出す）。
+      // Pin the empty-string sentinel for the no-user branch.
+      const { map, leafId } = chain({ id: "a", role: "assistant", content: "hi" });
+      expect(generateConversationTitleFromTree(map, leafId)).toBe("");
+    });
+
+    it("returns empty string when activeLeafId is null", () => {
+      // null のリーフは getActivePath で空配列を返すため、空文字に落ちる。
+      // Pin the null-leaf path through getActivePath.
+      const { map } = chain({ id: "a", role: "user", content: "ignored" });
+      expect(generateConversationTitleFromTree(map, null)).toBe("");
+    });
+
+    it("returns empty string for an empty map", () => {
+      // 空マップでも例外を出さず、空文字を返す。
+      // Pin the empty-map fallback.
+      expect(generateConversationTitleFromTree({}, "missing")).toBe("");
+    });
   });
 
-  it("uses first user message and truncates with ellipsis", () => {
-    const map = {
-      u: {
-        id: "u",
-        role: "user" as const,
-        content: "x".repeat(60),
-        timestamp: 1,
-        parentId: null,
-      },
-      a: {
-        id: "a",
-        role: "assistant" as const,
-        content: "ok",
-        timestamp: 2,
-        parentId: "u",
-      },
-    };
-    const title = generateConversationTitleFromTree(map, "a");
-    expect(title.endsWith("...")).toBe(true);
-    expect(title.length).toBeLessThanOrEqual(53);
+  describe("first-user-message selection", () => {
+    it("uses the FIRST user message on the path (not subsequent ones)", () => {
+      // assistant を挟んで複数の user メッセージがあるとき、最初の user の内容を使う。
+      // Pin `path.find(m => m.role === "user")`; a `findLast`/swap mutation surfaces here.
+      const { map, leafId } = chain(
+        { id: "u1", role: "user", content: "first message" },
+        { id: "a1", role: "assistant", content: "ack" },
+        { id: "u2", role: "user", content: "second message" },
+      );
+      expect(generateConversationTitleFromTree(map, leafId)).toBe("first message");
+    });
+
+    it("ignores assistant messages that come before the first user message", () => {
+      // assistant が path 先頭にあっても、それは無視して次の user を採用する。
+      // Pin the role filter so a `=== "assistant"` mutation surfaces.
+      const { map, leafId } = chain(
+        { id: "a0", role: "assistant", content: "system-ish prelude" },
+        { id: "u1", role: "user", content: "real prompt" },
+      );
+      expect(generateConversationTitleFromTree(map, leafId)).toBe("real prompt");
+    });
   });
 
-  it("does not add ellipsis when under 50 chars", () => {
-    const map = {
-      u: {
-        id: "u",
-        role: "user" as const,
-        content: "short",
-        timestamp: 1,
-        parentId: null,
-      },
-    };
-    expect(generateConversationTitleFromTree(map, "u")).toBe("short");
+  describe("truncation boundary at 50 characters", () => {
+    it("returns the content verbatim when it is shorter than 50 chars", () => {
+      const { map, leafId } = chain({ id: "u", role: "user", content: "short prompt" });
+      expect(generateConversationTitleFromTree(map, leafId)).toBe("short prompt");
+    });
+
+    it("returns the content verbatim when it is EXACTLY 50 chars (no ellipsis)", () => {
+      // 境界 50 文字ちょうどでは省略記号を付けない。`text.length < content.length` 経路を検証する。
+      // Kills the `<` → `<=` mutation at the 50-char boundary by asserting no "..." is appended.
+      const fifty = "a".repeat(50);
+      const { map, leafId } = chain({ id: "u", role: "user", content: fifty });
+      const out = generateConversationTitleFromTree(map, leafId);
+      expect(out).toBe(fifty);
+      expect(out.endsWith("...")).toBe(false);
+      expect(out.length).toBe(50);
+    });
+
+    it("appends '...' and truncates at 50 chars when content is 51 chars", () => {
+      // 境界の 1 文字超え (51 文字) で初めて省略記号が付く。
+      // Pin the just-over-boundary case so a `<` → `>` mutation flips behavior visibly.
+      const fiftyOne = "b".repeat(51);
+      const { map, leafId } = chain({ id: "u", role: "user", content: fiftyOne });
+      const out = generateConversationTitleFromTree(map, leafId);
+      expect(out).toBe(`${"b".repeat(50)}...`);
+      expect(out.length).toBe(53);
+    });
+
+    it("truncates at 50 chars and appends exactly '...' for long content", () => {
+      // 50 文字に切り詰め、末尾はちょうど "..." (3 文字)。
+      // Pin both the slice length and the literal ellipsis suffix.
+      const long = "0123456789".repeat(10); // 100 chars
+      const { map, leafId } = chain({ id: "u", role: "user", content: long });
+      const out = generateConversationTitleFromTree(map, leafId);
+      expect(out).toBe(`${long.slice(0, 50)}...`);
+      expect(out.endsWith("...")).toBe(true);
+      expect(out.length).toBe(53);
+    });
+
+    it("uses character-based slicing (not byte-based) for multibyte content", () => {
+      // 日本語のような multibyte 文字でも文字数 50 で切る（バイト数ではない）。
+      // Pin character semantics; `slice` is code-unit-based, not byte-based.
+      const fifty = "あ".repeat(50);
+      const { map, leafId } = chain({ id: "u", role: "user", content: fifty });
+      expect(generateConversationTitleFromTree(map, leafId)).toBe(fifty);
+
+      const fiftyOne = "あ".repeat(51);
+      const { map: m2, leafId: l2 } = chain({ id: "u", role: "user", content: fiftyOne });
+      expect(generateConversationTitleFromTree(m2, l2)).toBe(`${"あ".repeat(50)}...`);
+    });
+
+    it("returns empty string verbatim when first user content is empty", () => {
+      // 空文字 user content の場合、slice(0,50) も "" で、length 比較も等しく省略しない。
+      // Pin that an empty user content yields `""` (no spurious "..." gets appended).
+      const { map, leafId } = chain({ id: "u", role: "user", content: "" });
+      expect(generateConversationTitleFromTree(map, leafId)).toBe("");
+    });
   });
 });

--- a/src/lib/encryption.test.ts
+++ b/src/lib/encryption.test.ts
@@ -2,47 +2,202 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { encrypt, decrypt, clearEncryptionKey } from "./encryption";
 
 const hasSubtle = typeof globalThis.crypto?.subtle !== "undefined";
+const ENCRYPTION_KEY_NAME = "zedi-encryption-key";
+const IV_LENGTH = 12;
+
+/**
+ * Decode a Base64 ciphertext into the underlying byte array.
+ * Base64 文字列を生バイト列に戻す（IV と暗号化データの境界検証に使う）。
+ */
+function decodeBase64(s: string): Uint8Array {
+  return Uint8Array.from(atob(s), (c) => c.charCodeAt(0));
+}
 
 describe("encryption", () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
-  it.skipIf(!hasSubtle)("encrypt then decrypt returns original plaintext", async () => {
-    const plaintext = "Hello, World!";
-    const encrypted = await encrypt(plaintext);
-    const decrypted = await decrypt(encrypted);
-    expect(decrypted).toBe(plaintext);
+  describe("round-trip", () => {
+    it.skipIf(!hasSubtle)("encrypt then decrypt returns original plaintext", async () => {
+      const plaintext = "Hello, World!";
+      const encrypted = await encrypt(plaintext);
+      const decrypted = await decrypt(encrypted);
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it.skipIf(!hasSubtle)("works with empty string (decrypt returns '')", async () => {
+      // 空文字でも IV 付きで暗号化され、復号で空文字に戻る。
+      // Pin that empty input round-trips to empty output (catches off-by-one slice mutations).
+      const encrypted = await encrypt("");
+      const decrypted = await decrypt(encrypted);
+      expect(decrypted).toBe("");
+      // 暗号文の長さは IV(12B) + GCM tag(16B) = 28B 以上のはず。
+      // Even an empty plaintext yields at least 28 bytes (IV + 16-byte tag).
+      expect(decodeBase64(encrypted).length).toBeGreaterThanOrEqual(IV_LENGTH + 16);
+    });
+
+    it.skipIf(!hasSubtle)("works with unicode (multibyte) text", async () => {
+      const plaintext = "日本語テスト 🎉 émojis & spëcial chars";
+      const encrypted = await encrypt(plaintext);
+      const decrypted = await decrypt(encrypted);
+      expect(decrypted).toBe(plaintext);
+    });
   });
 
-  it.skipIf(!hasSubtle)("encrypt produces different output each time", async () => {
-    const plaintext = "Same input";
-    const a = await encrypt(plaintext);
-    const b = await encrypt(plaintext);
-    expect(a).not.toBe(b);
+  describe("IV semantics", () => {
+    it.skipIf(!hasSubtle)(
+      "produces a fresh IV per call (different ciphertexts for same input)",
+      async () => {
+        // 同一平文でも IV が毎回ランダムに生成されるため出力は異なる。
+        // Kills mutations to `crypto.getRandomValues` (e.g., zero-IV) and the IV-length constant.
+        const a = await encrypt("Same input");
+        const b = await encrypt("Same input");
+        expect(a).not.toBe(b);
+
+        // 先頭 IV_LENGTH バイト (= IV) が異なることを直接検証する。
+        // Pin that the first 12 bytes (the IV) differ between calls.
+        const ivA = decodeBase64(a).slice(0, IV_LENGTH);
+        const ivB = decodeBase64(b).slice(0, IV_LENGTH);
+        expect(Array.from(ivA)).not.toEqual(Array.from(ivB));
+      },
+    );
+
+    it.skipIf(!hasSubtle)(
+      "prepends the IV (not appends) and produces non-zero IV bytes",
+      async () => {
+        // IV は先頭に置かれ (`combined.set(iv, 0)`)、暗号化データはその後ろに続く
+        // (`combined.set(encryptedData, iv.length)`)。両 set 呼び出しのオフセット変異を殺す。
+        // Kills mutations to the offsets in the two `combined.set(...)` calls.
+        const ciphertext = await encrypt("payload");
+        const bytes = decodeBase64(ciphertext);
+
+        // 先頭 12 バイトはランダム IV である (= 全部 0 ではない)。
+        // The first 12 bytes form a random IV — not all zeros.
+        const iv = bytes.slice(0, IV_LENGTH);
+        expect(iv.length).toBe(IV_LENGTH);
+        expect(iv.some((b) => b !== 0)).toBe(true);
+
+        // IV を別物に書き換えると AES-GCM の認証タグ検証が必ず失敗する。
+        // Tampering the IV must trigger an authentication failure on decrypt.
+        const tampered = new Uint8Array(bytes);
+        tampered[0] ^= 0xff;
+        const tamperedB64 = btoa(String.fromCharCode(...tampered));
+        await expect(decrypt(tamperedB64)).rejects.toBeDefined();
+      },
+    );
+
+    it.skipIf(!hasSubtle)("reads the IV from the FIRST 12 bytes on decrypt", async () => {
+      // 復号時の `combined.slice(0, IV_LENGTH)` と `combined.slice(IV_LENGTH)` の境界を検証する。
+      // Truncating the first byte (so the IV starts at offset 1) must fail to decrypt.
+      // Kills mutations to the slice arguments on decrypt.
+      const ciphertext = await encrypt("payload");
+      const bytes = decodeBase64(ciphertext);
+      const shifted = bytes.slice(1); // 先頭 1 バイト落とす → IV 領域がズレる
+      const shiftedB64 = btoa(String.fromCharCode(...shifted));
+      await expect(decrypt(shiftedB64)).rejects.toBeDefined();
+    });
   });
 
-  it("clearEncryptionKey removes key from localStorage", async () => {
-    if (hasSubtle) {
-      await encrypt("trigger key generation");
-      expect(localStorage.getItem("zedi-encryption-key")).not.toBeNull();
-    } else {
-      localStorage.setItem("zedi-encryption-key", "dummy");
-    }
-    clearEncryptionKey();
-    expect(localStorage.getItem("zedi-encryption-key")).toBeNull();
+  describe("authentication / tamper resistance", () => {
+    it.skipIf(!hasSubtle)(
+      "decrypt throws when the encrypted data portion is tampered",
+      async () => {
+        // GCM の認証タグにより、暗号化データの 1 バイト改竄でも復号は失敗する。
+        // Pin that AES-GCM tag verification rejects payload tampering.
+        const ciphertext = await encrypt("authenticated payload");
+        const bytes = decodeBase64(ciphertext);
+        const tampered = new Uint8Array(bytes);
+        // IV ではなく暗号化データ部 (offset = IV_LENGTH 以降) を 1 バイト改竄する。
+        // Flip a bit in the encrypted-data portion (after the IV).
+        tampered[IV_LENGTH] ^= 0x01;
+        const tamperedB64 = btoa(String.fromCharCode(...tampered));
+        await expect(decrypt(tamperedB64)).rejects.toBeDefined();
+      },
+    );
   });
 
-  it.skipIf(!hasSubtle)("works with empty string", async () => {
-    const encrypted = await encrypt("");
-    const decrypted = await decrypt(encrypted);
-    expect(decrypted).toBe("");
+  describe("key persistence and reuse", () => {
+    it.skipIf(!hasSubtle)("stores the generated key in localStorage on first encrypt", async () => {
+      // 初回 encrypt はキーを生成し localStorage に Base64 で保存する。
+      // Pin the side effect that lets a future browser session decrypt past content.
+      expect(localStorage.getItem(ENCRYPTION_KEY_NAME)).toBeNull();
+      await encrypt("trigger key");
+      expect(localStorage.getItem(ENCRYPTION_KEY_NAME)).not.toBeNull();
+    });
+
+    it.skipIf(!hasSubtle)(
+      "reuses the stored key on subsequent encrypt calls (does not regenerate)",
+      async () => {
+        // 2 回目以降の encrypt は `if (storedKey)` 分岐に入り、保存済みキーをインポートして使う。
+        // Pin the stored-key branch; without this test it stays NoCoverage / killed by removal.
+        await encrypt("first");
+        const keyAfterFirst = localStorage.getItem(ENCRYPTION_KEY_NAME);
+        expect(keyAfterFirst).not.toBeNull();
+
+        await encrypt("second");
+        const keyAfterSecond = localStorage.getItem(ENCRYPTION_KEY_NAME);
+        expect(keyAfterSecond).toBe(keyAfterFirst);
+      },
+    );
+
+    it.skipIf(!hasSubtle)(
+      "decrypts ciphertext produced by an earlier encrypt call (key reuse end-to-end)",
+      async () => {
+        // 同一プロセス内で 2 つの異なる暗号文が同じキーで復号できることを確認する。
+        // End-to-end check that the stored-key branch is functional, not just present.
+        const ct1 = await encrypt("alpha");
+        const ct2 = await encrypt("beta");
+        expect(await decrypt(ct1)).toBe("alpha");
+        expect(await decrypt(ct2)).toBe("beta");
+      },
+    );
+
+    it.skipIf(!hasSubtle)(
+      "regenerates a new key after clearEncryptionKey, breaking old ciphertext",
+      async () => {
+        // クリア後は新しいキーが生成され、過去の暗号文は復号できなくなる。
+        // Pin both: (1) clearEncryptionKey removes the stored key, (2) new encrypt
+        // generates a fresh key (different bytes) so old ciphertext fails to decrypt.
+        const ct = await encrypt("before clear");
+        const oldKey = localStorage.getItem(ENCRYPTION_KEY_NAME);
+        expect(oldKey).not.toBeNull();
+
+        clearEncryptionKey();
+        expect(localStorage.getItem(ENCRYPTION_KEY_NAME)).toBeNull();
+
+        await encrypt("after clear");
+        const newKey = localStorage.getItem(ENCRYPTION_KEY_NAME);
+        expect(newKey).not.toBeNull();
+        expect(newKey).not.toBe(oldKey);
+
+        // 古い暗号文は新しいキーでは復号できない。
+        // Old ciphertext must fail under the new key.
+        await expect(decrypt(ct)).rejects.toBeDefined();
+      },
+    );
   });
 
-  it.skipIf(!hasSubtle)("works with unicode text", async () => {
-    const plaintext = "日本語テスト 🎉 émojis & spëcial chars";
-    const encrypted = await encrypt(plaintext);
-    const decrypted = await decrypt(encrypted);
-    expect(decrypted).toBe(plaintext);
+  describe("clearEncryptionKey", () => {
+    it("removes the key from localStorage when present", async () => {
+      // クリアにより localStorage の該当キーが削除される。
+      // Pin the side effect of clearEncryptionKey (key name and removal semantics).
+      if (hasSubtle) {
+        await encrypt("trigger key generation");
+        expect(localStorage.getItem(ENCRYPTION_KEY_NAME)).not.toBeNull();
+      } else {
+        localStorage.setItem(ENCRYPTION_KEY_NAME, "dummy");
+      }
+      clearEncryptionKey();
+      expect(localStorage.getItem(ENCRYPTION_KEY_NAME)).toBeNull();
+    });
+
+    it("is a no-op (no throw) when no key is stored", () => {
+      // 未保存状態でもエラーにならず、なにも起こらない。
+      // Pin the no-op semantics so a stricter "must exist" mutation surfaces.
+      localStorage.clear();
+      expect(() => clearEncryptionKey()).not.toThrow();
+      expect(localStorage.getItem(ENCRYPTION_KEY_NAME)).toBeNull();
+    });
   });
 });

--- a/src/lib/encryption.test.ts
+++ b/src/lib/encryption.test.ts
@@ -13,6 +13,19 @@ function decodeBase64(s: string): Uint8Array {
   return Uint8Array.from(atob(s), (c) => c.charCodeAt(0));
 }
 
+/**
+ * Re-encode the given bytes as Base64 and assert that `decrypt` rejects.
+ * Centralizes the "tamper bytes → expect rejection" flow used across IV /
+ * payload tamper tests so future drift only needs one update.
+ *
+ * 渡されたバイト列を Base64 化し、`decrypt` が必ず失敗することを検証する。
+ * IV / 暗号化データ改竄テストで繰り返される手順をここに集約する。
+ */
+async function expectDecryptRejectsFromBytes(bytes: Uint8Array): Promise<void> {
+  const b64 = btoa(String.fromCharCode(...bytes));
+  await expect(decrypt(b64)).rejects.toBeDefined();
+}
+
 describe("encryption", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -82,8 +95,7 @@ describe("encryption", () => {
         // Tampering the IV must trigger an authentication failure on decrypt.
         const tampered = new Uint8Array(bytes);
         tampered[0] ^= 0xff;
-        const tamperedB64 = btoa(String.fromCharCode(...tampered));
-        await expect(decrypt(tamperedB64)).rejects.toBeDefined();
+        await expectDecryptRejectsFromBytes(tampered);
       },
     );
 
@@ -94,8 +106,7 @@ describe("encryption", () => {
       const ciphertext = await encrypt("payload");
       const bytes = decodeBase64(ciphertext);
       const shifted = bytes.slice(1); // 先頭 1 バイト落とす → IV 領域がズレる
-      const shiftedB64 = btoa(String.fromCharCode(...shifted));
-      await expect(decrypt(shiftedB64)).rejects.toBeDefined();
+      await expectDecryptRejectsFromBytes(shifted);
     });
   });
 
@@ -111,8 +122,7 @@ describe("encryption", () => {
         // IV ではなく暗号化データ部 (offset = IV_LENGTH 以降) を 1 バイト改竄する。
         // Flip a bit in the encrypted-data portion (after the IV).
         tampered[IV_LENGTH] ^= 0x01;
-        const tamperedB64 = btoa(String.fromCharCode(...tampered));
-        await expect(decrypt(tamperedB64)).rejects.toBeDefined();
+        await expectDecryptRejectsFromBytes(tampered);
       },
     );
   });

--- a/src/lib/parseStdioArgs.test.ts
+++ b/src/lib/parseStdioArgs.test.ts
@@ -2,26 +2,120 @@ import { describe, expect, it } from "vitest";
 import { parseStdioArgsLine } from "./parseStdioArgs";
 
 describe("parseStdioArgsLine", () => {
-  it("splits on whitespace", () => {
-    expect(parseStdioArgsLine("a b c")).toEqual(["a", "b", "c"]);
+  describe("basic splitting", () => {
+    it("splits on whitespace", () => {
+      expect(parseStdioArgsLine("a b c")).toEqual(["a", "b", "c"]);
+    });
+
+    it("collapses consecutive whitespace into a single split (no empty tokens)", () => {
+      // 連続する空白は 1 つの境界として扱われ、空トークンは生まれない。
+      // Pin that runs of whitespace produce no empty tokens — kills mutations
+      // that flip the regex `+` to `*`.
+      expect(parseStdioArgsLine("a    b\t  c")).toEqual(["a", "b", "c"]);
+    });
+
+    it("returns an empty array for an empty string", () => {
+      // `if (!trimmed) return []` の早期 return を検証する。
+      // Pin the early-return on empty input.
+      expect(parseStdioArgsLine("")).toEqual([]);
+    });
+
+    it("returns an empty array for whitespace-only input", () => {
+      // `args.trim()` が効くこと。
+      // Pin the trim() guard so a removal mutation surfaces here.
+      expect(parseStdioArgsLine("   \t\n  ")).toEqual([]);
+    });
+
+    it("trims leading and trailing whitespace before tokenizing", () => {
+      // 前後の空白を剥がしてからトークナイズする。
+      // Pin trim() vs returning leading/trailing empty tokens.
+      expect(parseStdioArgsLine("  a b  ")).toEqual(["a", "b"]);
+    });
   });
 
-  it("preserves quoted segments with spaces", () => {
-    expect(parseStdioArgsLine('--path "C:\\Program Files\\foo"')).toEqual([
-      "--path",
-      "C:\\Program Files\\foo",
-    ]);
+  describe("double-quoted segments", () => {
+    it("preserves quoted segments with spaces (Windows path)", () => {
+      expect(parseStdioArgsLine('--path "C:\\Program Files\\foo"')).toEqual([
+        "--path",
+        "C:\\Program Files\\foo",
+      ]);
+    });
+
+    it("strips outer double quotes from a single token", () => {
+      expect(parseStdioArgsLine('"one two" three')).toEqual(["one two", "three"]);
+    });
+
+    it("unescapes backslash-escaped double quotes inside the segment", () => {
+      // `\"` → `"`。`replace(/\\"/g, '"')` のロジックを直接的に検証する。
+      // Pin the inner-quote unescape; without this test the replace can be deleted
+      // and the surviving mutant goes undetected.
+      // 入力: "say \"hi\" please" → say "hi" please
+      const input = String.raw`"say \"hi\" please"`;
+      expect(parseStdioArgsLine(input)).toEqual([`say "hi" please`]);
+    });
+
+    it("unescapes backslash-escaped backslashes inside the segment", () => {
+      // `\\` → `\`。`replace(/\\\\/g, "\\")` を検証する。
+      // Pin the backslash-unescape; the replace order matters so a swap breaks this.
+      // 入力: "a\\b" → a\b
+      const input = String.raw`"a\\b"`;
+      expect(parseStdioArgsLine(input)).toEqual([String.raw`a\b`]);
+    });
+
+    it("treats an empty quoted segment as the empty string token", () => {
+      // 空文字 "" は長さ 2 (`""`) なので length >= 2 を満たし、空文字に解釈される。
+      // Pin that empty `""` produces an empty string token (length-2 boundary).
+      expect(parseStdioArgsLine('""')).toEqual([""]);
+    });
+
+    it("preserves single quotes inside a double-quoted segment", () => {
+      // 二重引用内の単一引用はそのまま残る（unescape 対象は \" と \\ のみ）。
+      // Kills mutations to the unescape regex that would remove single quotes.
+      expect(parseStdioArgsLine(`"it's fine"`)).toEqual(["it's fine"]);
+    });
   });
 
-  it("handles single-quoted segments", () => {
-    expect(parseStdioArgsLine("--x '/my path/file'")).toEqual(["--x", "/my path/file"]);
+  describe("single-quoted segments", () => {
+    it("handles single-quoted segments with embedded spaces", () => {
+      expect(parseStdioArgsLine("--x '/my path/file'")).toEqual(["--x", "/my path/file"]);
+    });
+
+    it("does NOT process backslash escapes inside single quotes (literal preserved)", () => {
+      // 単一引用内ではバックスラッシュエスケープを解釈しない（literal）。
+      // Pin the asymmetry between single and double quotes; without this test a
+      // mutation that adds replace() to the single-quote branch survives.
+      const input = String.raw`'a\nb'`;
+      expect(parseStdioArgsLine(input)).toEqual([String.raw`a\nb`]);
+    });
+
+    it("treats an empty single-quoted segment as the empty string token", () => {
+      expect(parseStdioArgsLine("''")).toEqual([""]);
+    });
+
+    it("preserves double quotes inside a single-quoted segment", () => {
+      expect(parseStdioArgsLine(`'say "hi"'`)).toEqual([`say "hi"`]);
+    });
   });
 
-  it("returns empty array for blank", () => {
-    expect(parseStdioArgsLine("   ")).toEqual([]);
-  });
+  describe("mixed and adjacent segments", () => {
+    it("returns multi-token strings in input order", () => {
+      // 並び順を厳密に検証する（map/filter の順序逆転変異を殺す）。
+      // Pin token order so a `.reverse()` mutation surfaces here.
+      expect(parseStdioArgsLine("--a one --b two")).toEqual(["--a", "one", "--b", "two"]);
+    });
 
-  it("strips outer quotes from double-quoted token", () => {
-    expect(parseStdioArgsLine('"one two" three')).toEqual(["one two", "three"]);
+    it("concatenates adjacent quoted/unquoted parts into a single raw token (regex `+`)", () => {
+      // 正規表現末尾の `+` により隣接した引用・非引用が 1 トークンに結合される。
+      // 結合後トークンは `"` で始まらないため slice/unescape 経路を通らず、引用記号がそのまま残る。
+      // Pin the concat semantic: a single token comes back, and because it
+      // doesn't begin with `"`, the slice/unescape branch is bypassed (quotes preserved).
+      expect(parseStdioArgsLine(`pre"mid"post`)).toEqual([`pre"mid"post`]);
+    });
+
+    it("returns an unquoted token verbatim (no slice/no replace)", () => {
+      // 非引用トークンには slice/replace を適用しない経路を検証する。
+      // Pin the third branch (return t verbatim) so removing it shifts to slicing.
+      expect(parseStdioArgsLine("plain")).toEqual(["plain"]);
+    });
   });
 });


### PR DESCRIPTION
## 概要

大幅にテストカバレッジを拡張し、境界値、エラーハンドリング、状態遷移、キー再利用などの細かなロジックを検証するテストを追加しました。各テストは特定の実装詳細（例：正規表現の `+` vs `*`、比較演算子の `<` vs `<=`、配列スライスのオフセット）を狙った変異テストキラーとして設計されています。

## 変更点

### `src/hooks/useImageUpload.test.ts`
- **モック構造の改善**: ホイスト済みモック状態コンテナを導入し、各テストがモジュール再定義ではなく状態を直接変更できるように改善
- **ヘルパー関数追加**: `makeFile()` で簡潔にテスト用ファイルを生成
- **uploadImage メソッドの包括的テスト**:
  - AbortSignal の伝播、戻り値の検証
  - 既に abort 済みの signal での同期的エラー
  - ストレージ未設定時のエラーメッセージ固定
  - 非画像ファイル型の拒否（`image/` 判定の変異を殺す）
  - JPEG/PNG の WebP 変換、GIF/WebP/SVG の非変換（条件分岐の反転変異を殺す）
  - onProgress コールバックの配線検証
  - エラーハンドリング（Error vs 非Error、abort vs 通常エラー）
  - 成功時の終端状態（isUploading=false、progress=100%）
- **uploadImages メソッドの包括的テスト**:
  - 非画像ファイルのフィルタリング
  - フィルタ後に画像が 0 件の場合のエラー
  - 入力順の保持（Promise.all の順序保証）
  - バッチエラーハンドリング
- **isConfigured プロパティのテスト**:
  - ロード中の false、未設定時の false、設定済みの true
- **clearError メソッドのテスト**:
  - error のみリセット、他の状態は不変

### `src/lib/encryption.test.ts`
- **テスト構造の再編成**: 「round-trip」「IV semantics」「authentication」「key persistence」「clearEncryptionKey」の 5 つのカテゴリに分類
- **round-trip テスト**:
  - 空文字列の暗号化・復号（off-by-one スライス変異を殺す）
  - Unicode/multibyte テキストの検証
- **IV セマンティクスの検証**:
  - 毎回異なる IV 生成（`crypto.getRandomValues` の削除変異を殺す）
  - IV が先頭に配置されていることの直接検証（`combined.set()` のオフセット変異を殺す）
  - IV 改竄時の復号失敗
  - 復号時の IV 読み込み位置検証（スライス引数の変異を殺す）
- **認証・改竄耐性**:
  - 暗号化データ部の改竄検出（GCM タグ検証）
- **キー永続化と再利用**:
  - 初回 encrypt での localStorage 保存
  - 2 回目以降の encrypt での既存キー再利用（新規

https://claude.ai/code/session_012VD4wm7gStZmNZ2tf4gST9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and reorganized test suites across image uploads, conversation title generation, encryption, and argument parsing.
  * Image upload tests: abort/timeout handling, progress, MIME/type-specific conversion rules, error states, provider passthrough, and multi-file flows.
  * Title generation: selection rules, truncation (including multibyte), and edge cases.
  * Encryption: IV placement, tamper resistance, key persistence/clearing, and round-trip cases.
  * Argument parsing: whitespace, quoting, escapes, and mixed-token behaviors; added reusable test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->