### PR TITLE
test(P1): add TDD coverage for src/lib/aiService* (#742)

### DIFF
--- a/src/lib/aiClient.test.ts
+++ b/src/lib/aiClient.test.ts
@@ -181,12 +181,15 @@ describe("aiClient", () => {
       expect(stored.openai.models).toEqual(["gpt-5"]);
     });
 
-    it("recovers when existing cache JSON is corrupt", () => {
+    it("壊れた既存キャッシュがあっても落ちず、生データは上書きしない / does not crash or overwrite when existing cache JSON is corrupt", () => {
       localStorage.setItem(CACHE_KEY, "{not json");
       const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       saveCachedModels("openai", ["gpt-5"]);
+      // parse 失敗をログに残す。`getCachedModels` 経由では null が返るが、
+      // 生の localStorage は壊れたまま放置される（saveCachedModels は catch して終わるため）。
+      // The parse failure is logged. `getCachedModels` returns null afterward,
+      // but the raw localStorage value stays untouched (saveCachedModels exits in the catch).
       expect(errSpy).toHaveBeenCalled();
-      // 2 回目以降の getItem では従来通り null （壊れた JSON のまま放置）
       expect(localStorage.getItem(CACHE_KEY)).toBe("{not json");
     });
   });

--- a/src/lib/aiClient.test.ts
+++ b/src/lib/aiClient.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   createAIClient,
   getCachedModels,
@@ -140,7 +140,70 @@ describe("aiClient", () => {
     });
   });
 
-  describe("testConnection", () => {
+  describe("createAIClient - claude-code", () => {
+    it("throws because Claude Code does not use a traditional client", () => {
+      expect(() =>
+        createAIClient({
+          provider: "claude-code",
+          apiKey: "",
+          model: "",
+          modelId: "",
+          isConfigured: true,
+        }),
+      ).toThrow(/Claude Code/);
+    });
+  });
+
+  describe("getCachedModels - corrupt cache", () => {
+    it("returns null when cache JSON is malformed", () => {
+      localStorage.setItem(CACHE_KEY, "not json");
+      expect(getCachedModels("openai")).toBeNull();
+    });
+
+    it("returns null when provider is missing from cache", () => {
+      localStorage.setItem(
+        CACHE_KEY,
+        JSON.stringify({ google: { provider: "google", models: [], cachedAt: Date.now() } }),
+      );
+      expect(getCachedModels("openai")).toBeNull();
+    });
+  });
+
+  describe("saveCachedModels - merging", () => {
+    it("does not overwrite other providers in cache", () => {
+      const initial = {
+        anthropic: { provider: "anthropic", models: ["claude-x"], cachedAt: 1 },
+      };
+      localStorage.setItem(CACHE_KEY, JSON.stringify(initial));
+      saveCachedModels("openai", ["gpt-5"]);
+      const stored = JSON.parse(localStorage.getItem(CACHE_KEY) ?? "{}");
+      expect(stored.anthropic.models).toEqual(["claude-x"]);
+      expect(stored.openai.models).toEqual(["gpt-5"]);
+    });
+
+    it("recovers when existing cache JSON is corrupt", () => {
+      localStorage.setItem(CACHE_KEY, "{not json");
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      saveCachedModels("openai", ["gpt-5"]);
+      expect(errSpy).toHaveBeenCalled();
+      // 2 回目以降の getItem では従来通り null （壊れた JSON のまま放置）
+      expect(localStorage.getItem(CACHE_KEY)).toBe("{not json");
+    });
+  });
+
+  describe("getAvailableModels - empty cache", () => {
+    it("falls back to defaults when cache exists but list is empty", () => {
+      const cache = {
+        openai: { provider: "openai", models: [], cachedAt: Date.now() },
+      };
+      localStorage.setItem(CACHE_KEY, JSON.stringify(cache));
+      const models = getAvailableModels("openai");
+      expect(models.length).toBeGreaterThan(0);
+      expect(models).toContain("gpt-5-mini");
+    });
+  });
+
+  describe("testConnection - input validation", () => {
     it("returns failure for empty API key", async () => {
       const result = await testConnection("openai", "");
       expect(result.success).toBe(false);
@@ -157,6 +220,265 @@ describe("aiClient", () => {
       const result = await testConnection("claude-code", "");
       expect(result.success).toBe(false);
       expect(result.message).toContain("Claude Code");
+    });
+  });
+
+  describe("testConnection - openai", () => {
+    it("returns success with sorted/filtered GPT models on success", async () => {
+      const list = vi.fn().mockResolvedValue({
+        data: [
+          { id: "gpt-3.5-turbo" },
+          { id: "gpt-4o" },
+          { id: "gpt-4-vision-preview" }, // filtered out
+          { id: "gpt-4-instruct" }, // filtered out
+          { id: "gpt-4o-realtime" }, // filtered out
+          { id: "gpt-4-audio" }, // filtered out
+          { id: "text-embedding" }, // filtered out
+          { id: "gpt-4-turbo" },
+        ],
+      });
+      vi.mocked(OpenAI).mockImplementation(function (this: unknown) {
+        return { models: { list } } as unknown as OpenAI;
+      });
+
+      const result = await testConnection("openai", "sk-test");
+      expect(result.success).toBe(true);
+      expect(result.models).toEqual(["gpt-4o", "gpt-4-turbo", "gpt-3.5-turbo"]);
+      expect(result.message).toContain("3個");
+
+      // キャッシュにも保存される
+      const stored = JSON.parse(localStorage.getItem(CACHE_KEY) ?? "{}");
+      expect(stored.openai.models).toEqual(["gpt-4o", "gpt-4-turbo", "gpt-3.5-turbo"]);
+    });
+
+    it("falls back to default models when API returns no GPT models", async () => {
+      vi.mocked(OpenAI).mockImplementation(function (this: unknown) {
+        return {
+          models: { list: vi.fn().mockResolvedValue({ data: [{ id: "dall-e-3" }] }) },
+        } as unknown as OpenAI;
+      });
+      const result = await testConnection("openai", "sk-test");
+      expect(result.success).toBe(true);
+      expect(result.models).toContain("gpt-5-mini");
+    });
+
+    it("maps 401 error to APIキーが無効です", async () => {
+      vi.mocked(OpenAI).mockImplementation(function (this: unknown) {
+        return {
+          models: { list: vi.fn().mockRejectedValue(new Error("401 Unauthorized")) },
+        } as unknown as OpenAI;
+      });
+      const result = await testConnection("openai", "sk-test");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("APIキーが無効");
+      expect(result.error).toContain("401");
+    });
+
+    it("maps invalid_api_key error to APIキーが無効です", async () => {
+      vi.mocked(OpenAI).mockImplementation(function (this: unknown) {
+        return {
+          models: {
+            list: vi.fn().mockRejectedValue(new Error("invalid_api_key")),
+          },
+        } as unknown as OpenAI;
+      });
+      const result = await testConnection("openai", "sk-test");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("APIキーが無効");
+    });
+
+    it("maps generic error to 接続に失敗しました", async () => {
+      vi.mocked(OpenAI).mockImplementation(function (this: unknown) {
+        return {
+          models: { list: vi.fn().mockRejectedValue(new Error("network down")) },
+        } as unknown as OpenAI;
+      });
+      const result = await testConnection("openai", "sk-test");
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("接続に失敗しました");
+      expect(result.error).toBe("network down");
+    });
+
+    it("uses 'Unknown error' when thrown value is not an Error", async () => {
+      vi.mocked(OpenAI).mockImplementation(function (this: unknown) {
+        return {
+          models: { list: vi.fn().mockRejectedValue("string failure") },
+        } as unknown as OpenAI;
+      });
+      const result = await testConnection("openai", "sk-test");
+      expect(result.error).toBe("Unknown error");
+    });
+  });
+
+  describe("testConnection - anthropic", () => {
+    it("returns success and default models when ping succeeds", async () => {
+      const create = vi.fn().mockResolvedValue({ id: "msg_123" });
+      vi.mocked(Anthropic).mockImplementation(function (this: unknown) {
+        return { messages: { create } } as unknown as Anthropic;
+      });
+      const result = await testConnection("anthropic", "sk-ant-x");
+      expect(result.success).toBe(true);
+      expect(result.models).toEqual(
+        expect.arrayContaining(["claude-opus-4-6", "claude-sonnet-4-20250514"]),
+      );
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: "claude-3-haiku-20240307",
+          max_tokens: 10,
+          messages: [{ role: "user", content: "Hi" }],
+        }),
+      );
+    });
+
+    it("returns 予期しないレスポンス形式 when response has no id", async () => {
+      vi.mocked(Anthropic).mockImplementation(function (this: unknown) {
+        return {
+          messages: { create: vi.fn().mockResolvedValue({ content: [] }) },
+        } as unknown as Anthropic;
+      });
+      const result = await testConnection("anthropic", "sk-ant-x");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("予期しないレスポンス");
+    });
+
+    it("maps authentication error to APIキーが無効です", async () => {
+      vi.mocked(Anthropic).mockImplementation(function (this: unknown) {
+        return {
+          messages: {
+            create: vi.fn().mockRejectedValue(new Error("authentication failed")),
+          },
+        } as unknown as Anthropic;
+      });
+      const result = await testConnection("anthropic", "sk-ant-x");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("APIキーが無効");
+    });
+
+    it("maps 401 error to APIキーが無効です", async () => {
+      vi.mocked(Anthropic).mockImplementation(function (this: unknown) {
+        return {
+          messages: { create: vi.fn().mockRejectedValue(new Error("401")) },
+        } as unknown as Anthropic;
+      });
+      const result = await testConnection("anthropic", "sk-ant-x");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("APIキーが無効");
+    });
+
+    it("maps generic error to 接続に失敗しました", async () => {
+      vi.mocked(Anthropic).mockImplementation(function (this: unknown) {
+        return {
+          messages: { create: vi.fn().mockRejectedValue(new Error("boom")) },
+        } as unknown as Anthropic;
+      });
+      const result = await testConnection("anthropic", "sk-ant-x");
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("接続に失敗しました");
+    });
+  });
+
+  describe("testConnection - google", () => {
+    function mockFetch(impl: ReturnType<typeof vi.fn>): void {
+      vi.stubGlobal("fetch", impl);
+    }
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("filters Gemini models, sorts by version, and caches", async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            models: [
+              {
+                name: "models/gemini-1.5-flash",
+                supportedGenerationMethods: ["generateContent"],
+              },
+              {
+                name: "models/gemini-1.5-pro",
+                supportedGenerationMethods: ["generateContent"],
+              },
+              {
+                name: "models/gemini-2.0-flash",
+                supportedGenerationMethods: ["generateContent"],
+              },
+              {
+                name: "models/gemini-2.5-pro",
+                supportedGenerationMethods: ["generateContent"],
+              },
+              {
+                name: "models/text-bison",
+                supportedGenerationMethods: ["generateContent"],
+              }, // 除外
+              {
+                name: "models/gemini-embedding",
+                supportedGenerationMethods: ["embedContent"],
+              }, // 除外
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+      mockFetch(fetchSpy);
+
+      const result = await testConnection("google", "AIza-x");
+      expect(result.success).toBe(true);
+      expect(result.models).toEqual([
+        "gemini-2.5-pro",
+        "gemini-2.0-flash",
+        "gemini-1.5-pro",
+        "gemini-1.5-flash",
+      ]);
+      expect(result.message).toContain("4個");
+      expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining("AIza-x"));
+
+      const stored = JSON.parse(localStorage.getItem(CACHE_KEY) ?? "{}");
+      expect(stored.google.models).toEqual(result.models);
+    });
+
+    it("returns default models when no Gemini models match", async () => {
+      mockFetch(
+        vi.fn().mockResolvedValue(new Response(JSON.stringify({ models: [] }), { status: 200 })),
+      );
+      const result = await testConnection("google", "AIza-x");
+      expect(result.success).toBe(true);
+      // フォールバック先のデフォルトモデルを返す
+      expect(result.models?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("maps error containing 400 to APIキーが無効です", async () => {
+      // 例: fetch reject の例外メッセージに 400 が含まれるケース。
+      mockFetch(vi.fn().mockRejectedValue(new Error("HTTP 400 invalid key")));
+      const result = await testConnection("google", "AIza-x");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("APIキーが無効");
+    });
+
+    it("maps API_KEY_INVALID error message to APIキーが無効です", async () => {
+      mockFetch(vi.fn().mockRejectedValue(new Error("API_KEY_INVALID detail")));
+      const result = await testConnection("google", "AIza-x");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("APIキーが無効");
+    });
+
+    it("maps generic error to 接続に失敗しました", async () => {
+      mockFetch(
+        vi
+          .fn()
+          .mockResolvedValue(new Response("oops", { status: 500, statusText: "Server Error" })),
+      );
+      const result = await testConnection("google", "AIza-x");
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("接続に失敗しました");
+    });
+  });
+
+  describe("testConnection - unknown provider", () => {
+    it("returns failure with 不明なプロバイダー", async () => {
+      const result = await testConnection("xxx" as never, "key");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("不明なプロバイダー");
     });
   });
 });

--- a/src/lib/aiService.test.ts
+++ b/src/lib/aiService.test.ts
@@ -725,11 +725,17 @@ describe("aiService - 回帰テスト", () => {
       | { type: "error"; content: string }
       | { type: "done"; content: "" };
 
+    // 実モジュールの型に揃えることで `createClaudeCodeProvider` のシグネチャ変更を
+    // テスト側でも型検査でき、`UnifiedAIProvider` 契約のドリフトを早期に検知する。
+    // Anchor the mock to the real module type so a signature change in
+    // `createClaudeCodeProvider` (or `UnifiedAIProvider`) is caught here at compile time.
+    type ClaudeCodeProviderModule = typeof import("@/lib/aiProviders/claudeCodeProvider");
+
     function buildProviderModule(opts: {
       available: boolean;
       chunks?: FakeChunk[];
       throwOnQuery?: unknown;
-    }) {
+    }): Pick<ClaudeCodeProviderModule, "createClaudeCodeProvider"> {
       return {
         createClaudeCodeProvider: () => ({
           id: "claude-code" as const,

--- a/src/lib/aiService.test.ts
+++ b/src/lib/aiService.test.ts
@@ -638,5 +638,312 @@ describe("aiService - 回帰テスト", () => {
       expect(callbacks.onError).toHaveBeenCalled();
       expect(callbacks.onComplete).not.toHaveBeenCalled();
     });
+
+    it("settings.modelId が指定されていればリクエストの model を上書きする", async () => {
+      const fetchSpy = vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({ content: "ok" }), { status: 200 }));
+      vi.stubGlobal("fetch", fetchSpy);
+      vi.stubEnv("VITE_API_BASE_URL", "https://api.example.com");
+
+      const settings: AISettings = {
+        provider: "openai",
+        apiKey: "",
+        apiMode: "api_server",
+        model: "gpt-4o",
+        modelId: "openai:gpt-5-pro",
+        isConfigured: false,
+      };
+      const callbacks: AIServiceCallbacks = { onComplete: vi.fn(), onError: vi.fn() };
+      await callAIService(
+        settings,
+        {
+          provider: "openai",
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "hi" }],
+          options: { stream: false },
+        },
+        callbacks,
+      );
+
+      const init = fetchSpy.mock.calls[0]?.[1];
+      const body = JSON.parse(init?.body ?? "{}");
+      expect(body.model).toBe("openai:gpt-5-pro");
+      expect(callbacks.onComplete).toHaveBeenCalled();
+
+      vi.unstubAllEnvs();
+      vi.unstubAllGlobals();
+    });
+
+    it("apiMode が未設定でも api_server へフォールバックする", async () => {
+      const fetchSpy = vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({ content: "ok" }), { status: 200 }));
+      vi.stubGlobal("fetch", fetchSpy);
+      vi.stubEnv("VITE_API_BASE_URL", "https://api.example.com");
+
+      const settings: AISettings = {
+        provider: "openai",
+        apiKey: "should-be-ignored",
+        // apiMode 未設定
+        model: "gpt-4o",
+        modelId: "openai:gpt-4o",
+        isConfigured: false,
+      };
+      const callbacks: AIServiceCallbacks = { onComplete: vi.fn(), onError: vi.fn() };
+      await callAIService(
+        settings,
+        {
+          provider: "openai",
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "hi" }],
+          options: { stream: false },
+        },
+        callbacks,
+      );
+
+      // ユーザーキーモードならクライアントSDKが呼ばれるが、ここでは fetch のみ呼ばれることを確認。
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      vi.unstubAllEnvs();
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe("callAIService - claude-code モード", () => {
+    /**
+     * Build a fake provider object for `createClaudeCodeProvider`.
+     * テスト用の Claude Code プロバイダのフェイクを作る。
+     */
+    type FakeChunk =
+      | { type: "text"; content: string }
+      | { type: "tool_use_start"; content: ""; toolName?: string }
+      | { type: "tool_use_complete"; content: ""; toolName?: string }
+      | { type: "error"; content: string }
+      | { type: "done"; content: "" };
+
+    function buildProviderModule(opts: {
+      available: boolean;
+      chunks?: FakeChunk[];
+      throwOnQuery?: unknown;
+    }) {
+      return {
+        createClaudeCodeProvider: () => ({
+          id: "claude-code" as const,
+          name: "Claude Code",
+          capabilities: {
+            textGeneration: true,
+            fileAccess: true,
+            commandExecution: true,
+            webSearch: true,
+            mcpIntegration: true,
+            agentLoop: true,
+          },
+          isAvailable: vi.fn().mockResolvedValue(opts.available),
+          abort: vi.fn(),
+          query: () => {
+            if (opts.throwOnQuery !== undefined) {
+              // テスト用に意図的に yield せず即時 throw するジェネレータ。
+              // eslint-disable-next-line require-yield
+              return (async function* () {
+                throw opts.throwOnQuery;
+              })();
+            }
+            return (async function* () {
+              for (const c of opts.chunks ?? []) yield c;
+            })();
+          },
+        }),
+      };
+    }
+
+    function makeClaudeSettings(): AISettings {
+      return {
+        provider: "claude-code",
+        apiKey: "",
+        model: "claude-sonnet-4",
+        modelId: "claude-code:claude-sonnet-4",
+        isConfigured: true,
+      };
+    }
+
+    function makeClaudeRequest(): AIServiceRequest {
+      return {
+        provider: "claude-code",
+        model: "claude-sonnet-4",
+        messages: [
+          { role: "system", content: "rules" },
+          { role: "user", content: "hello" },
+        ],
+        options: { temperature: 0.5, maxTokens: 1024, stream: true, cwd: "/work" },
+      };
+    }
+
+    afterEach(() => {
+      vi.doUnmock("@/lib/aiProviders/claudeCodeProvider");
+    });
+
+    it("isAvailable が false なら onError を呼ぶ", async () => {
+      vi.doMock("@/lib/aiProviders/claudeCodeProvider", () =>
+        buildProviderModule({ available: false }),
+      );
+      const callbacks: AIServiceCallbacks = { onError: vi.fn(), onComplete: vi.fn() };
+      await callAIService(makeClaudeSettings(), makeClaudeRequest(), callbacks);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("Claude Code"),
+        }),
+      );
+      expect(callbacks.onComplete).not.toHaveBeenCalled();
+    });
+
+    it("text チャンクを蓄積し done で onComplete を呼ぶ", async () => {
+      vi.doMock("@/lib/aiProviders/claudeCodeProvider", () =>
+        buildProviderModule({
+          available: true,
+          chunks: [
+            { type: "text", content: "Hel" },
+            { type: "text", content: "lo" },
+            { type: "done", content: "" },
+            { type: "text", content: "ignored after done" },
+          ],
+        }),
+      );
+      const callbacks: AIServiceCallbacks = {
+        onChunk: vi.fn(),
+        onComplete: vi.fn(),
+        onError: vi.fn(),
+      };
+      await callAIService(makeClaudeSettings(), makeClaudeRequest(), callbacks);
+      expect(callbacks.onChunk).toHaveBeenNthCalledWith(1, "Hel");
+      expect(callbacks.onChunk).toHaveBeenNthCalledWith(2, "lo");
+      expect(callbacks.onChunk).toHaveBeenCalledTimes(2);
+      expect(callbacks.onComplete).toHaveBeenCalledWith({
+        content: "Hello",
+        finishReason: "stop",
+      });
+      expect(callbacks.onError).not.toHaveBeenCalled();
+    });
+
+    it("done が来ずに終わっても finishReason='stop' で onComplete を呼ぶ (内容あり)", async () => {
+      vi.doMock("@/lib/aiProviders/claudeCodeProvider", () =>
+        buildProviderModule({
+          available: true,
+          chunks: [{ type: "text", content: "abc" }],
+        }),
+      );
+      const callbacks: AIServiceCallbacks = {
+        onChunk: vi.fn(),
+        onComplete: vi.fn(),
+        onError: vi.fn(),
+      };
+      await callAIService(makeClaudeSettings(), makeClaudeRequest(), callbacks);
+      expect(callbacks.onComplete).toHaveBeenCalledWith({
+        content: "abc",
+        finishReason: "stop",
+      });
+    });
+
+    it("done も text も来なければ finishReason='abort'", async () => {
+      vi.doMock("@/lib/aiProviders/claudeCodeProvider", () =>
+        buildProviderModule({ available: true, chunks: [] }),
+      );
+      const callbacks: AIServiceCallbacks = { onComplete: vi.fn(), onError: vi.fn() };
+      await callAIService(makeClaudeSettings(), makeClaudeRequest(), callbacks);
+      expect(callbacks.onComplete).toHaveBeenCalledWith({
+        content: "",
+        finishReason: "abort",
+      });
+    });
+
+    it("tool_use_start / tool_use_complete をコールバックに転送する", async () => {
+      vi.doMock("@/lib/aiProviders/claudeCodeProvider", () =>
+        buildProviderModule({
+          available: true,
+          chunks: [
+            { type: "tool_use_start", content: "", toolName: "bash" },
+            { type: "text", content: "ran" },
+            { type: "tool_use_complete", content: "", toolName: "bash" },
+            { type: "done", content: "" },
+          ],
+        }),
+      );
+      const callbacks: AIServiceCallbacks = {
+        onChunk: vi.fn(),
+        onComplete: vi.fn(),
+        onToolUseStart: vi.fn(),
+        onToolUseComplete: vi.fn(),
+        onError: vi.fn(),
+      };
+      await callAIService(makeClaudeSettings(), makeClaudeRequest(), callbacks);
+      expect(callbacks.onToolUseStart).toHaveBeenCalledWith("bash");
+      expect(callbacks.onToolUseComplete).toHaveBeenCalledWith("bash");
+      expect(callbacks.onComplete).toHaveBeenCalledWith({
+        content: "ran",
+        finishReason: "stop",
+      });
+    });
+
+    it("toolName が無ければ 'unknown' を渡す", async () => {
+      vi.doMock("@/lib/aiProviders/claudeCodeProvider", () =>
+        buildProviderModule({
+          available: true,
+          chunks: [
+            { type: "tool_use_start", content: "" },
+            { type: "tool_use_complete", content: "" },
+            { type: "done", content: "" },
+          ],
+        }),
+      );
+      const callbacks: AIServiceCallbacks = {
+        onToolUseStart: vi.fn(),
+        onToolUseComplete: vi.fn(),
+        onComplete: vi.fn(),
+      };
+      await callAIService(makeClaudeSettings(), makeClaudeRequest(), callbacks);
+      expect(callbacks.onToolUseStart).toHaveBeenCalledWith("unknown");
+      expect(callbacks.onToolUseComplete).toHaveBeenCalledWith("unknown");
+    });
+
+    it("error チャンクは onError へラップして渡す", async () => {
+      vi.doMock("@/lib/aiProviders/claudeCodeProvider", () =>
+        buildProviderModule({
+          available: true,
+          chunks: [{ type: "error", content: "sidecar crashed" }],
+        }),
+      );
+      const callbacks: AIServiceCallbacks = { onError: vi.fn(), onComplete: vi.fn() };
+      await callAIService(makeClaudeSettings(), makeClaudeRequest(), callbacks);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "sidecar crashed" }),
+      );
+      expect(callbacks.onComplete).not.toHaveBeenCalled();
+    });
+
+    it("非 Error の例外は 'Claude Code 呼び出しエラー' に正規化する", async () => {
+      vi.doMock("@/lib/aiProviders/claudeCodeProvider", () =>
+        buildProviderModule({ available: true, throwOnQuery: "string failure" }),
+      );
+      const callbacks: AIServiceCallbacks = { onError: vi.fn(), onComplete: vi.fn() };
+      await callAIService(makeClaudeSettings(), makeClaudeRequest(), callbacks);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Claude Code 呼び出しエラー" }),
+      );
+    });
+
+    it("abortSignal が aborted ならループ内で ABORTED を投げて onError へ", async () => {
+      vi.doMock("@/lib/aiProviders/claudeCodeProvider", () =>
+        buildProviderModule({
+          available: true,
+          chunks: [{ type: "text", content: "x" }],
+        }),
+      );
+      const ac = new AbortController();
+      ac.abort();
+      const callbacks: AIServiceCallbacks = { onError: vi.fn(), onComplete: vi.fn() };
+      await callAIService(makeClaudeSettings(), makeClaudeRequest(), callbacks, ac.signal);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "ABORTED" }),
+      );
+    });
   });
 });

--- a/src/lib/aiService.test.ts
+++ b/src/lib/aiService.test.ts
@@ -778,8 +778,19 @@ describe("aiService - 回帰テスト", () => {
       };
     }
 
+    // `aiService.ts` は claude-code provider を動的 import するため、`vi.doMock` の効果を確実に切り替えるには
+    // モジュールキャッシュもリセットする必要がある。`doUnmock` はレジストリ上の mock 登録を消すだけで、
+    // 既に動的 import 済みのモジュールキャッシュには手を入れないため、`resetModules()` を併用する。
+    // The provider is loaded via dynamic import; `vi.doUnmock` only removes the mock registration
+    // and does not invalidate the cached module. Reset the module registry between tests so that
+    // each `vi.doMock` factory is the one returned by the next dynamic import.
+    beforeEach(() => {
+      vi.resetModules();
+    });
+
     afterEach(() => {
       vi.doUnmock("@/lib/aiProviders/claudeCodeProvider");
+      vi.resetModules();
     });
 
     it("isAvailable が false なら onError を呼ぶ", async () => {

--- a/src/lib/aiService.test.ts
+++ b/src/lib/aiService.test.ts
@@ -607,6 +607,15 @@ describe("aiService - 回帰テスト", () => {
   });
 
   describe("callAIService - APIサーバー経由モード", () => {
+    // assertion 失敗時にも `fetch` / env の stub を確実に解除する。tail-cleanup だと
+    // 失敗時に後続テストへ stub が漏れるため、afterEach で unconditional に剥がす。
+    // Guarantee `fetch` / env stubs are cleared even when an assertion throws —
+    // tail-of-body cleanup would leak stubs into later tests.
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      vi.unstubAllGlobals();
+    });
+
     it("api_serverモードでAPIサーバーURLが未設定の場合はonErrorが呼ばれる", async () => {
       const settings: AISettings = {
         provider: "openai",
@@ -670,9 +679,6 @@ describe("aiService - 回帰テスト", () => {
       const body = JSON.parse(init?.body ?? "{}");
       expect(body.model).toBe("openai:gpt-5-pro");
       expect(callbacks.onComplete).toHaveBeenCalled();
-
-      vi.unstubAllEnvs();
-      vi.unstubAllGlobals();
     });
 
     it("apiMode が未設定でも api_server へフォールバックする", async () => {
@@ -704,8 +710,6 @@ describe("aiService - 回帰テスト", () => {
 
       // ユーザーキーモードならクライアントSDKが呼ばれるが、ここでは fetch のみ呼ばれることを確認。
       expect(fetchSpy).toHaveBeenCalledTimes(1);
-      vi.unstubAllEnvs();
-      vi.unstubAllGlobals();
     });
   });
 

--- a/src/lib/aiServiceDirectProviders.test.ts
+++ b/src/lib/aiServiceDirectProviders.test.ts
@@ -1,0 +1,739 @@
+/**
+ * Tests for direct-SDK provider calls (OpenAI / Anthropic / Google).
+ * 直接 SDK 経由のプロバイダ呼び出しのテスト。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { callOpenAI, callAnthropic, callGoogle } from "./aiServiceDirectProviders";
+import type { AIServiceRequest, AIServiceCallbacks } from "./aiService";
+import type { AISettings } from "@/types/ai";
+
+// --- Module mocks --------------------------------------------------------- //
+
+let openAIMock: {
+  chat: { completions: { create: ReturnType<typeof vi.fn> } };
+} | null = null;
+let anthropicMock: {
+  messages: {
+    create: ReturnType<typeof vi.fn>;
+    stream: ReturnType<typeof vi.fn>;
+  };
+} | null = null;
+let googleMock: {
+  models: {
+    generateContent: ReturnType<typeof vi.fn>;
+    generateContentStream: ReturnType<typeof vi.fn>;
+  };
+} | null = null;
+
+const openAICtor = vi.fn();
+const anthropicCtor = vi.fn();
+const googleCtor = vi.fn();
+
+vi.mock("openai", () => ({
+  default: function OpenAI(args: unknown) {
+    openAICtor(args);
+    if (!openAIMock) throw new Error("OpenAI mock is not configured");
+    return openAIMock;
+  },
+}));
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: function Anthropic(args: unknown) {
+    anthropicCtor(args);
+    if (!anthropicMock) throw new Error("Anthropic mock is not configured");
+    return anthropicMock;
+  },
+}));
+vi.mock("@google/genai", () => ({
+  GoogleGenAI: function GoogleGenAI(args: unknown) {
+    googleCtor(args);
+    if (!googleMock) throw new Error("GoogleGenAI mock is not configured");
+    return googleMock;
+  },
+}));
+
+// --- Helpers --------------------------------------------------------------- //
+
+async function* asyncGen<T>(items: T[]): AsyncGenerator<T> {
+  for (const it of items) yield it;
+}
+
+function buildSettings(provider: AISettings["provider"], apiKey = "key"): AISettings {
+  return {
+    provider,
+    apiKey,
+    apiMode: "user_api_key",
+    model: "x",
+    modelId: `${provider}:x`,
+    isConfigured: true,
+  };
+}
+
+function buildCallbacks(): Required<
+  Pick<AIServiceCallbacks, "onChunk" | "onComplete" | "onError">
+> {
+  return {
+    onChunk: vi.fn(),
+    onComplete: vi.fn(),
+    onError: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  openAIMock = null;
+  anthropicMock = null;
+  googleMock = null;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// =========================================================================== //
+// OpenAI
+// =========================================================================== //
+
+describe("callOpenAI", () => {
+  it("API キーと dangerouslyAllowBrowser を渡してクライアントを生成する", async () => {
+    openAIMock = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: "ok" }, finish_reason: "stop" }],
+          }),
+        },
+      },
+    };
+    const request: AIServiceRequest = {
+      provider: "openai",
+      model: "gpt-5",
+      messages: [{ role: "user", content: "hi" }],
+      options: { stream: false },
+    };
+    await callOpenAI(buildSettings("openai", "sk-test"), request, buildCallbacks());
+    expect(openAICtor).toHaveBeenCalledWith({
+      apiKey: "sk-test",
+      dangerouslyAllowBrowser: true,
+    });
+  });
+
+  it("非ストリーミング: 既定の max_tokens=4000, temperature=0.7 を渡す", async () => {
+    const create = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: "Hello" }, finish_reason: "stop" }],
+    });
+    openAIMock = { chat: { completions: { create } } };
+
+    const request: AIServiceRequest = {
+      provider: "openai",
+      model: "gpt-5",
+      messages: [{ role: "user", content: "hi" }],
+      options: { stream: false },
+    };
+    const callbacks = buildCallbacks();
+    await callOpenAI(buildSettings("openai"), request, callbacks);
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gpt-5",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 4000,
+        temperature: 0.7,
+        stream: false,
+      }),
+      expect.objectContaining({ signal: undefined }),
+    );
+    expect(callbacks.onComplete).toHaveBeenCalledWith({
+      content: "Hello",
+      finishReason: "stop",
+    });
+  });
+
+  it("非ストリーミング: 明示の maxTokens / temperature を尊重する", async () => {
+    const create = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: "x" }, finish_reason: "length" }],
+    });
+    openAIMock = { chat: { completions: { create } } };
+    const request: AIServiceRequest = {
+      provider: "openai",
+      model: "gpt-5",
+      messages: [{ role: "user", content: "hi" }],
+      options: { stream: false, maxTokens: 256, temperature: 0.1 },
+    };
+    await callOpenAI(buildSettings("openai"), request, buildCallbacks());
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ max_tokens: 256, temperature: 0.1 }),
+      expect.anything(),
+    );
+  });
+
+  it("非ストリーミング: choices[0].message.content が無いと空文字で onComplete", async () => {
+    openAIMock = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: {}, finish_reason: undefined }],
+          }),
+        },
+      },
+    };
+    const callbacks = buildCallbacks();
+    await callOpenAI(
+      buildSettings("openai"),
+      {
+        provider: "openai",
+        model: "gpt-5",
+        messages: [{ role: "user", content: "hi" }],
+        options: { stream: false },
+      },
+      callbacks,
+    );
+    expect(callbacks.onComplete).toHaveBeenCalledWith({
+      content: "",
+      finishReason: undefined,
+    });
+  });
+
+  it("ストリーミング: 累積した content と最終 onComplete が呼ばれる", async () => {
+    const stream = asyncGen([
+      { choices: [{ delta: { content: "He" } }] },
+      { choices: [{ delta: { content: "llo" } }] },
+      { choices: [{ delta: {} }] }, // 空 delta はスキップ
+    ]);
+    const create = vi.fn().mockResolvedValue(stream);
+    openAIMock = { chat: { completions: { create } } };
+
+    const callbacks = buildCallbacks();
+    await callOpenAI(
+      buildSettings("openai"),
+      {
+        provider: "openai",
+        model: "gpt-5",
+        messages: [{ role: "user", content: "hi" }],
+        options: { stream: true },
+      },
+      callbacks,
+    );
+
+    expect(callbacks.onChunk).toHaveBeenCalledTimes(2);
+    expect(callbacks.onChunk).toHaveBeenNthCalledWith(1, "He");
+    expect(callbacks.onChunk).toHaveBeenNthCalledWith(2, "llo");
+    expect(callbacks.onComplete).toHaveBeenCalledWith({
+      content: "Hello",
+      finishReason: "stop",
+    });
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ stream: true }),
+      expect.anything(),
+    );
+  });
+
+  it("ストリーミング: webSearchOptions が SDK に渡される", async () => {
+    const create = vi.fn().mockResolvedValue(asyncGen<unknown>([]));
+    openAIMock = { chat: { completions: { create } } };
+    await callOpenAI(
+      buildSettings("openai"),
+      {
+        provider: "openai",
+        model: "gpt-5",
+        messages: [{ role: "user", content: "hi" }],
+        options: {
+          stream: true,
+          webSearchOptions: { search_context_size: "high" },
+        },
+      },
+      buildCallbacks(),
+    );
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        web_search_options: { search_context_size: "high" },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("ストリーミング: abortSignal が aborted の場合は ABORTED で reject", async () => {
+    const stream = asyncGen([
+      { choices: [{ delta: { content: "hi" } }] },
+      { choices: [{ delta: { content: "more" } }] },
+    ]);
+    openAIMock = {
+      chat: { completions: { create: vi.fn().mockResolvedValue(stream) } },
+    };
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      callOpenAI(
+        buildSettings("openai"),
+        {
+          provider: "openai",
+          model: "gpt-5",
+          messages: [{ role: "user", content: "hi" }],
+          options: { stream: true },
+        },
+        buildCallbacks(),
+        ac.signal,
+      ),
+    ).rejects.toThrow("ABORTED");
+  });
+});
+
+// =========================================================================== //
+// Anthropic
+// =========================================================================== //
+
+describe("callAnthropic", () => {
+  it("API キーでクライアントを生成する", async () => {
+    anthropicMock = {
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: "end_turn",
+        }),
+        stream: vi.fn(),
+      },
+    };
+    await callAnthropic(
+      buildSettings("anthropic", "sk-ant-x"),
+      {
+        provider: "anthropic",
+        model: "claude-3-5-sonnet-20241022",
+        messages: [{ role: "user", content: "hi" }],
+        options: { stream: false },
+      },
+      buildCallbacks(),
+    );
+    expect(anthropicCtor).toHaveBeenCalledWith({ apiKey: "sk-ant-x" });
+  });
+
+  it("system メッセージは system フィールドへ集約する", async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+    });
+    anthropicMock = { messages: { create, stream: vi.fn() } };
+    await callAnthropic(
+      buildSettings("anthropic"),
+      {
+        provider: "anthropic",
+        model: "claude-3-5-sonnet-20241022",
+        messages: [
+          { role: "system", content: "rule A" },
+          { role: "system", content: "rule B" },
+          { role: "user", content: "go" },
+        ],
+        options: { stream: false },
+      },
+      buildCallbacks(),
+    );
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: "rule A\n\nrule B",
+        messages: [{ role: "user", content: "go" }],
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("system メッセージが無ければ system フィールドは付かない", async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+    });
+    anthropicMock = { messages: { create, stream: vi.fn() } };
+    await callAnthropic(
+      buildSettings("anthropic"),
+      {
+        provider: "anthropic",
+        model: "claude-3-5-sonnet-20241022",
+        messages: [{ role: "user", content: "go" }],
+        options: { stream: false },
+      },
+      buildCallbacks(),
+    );
+    const arg = create.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.system).toBeUndefined();
+  });
+
+  it("対応モデル名なら自動で web_search ツールを付ける", async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+    });
+    anthropicMock = { messages: { create, stream: vi.fn() } };
+    await callAnthropic(
+      buildSettings("anthropic"),
+      {
+        provider: "anthropic",
+        model: "claude-3-5-sonnet-20241022",
+        messages: [{ role: "user", content: "go" }],
+        options: { stream: false },
+      },
+      buildCallbacks(),
+    );
+    const arg = create.mock.calls[0][0] as { tools?: Array<{ name: string }> };
+    expect(arg.tools?.[0]?.name).toBe("web_search");
+  });
+
+  it("対応外モデル名ならツールは付かない", async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+    });
+    anthropicMock = { messages: { create, stream: vi.fn() } };
+    await callAnthropic(
+      buildSettings("anthropic"),
+      {
+        provider: "anthropic",
+        model: "claude-2.1",
+        messages: [{ role: "user", content: "go" }],
+        options: { stream: false },
+      },
+      buildCallbacks(),
+    );
+    const arg = create.mock.calls[0][0] as { tools?: unknown };
+    expect(arg.tools).toBeUndefined();
+  });
+
+  it("useWebSearch=false なら対応モデルでもツールを付けない", async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+    });
+    anthropicMock = { messages: { create, stream: vi.fn() } };
+    await callAnthropic(
+      buildSettings("anthropic"),
+      {
+        provider: "anthropic",
+        model: "claude-3-5-sonnet-20241022",
+        messages: [{ role: "user", content: "go" }],
+        options: { stream: false, useWebSearch: false },
+      },
+      buildCallbacks(),
+    );
+    const arg = create.mock.calls[0][0] as { tools?: unknown };
+    expect(arg.tools).toBeUndefined();
+  });
+
+  it("useWebSearch=true なら対応外モデルでもツールを付ける", async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+    });
+    anthropicMock = { messages: { create, stream: vi.fn() } };
+    await callAnthropic(
+      buildSettings("anthropic"),
+      {
+        provider: "anthropic",
+        model: "claude-2.1",
+        messages: [{ role: "user", content: "go" }],
+        options: { stream: false, useWebSearch: true },
+      },
+      buildCallbacks(),
+    );
+    const arg = create.mock.calls[0][0] as { tools?: Array<{ name: string }> };
+    expect(arg.tools?.[0]?.name).toBe("web_search");
+  });
+
+  it("非ストリーミング: text ブロックの内容を onComplete に渡す", async () => {
+    anthropicMock = {
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [
+            { type: "tool_use", id: "x", name: "y", input: {} },
+            { type: "text", text: "Hello!" },
+          ],
+          stop_reason: "end_turn",
+        }),
+        stream: vi.fn(),
+      },
+    };
+    const callbacks = buildCallbacks();
+    await callAnthropic(
+      buildSettings("anthropic"),
+      {
+        provider: "anthropic",
+        model: "claude-3-5-sonnet-20241022",
+        messages: [{ role: "user", content: "hi" }],
+        options: { stream: false },
+      },
+      callbacks,
+    );
+    expect(callbacks.onComplete).toHaveBeenCalledWith({
+      content: "Hello!",
+      finishReason: "end_turn",
+    });
+  });
+
+  it("非ストリーミング: text ブロックが無ければ空文字で onComplete", async () => {
+    anthropicMock = {
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ type: "tool_use", id: "x", name: "y", input: {} }],
+          stop_reason: "tool_use",
+        }),
+        stream: vi.fn(),
+      },
+    };
+    const callbacks = buildCallbacks();
+    await callAnthropic(
+      buildSettings("anthropic"),
+      {
+        provider: "anthropic",
+        model: "claude-3-5-sonnet-20241022",
+        messages: [{ role: "user", content: "hi" }],
+        options: { stream: false },
+      },
+      callbacks,
+    );
+    expect(callbacks.onComplete).toHaveBeenCalledWith({
+      content: "",
+      finishReason: "tool_use",
+    });
+  });
+
+  it("ストリーミング: text_delta だけをチャンクとして流す", async () => {
+    const events = [
+      { type: "message_start" },
+      {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "Hel" },
+      },
+      {
+        type: "content_block_delta",
+        delta: { type: "input_json_delta", partial_json: "{" },
+      },
+      {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "lo" },
+      },
+    ];
+    const streamFn = vi.fn().mockReturnValue(asyncGen(events));
+    anthropicMock = { messages: { create: vi.fn(), stream: streamFn } };
+
+    const callbacks = buildCallbacks();
+    await callAnthropic(
+      buildSettings("anthropic"),
+      {
+        provider: "anthropic",
+        model: "claude-3-5-sonnet-20241022",
+        messages: [{ role: "user", content: "hi" }],
+        options: { stream: true },
+      },
+      callbacks,
+    );
+
+    expect(callbacks.onChunk).toHaveBeenCalledTimes(2);
+    expect(callbacks.onChunk).toHaveBeenNthCalledWith(1, "Hel");
+    expect(callbacks.onChunk).toHaveBeenNthCalledWith(2, "lo");
+    expect(callbacks.onComplete).toHaveBeenCalledWith({
+      content: "Hello",
+      finishReason: "stop",
+    });
+  });
+
+  it("ストリーミング: 既に aborted のシグナルなら ABORTED で reject", async () => {
+    const events = [{ type: "content_block_delta", delta: { type: "text_delta", text: "x" } }];
+    const streamFn = vi.fn().mockReturnValue(asyncGen(events));
+    anthropicMock = { messages: { create: vi.fn(), stream: streamFn } };
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      callAnthropic(
+        buildSettings("anthropic"),
+        {
+          provider: "anthropic",
+          model: "claude-3-5-sonnet-20241022",
+          messages: [{ role: "user", content: "hi" }],
+          options: { stream: true },
+        },
+        buildCallbacks(),
+        ac.signal,
+      ),
+    ).rejects.toThrow("ABORTED");
+  });
+});
+
+// =========================================================================== //
+// Google
+// =========================================================================== //
+
+describe("callGoogle", () => {
+  it("API キーでクライアントを生成する", async () => {
+    googleMock = {
+      models: {
+        generateContent: vi.fn().mockResolvedValue({ text: "ok" }),
+        generateContentStream: vi.fn(),
+      },
+    };
+    await callGoogle(
+      buildSettings("google", "AIza-x"),
+      {
+        provider: "google",
+        model: "gemini-3-flash",
+        messages: [{ role: "user", content: "hi" }],
+        options: { stream: false },
+      },
+      buildCallbacks(),
+    );
+    expect(googleCtor).toHaveBeenCalledWith({ apiKey: "AIza-x" });
+  });
+
+  it("非ストリーミング: 既定で googleSearch ツールを付ける", async () => {
+    const generateContent = vi.fn().mockResolvedValue({ text: "Hello" });
+    googleMock = {
+      models: { generateContent, generateContentStream: vi.fn() },
+    };
+    const callbacks = buildCallbacks();
+    await callGoogle(
+      buildSettings("google"),
+      {
+        provider: "google",
+        model: "gemini-3-flash",
+        messages: [
+          { role: "user", content: "msg1" },
+          { role: "user", content: "msg2" },
+        ],
+        options: { stream: false, temperature: 0.3 },
+      },
+      callbacks,
+    );
+
+    expect(generateContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gemini-3-flash",
+        contents: "msg1\n\nmsg2",
+        config: expect.objectContaining({
+          temperature: 0.3,
+          tools: [{ googleSearch: {} }],
+        }),
+      }),
+    );
+    expect(callbacks.onComplete).toHaveBeenCalledWith({
+      content: "Hello",
+      finishReason: "stop",
+    });
+  });
+
+  it("非ストリーミング: useGoogleSearch=false ならツールを undefined にする", async () => {
+    const generateContent = vi.fn().mockResolvedValue({ text: "x" });
+    googleMock = {
+      models: { generateContent, generateContentStream: vi.fn() },
+    };
+    await callGoogle(
+      buildSettings("google"),
+      {
+        provider: "google",
+        model: "gemini-3-flash",
+        messages: [{ role: "user", content: "hi" }],
+        options: { stream: false, useGoogleSearch: false },
+      },
+      buildCallbacks(),
+    );
+    const cfg = (generateContent.mock.calls[0][0] as { config: { tools?: unknown } }).config;
+    expect(cfg.tools).toBeUndefined();
+  });
+
+  it("非ストリーミング: text 未定義なら空文字で onComplete", async () => {
+    googleMock = {
+      models: {
+        generateContent: vi.fn().mockResolvedValue({}),
+        generateContentStream: vi.fn(),
+      },
+    };
+    const callbacks = buildCallbacks();
+    await callGoogle(
+      buildSettings("google"),
+      {
+        provider: "google",
+        model: "gemini-3-flash",
+        messages: [{ role: "user", content: "hi" }],
+        options: { stream: false },
+      },
+      callbacks,
+    );
+    expect(callbacks.onComplete).toHaveBeenCalledWith({
+      content: "",
+      finishReason: "stop",
+    });
+  });
+
+  it("ストリーミング: 既定の maxOutputTokens=4000 / temperature=0.7 を渡す", async () => {
+    const generateContentStream = vi.fn().mockResolvedValue(asyncGen<unknown>([]));
+    googleMock = {
+      models: { generateContent: vi.fn(), generateContentStream },
+    };
+    await callGoogle(
+      buildSettings("google"),
+      {
+        provider: "google",
+        model: "gemini-3-flash",
+        messages: [{ role: "user", content: "hi" }],
+        options: { stream: true },
+      },
+      buildCallbacks(),
+    );
+    expect(generateContentStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          maxOutputTokens: 4000,
+          temperature: 0.7,
+          tools: [{ googleSearch: {} }],
+        }),
+      }),
+    );
+  });
+
+  it("ストリーミング: 文字列を蓄積し最終 onComplete を呼ぶ", async () => {
+    const chunks = [{ text: "He" }, { text: "" }, { text: "llo" }];
+    googleMock = {
+      models: {
+        generateContent: vi.fn(),
+        generateContentStream: vi.fn().mockResolvedValue(asyncGen(chunks)),
+      },
+    };
+    const callbacks = buildCallbacks();
+    await callGoogle(
+      buildSettings("google"),
+      {
+        provider: "google",
+        model: "gemini-3-flash",
+        messages: [{ role: "user", content: "hi" }],
+        options: { stream: true, useGoogleSearch: false, maxTokens: 1000 },
+      },
+      callbacks,
+    );
+    expect(callbacks.onChunk).toHaveBeenCalledTimes(2);
+    expect(callbacks.onChunk).toHaveBeenNthCalledWith(1, "He");
+    expect(callbacks.onChunk).toHaveBeenNthCalledWith(2, "llo");
+    expect(callbacks.onComplete).toHaveBeenCalledWith({
+      content: "Hello",
+      finishReason: "stop",
+    });
+  });
+
+  it("ストリーミング: aborted のシグナルなら ABORTED で reject", async () => {
+    googleMock = {
+      models: {
+        generateContent: vi.fn(),
+        generateContentStream: vi.fn().mockResolvedValue(asyncGen([{ text: "x" }, { text: "y" }])),
+      },
+    };
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      callGoogle(
+        buildSettings("google"),
+        {
+          provider: "google",
+          model: "gemini-3-flash",
+          messages: [{ role: "user", content: "hi" }],
+          options: { stream: true },
+        },
+        buildCallbacks(),
+        ac.signal,
+      ),
+    ).rejects.toThrow("ABORTED");
+  });
+});

--- a/src/lib/aiServiceModels.test.ts
+++ b/src/lib/aiServiceModels.test.ts
@@ -279,25 +279,19 @@ describe("aiServiceModels", () => {
       });
     });
 
-    it("無限大や NaN の cost は 0 に正規化する", async () => {
-      fetchSpy.mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            models: [
-              {
-                id: "x:y",
-                provider: "openai",
-                model_id: "x",
-                display_name: "X",
-                input_cost_units: Number.POSITIVE_INFINITY,
-                output_cost_units: Number.NaN,
-              },
-            ],
-            tier: "free",
-          }),
-          { status: 200 },
-        ),
-      );
+    it("非有限数 (±Infinity) の cost は 0 に正規化する / non-finite cost values fall back to 0", async () => {
+      // `JSON.stringify(Infinity)` は `null` になり Number.isFinite ガードを通らないため、
+      // 生 JSON リテラル `1e1000` で `JSON.parse` に実際の Infinity を作らせる。
+      // (NaN は JSON 表現不可能だが、Number.isFinite ガードは符号無関係に同じ分岐へ落ちる。)
+      // We avoid `JSON.stringify(Infinity)` (which collapses to `null` and would only
+      // exercise the missing-field path). A raw `1e1000` literal yields an actual
+      // Infinity from `JSON.parse`, so this test really exercises the
+      // `Number.isFinite` guard in `toNum`.
+      const rawBody =
+        '{"models":[{"id":"x:y","provider":"openai","model_id":"x",' +
+        '"display_name":"X","input_cost_units":1e1000,"output_cost_units":-1e1000}],' +
+        '"tier":"free"}';
+      fetchSpy.mockResolvedValue(new Response(rawBody, { status: 200 }));
 
       const result = await fetchServerModels();
       expect(result.models[0].inputCostUnits).toBe(0);

--- a/src/lib/aiServiceModels.test.ts
+++ b/src/lib/aiServiceModels.test.ts
@@ -1,0 +1,506 @@
+/**
+ * Tests for AI service model listing & usage helpers.
+ * AI サービスのモデル一覧／使用量取得のテスト。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { FetchServerModelsError, fetchServerModels, fetchUsage } from "./aiServiceModels";
+import type { AIModel, AIUsage, UserTier } from "@/types/ai";
+
+const SERVER_MODELS_CACHE_KEY = "zedi-ai-server-models";
+const TEN_MINUTES_MS = 10 * 60 * 1000;
+
+/**
+ * Build a fully-populated AIModel for cache fixtures.
+ * キャッシュ用のテストモデルを生成する。
+ */
+function buildModel(overrides: Partial<AIModel> = {}): AIModel {
+  return {
+    id: "openai:gpt-5",
+    provider: "openai",
+    modelId: "gpt-5",
+    displayName: "GPT-5",
+    tierRequired: "free",
+    available: true,
+    inputCostUnits: 1,
+    outputCostUnits: 2,
+    ...overrides,
+  };
+}
+
+describe("aiServiceModels", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.stubEnv("VITE_API_BASE_URL", "https://api.example.com");
+    // Suppress noisy console output triggered by error paths.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  describe("FetchServerModelsError", () => {
+    it("正しい name と code を保持する", () => {
+      const err = new FetchServerModelsError("boom", "NETWORK", { status: 500 });
+      expect(err).toBeInstanceOf(Error);
+      expect(err.name).toBe("FetchServerModelsError");
+      expect(err.message).toBe("boom");
+      expect(err.code).toBe("NETWORK");
+      expect(err.details).toEqual({ status: 500 });
+    });
+
+    it("details は省略可能", () => {
+      const err = new FetchServerModelsError("x", "HTTP");
+      expect(err.details).toBeUndefined();
+    });
+  });
+
+  describe("fetchServerModels - cache hit", () => {
+    it("TTL 内のキャッシュをそのまま返し、API を呼ばない", async () => {
+      const cached = {
+        models: [buildModel({ id: "openai:gpt-5", modelId: "gpt-5" })],
+        tier: "pro" as UserTier,
+        cachedAt: Date.now(),
+      };
+      localStorage.setItem(SERVER_MODELS_CACHE_KEY, JSON.stringify(cached));
+
+      const result = await fetchServerModels();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(result.tier).toBe("pro");
+      expect(result.models).toHaveLength(1);
+      expect(result.models[0].id).toBe("openai:gpt-5");
+    });
+
+    it("snake_case のキャッシュも camelCase へ正規化する", async () => {
+      // キャッシュが古いフォーマット (snake_case) で書かれていた場合の互換性。
+      const rawCache = {
+        models: [
+          {
+            id: "openai:gpt-5",
+            provider: "openai",
+            model_id: "gpt-5",
+            display_name: "GPT-5",
+            tier_required: "pro",
+            available: true,
+            input_cost_units: 5,
+            output_cost_units: 6,
+          },
+        ],
+        tier: "pro",
+        cachedAt: Date.now(),
+      };
+      localStorage.setItem(SERVER_MODELS_CACHE_KEY, JSON.stringify(rawCache));
+
+      const result = await fetchServerModels();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(result.models[0]).toEqual({
+        id: "openai:gpt-5",
+        provider: "openai",
+        modelId: "gpt-5",
+        displayName: "GPT-5",
+        tierRequired: "pro",
+        available: true,
+        inputCostUnits: 5,
+        outputCostUnits: 6,
+      });
+      expect(result.tier).toBe("pro");
+    });
+
+    it("キャッシュの tier が pro 以外の値なら free にフォールバック", async () => {
+      const cached = {
+        models: [],
+        tier: "enterprise",
+        cachedAt: Date.now(),
+      };
+      localStorage.setItem(SERVER_MODELS_CACHE_KEY, JSON.stringify(cached));
+
+      const result = await fetchServerModels();
+      expect(result.tier).toBe("free");
+    });
+
+    it("TTL を過ぎたキャッシュは無視して API を叩く", async () => {
+      const cached = {
+        models: [buildModel({ id: "old:model" })],
+        tier: "free" as UserTier,
+        cachedAt: Date.now() - (TEN_MINUTES_MS + 1),
+      };
+      localStorage.setItem(SERVER_MODELS_CACHE_KEY, JSON.stringify(cached));
+
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ models: [], tier: "free" }), { status: 200 }),
+      );
+
+      const result = await fetchServerModels();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(result.models).toEqual([]);
+    });
+
+    it("forceRefresh=true なら有効なキャッシュも無視する", async () => {
+      const cached = {
+        models: [buildModel({ id: "openai:cached", modelId: "cached" })],
+        tier: "pro" as UserTier,
+        cachedAt: Date.now(),
+      };
+      localStorage.setItem(SERVER_MODELS_CACHE_KEY, JSON.stringify(cached));
+
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ models: [], tier: "free" }), { status: 200 }),
+      );
+
+      const result = await fetchServerModels(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(result.tier).toBe("free");
+    });
+
+    it("不正な JSON のキャッシュは無視して API を叩く", async () => {
+      localStorage.setItem(SERVER_MODELS_CACHE_KEY, "{not valid json");
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ models: [], tier: "free" }), { status: 200 }),
+      );
+
+      await fetchServerModels();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("fetchServerModels - API success", () => {
+    it("API レスポンスを正規化して返し、キャッシュへ保存する", async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            models: [
+              {
+                id: "openai:gpt-5",
+                provider: "openai",
+                model_id: "gpt-5",
+                display_name: "GPT-5",
+                tier_required: "pro",
+                available: true,
+                input_cost_units: 1,
+                output_cost_units: 2,
+              },
+              {
+                id: "google:gemini",
+                provider: "google",
+                modelId: "gemini-3-flash",
+                displayName: "Gemini 3 Flash",
+                tierRequired: "free",
+                available: false,
+                inputCostUnits: 0.5,
+                outputCostUnits: 1.5,
+              },
+            ],
+            tier: "pro",
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const result = await fetchServerModels();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://api.example.com/api/ai/models",
+        expect.objectContaining({
+          method: "GET",
+          credentials: "include",
+        }),
+      );
+      expect(result.tier).toBe("pro");
+      expect(result.models).toHaveLength(2);
+      expect(result.models[0].modelId).toBe("gpt-5");
+      expect(result.models[0].tierRequired).toBe("pro");
+      expect(result.models[1].modelId).toBe("gemini-3-flash");
+      expect(result.models[1].tierRequired).toBe("free");
+
+      const stored = localStorage.getItem(SERVER_MODELS_CACHE_KEY);
+      expect(stored).toBeTruthy();
+      const parsed = JSON.parse(stored ?? "{}");
+      expect(parsed.tier).toBe("pro");
+      expect(parsed.models).toHaveLength(2);
+      expect(typeof parsed.cachedAt).toBe("number");
+    });
+
+    it("不正なプロバイダー文字列は google にフォールバックする", async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            models: [
+              {
+                id: "x:y",
+                provider: "weird-provider",
+                model_id: "x",
+                display_name: "X",
+              },
+            ],
+            tier: "free",
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const result = await fetchServerModels();
+      expect(result.models[0].provider).toBe("google");
+    });
+
+    it("欠損フィールドはデフォルト値で埋める", async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            models: [{}],
+            tier: "free",
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const result = await fetchServerModels();
+      expect(result.models[0]).toEqual({
+        id: "",
+        provider: "google",
+        modelId: "",
+        displayName: "",
+        tierRequired: "free",
+        available: false,
+        inputCostUnits: 0,
+        outputCostUnits: 0,
+      });
+    });
+
+    it("無限大や NaN の cost は 0 に正規化する", async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            models: [
+              {
+                id: "x:y",
+                provider: "openai",
+                model_id: "x",
+                display_name: "X",
+                input_cost_units: Number.POSITIVE_INFINITY,
+                output_cost_units: Number.NaN,
+              },
+            ],
+            tier: "free",
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const result = await fetchServerModels();
+      expect(result.models[0].inputCostUnits).toBe(0);
+      expect(result.models[0].outputCostUnits).toBe(0);
+    });
+
+    it("tier が不明なら free にフォールバックする", async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ models: [], tier: "unknown" }), { status: 200 }),
+      );
+
+      const result = await fetchServerModels();
+      expect(result.tier).toBe("free");
+    });
+
+    it("localStorage の setItem が失敗しても結果は返す", async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ models: [], tier: "free" }), { status: 200 }),
+      );
+      const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new Error("quota exceeded");
+      });
+
+      await expect(fetchServerModels()).resolves.toEqual({ models: [], tier: "free" });
+      expect(setItemSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("fetchServerModels - error paths", () => {
+    it("VITE_API_BASE_URL 未設定なら NO_BASE_URL を投げる", async () => {
+      vi.stubEnv("VITE_API_BASE_URL", "");
+      await expect(fetchServerModels()).rejects.toMatchObject({
+        name: "FetchServerModelsError",
+        code: "NO_BASE_URL",
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("fetch が TypeError(fetch) ならネットワークエラーメッセージにする", async () => {
+      fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
+      try {
+        await fetchServerModels();
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(FetchServerModelsError);
+        const e = err as FetchServerModelsError;
+        expect(e.code).toBe("NETWORK");
+        expect(e.message).toContain("ネットワークエラー");
+      }
+    });
+
+    it("fetch が一般的な Error ならリクエスト失敗メッセージにする", async () => {
+      fetchSpy.mockRejectedValue(new Error("DNS failure"));
+      try {
+        await fetchServerModels();
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(FetchServerModelsError);
+        const e = err as FetchServerModelsError;
+        expect(e.code).toBe("NETWORK");
+        expect(e.message).toContain("リクエスト失敗");
+        expect(e.message).toContain("DNS failure");
+      }
+    });
+
+    it("fetch が非 Error 値を投げてもラップする", async () => {
+      fetchSpy.mockRejectedValue("plain string failure");
+      await expect(fetchServerModels()).rejects.toMatchObject({
+        code: "NETWORK",
+      });
+    });
+
+    it("HTTP エラーは status / statusText / 抜粋 body を保持する", async () => {
+      const longBody = "x".repeat(1000);
+      fetchSpy.mockResolvedValue(
+        new Response(longBody, { status: 503, statusText: "Service Unavailable" }),
+      );
+
+      try {
+        await fetchServerModels();
+        expect.fail("should have thrown");
+      } catch (err) {
+        const e = err as FetchServerModelsError;
+        expect(e.code).toBe("HTTP");
+        expect(e.details?.status).toBe(503);
+        expect(e.details?.statusText).toBe("Service Unavailable");
+        expect(e.details?.body?.length).toBe(500);
+      }
+    });
+
+    it("レスポンスが JSON でなければ INVALID_RESPONSE", async () => {
+      fetchSpy.mockResolvedValue(new Response("not json at all", { status: 200 }));
+      try {
+        await fetchServerModels();
+        expect.fail("should have thrown");
+      } catch (err) {
+        const e = err as FetchServerModelsError;
+        expect(e.code).toBe("INVALID_RESPONSE");
+      }
+    });
+
+    it("models フィールドが配列でなければ INVALID_RESPONSE", async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ models: "oops", tier: "free" }), { status: 200 }),
+      );
+      try {
+        await fetchServerModels();
+        expect.fail("should have thrown");
+      } catch (err) {
+        const e = err as FetchServerModelsError;
+        expect(e.code).toBe("INVALID_RESPONSE");
+      }
+    });
+
+    it("response.text() が失敗したら NETWORK エラーへ変換する", async () => {
+      const badResponse = {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: vi.fn().mockRejectedValue(new Error("read failed")),
+      };
+      fetchSpy.mockResolvedValue(badResponse as unknown as Response);
+
+      try {
+        await fetchServerModels();
+        expect.fail("should have thrown");
+      } catch (err) {
+        const e = err as FetchServerModelsError;
+        expect(e.code).toBe("NETWORK");
+        expect(e.message).toContain("レスポンスの読み取り");
+      }
+    });
+  });
+
+  describe("fetchUsage", () => {
+    function buildUsage(overrides: Partial<AIUsage> = {}): AIUsage {
+      return {
+        usagePercent: 12.5,
+        consumedUnits: 100,
+        budgetUnits: 800,
+        remaining: 700,
+        tier: "free",
+        yearMonth: "2026-04",
+        ...overrides,
+      };
+    }
+
+    it("ベース URL 未設定なら空の使用量オブジェクトを返す", async () => {
+      vi.stubEnv("VITE_API_BASE_URL", "");
+      const usage = await fetchUsage();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(usage).toEqual({
+        usagePercent: 0,
+        consumedUnits: 0,
+        budgetUnits: 0,
+        remaining: 0,
+        tier: "free",
+        yearMonth: "",
+      });
+    });
+
+    it("正常レスポンスをそのまま返す", async () => {
+      const expected = buildUsage({ tier: "pro", yearMonth: "2026-04" });
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify(expected), { status: 200 }));
+
+      const usage = await fetchUsage();
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://api.example.com/api/ai/usage",
+        expect.objectContaining({ method: "GET", credentials: "include" }),
+      );
+      expect(usage).toEqual(expected);
+    });
+
+    it("401 なら AUTH_REQUIRED を投げる", async () => {
+      fetchSpy.mockResolvedValue(new Response("", { status: 401 }));
+      await expect(fetchUsage()).rejects.toThrow("AUTH_REQUIRED");
+    });
+
+    it("その他の HTTP エラーは Failed to fetch usage を投げる", async () => {
+      fetchSpy.mockResolvedValue(new Response("", { status: 500 }));
+      await expect(fetchUsage()).rejects.toThrow("Failed to fetch usage");
+    });
+
+    it("レスポンスが usage 形式でなければ INVALID_USAGE_RESPONSE を投げる", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ tier: "free" }), { status: 200 }));
+      await expect(fetchUsage()).rejects.toThrow("INVALID_USAGE_RESPONSE");
+    });
+
+    it("tier が不正な値なら INVALID_USAGE_RESPONSE を投げる", async () => {
+      const invalid = { ...buildUsage(), tier: "enterprise" };
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify(invalid), { status: 200 }));
+      await expect(fetchUsage()).rejects.toThrow("INVALID_USAGE_RESPONSE");
+    });
+
+    it("数値フィールドが欠落していたら INVALID_USAGE_RESPONSE を投げる", async () => {
+      const invalid = { ...buildUsage(), usagePercent: undefined };
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify(invalid), { status: 200 }));
+      await expect(fetchUsage()).rejects.toThrow("INVALID_USAGE_RESPONSE");
+    });
+
+    it("payload が null なら INVALID_USAGE_RESPONSE を投げる", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify(null), { status: 200 }));
+      await expect(fetchUsage()).rejects.toThrow("INVALID_USAGE_RESPONSE");
+    });
+  });
+});

--- a/src/lib/aiServiceServer.test.ts
+++ b/src/lib/aiServiceServer.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for AI service server-mode (SSE streaming) calls.
+ * AI サービス（API サーバー経由・SSE）のテスト。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { callAIWithServer } from "./aiServiceServer";
+import type { AIServiceRequest, AIServiceCallbacks } from "./aiService";
+
+/**
+ * Build a mock streaming Response whose body is a `ReadableStream<Uint8Array>`
+ * fed by the chunks the test wants to deliver.
+ * テストが指定したチャンク列を流す ReadableStream 入りのレスポンスを作る。
+ */
+function makeStreamingResponse(chunks: string[], status = 200): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      for (const c of chunks) {
+        controller.enqueue(encoder.encode(c));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status,
+    statusText: status === 200 ? "OK" : `Status ${status}`,
+  });
+}
+
+function buildRequest(overrides: Partial<AIServiceRequest> = {}): AIServiceRequest {
+  return {
+    provider: "openai",
+    model: "gpt-5",
+    messages: [{ role: "user", content: "hello" }],
+    options: { stream: true, temperature: 0.5 },
+    ...overrides,
+  };
+}
+
+function buildCallbacks(): Required<
+  Pick<AIServiceCallbacks, "onChunk" | "onComplete" | "onError" | "onUsageUpdate">
+> {
+  return {
+    onChunk: vi.fn(),
+    onComplete: vi.fn(),
+    onError: vi.fn(),
+    onUsageUpdate: vi.fn(),
+  };
+}
+
+describe("aiServiceServer / callAIWithServer", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.stubEnv("VITE_API_BASE_URL", "https://api.example.com");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe("URL 設定", () => {
+    it("VITE_API_BASE_URL 未設定時は onError(URLが設定されていません)", async () => {
+      vi.stubEnv("VITE_API_BASE_URL", "");
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(callbacks.onError).toHaveBeenCalledTimes(1);
+      const errArg = callbacks.onError.mock.calls[0][0] as Error;
+      expect(errArg.message).toContain("URL");
+      expect(callbacks.onComplete).not.toHaveBeenCalled();
+    });
+
+    it("正しい URL/JSON ボディ/credentials で fetch される", async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ content: "ok", finishReason: "stop" }), { status: 200 }),
+      );
+      const request = buildRequest({ options: { stream: false } });
+      await callAIWithServer(request, buildCallbacks());
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchSpy.mock.calls[0];
+      expect(url).toBe("https://api.example.com/api/ai/chat");
+      expect(init.method).toBe("POST");
+      expect(init.credentials).toBe("include");
+      expect(init.headers).toEqual({ "Content-Type": "application/json" });
+      const body = JSON.parse(init.body);
+      expect(body).toEqual({
+        provider: "openai",
+        model: "gpt-5",
+        messages: [{ role: "user", content: "hello" }],
+        options: { stream: false },
+      });
+    });
+  });
+
+  describe("HTTP ステータスマッピング", () => {
+    it("401 は AUTH_REQUIRED として onError へ", async () => {
+      fetchSpy.mockResolvedValue(new Response("", { status: 401 }));
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "AUTH_REQUIRED" }),
+      );
+    });
+
+    it("ボディに error フィールドがあればそのメッセージを使う", async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ error: "rate limited" }), { status: 429 }),
+      );
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "rate limited" }),
+      );
+    });
+
+    it("ボディが JSON でなければ statusText を使う", async () => {
+      fetchSpy.mockResolvedValue(
+        new Response("plain text", { status: 503, statusText: "Service Unavailable" }),
+      );
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Service Unavailable" }),
+      );
+    });
+
+    it("statusText も空ならフォールバック文字列を使う", async () => {
+      fetchSpy.mockResolvedValue(new Response("plain text", { status: 500, statusText: "" }));
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "AI API呼び出しエラー" }),
+      );
+    });
+
+    it("fetch 自体が reject したら onError(Error)", async () => {
+      fetchSpy.mockRejectedValue(new Error("network down"));
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "network down" }),
+      );
+    });
+
+    it("fetch が非 Error 値で reject しても汎用メッセージへ変換する", async () => {
+      fetchSpy.mockRejectedValue("string failure");
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "AI API呼び出しエラー" }),
+      );
+    });
+  });
+
+  describe("非ストリーミング", () => {
+    it("usage 付きレスポンスで onUsageUpdate と onComplete が呼ばれる", async () => {
+      const usage = { inputTokens: 5, outputTokens: 8, costUnits: 1, usagePercent: 0.1 };
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ content: "Hello!", finishReason: "stop", usage }), {
+          status: 200,
+        }),
+      );
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest({ options: { stream: false } }), callbacks);
+
+      expect(callbacks.onUsageUpdate).toHaveBeenCalledWith(usage);
+      expect(callbacks.onComplete).toHaveBeenCalledWith({
+        content: "Hello!",
+        finishReason: "stop",
+        usage,
+      });
+      expect(callbacks.onError).not.toHaveBeenCalled();
+    });
+
+    it("content 欠落時は空文字で onComplete が呼ばれる", async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ finishReason: "stop" }), { status: 200 }),
+      );
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest({ options: { stream: false } }), callbacks);
+
+      expect(callbacks.onComplete).toHaveBeenCalledWith({
+        content: "",
+        finishReason: "stop",
+        usage: undefined,
+      });
+    });
+
+    it("usage が無ければ onUsageUpdate は呼ばれない", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ content: "ok" }), { status: 200 }));
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest({ options: { stream: false } }), callbacks);
+      expect(callbacks.onUsageUpdate).not.toHaveBeenCalled();
+      expect(callbacks.onComplete).toHaveBeenCalledWith({
+        content: "ok",
+        finishReason: undefined,
+        usage: undefined,
+      });
+    });
+  });
+
+  describe("ストリーミング (SSE)", () => {
+    it("複数の data 行を順次 onChunk で受け取り、done で onComplete を呼ぶ", async () => {
+      fetchSpy.mockResolvedValue(
+        makeStreamingResponse([
+          'data: {"content":"Hel"}\n',
+          'data: {"content":"lo"}\n',
+          'data: {"content":"!","done":true,"finishReason":"stop"}\n',
+        ]),
+      );
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+
+      expect(callbacks.onChunk).toHaveBeenCalledTimes(3);
+      expect(callbacks.onChunk).toHaveBeenNthCalledWith(1, "Hel");
+      expect(callbacks.onChunk).toHaveBeenNthCalledWith(2, "lo");
+      expect(callbacks.onChunk).toHaveBeenNthCalledWith(3, "!");
+      expect(callbacks.onComplete).toHaveBeenCalledWith({
+        content: "Hello!",
+        finishReason: "stop",
+        usage: undefined,
+      });
+      expect(callbacks.onError).not.toHaveBeenCalled();
+    });
+
+    it("data: 以外の行はスキップする", async () => {
+      fetchSpy.mockResolvedValue(
+        makeStreamingResponse([
+          ": comment\n",
+          "event: ping\n",
+          'data: {"content":"X","done":true,"finishReason":"stop"}\n',
+        ]),
+      );
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onChunk).toHaveBeenCalledTimes(1);
+      expect(callbacks.onChunk).toHaveBeenCalledWith("X");
+      expect(callbacks.onComplete).toHaveBeenCalled();
+    });
+
+    it("`data:` の後ろが空のペイロードはスキップする", async () => {
+      fetchSpy.mockResolvedValue(
+        makeStreamingResponse(["data:    \n", 'data: {"done":true,"finishReason":"stop"}\n']),
+      );
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onComplete).toHaveBeenCalledWith({
+        content: "",
+        finishReason: "stop",
+        usage: undefined,
+      });
+    });
+
+    it("usage 含むイベントで onUsageUpdate と最終 onComplete が呼ばれる", async () => {
+      const usage = { inputTokens: 1, outputTokens: 2, costUnits: 3, usagePercent: 0.4 };
+      fetchSpy.mockResolvedValue(
+        makeStreamingResponse([
+          'data: {"content":"hi"}\n',
+          `data: ${JSON.stringify({ usage })}\n`,
+          'data: {"done":true,"finishReason":"stop"}\n',
+        ]),
+      );
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+
+      expect(callbacks.onUsageUpdate).toHaveBeenCalledWith(usage);
+      expect(callbacks.onComplete).toHaveBeenCalledWith({
+        content: "hi",
+        finishReason: "stop",
+        usage,
+      });
+    });
+
+    it("チャンクを跨いで分割された行を再構築する", async () => {
+      fetchSpy.mockResolvedValue(
+        makeStreamingResponse([
+          'data: {"content":"He',
+          'llo"}\n',
+          'data: {"done":true,"finishReason":"stop"}\n',
+        ]),
+      );
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onChunk).toHaveBeenCalledWith("Hello");
+    });
+
+    it("末尾改行なしの最終 data 行も処理する", async () => {
+      fetchSpy.mockResolvedValue(
+        makeStreamingResponse([
+          'data: {"content":"a"}\n',
+          'data: {"done":true,"finishReason":"stop"}',
+        ]),
+      );
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onComplete).toHaveBeenCalledWith({
+        content: "a",
+        finishReason: "stop",
+        usage: undefined,
+      });
+    });
+
+    it("done が来ずに切断されたが内容があれば onComplete を呼ぶ", async () => {
+      fetchSpy.mockResolvedValue(makeStreamingResponse(['data: {"content":"partial"}\n']));
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onComplete).toHaveBeenCalledWith({
+        content: "partial",
+        finishReason: undefined,
+        usage: undefined,
+      });
+      expect(callbacks.onError).not.toHaveBeenCalled();
+    });
+
+    it("done が来ず内容も無ければ onError(空のまま切断)", async () => {
+      fetchSpy.mockResolvedValue(makeStreamingResponse([": comment only\n"]));
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining("空のまま") }),
+      );
+      expect(callbacks.onComplete).not.toHaveBeenCalled();
+    });
+
+    it("data の error フィールドは onError へ", async () => {
+      fetchSpy.mockResolvedValue(makeStreamingResponse(['data: {"error":"upstream failure"}\n']));
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "upstream failure" }),
+      );
+    });
+
+    it("response.body が無ければ onError(取得できません)", async () => {
+      fetchSpy.mockResolvedValue(new Response(null, { status: 200 }) as unknown as Response);
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining("取得できません") }),
+      );
+    });
+
+    it("abortSignal が aborted なら ABORTED エラーを onError へ送る", async () => {
+      const abortController = new AbortController();
+      // 1 つ流したあとループの先頭で abort を検知させる。
+      const encoder = new TextEncoder();
+      let pulledOnce = false;
+      const stream = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          if (!pulledOnce) {
+            pulledOnce = true;
+            controller.enqueue(encoder.encode('data: {"content":"a"}\n'));
+            // 次の pull の前に abort
+            abortController.abort();
+            return;
+          }
+          controller.enqueue(encoder.encode(":\n"));
+        },
+      });
+      fetchSpy.mockResolvedValue(new Response(stream, { status: 200 }));
+
+      const callbacks = buildCallbacks();
+      await callAIWithServer(buildRequest(), callbacks, abortController.signal);
+
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "ABORTED" }),
+      );
+      expect(callbacks.onComplete).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
`src/lib/aiService*` and `aiClient.ts` were under Stryker `mutate` but had
near-zero coverage in 4 of 5 files. Add table-driven tests covering normal,
boundary, error, and abort paths so callbacks and provider routing are
verified against mutation.

Coverage (statements):
- aiClient.ts                   31.4% → 99.0%
- aiService.ts                  41.3% → 95.7%
- aiServiceDirectProviders.ts   95.5% → 100%
- aiServiceModels.ts             9.3% → 100%
- aiServiceServer.ts            10.3% → 100%

Local mutation scores (per source file, threshold 70%):
- aiClient.ts                   90.20%
- aiService.ts                  77.78%
- aiServiceDirectProviders.ts   80.90%
- aiServiceModels.ts            76.52%
- aiServiceServer.ts            81.58%

Notes:
- `aiServiceModels.test.ts` covers cache hit/expiry/forceRefresh, snake_case
  normalization, fetch error mapping (NO_BASE_URL / NETWORK / HTTP /
  INVALID_RESPONSE), and `fetchUsage` payload validation.
- `aiServiceServer.test.ts` covers SSE chunking across boundaries, done
  detection, partial completion fallback, 401 → AUTH_REQUIRED mapping,
  abortSignal, and missing response body.
- `aiServiceDirectProviders.test.ts` covers Anthropic system-message
  aggregation, Claude web-search auto-detection toggle, Google search
  default, default `max_tokens` / `temperature`, and abort propagation per
  provider.
- `aiService.test.ts` adds claude-code dispatch (isAvailable / done /
  tool_use_start+complete / error / abort), `settings.modelId` override,
  and the `apiMode` undefined → `api_server` fallback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and reorganized test suites across AI integrations to improve model discovery, caching, fallback, and persistence behaviors.
  * Broadened provider-specific coverage (OpenAI, Anthropic, Google, Claude) for streaming/non-streaming flows, payload shaping, and SDK interactions.
  * Strengthened error mapping and abort handling (including non-Error throws and localized messages).
  * Added comprehensive server-side and usage-reporting tests, plus more robust cleanup to avoid test leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->