### PR TITLE
test(hooks): add coverage for 6 high-value src/hooks/ modules (#743)

### DIFF
--- a/src/hooks/useAIChatPanelContentLogic.test.ts
+++ b/src/hooks/useAIChatPanelContentLogic.test.ts
@@ -67,7 +67,11 @@ vi.mock("@/hooks/useAIChatConversations", () => ({
     getConversation: (id: string) => mockGetConversation(id),
     getConversationsForPage: (pageId: string | undefined, type: string | undefined) =>
       mockGetConversationsForPage(pageId, type),
-    createConversation: () => mockCreateConversation(),
+    // 実装は `createConversation({ type, pageId, pageTitle })` の形でスナップショットを渡すため、
+    // 引数を破棄せず転送して回帰（snapshot を渡し忘れる変更）を検知できるようにする。
+    // The handler invokes `createConversation` with a `PageContextSnapshot`; forward
+    // the args so a regression that drops the snapshot is caught by the test.
+    createConversation: (...args: unknown[]) => mockCreateConversation(...args),
     updateConversation: (id: string, patch: unknown) => mockUpdateConversation(id, patch),
     deleteConversation: (id: string) => mockDeleteConversation(id),
   }),
@@ -317,6 +321,15 @@ describe("useAIChatPanelContentLogic - handlers wiring", () => {
     });
 
     expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+    // 実装は editorContext の `{ type, pageId, pageTitle }` だけを抜き出してスナップショット化するので
+    // pageFullContent などの他のフィールドは含めずに比較する。
+    // The handler should pass a snapshot containing only the discriminant fields,
+    // not the full PageContext (e.g. pageFullContent must be excluded).
+    expect(mockCreateConversation).toHaveBeenCalledWith({
+      type: editorContext.type,
+      pageId: editorContext.pageId,
+      pageTitle: editorContext.pageTitle,
+    });
     expect(setActive).toHaveBeenCalledWith("new-conv");
     expect(mockSendMessage).toHaveBeenCalledWith("hi", []);
   });

--- a/src/hooks/useAIChatPanelContentLogic.test.ts
+++ b/src/hooks/useAIChatPanelContentLogic.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Tests for {@link useAIChatPanelContentLogic}.
+ * {@link useAIChatPanelContentLogic} のテスト。
+ *
+ * Issue #743: cover the composition contract — page-title derivation feeds
+ * `useAIChat`, page conversations come from the `useAIChatConversations`
+ * helper, lifecycle/handler params receive the right values, and the returned
+ * object exposes both transcript state and handlers.
+ * Issue #743: 構成上の契約を検証する — ページタイトル抽出が `useAIChat` に渡る、
+ * `useAIChatConversations` ヘルパーから page conversations が取得される、ライフサイクルと
+ * ハンドラに正しい値が渡る、戻り値にトランスクリプト状態とハンドラが揃う。
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import type {
+  Conversation,
+  MessageMap,
+  PageContext,
+  ReferencedPage,
+  TreeChatMessage,
+} from "@/types/aiChat";
+
+// --- Mock setup ---------------------------------------------------------
+
+const mockUseAIChatContext = vi.fn();
+const mockUsePagesSummary = vi.fn();
+
+const mockGetConversation = vi.fn();
+const mockGetConversationsForPage = vi.fn();
+const mockCreateConversation = vi.fn();
+const mockUpdateConversation = vi.fn();
+const mockDeleteConversation = vi.fn();
+
+const mockHandleExecuteAction = vi.fn();
+
+type AIChatHookSpy = {
+  options: unknown;
+};
+const aiChatHookSpy: AIChatHookSpy = { options: undefined };
+
+const mockSendMessage = vi.fn();
+const mockStopStreaming = vi.fn();
+const mockClearMessages = vi.fn();
+const mockLoadConversation = vi.fn();
+const mockEditAndResend = vi.fn();
+const mockSwitchBranch = vi.fn();
+const mockNavigateToNode = vi.fn();
+const mockSetBranchPoint = vi.fn();
+const mockDeleteBranch = vi.fn();
+const mockPrepareBranchFromUserMessage = vi.fn();
+
+const lifecycleSpy = vi.fn();
+
+vi.mock("@/contexts/AIChatContext", () => ({
+  useAIChatContext: () => mockUseAIChatContext(),
+}));
+
+vi.mock("@/hooks/usePageQueries", () => ({
+  usePagesSummary: () => mockUsePagesSummary(),
+}));
+
+vi.mock("@/hooks/useAIChatConversations", () => ({
+  useAIChatConversations: () => ({
+    getConversation: (id: string) => mockGetConversation(id),
+    getConversationsForPage: (pageId: string | undefined, type: string | undefined) =>
+      mockGetConversationsForPage(pageId, type),
+    createConversation: () => mockCreateConversation(),
+    updateConversation: (id: string, patch: unknown) => mockUpdateConversation(id, patch),
+    deleteConversation: (id: string) => mockDeleteConversation(id),
+  }),
+}));
+
+vi.mock("@/hooks/useAIChatActions", () => ({
+  useAIChatActions: ({ pageContext }: { pageContext: PageContext | null }) => ({
+    handleExecuteAction: (...args: unknown[]) => mockHandleExecuteAction(pageContext, ...args),
+  }),
+}));
+
+vi.mock("@/hooks/useAIChat", () => ({
+  useAIChat: (options: unknown) => {
+    aiChatHookSpy.options = options;
+    return {
+      messages: [{ id: "u1", role: "user", content: "Hi", timestamp: 0 }] as TreeChatMessage[],
+      messageMap: {
+        u1: { id: "u1", role: "user", parentId: null, content: "Hi", timestamp: 0 },
+      } satisfies MessageMap,
+      rootMessageId: "u1",
+      activeLeafId: "u1",
+      sendMessage: (...args: unknown[]) => mockSendMessage(...args),
+      stopStreaming: (...args: unknown[]) => mockStopStreaming(...args),
+      clearMessages: () => mockClearMessages(),
+      loadConversation: (c: Conversation) => mockLoadConversation(c),
+      editAndResend: (...args: unknown[]) => mockEditAndResend(...args),
+      switchBranch: (...args: unknown[]) => mockSwitchBranch(...args),
+      navigateToNode: (id: string) => mockNavigateToNode(id),
+      setBranchPoint: (id: string) => mockSetBranchPoint(id),
+      deleteBranch: (id: string) => mockDeleteBranch(id),
+      prepareBranchFromUserMessage: (id: string) => mockPrepareBranchFromUserMessage(id),
+      isStreaming: true,
+    };
+  },
+}));
+
+vi.mock("@/hooks/useAIChatPanelContentLifecycle", () => ({
+  useAIChatPanelContentLifecycle: (params: unknown) => {
+    lifecycleSpy(params);
+  },
+}));
+
+import { useAIChatPanelContentLogic } from "./useAIChatPanelContentLogic";
+
+// --- Test helpers -------------------------------------------------------
+
+const baseSetActiveConversation = vi.fn();
+
+const editorContext: PageContext = {
+  type: "editor",
+  pageId: "page-1",
+  pageTitle: "Note",
+  pageFullContent: "",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  aiChatHookSpy.options = undefined;
+  mockUseAIChatContext.mockReturnValue({ pageContext: editorContext });
+  mockUsePagesSummary.mockReturnValue({ data: [] });
+  mockGetConversation.mockReturnValue(undefined);
+  mockGetConversationsForPage.mockReturnValue([]);
+});
+
+// --- Tests --------------------------------------------------------------
+
+describe("useAIChatPanelContentLogic - composition", () => {
+  it("forwards pageContext, contextEnabled, and existingPageTitles to useAIChat", () => {
+    mockUsePagesSummary.mockReturnValue({
+      data: [
+        { id: "p1", title: "  Alpha  ", isDeleted: false },
+        { id: "p2", title: "Beta", isDeleted: false },
+        { id: "p3", title: "Gamma", isDeleted: true },
+        { id: "p4", title: "   ", isDeleted: false },
+      ],
+    });
+
+    renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: null,
+        setActiveConversation: baseSetActiveConversation,
+        contextEnabled: true,
+      }),
+    );
+
+    expect(aiChatHookSpy.options).toMatchObject({
+      pageContext: editorContext,
+      contextEnabled: true,
+    });
+    const opts = aiChatHookSpy.options as {
+      existingPageTitles: string[];
+      availablePages: Array<{ id: string; title: string; isDeleted: boolean }>;
+    };
+    expect(opts.existingPageTitles).toEqual(["Alpha", "Beta"]);
+    expect(opts.availablePages).toHaveLength(4);
+  });
+
+  it("queries pageConversations using pageContext.pageId and pageContext.type", () => {
+    mockGetConversationsForPage.mockReturnValue([
+      {
+        id: "c1",
+        title: "",
+        messageMap: {},
+        rootMessageId: null,
+        activeLeafId: null,
+        createdAt: 0,
+        updatedAt: 0,
+      } as Conversation,
+    ]);
+
+    const { result } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: null,
+        setActiveConversation: baseSetActiveConversation,
+        contextEnabled: false,
+      }),
+    );
+
+    expect(mockGetConversationsForPage).toHaveBeenCalledWith("page-1", "editor");
+    expect(result.current.pageConversations).toHaveLength(1);
+  });
+
+  it("passes pageContext through to useAIChatActions and exposes handleExecuteAction", () => {
+    const { result } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: null,
+        setActiveConversation: baseSetActiveConversation,
+        contextEnabled: false,
+      }),
+    );
+
+    result.current.handleExecuteAction({ type: "noop" } as unknown as Parameters<
+      typeof result.current.handleExecuteAction
+    >[0]);
+
+    expect(mockHandleExecuteAction).toHaveBeenCalledTimes(1);
+    expect(mockHandleExecuteAction.mock.calls[0][0]).toEqual(editorContext);
+    expect(mockHandleExecuteAction.mock.calls[0][1]).toEqual({ type: "noop" });
+  });
+
+  it("returns the streaming/messages snapshot from useAIChat", () => {
+    const { result } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: null,
+        setActiveConversation: baseSetActiveConversation,
+        contextEnabled: false,
+      }),
+    );
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.rootMessageId).toBe("u1");
+    expect(result.current.activeLeafId).toBe("u1");
+    expect(result.current.isStreaming).toBe(true);
+  });
+
+  it("forwards the active conversation lookup to the lifecycle hook", () => {
+    const conv: Conversation = {
+      id: "c-active",
+      title: "T",
+      messageMap: {},
+      rootMessageId: null,
+      activeLeafId: null,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    mockGetConversation.mockReturnValue(conv);
+
+    renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: "c-active",
+        setActiveConversation: baseSetActiveConversation,
+        contextEnabled: false,
+      }),
+    );
+
+    expect(mockGetConversation).toHaveBeenCalledWith("c-active");
+    expect(lifecycleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageContext: editorContext,
+        activeConversation: conv,
+        activeConversationId: "c-active",
+      }),
+    );
+  });
+
+  it("does not look up a conversation when activeConversationId is null", () => {
+    renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: null,
+        setActiveConversation: baseSetActiveConversation,
+        contextEnabled: false,
+      }),
+    );
+
+    expect(mockGetConversation).not.toHaveBeenCalled();
+    expect(lifecycleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ activeConversation: undefined }),
+    );
+  });
+
+  it("memoizes existingPageTitles when pages reference is unchanged", () => {
+    const pages = [
+      { id: "p1", title: "Alpha", isDeleted: false },
+      { id: "p2", title: "Beta", isDeleted: false },
+    ];
+    mockUsePagesSummary.mockReturnValue({ data: pages });
+
+    const { rerender } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: null,
+        setActiveConversation: baseSetActiveConversation,
+        contextEnabled: false,
+      }),
+    );
+
+    const titlesA = (aiChatHookSpy.options as { existingPageTitles: string[] }).existingPageTitles;
+    rerender();
+    const titlesB = (aiChatHookSpy.options as { existingPageTitles: string[] }).existingPageTitles;
+
+    expect(titlesA).toBe(titlesB);
+  });
+});
+
+describe("useAIChatPanelContentLogic - handlers wiring", () => {
+  it("handleSendMessage creates a conversation snapshot from pageContext on first send", async () => {
+    mockCreateConversation.mockReturnValue({
+      id: "new-conv",
+      title: "",
+      messageMap: {},
+      rootMessageId: null,
+      activeLeafId: null,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    const setActive = vi.fn();
+    const { result } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: null,
+        setActiveConversation: setActive,
+        contextEnabled: false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleSendMessage("hi", [] as ReferencedPage[]);
+    });
+
+    expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+    expect(setActive).toHaveBeenCalledWith("new-conv");
+    expect(mockSendMessage).toHaveBeenCalledWith("hi", []);
+  });
+
+  it("handleSelectConversation just delegates to setActiveConversation", () => {
+    const setActive = vi.fn();
+    const { result } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: "c1",
+        setActiveConversation: setActive,
+        contextEnabled: false,
+      }),
+    );
+
+    act(() => {
+      result.current.handleSelectConversation("c2");
+    });
+
+    expect(setActive).toHaveBeenCalledWith("c2");
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+  });
+
+  it("handleDeleteConversation clears active when deleting the active id", () => {
+    const setActive = vi.fn();
+    const { result } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: "c1",
+        setActiveConversation: setActive,
+        contextEnabled: false,
+      }),
+    );
+
+    act(() => {
+      result.current.handleDeleteConversation("c1");
+    });
+
+    expect(mockDeleteConversation).toHaveBeenCalledWith("c1");
+    expect(setActive).toHaveBeenCalledWith(null);
+    expect(mockClearMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("handleDeleteConversation leaves active alone when deleting another id", () => {
+    const setActive = vi.fn();
+    const { result } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: "c1",
+        setActiveConversation: setActive,
+        contextEnabled: false,
+      }),
+    );
+
+    act(() => {
+      result.current.handleDeleteConversation("c-other");
+    });
+
+    expect(mockDeleteConversation).toHaveBeenCalledWith("c-other");
+    expect(setActive).not.toHaveBeenCalled();
+    expect(mockClearMessages).not.toHaveBeenCalled();
+  });
+
+  it("handleEditMessage forwards to editAndResend", () => {
+    const { result } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: "c1",
+        setActiveConversation: baseSetActiveConversation,
+        contextEnabled: false,
+      }),
+    );
+
+    act(() => {
+      result.current.handleEditMessage("m1", "new");
+    });
+
+    expect(mockEditAndResend).toHaveBeenCalledWith("m1", "new");
+  });
+
+  it("handleSelectBranch navigates and switches view tab to chat", () => {
+    const { result } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: "c1",
+        setActiveConversation: baseSetActiveConversation,
+        contextEnabled: false,
+      }),
+    );
+
+    act(() => {
+      // Move to a different tab first to assert the switch back to "chat".
+      result.current.setActiveViewTab("branchTree");
+    });
+    expect(result.current.activeViewTab).toBe("branchTree");
+
+    act(() => {
+      result.current.handleSelectBranch("u1");
+    });
+
+    expect(mockNavigateToNode).toHaveBeenCalledWith("u1");
+    expect(result.current.activeViewTab).toBe("chat");
+  });
+
+  it("handleBranchFrom on a user message prefills input with branch text", () => {
+    mockPrepareBranchFromUserMessage.mockReturnValue("draft from user");
+
+    const { result } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: "c1",
+        setActiveConversation: baseSetActiveConversation,
+        contextEnabled: false,
+      }),
+    );
+
+    act(() => {
+      result.current.handleBranchFrom("u1");
+    });
+
+    expect(mockSetBranchPoint).toHaveBeenCalledWith("u1");
+    expect(mockPrepareBranchFromUserMessage).toHaveBeenCalledWith("u1");
+    expect(result.current.inputPrefill?.text).toBe("draft from user");
+    expect(result.current.activeViewTab).toBe("chat");
+  });
+
+  it("handleBranchFrom is a no-op when nodeId is unknown", () => {
+    const { result } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: "c1",
+        setActiveConversation: baseSetActiveConversation,
+        contextEnabled: false,
+      }),
+    );
+
+    act(() => {
+      result.current.handleBranchFrom("unknown");
+    });
+
+    expect(mockSetBranchPoint).not.toHaveBeenCalled();
+    expect(mockPrepareBranchFromUserMessage).not.toHaveBeenCalled();
+  });
+
+  it("handleDeleteBranchFromTree forwards to deleteBranch", () => {
+    const { result } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: "c1",
+        setActiveConversation: baseSetActiveConversation,
+        contextEnabled: false,
+      }),
+    );
+
+    act(() => {
+      result.current.handleDeleteBranchFromTree("u1");
+    });
+
+    expect(mockDeleteBranch).toHaveBeenCalledWith("u1");
+  });
+
+  it("stopStreaming and switchBranch on the returned object call the underlying hook", () => {
+    const { result } = renderHook(() =>
+      useAIChatPanelContentLogic({
+        activeConversationId: "c1",
+        setActiveConversation: baseSetActiveConversation,
+        contextEnabled: false,
+      }),
+    );
+
+    act(() => {
+      result.current.stopStreaming();
+      result.current.switchBranch("u1", "next");
+    });
+
+    expect(mockStopStreaming).toHaveBeenCalledTimes(1);
+    expect(mockSwitchBranch).toHaveBeenCalledWith("u1", "next");
+  });
+});
+
+// React unused-import guard: keeps module reference live for JSX runtime.
+void React;

--- a/src/hooks/useAISettings.test.ts
+++ b/src/hooks/useAISettings.test.ts
@@ -103,7 +103,7 @@ describe("useAISettings - initial load", () => {
 
     expect(result.current.settings).toEqual(baseDefaults);
     expect(errorSpy).toHaveBeenCalled();
-    errorSpy.mockRestore();
+    // The file-wide afterEach restores all spies, so no inline mockRestore is needed.
   });
 });
 
@@ -282,7 +282,7 @@ describe("useAISettings - save", () => {
     expect(saved).toBe(false);
     expect(result.current.isSaving).toBe(false);
     expect(errorSpy).toHaveBeenCalled();
-    errorSpy.mockRestore();
+    // Spy restoration is handled by the file-wide afterEach.
   });
 });
 
@@ -358,7 +358,11 @@ describe("useAISettings - test (connection)", () => {
   });
 
   it("captures errors thrown synchronously by testConnection", async () => {
-    mockTestConnection.mockRejectedValueOnce(new Error("network down"));
+    // 同期 throw を再現することでテスト名と挙動を一致させる。
+    // Use a synchronous throw so the test exercises the path implied by its title.
+    mockTestConnection.mockImplementationOnce(() => {
+      throw new Error("network down");
+    });
 
     const { result } = renderHook(() => useAISettings());
     await waitFor(() => expect(result.current.isLoading).toBe(false));

--- a/src/hooks/useAISettings.test.ts
+++ b/src/hooks/useAISettings.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Tests for {@link useAISettings}.
+ * {@link useAISettings} のテスト。
+ *
+ * Issue #743: cover async load fallback paths, provider/model switching rules,
+ * connection-test side effects (model list refresh + selected model fallback),
+ * save flow, and reset.
+ * Issue #743: 非同期ロードのフォールバック分岐、プロバイダー/モデル切り替え規則、
+ * 接続テストの副作用（モデル一覧更新と選択モデルのフォールバック）、save、reset を検証する。
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { AISettings, AIProviderType } from "@/types/ai";
+import type { ConnectionTestResult } from "@/lib/aiClient";
+
+const mockLoadAISettings = vi.fn();
+const mockSaveAISettings = vi.fn();
+const mockClearAISettings = vi.fn();
+const mockGetDefaultAISettings = vi.fn();
+
+const mockTestConnection = vi.fn();
+const mockGetAvailableModels = vi.fn();
+const mockClearModelsCache = vi.fn();
+
+vi.mock("@/lib/aiSettings", () => ({
+  loadAISettings: () => mockLoadAISettings(),
+  saveAISettings: (s: AISettings) => mockSaveAISettings(s),
+  clearAISettings: () => mockClearAISettings(),
+  getDefaultAISettings: () => mockGetDefaultAISettings(),
+}));
+
+vi.mock("@/lib/aiClient", () => ({
+  testConnection: (provider: AIProviderType, apiKey: string) =>
+    mockTestConnection(provider, apiKey),
+  getAvailableModels: (provider: AIProviderType) => mockGetAvailableModels(provider),
+  clearModelsCache: () => mockClearModelsCache(),
+}));
+
+import { useAISettings } from "./useAISettings";
+
+const baseDefaults: AISettings = {
+  provider: "google",
+  apiKey: "",
+  apiMode: "api_server",
+  model: "gemini-3-flash-preview",
+  modelId: "google:gemini-3-flash-preview",
+  isConfigured: false,
+};
+
+describe("useAISettings - initial load", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDefaultAISettings.mockReturnValue({ ...baseDefaults });
+    mockGetAvailableModels.mockReturnValue(["gemini-3-flash-preview", "gemini-3-pro-preview"]);
+  });
+
+  it("loads stored settings and uses cached models for the loaded provider", async () => {
+    const stored: AISettings = {
+      ...baseDefaults,
+      provider: "openai",
+      model: "gpt-5.2",
+      modelId: "openai:gpt-5.2",
+      apiKey: "sk-test",
+      apiMode: "user_api_key",
+      isConfigured: true,
+    };
+    mockLoadAISettings.mockResolvedValue(stored);
+    mockGetAvailableModels.mockReturnValue(["gpt-5.2", "gpt-5-mini"]);
+
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.settings).toEqual(stored);
+    expect(result.current.availableModels).toEqual(["gpt-5.2", "gpt-5-mini"]);
+    expect(mockGetAvailableModels).toHaveBeenCalledWith("openai");
+  });
+
+  it("falls back to defaults when no stored settings exist", async () => {
+    mockLoadAISettings.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.settings).toEqual(baseDefaults);
+    expect(result.current.availableModels.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to defaults and logs error when loadAISettings rejects", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockLoadAISettings.mockRejectedValue(new Error("decryption failed"));
+
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.settings).toEqual(baseDefaults);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});
+
+describe("useAISettings - updateSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDefaultAISettings.mockReturnValue({ ...baseDefaults });
+    mockGetAvailableModels.mockImplementation((provider: AIProviderType) => {
+      if (provider === "openai") return ["gpt-5.2", "gpt-5-mini"];
+      if (provider === "anthropic") return ["claude-opus-4-6"];
+      return ["gemini-3-flash-preview", "gemini-3-pro-preview"];
+    });
+    mockLoadAISettings.mockResolvedValue({ ...baseDefaults });
+  });
+
+  it("changing provider swaps the model list and picks the first model", async () => {
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.updateSettings({ provider: "openai" });
+    });
+
+    expect(result.current.settings.provider).toBe("openai");
+    expect(result.current.availableModels).toEqual(["gpt-5.2", "gpt-5-mini"]);
+    expect(result.current.settings.model).toBe("gpt-5.2");
+    // modelId は明示指定がないのでクリアされる
+    expect(result.current.settings.modelId).toBe("");
+  });
+
+  it("respects an explicit model when provider changes", async () => {
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.updateSettings({ provider: "openai", model: "gpt-5-mini" });
+    });
+
+    expect(result.current.settings.provider).toBe("openai");
+    expect(result.current.settings.model).toBe("gpt-5-mini");
+  });
+
+  it("changing only the model also clears modelId unless explicit", async () => {
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Pre-populate the modelId via save flow
+    act(() => {
+      result.current.updateSettings({ model: "gemini-3-pro-preview" });
+    });
+
+    expect(result.current.settings.model).toBe("gemini-3-pro-preview");
+    expect(result.current.settings.modelId).toBe("");
+  });
+
+  it("updateSettings preserves modelId when caller passes it explicitly", async () => {
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.updateSettings({
+        model: "gemini-3-pro-preview",
+        modelId: "google:gemini-3-pro-preview",
+      });
+    });
+
+    expect(result.current.settings.modelId).toBe("google:gemini-3-pro-preview");
+  });
+
+  it("updateSettings resets the previous testResult", async () => {
+    mockTestConnection.mockResolvedValue({
+      success: true,
+      message: "ok",
+      models: ["gpt-5.2"],
+    } satisfies ConnectionTestResult);
+
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.updateSettings({ provider: "openai", apiKey: "sk-test" });
+    });
+
+    await act(async () => {
+      await result.current.test();
+    });
+    expect(result.current.testResult?.success).toBe(true);
+
+    act(() => {
+      result.current.updateSettings({ apiKey: "sk-new" });
+    });
+    expect(result.current.testResult).toBeNull();
+  });
+});
+
+describe("useAISettings - save", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDefaultAISettings.mockReturnValue({ ...baseDefaults });
+    mockGetAvailableModels.mockReturnValue(["gemini-3-flash-preview"]);
+    mockLoadAISettings.mockResolvedValue({ ...baseDefaults });
+    mockSaveAISettings.mockResolvedValue(undefined);
+  });
+
+  it("save returns true and sends a namespaced modelId", async () => {
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.updateSettings({
+        provider: "openai",
+        model: "gpt-5.2",
+        apiKey: "sk-test",
+        apiMode: "user_api_key",
+      });
+    });
+
+    let saved = false;
+    await act(async () => {
+      saved = await result.current.save();
+    });
+
+    expect(saved).toBe(true);
+    expect(mockSaveAISettings).toHaveBeenCalledTimes(1);
+    const arg = mockSaveAISettings.mock.calls[0][0] as AISettings;
+    expect(arg.modelId).toBe("openai:gpt-5.2");
+    expect(arg.isConfigured).toBe(true);
+  });
+
+  it("save uses the special claude-code:default modelId when provider is claude-code", async () => {
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.updateSettings({ provider: "claude-code" });
+    });
+    await act(async () => {
+      await result.current.save();
+    });
+
+    const arg = mockSaveAISettings.mock.calls[0][0] as AISettings;
+    expect(arg.modelId).toBe("claude-code:default");
+    expect(arg.isConfigured).toBe(true);
+  });
+
+  it("save marks isConfigured=false when API key is required but missing", async () => {
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.updateSettings({
+        provider: "anthropic",
+        apiKey: "",
+        apiMode: "user_api_key",
+      });
+    });
+    await act(async () => {
+      await result.current.save();
+    });
+
+    const arg = mockSaveAISettings.mock.calls[0][0] as AISettings;
+    expect(arg.isConfigured).toBe(false);
+  });
+
+  it("save returns false when saveAISettings rejects", async () => {
+    mockSaveAISettings.mockRejectedValueOnce(new Error("storage"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let saved: boolean | undefined;
+    await act(async () => {
+      saved = await result.current.save();
+    });
+
+    expect(saved).toBe(false);
+    expect(result.current.isSaving).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});
+
+describe("useAISettings - test (connection)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDefaultAISettings.mockReturnValue({ ...baseDefaults });
+    mockGetAvailableModels.mockReturnValue(["gemini-3-flash-preview"]);
+    mockLoadAISettings.mockResolvedValue({
+      ...baseDefaults,
+      provider: "openai",
+      model: "gpt-5.2",
+      apiKey: "sk-test",
+      apiMode: "user_api_key",
+    });
+  });
+
+  it("test returns the result and refreshes availableModels on success", async () => {
+    mockTestConnection.mockResolvedValue({
+      success: true,
+      message: "ok",
+      models: ["gpt-5.2", "gpt-5-mini", "gpt-5-nano"],
+    } satisfies ConnectionTestResult);
+
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let returned: ConnectionTestResult | undefined;
+    await act(async () => {
+      returned = await result.current.test();
+    });
+
+    expect(returned?.success).toBe(true);
+    expect(result.current.availableModels).toEqual(["gpt-5.2", "gpt-5-mini", "gpt-5-nano"]);
+    expect(result.current.testResult?.success).toBe(true);
+    expect(result.current.isTesting).toBe(false);
+    expect(mockTestConnection).toHaveBeenCalledWith("openai", "sk-test");
+  });
+
+  it("falls back to first model when current model is missing from refreshed list", async () => {
+    mockTestConnection.mockResolvedValue({
+      success: true,
+      message: "ok",
+      models: ["gpt-5-mini", "gpt-5-nano"],
+    } satisfies ConnectionTestResult);
+
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.test();
+    });
+
+    expect(result.current.settings.model).toBe("gpt-5-mini");
+    expect(result.current.settings.modelId).toBe("openai:gpt-5-mini");
+  });
+
+  it("preserves selected model when it is still in the refreshed list", async () => {
+    mockTestConnection.mockResolvedValue({
+      success: true,
+      message: "ok",
+      models: ["gpt-5.2", "gpt-5-mini"],
+    } satisfies ConnectionTestResult);
+
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.test();
+    });
+
+    expect(result.current.settings.model).toBe("gpt-5.2");
+  });
+
+  it("captures errors thrown synchronously by testConnection", async () => {
+    mockTestConnection.mockRejectedValueOnce(new Error("network down"));
+
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let returned: ConnectionTestResult | undefined;
+    await act(async () => {
+      returned = await result.current.test();
+    });
+
+    expect(returned?.success).toBe(false);
+    expect(returned?.error).toBe("network down");
+    expect(result.current.testResult?.success).toBe(false);
+    expect(result.current.isTesting).toBe(false);
+  });
+});
+
+describe("useAISettings - reset", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDefaultAISettings.mockReturnValue({ ...baseDefaults });
+    mockGetAvailableModels.mockReturnValue(["gemini-3-flash-preview"]);
+    mockLoadAISettings.mockResolvedValue({
+      ...baseDefaults,
+      provider: "openai",
+      apiKey: "sk-test",
+    });
+  });
+
+  it("clears persisted settings, model cache, and resets state to defaults", async () => {
+    const { result } = renderHook(() => useAISettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(mockClearAISettings).toHaveBeenCalledTimes(1);
+    expect(mockClearModelsCache).toHaveBeenCalledTimes(1);
+    expect(result.current.settings).toEqual(baseDefaults);
+    expect(result.current.testResult).toBeNull();
+  });
+});

--- a/src/hooks/useAISettings.test.ts
+++ b/src/hooks/useAISettings.test.ts
@@ -9,19 +9,20 @@
  * 接続テストの副作用（モデル一覧更新と選択モデルのフォールバック）、save、reset を検証する。
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import type { AISettings, AIProviderType } from "@/types/ai";
 import type { ConnectionTestResult } from "@/lib/aiClient";
 
-const mockLoadAISettings = vi.fn();
-const mockSaveAISettings = vi.fn();
-const mockClearAISettings = vi.fn();
-const mockGetDefaultAISettings = vi.fn();
+const mockLoadAISettings = vi.fn<() => Promise<AISettings | null>>();
+const mockSaveAISettings = vi.fn<(s: AISettings) => Promise<void>>();
+const mockClearAISettings = vi.fn<() => void>();
+const mockGetDefaultAISettings = vi.fn<() => AISettings>();
 
-const mockTestConnection = vi.fn();
-const mockGetAvailableModels = vi.fn();
-const mockClearModelsCache = vi.fn();
+const mockTestConnection =
+  vi.fn<(provider: AIProviderType, apiKey: string) => Promise<ConnectionTestResult>>();
+const mockGetAvailableModels = vi.fn<(provider: AIProviderType) => string[]>();
+const mockClearModelsCache = vi.fn<() => void>();
 
 vi.mock("@/lib/aiSettings", () => ({
   loadAISettings: () => mockLoadAISettings(),
@@ -38,6 +39,13 @@ vi.mock("@/lib/aiClient", () => ({
 }));
 
 import { useAISettings } from "./useAISettings";
+
+// テスト失敗時も console.error 等の spy が確実に元に戻るよう、ファイル全体で後始末する。
+// File-wide cleanup so any console spy (e.g. console.error) is restored even
+// when an assertion throws before the test reaches its inline mockRestore().
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const baseDefaults: AISettings = {
   provider: "google",

--- a/src/hooks/useAISettings.test.ts
+++ b/src/hooks/useAISettings.test.ts
@@ -150,7 +150,6 @@ describe("useAISettings - updateSettings", () => {
     const { result } = renderHook(() => useAISettings());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    // Pre-populate the modelId via save flow
     act(() => {
       result.current.updateSettings({ model: "gemini-3-pro-preview" });
     });

--- a/src/hooks/useGeneralSettings.test.ts
+++ b/src/hooks/useGeneralSettings.test.ts
@@ -170,9 +170,12 @@ describe("useGeneralSettings", () => {
     );
   });
 
-  it("save returns true and toggles isSaving flag", async () => {
+  it("save returns true, persists via saveGeneralSettings, and toggles isSaving flag", async () => {
     const { result } = renderHook(() => useGeneralSettings());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
+    // 初回ロードで saveGeneralSettings は呼ばれていないが、念のためクリアしてから assert する。
+    // Clear any prior calls so the assertion below pinpoints save()'s side effect.
+    mockSaveGeneralSettings.mockClear();
 
     let saved = false;
     await act(async () => {
@@ -180,6 +183,8 @@ describe("useGeneralSettings", () => {
     });
 
     expect(saved).toBe(true);
+    expect(mockSaveGeneralSettings).toHaveBeenCalledTimes(1);
+    expect(mockSaveGeneralSettings).toHaveBeenCalledWith(result.current.settings);
     expect(result.current.isSaving).toBe(false);
   });
 

--- a/src/hooks/useGeneralSettings.test.ts
+++ b/src/hooks/useGeneralSettings.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for {@link useGeneralSettings}.
+ * {@link useGeneralSettings} のテスト。
+ *
+ * Issue #743: cover load/save lifecycle, theme/locale sync, font-size clamping,
+ * and error handling on persistence failures.
+ * Issue #743: 読み込み/保存ライフサイクル、テーマ/言語同期、フォントサイズの clamp、
+ * 永続化失敗時のエラーハンドリングを検証する。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+const mockSetTheme = vi.fn();
+const mockChangeLanguage = vi.fn();
+const mockLoadGeneralSettings = vi.fn();
+const mockSaveGeneralSettings = vi.fn();
+
+// `useTheme()` / `useTranslation()` の戻り値はレンダーごとに同一参照に固定する。
+// 内部 effect の依存配列が `[setTheme, i18n]` のため、毎回新しい参照を返すと
+// effect が再実行され、テスト中の状態更新が `loadGeneralSettings` の戻り値で
+// 上書きされてしまう。
+// Stabilize hook return values across renders. The component-side effect
+// depends on `[setTheme, i18n]`, so unstable references cause it to re-run
+// after every state update and clobber the test's local mutations.
+const stableI18n = { changeLanguage: mockChangeLanguage };
+const stableTheme = { setTheme: mockSetTheme };
+
+vi.mock("next-themes", () => ({
+  useTheme: () => stableTheme,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    i18n: stableI18n,
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/lib/generalSettings", () => ({
+  loadGeneralSettings: () => mockLoadGeneralSettings(),
+  saveGeneralSettings: (settings: unknown) => mockSaveGeneralSettings(settings),
+}));
+
+import { DEFAULT_GENERAL_SETTINGS } from "@/types/generalSettings";
+import { useGeneralSettings } from "./useGeneralSettings";
+
+describe("useGeneralSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadGeneralSettings.mockReturnValue({ ...DEFAULT_GENERAL_SETTINGS });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loads stored settings and syncs theme + locale on mount", async () => {
+    mockLoadGeneralSettings.mockReturnValue({
+      ...DEFAULT_GENERAL_SETTINGS,
+      theme: "dark",
+      locale: "en",
+    });
+
+    const { result } = renderHook(() => useGeneralSettings());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.settings.theme).toBe("dark");
+    expect(result.current.settings.locale).toBe("en");
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+    expect(mockChangeLanguage).toHaveBeenCalledWith("en");
+  });
+
+  it("updateTheme persists, updates state, and syncs next-themes", async () => {
+    const { result } = renderHook(() => useGeneralSettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    mockSaveGeneralSettings.mockClear();
+    mockSetTheme.mockClear();
+
+    act(() => {
+      result.current.updateTheme("light");
+    });
+
+    expect(result.current.settings.theme).toBe("light");
+    expect(mockSetTheme).toHaveBeenCalledWith("light");
+    expect(mockSaveGeneralSettings).toHaveBeenCalledTimes(1);
+    expect(mockSaveGeneralSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ theme: "light" }),
+    );
+  });
+
+  it("updateEditorFontSize persists the new preset", async () => {
+    const { result } = renderHook(() => useGeneralSettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    mockSaveGeneralSettings.mockClear();
+
+    act(() => {
+      result.current.updateEditorFontSize("large");
+    });
+
+    expect(result.current.settings.editorFontSize).toBe("large");
+    expect(mockSaveGeneralSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ editorFontSize: "large" }),
+    );
+  });
+
+  it("updateCustomFontSizePx clamps below 12", async () => {
+    const { result } = renderHook(() => useGeneralSettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.updateCustomFontSizePx(2);
+    });
+
+    expect(result.current.settings.customFontSizePx).toBe(12);
+  });
+
+  it("updateCustomFontSizePx clamps above 24", async () => {
+    const { result } = renderHook(() => useGeneralSettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.updateCustomFontSizePx(99);
+    });
+
+    expect(result.current.settings.customFontSizePx).toBe(24);
+  });
+
+  it("updateCustomFontSizePx keeps values within range as-is", async () => {
+    const { result } = renderHook(() => useGeneralSettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.updateCustomFontSizePx(20);
+    });
+
+    expect(result.current.settings.customFontSizePx).toBe(20);
+  });
+
+  it("updateLocale persists and triggers i18n.changeLanguage", async () => {
+    const { result } = renderHook(() => useGeneralSettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    mockChangeLanguage.mockClear();
+    mockSaveGeneralSettings.mockClear();
+
+    act(() => {
+      result.current.updateLocale("en");
+    });
+
+    expect(result.current.settings.locale).toBe("en");
+    expect(mockChangeLanguage).toHaveBeenCalledWith("en");
+    expect(mockSaveGeneralSettings).toHaveBeenCalledWith(expect.objectContaining({ locale: "en" }));
+  });
+
+  it("updateExecutableCodeConfirmBeforeRun toggles persisted flag", async () => {
+    const { result } = renderHook(() => useGeneralSettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    mockSaveGeneralSettings.mockClear();
+
+    act(() => {
+      result.current.updateExecutableCodeConfirmBeforeRun(false);
+    });
+
+    expect(result.current.settings.executableCodeConfirmBeforeRun).toBe(false);
+    expect(mockSaveGeneralSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ executableCodeConfirmBeforeRun: false }),
+    );
+  });
+
+  it("save returns true and toggles isSaving flag", async () => {
+    const { result } = renderHook(() => useGeneralSettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let saved = false;
+    await act(async () => {
+      saved = await result.current.save();
+    });
+
+    expect(saved).toBe(true);
+    expect(result.current.isSaving).toBe(false);
+  });
+
+  it("save returns false and logs when saveGeneralSettings throws", async () => {
+    const { result } = renderHook(() => useGeneralSettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    mockSaveGeneralSettings.mockImplementationOnce(() => {
+      throw new Error("disk full");
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    let saved: boolean | undefined;
+    await act(async () => {
+      saved = await result.current.save();
+    });
+
+    expect(saved).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(result.current.isSaving).toBe(false);
+  });
+
+  it("editorFontSizePx resolves preset px from FONT_SIZE_OPTIONS", async () => {
+    mockLoadGeneralSettings.mockReturnValue({
+      ...DEFAULT_GENERAL_SETTINGS,
+      editorFontSize: "large",
+    });
+
+    const { result } = renderHook(() => useGeneralSettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.editorFontSizePx).toBe(18);
+  });
+
+  it("editorFontSizePx resolves customFontSizePx when editorFontSize is custom", async () => {
+    mockLoadGeneralSettings.mockReturnValue({
+      ...DEFAULT_GENERAL_SETTINGS,
+      editorFontSize: "custom",
+      customFontSizePx: 22,
+    });
+
+    const { result } = renderHook(() => useGeneralSettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.editorFontSizePx).toBe(22);
+  });
+
+  it("editorFontSizePx falls back to 16 when custom px is missing", async () => {
+    mockLoadGeneralSettings.mockReturnValue({
+      ...DEFAULT_GENERAL_SETTINGS,
+      editorFontSize: "custom",
+      customFontSizePx: undefined,
+    });
+
+    const { result } = renderHook(() => useGeneralSettings());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.editorFontSizePx).toBe(16);
+  });
+});

--- a/src/hooks/useMermaidGenerator.test.ts
+++ b/src/hooks/useMermaidGenerator.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for {@link useMermaidGenerator}.
+ * {@link useMermaidGenerator} のテスト。
+ *
+ * Issue #743: cover the state machine (idle to generating to completed or error),
+ * input validation, callback wiring, AI configuration check, and reset.
+ * Issue #743: 状態遷移（idle から generating、完了またはエラーへ）、入力バリデーション、
+ * コールバック呼び出し、AI 設定確認、reset を検証する。
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type {
+  MermaidDiagramType,
+  MermaidGeneratorCallbacks,
+  MermaidGeneratorResult,
+} from "@/lib/mermaidGenerator";
+
+const mockGenerateMermaidDiagram = vi.fn();
+const mockGetAISettingsOrThrow = vi.fn();
+
+vi.mock("@/lib/mermaidGenerator", () => ({
+  generateMermaidDiagram: (
+    text: string,
+    diagramTypes: MermaidDiagramType[],
+    callbacks: MermaidGeneratorCallbacks,
+  ) => mockGenerateMermaidDiagram(text, diagramTypes, callbacks),
+  getAISettingsOrThrow: () => mockGetAISettingsOrThrow(),
+}));
+
+import { useMermaidGenerator } from "./useMermaidGenerator";
+
+describe("useMermaidGenerator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in idle state with no result/error", () => {
+    const { result } = renderHook(() => useMermaidGenerator());
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.result).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.isAIConfigured).toBeNull();
+  });
+
+  it("generate with empty text sets error status and does not call generateMermaidDiagram", async () => {
+    const { result } = renderHook(() => useMermaidGenerator());
+
+    await act(async () => {
+      await result.current.generate("   ", ["flowchart"]);
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe("テキストが空です");
+    expect(mockGenerateMermaidDiagram).not.toHaveBeenCalled();
+  });
+
+  it("generate with empty diagramTypes sets error status", async () => {
+    const { result } = renderHook(() => useMermaidGenerator());
+
+    await act(async () => {
+      await result.current.generate("hello", []);
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error?.message).toBe("ダイアグラムタイプを選択してください");
+    expect(mockGenerateMermaidDiagram).not.toHaveBeenCalled();
+  });
+
+  it("generate transitions to completed on onComplete callback", async () => {
+    const completedResult: MermaidGeneratorResult = {
+      code: "flowchart TD\nA-->B",
+      diagramType: "flowchart",
+    };
+    mockGenerateMermaidDiagram.mockImplementation(
+      (
+        _text: string,
+        _types: MermaidDiagramType[],
+        callbacks: MermaidGeneratorCallbacks,
+      ): Promise<void> => {
+        callbacks.onComplete(completedResult);
+        return Promise.resolve();
+      },
+    );
+
+    const { result } = renderHook(() => useMermaidGenerator());
+
+    await act(async () => {
+      await result.current.generate("topic", ["flowchart"]);
+    });
+
+    expect(result.current.status).toBe("completed");
+    expect(result.current.result).toEqual(completedResult);
+    expect(result.current.error).toBeNull();
+    expect(mockGenerateMermaidDiagram).toHaveBeenCalledWith(
+      "topic",
+      ["flowchart"],
+      expect.any(Object),
+    );
+  });
+
+  it("generate transitions to error when callbacks.onError is invoked", async () => {
+    const failure = new Error("boom");
+    mockGenerateMermaidDiagram.mockImplementation(
+      (
+        _text: string,
+        _types: MermaidDiagramType[],
+        callbacks: MermaidGeneratorCallbacks,
+      ): Promise<void> => {
+        callbacks.onError(failure);
+        return Promise.resolve();
+      },
+    );
+
+    const { result } = renderHook(() => useMermaidGenerator());
+
+    await act(async () => {
+      await result.current.generate("topic", ["sequence"]);
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe(failure);
+    expect(result.current.result).toBeNull();
+  });
+
+  it("generate catches synchronous throws from generateMermaidDiagram and sets error", async () => {
+    mockGenerateMermaidDiagram.mockRejectedValueOnce(new Error("network"));
+
+    const { result } = renderHook(() => useMermaidGenerator());
+
+    await act(async () => {
+      await result.current.generate("topic", ["pie"]);
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error?.message).toBe("network");
+  });
+
+  it("generate wraps non-Error rejections into a generic error", async () => {
+    mockGenerateMermaidDiagram.mockRejectedValueOnce("not an error");
+
+    const { result } = renderHook(() => useMermaidGenerator());
+
+    await act(async () => {
+      await result.current.generate("topic", ["pie"]);
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error?.message).toBe("生成中にエラーが発生しました");
+  });
+
+  it("reset returns the state machine to idle and clears result/error", async () => {
+    mockGenerateMermaidDiagram.mockImplementation(
+      (
+        _text: string,
+        _types: MermaidDiagramType[],
+        callbacks: MermaidGeneratorCallbacks,
+      ): Promise<void> => {
+        callbacks.onComplete({ code: "x", diagramType: "flowchart" });
+        return Promise.resolve();
+      },
+    );
+
+    const { result } = renderHook(() => useMermaidGenerator());
+
+    await act(async () => {
+      await result.current.generate("topic", ["flowchart"]);
+    });
+    expect(result.current.status).toBe("completed");
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.result).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("checkAIConfigured returns true and sets flag when settings load", async () => {
+    mockGetAISettingsOrThrow.mockResolvedValue({ provider: "google" });
+
+    const { result } = renderHook(() => useMermaidGenerator());
+
+    let configured: boolean | undefined;
+    await act(async () => {
+      configured = await result.current.checkAIConfigured();
+    });
+
+    expect(configured).toBe(true);
+    await waitFor(() => expect(result.current.isAIConfigured).toBe(true));
+  });
+
+  it("checkAIConfigured returns false and sets flag when getAISettingsOrThrow rejects", async () => {
+    mockGetAISettingsOrThrow.mockRejectedValue(new Error("AI_NOT_CONFIGURED"));
+
+    const { result } = renderHook(() => useMermaidGenerator());
+
+    let configured: boolean | undefined;
+    await act(async () => {
+      configured = await result.current.checkAIConfigured();
+    });
+
+    expect(configured).toBe(false);
+    await waitFor(() => expect(result.current.isAIConfigured).toBe(false));
+  });
+
+  it("generate clears any previous error before transitioning to generating", async () => {
+    const { result } = renderHook(() => useMermaidGenerator());
+
+    // Trigger an initial error first.
+    await act(async () => {
+      await result.current.generate("", ["flowchart"]);
+    });
+    expect(result.current.status).toBe("error");
+
+    // Stub a long-running generation that resolves later so we can observe the
+    // transitional state.
+    let resolveCb: (() => void) | null = null;
+    mockGenerateMermaidDiagram.mockImplementation(
+      (
+        _text: string,
+        _types: MermaidDiagramType[],
+        callbacks: MermaidGeneratorCallbacks,
+      ): Promise<void> => {
+        return new Promise<void>((resolve) => {
+          resolveCb = () => {
+            callbacks.onComplete({ code: "x", diagramType: "flowchart" });
+            resolve();
+          };
+        });
+      },
+    );
+
+    let pending: Promise<void> | undefined;
+    act(() => {
+      pending = result.current.generate("topic", ["flowchart"]);
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("generating"));
+    expect(result.current.error).toBeNull();
+    expect(result.current.result).toBeNull();
+
+    await act(async () => {
+      resolveCb?.();
+      await pending;
+    });
+    expect(result.current.status).toBe("completed");
+  });
+});

--- a/src/hooks/useMermaidGenerator.test.ts
+++ b/src/hooks/useMermaidGenerator.test.ts
@@ -8,16 +8,24 @@
  * コールバック呼び出し、AI 設定確認、reset を検証する。
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import type {
   MermaidDiagramType,
   MermaidGeneratorCallbacks,
   MermaidGeneratorResult,
 } from "@/lib/mermaidGenerator";
+import type { AISettings } from "@/types/ai";
 
-const mockGenerateMermaidDiagram = vi.fn();
-const mockGetAISettingsOrThrow = vi.fn();
+const mockGenerateMermaidDiagram =
+  vi.fn<
+    (
+      text: string,
+      diagramTypes: MermaidDiagramType[],
+      callbacks: MermaidGeneratorCallbacks,
+    ) => Promise<void>
+  >();
+const mockGetAISettingsOrThrow = vi.fn<() => Promise<AISettings>>();
 
 vi.mock("@/lib/mermaidGenerator", () => ({
   generateMermaidDiagram: (
@@ -29,6 +37,12 @@ vi.mock("@/lib/mermaidGenerator", () => ({
 }));
 
 import { useMermaidGenerator } from "./useMermaidGenerator";
+
+// Safety net to keep spies (e.g. console.error if added in future tests) and
+// any module-level setup from leaking between tests on assertion failures.
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("useMermaidGenerator", () => {
   beforeEach(() => {

--- a/src/hooks/useWorkflowDraft.test.ts
+++ b/src/hooks/useWorkflowDraft.test.ts
@@ -8,7 +8,7 @@
  * JSON インポート/エクスポート、保存済み定義の選択ライフサイクルを検証する。
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 
 const mockToast = vi.fn();
@@ -48,6 +48,18 @@ function resetStore(initial: WorkflowDefinition[] = []): void {
     },
   });
 }
+
+// テスト失敗時もスパイ（URL.createObjectURL / HTMLAnchorElement.prototype.click 等）が
+// 確実に元に戻るよう、ファイル全体で共通の後始末を行う。fake timers を使ったテストは
+// 自分で `vi.useRealTimers()` を呼ぶか、ここで restore される前提でクリーンアップする。
+// File-wide cleanup so spies on globals (URL.createObjectURL,
+// HTMLAnchorElement.prototype.click, ...) are restored even if a test throws.
+// Tests that opt into fake timers should restore real timers themselves;
+// this hook handles spy restoration as a safety net.
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 describe("useWorkflowDraft - initial state and steps", () => {
   beforeEach(() => {
@@ -184,6 +196,11 @@ describe("useWorkflowDraft - import / export", () => {
   });
 
   it("exportJson opens a download link with sanitized filename", () => {
+    // 実装は `window.setTimeout(..., 0)` で revokeObjectURL を遅延させるため、
+    // fake timers を使ってフラッシュすることでフレーキーな実 setTimeout 待ちを避ける。
+    // The hook defers `revokeObjectURL` via `window.setTimeout(..., 0)`; use fake
+    // timers to flush deterministically and avoid flaky real-time waits.
+    vi.useFakeTimers();
     const createObjectURLSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-url");
     const revokeObjectURLSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
     const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
@@ -201,24 +218,18 @@ describe("useWorkflowDraft - import / export", () => {
     expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
     expect(clickSpy).toHaveBeenCalledTimes(1);
 
-    // revoke is queued via setTimeout; flush it
-    return new Promise<void>((resolve) => {
-      setTimeout(() => {
-        expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:mock-url");
-        createObjectURLSpy.mockRestore();
-        revokeObjectURLSpy.mockRestore();
-        clickSpy.mockRestore();
-        resolve();
-      }, 5);
-    });
+    // Flush the queued setTimeout(..., 0) that triggers revokeObjectURL.
+    vi.runAllTimers();
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:mock-url");
   });
 
   it("exportJson uses 'workflow' as the fallback when name is empty", () => {
-    const createObjectURLSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-url");
+    vi.useFakeTimers();
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-url");
     vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
 
     let downloadName = "";
-    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
       this: HTMLAnchorElement,
     ) {
       downloadName = this.download;
@@ -230,8 +241,7 @@ describe("useWorkflowDraft - import / export", () => {
     });
 
     expect(downloadName).toBe("workflow.json");
-    createObjectURLSpy.mockRestore();
-    clickSpy.mockRestore();
+    vi.runAllTimers();
   });
 
   it("onImportFile populates draft from a valid JSON file", async () => {

--- a/src/hooks/useWorkflowDraft.test.ts
+++ b/src/hooks/useWorkflowDraft.test.ts
@@ -32,12 +32,19 @@ import { useWorkflowDraft } from "./useWorkflowDraft";
 function resetStore(initial: WorkflowDefinition[] = []): void {
   useWorkflowDefinitionsStore.setState({
     definitions: initial,
+    // 実装の `useWorkflowDefinitionsStore` は upsert 時に updatedAt 降順で並び替えるため
+    // モックでも同じ並びを保つ。順序依存のリグレッションが隠れないようにするため。
+    // Mirror the real store: sort by `updatedAt` descending after upsert so the
+    // test setup matches production ordering and order-dependent regressions
+    // can surface.
     upsertDefinition: (def: WorkflowDefinition) => {
       mockUpsertDefinition(def);
-      useWorkflowDefinitionsStore.setState((s) => ({
-        ...s,
-        definitions: [...s.definitions.filter((d) => d.id !== def.id), def],
-      }));
+      useWorkflowDefinitionsStore.setState((s) => {
+        const next = [...s.definitions.filter((d) => d.id !== def.id), def].sort(
+          (a, b) => b.updatedAt - a.updatedAt,
+        );
+        return { ...s, definitions: next };
+      });
     },
     removeDefinition: (id: string) => {
       mockRemoveDefinition(id);
@@ -99,7 +106,7 @@ describe("useWorkflowDraft - initial state and steps", () => {
       vi.useRealTimers();
     });
 
-    expect(result.current.draft.updatedAt).toBeGreaterThanOrEqual(before);
+    expect(result.current.draft.updatedAt).toBeGreaterThan(before);
   });
 
   it("removeStep removes the step at index", () => {

--- a/src/hooks/useWorkflowDraft.test.ts
+++ b/src/hooks/useWorkflowDraft.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Tests for {@link useWorkflowDraft}.
+ * {@link useWorkflowDraft} のテスト。
+ *
+ * Issue #743: cover step CRUD, template loading, save validation, JSON
+ * import/export, and saved-definition selection lifecycle.
+ * Issue #743: ステップ CRUD、テンプレートのロード、保存時のバリデーション、
+ * JSON インポート/エクスポート、保存済み定義の選択ライフサイクルを検証する。
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+const mockToast = vi.fn();
+const mockUpsertDefinition = vi.fn();
+const mockRemoveDefinition = vi.fn();
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@zedi/ui", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+import { useWorkflowDefinitionsStore } from "@/stores/workflowDefinitionsStore";
+import type { WorkflowDefinition } from "@/lib/workflow/types";
+import { useWorkflowDraft } from "./useWorkflowDraft";
+
+function resetStore(initial: WorkflowDefinition[] = []): void {
+  useWorkflowDefinitionsStore.setState({
+    definitions: initial,
+    upsertDefinition: (def: WorkflowDefinition) => {
+      mockUpsertDefinition(def);
+      useWorkflowDefinitionsStore.setState((s) => ({
+        ...s,
+        definitions: [...s.definitions.filter((d) => d.id !== def.id), def],
+      }));
+    },
+    removeDefinition: (id: string) => {
+      mockRemoveDefinition(id);
+      useWorkflowDefinitionsStore.setState((s) => ({
+        ...s,
+        definitions: s.definitions.filter((d) => d.id !== id),
+      }));
+    },
+  });
+}
+
+describe("useWorkflowDraft - initial state and steps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("starts with one empty step and an auto-generated id/name", () => {
+    const { result } = renderHook(() => useWorkflowDraft());
+
+    expect(result.current.draft.name).toBe("");
+    expect(result.current.draft.steps).toHaveLength(1);
+    expect(result.current.draft.steps[0]).toMatchObject({ title: "", instruction: "" });
+    expect(result.current.draft.steps[0].id).toBeTruthy();
+    expect(result.current.selectedSavedId).toBe("");
+  });
+
+  it("addStep appends a new empty step", () => {
+    const { result } = renderHook(() => useWorkflowDraft());
+
+    act(() => {
+      result.current.addStep();
+    });
+
+    expect(result.current.draft.steps).toHaveLength(2);
+    expect(result.current.draft.steps[1]).toMatchObject({ title: "", instruction: "" });
+  });
+
+  it("addStep bumps updatedAt", () => {
+    const { result } = renderHook(() => useWorkflowDraft());
+    const before = result.current.draft.updatedAt;
+
+    act(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(before + 1000));
+      result.current.addStep();
+      vi.useRealTimers();
+    });
+
+    expect(result.current.draft.updatedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it("removeStep removes the step at index", () => {
+    const { result } = renderHook(() => useWorkflowDraft());
+    act(() => {
+      result.current.addStep();
+      result.current.addStep();
+    });
+    expect(result.current.draft.steps).toHaveLength(3);
+
+    act(() => {
+      result.current.updateStep(0, { title: "first" });
+      result.current.updateStep(1, { title: "second" });
+      result.current.updateStep(2, { title: "third" });
+    });
+    act(() => {
+      result.current.removeStep(1);
+    });
+
+    expect(result.current.draft.steps).toHaveLength(2);
+    expect(result.current.draft.steps.map((s) => s.title)).toEqual(["first", "third"]);
+  });
+
+  it("updateStep applies a partial patch", () => {
+    const { result } = renderHook(() => useWorkflowDraft());
+
+    act(() => {
+      result.current.updateStep(0, { title: "T", instruction: "I" });
+    });
+
+    expect(result.current.draft.steps[0]).toMatchObject({ title: "T", instruction: "I" });
+  });
+});
+
+describe("useWorkflowDraft - templates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("loadTemplate populates the draft from a template id and clears selectedSavedId", () => {
+    const { result } = renderHook(() => useWorkflowDraft());
+
+    act(() => {
+      result.current.loadTemplate("code-investigate-design");
+    });
+
+    expect(result.current.draft.steps.length).toBeGreaterThanOrEqual(1);
+    expect(result.current.draft.name).toBe("aiChat.workflow.templates.codeInvestigateDesign");
+    expect(result.current.selectedSavedId).toBe("");
+  });
+});
+
+describe("useWorkflowDraft - saveCustom", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("rejects save when draft.name is empty and toasts a destructive notice", () => {
+    const { result } = renderHook(() => useWorkflowDraft());
+
+    act(() => {
+      result.current.saveCustom();
+    });
+
+    expect(mockUpsertDefinition).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "aiChat.workflow.nameRequired",
+      variant: "destructive",
+    });
+  });
+
+  it("upserts draft into the store and toasts success when name is set", () => {
+    const { result } = renderHook(() => useWorkflowDraft());
+
+    act(() => {
+      result.current.setDraft((d) => ({ ...d, name: "My Flow" }));
+    });
+    act(() => {
+      result.current.saveCustom();
+    });
+
+    expect(mockUpsertDefinition).toHaveBeenCalledTimes(1);
+    expect(mockUpsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ name: "My Flow" }));
+    expect(mockToast).toHaveBeenCalledWith({ title: "aiChat.workflow.saved" });
+  });
+});
+
+describe("useWorkflowDraft - import / export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("exportJson opens a download link with sanitized filename", () => {
+    const createObjectURLSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-url");
+    const revokeObjectURLSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    const { result } = renderHook(() => useWorkflowDraft());
+
+    act(() => {
+      result.current.setDraft((d) => ({ ...d, name: "Plan A" }));
+    });
+
+    act(() => {
+      result.current.exportJson();
+    });
+
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    // revoke is queued via setTimeout; flush it
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:mock-url");
+        createObjectURLSpy.mockRestore();
+        revokeObjectURLSpy.mockRestore();
+        clickSpy.mockRestore();
+        resolve();
+      }, 5);
+    });
+  });
+
+  it("exportJson uses 'workflow' as the fallback when name is empty", () => {
+    const createObjectURLSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-url");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+
+    let downloadName = "";
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      downloadName = this.download;
+    });
+
+    const { result } = renderHook(() => useWorkflowDraft());
+    act(() => {
+      result.current.exportJson();
+    });
+
+    expect(downloadName).toBe("workflow.json");
+    createObjectURLSpy.mockRestore();
+    clickSpy.mockRestore();
+  });
+
+  it("onImportFile populates draft from a valid JSON file", async () => {
+    const json = JSON.stringify({
+      name: "Imported",
+      steps: [{ title: "S1", instruction: "do" }],
+    });
+    const file = new File([json], "flow.json", { type: "application/json" });
+
+    const { result } = renderHook(() => useWorkflowDraft());
+
+    const fakeInput = document.createElement("input");
+    fakeInput.type = "file";
+    Object.defineProperty(fakeInput, "files", {
+      value: [file],
+      configurable: true,
+    });
+    const event = {
+      target: fakeInput,
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+    act(() => {
+      result.current.onImportFile(event);
+    });
+
+    await waitFor(() => {
+      expect(result.current.draft.name).toBe("Imported");
+    });
+    expect(result.current.draft.steps).toHaveLength(1);
+    expect(result.current.draft.steps[0]).toMatchObject({ title: "S1", instruction: "do" });
+    expect(mockToast).toHaveBeenCalledWith({ title: "aiChat.workflow.imported" });
+  });
+
+  it("onImportFile is a no-op when no file is selected", () => {
+    const { result } = renderHook(() => useWorkflowDraft());
+    const initialName = result.current.draft.name;
+
+    const event = {
+      target: { files: null, value: "" } as unknown as HTMLInputElement,
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+    act(() => {
+      result.current.onImportFile(event);
+    });
+
+    expect(result.current.draft.name).toBe(initialName);
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("onImportFile toasts importFailed when JSON is invalid", async () => {
+    const file = new File(["not json"], "bad.json", { type: "application/json" });
+
+    const { result } = renderHook(() => useWorkflowDraft());
+
+    const fakeInput = document.createElement("input");
+    fakeInput.type = "file";
+    Object.defineProperty(fakeInput, "files", {
+      value: [file],
+      configurable: true,
+    });
+    const event = {
+      target: fakeInput,
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+    act(() => {
+      result.current.onImportFile(event);
+    });
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({
+        title: "aiChat.workflow.importFailed",
+        variant: "destructive",
+      });
+    });
+  });
+});
+
+describe("useWorkflowDraft - saved definitions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loadSaved copies the matching definition into the draft", () => {
+    const saved: WorkflowDefinition = {
+      id: "saved-1",
+      name: "Saved",
+      steps: [{ id: "s1", title: "T", instruction: "I" }],
+      createdAt: 100,
+      updatedAt: 200,
+    };
+    resetStore([saved]);
+    const { result } = renderHook(() => useWorkflowDraft());
+
+    act(() => {
+      result.current.loadSaved("saved-1");
+    });
+
+    expect(result.current.draft.id).toBe("saved-1");
+    expect(result.current.draft.name).toBe("Saved");
+    expect(result.current.selectedSavedId).toBe("saved-1");
+  });
+
+  it("loadSaved is a no-op when the id is unknown", () => {
+    resetStore([]);
+    const { result } = renderHook(() => useWorkflowDraft());
+    const before = result.current.draft;
+
+    act(() => {
+      result.current.loadSaved("missing");
+    });
+
+    expect(result.current.draft).toBe(before);
+    expect(result.current.selectedSavedId).toBe("");
+  });
+
+  it("deleteSaved is a no-op when nothing is selected", () => {
+    resetStore([]);
+    const { result } = renderHook(() => useWorkflowDraft());
+
+    act(() => {
+      result.current.deleteSaved();
+    });
+
+    expect(mockRemoveDefinition).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("deleteSaved removes the selected definition and toasts deleted", () => {
+    const saved: WorkflowDefinition = {
+      id: "saved-2",
+      name: "Saved Two",
+      steps: [{ id: "s1", title: "T", instruction: "I" }],
+      createdAt: 100,
+      updatedAt: 200,
+    };
+    resetStore([saved]);
+    const { result } = renderHook(() => useWorkflowDraft());
+
+    act(() => {
+      result.current.loadSaved("saved-2");
+    });
+    act(() => {
+      result.current.deleteSaved();
+    });
+
+    expect(mockRemoveDefinition).toHaveBeenCalledWith("saved-2");
+    expect(result.current.selectedSavedId).toBe("");
+    expect(mockToast).toHaveBeenCalledWith({ title: "aiChat.workflow.deleted" });
+  });
+});

--- a/src/hooks/useWorkflowRunSession.test.ts
+++ b/src/hooks/useWorkflowRunSession.test.ts
@@ -110,13 +110,18 @@ describe("useWorkflowRunSession - validation guards", () => {
   });
 
   it("aborts with editorRequired toast when pageContext is not editor", async () => {
+    // 実装では type !== "editor" のときに editorRequired を出す。
+    // PageContext.type の有効値（"editor" | "home" | "search" | "other"）から
+    // editor 以外を選ぶことで unsafe な cast を避ける。
+    // The hook gates execution on `type === "editor"`. Use the valid "home"
+    // discriminant so we exercise the "not editor" branch without an as-cast.
     const { result } = renderHook(() => useWorkflowRunSession(makeDraft()), {
       wrapper: createWrapper({
-        type: "wiki",
+        type: "home",
         pageId: "w1",
-        pageTitle: "Wiki",
+        pageTitle: "Home",
         pageContent: "",
-      } as PageContext),
+      }),
     });
 
     await act(async () => {

--- a/src/hooks/useWorkflowRunSession.test.ts
+++ b/src/hooks/useWorkflowRunSession.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Tests for {@link useWorkflowRunSession}.
+ * {@link useWorkflowRunSession} のテスト。
+ *
+ * Issue #743: cover the orchestration entry points (validation guards, mode
+ * dispatch, completed/paused/stopped/error outcomes), abort cleanup on unmount,
+ * and pause / stop signal forwarding.
+ * Issue #743: 実行入口（バリデーション、モード分岐、completed/paused/stopped/error の
+ * 結果反映）、unmount 時の abort クリーンアップ、pause/stop の信号伝搬を検証する。
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+import type { WorkflowDefinition } from "@/lib/workflow/types";
+import type { WorkflowExecutionOutcome } from "@/lib/workflow/runWorkflowExecution";
+
+const mockToast = vi.fn();
+const mockIsTauriDesktop = vi.fn();
+const mockRunWorkflowExecution = vi.fn();
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock("@zedi/ui", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/lib/platform", () => ({
+  isTauriDesktop: () => mockIsTauriDesktop(),
+}));
+
+vi.mock("@/lib/workflow/runWorkflowExecution", () => ({
+  runWorkflowExecution: (...args: unknown[]) => mockRunWorkflowExecution(...args),
+}));
+
+import { AIChatProvider, useAIChatContext } from "@/contexts/AIChatContext";
+import type { PageContext } from "@/types/aiChat";
+import { useWorkflowRunSession } from "./useWorkflowRunSession";
+
+function makeDraft(overrides?: Partial<WorkflowDefinition>): WorkflowDefinition {
+  const now = Date.now();
+  return {
+    id: "wf-1",
+    name: "Test Flow",
+    steps: [
+      { id: "s1", title: "Step One", instruction: "do" },
+      { id: "s2", title: "Step Two", instruction: "next" },
+    ],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function ContextSetter({ pageContext }: { pageContext: PageContext | null }) {
+  const { setPageContext } = useAIChatContext();
+  React.useEffect(() => {
+    setPageContext(pageContext);
+  }, [pageContext, setPageContext]);
+  return null;
+}
+
+function createWrapper(pageContext: PageContext | null) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      AIChatProvider,
+      null,
+      React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(ContextSetter, { pageContext }),
+        children,
+      ),
+    );
+  };
+}
+
+const editorContext: PageContext = {
+  type: "editor",
+  pageId: "p1",
+  pageTitle: "Note",
+  pageFullContent: "",
+  claudeWorkspaceRoot: "/tmp/wsroot",
+};
+
+describe("useWorkflowRunSession - validation guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsTauriDesktop.mockReturnValue(true);
+  });
+
+  it("aborts with desktopOnly toast outside of Tauri", async () => {
+    mockIsTauriDesktop.mockReturnValue(false);
+    const { result } = renderHook(() => useWorkflowRunSession(makeDraft()), {
+      wrapper: createWrapper(editorContext),
+    });
+
+    await act(async () => {
+      await result.current.runExecution("fresh");
+    });
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "aiChat.workflow.desktopOnly",
+      variant: "destructive",
+    });
+    expect(mockRunWorkflowExecution).not.toHaveBeenCalled();
+  });
+
+  it("aborts with editorRequired toast when pageContext is not editor", async () => {
+    const { result } = renderHook(() => useWorkflowRunSession(makeDraft()), {
+      wrapper: createWrapper({
+        type: "wiki",
+        pageId: "w1",
+        pageTitle: "Wiki",
+        pageContent: "",
+      } as PageContext),
+    });
+
+    await act(async () => {
+      await result.current.runExecution("fresh");
+    });
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "aiChat.workflow.editorRequired",
+      variant: "destructive",
+    });
+    expect(mockRunWorkflowExecution).not.toHaveBeenCalled();
+  });
+
+  it("aborts with nameRequired when draft.name is empty", async () => {
+    const { result } = renderHook(() => useWorkflowRunSession(makeDraft({ name: "  " })), {
+      wrapper: createWrapper(editorContext),
+    });
+
+    await act(async () => {
+      await result.current.runExecution("fresh");
+    });
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "aiChat.workflow.nameRequired",
+      variant: "destructive",
+    });
+    expect(mockRunWorkflowExecution).not.toHaveBeenCalled();
+  });
+
+  it("aborts with stepsRequired when no step has both title and instruction", async () => {
+    const { result } = renderHook(
+      () => useWorkflowRunSession(makeDraft({ steps: [{ id: "s1", title: "", instruction: "" }] })),
+      { wrapper: createWrapper(editorContext) },
+    );
+
+    await act(async () => {
+      await result.current.runExecution("fresh");
+    });
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "aiChat.workflow.stepsRequired",
+      variant: "destructive",
+    });
+    expect(mockRunWorkflowExecution).not.toHaveBeenCalled();
+  });
+
+  it("aborts resume mode with nothingToResume when no paused state exists", async () => {
+    const { result } = renderHook(() => useWorkflowRunSession(makeDraft()), {
+      wrapper: createWrapper(editorContext),
+    });
+
+    await act(async () => {
+      await result.current.runExecution("resume");
+    });
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "aiChat.workflow.nothingToResume",
+      variant: "destructive",
+    });
+    expect(mockRunWorkflowExecution).not.toHaveBeenCalled();
+  });
+});
+
+describe("useWorkflowRunSession - run outcomes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsTauriDesktop.mockReturnValue(true);
+  });
+
+  it("fresh run dispatches to runWorkflowExecution with valid steps and reports completed", async () => {
+    mockRunWorkflowExecution.mockResolvedValue({
+      outcome: "completed",
+    } satisfies WorkflowExecutionOutcome);
+
+    const { result } = renderHook(() => useWorkflowRunSession(makeDraft()), {
+      wrapper: createWrapper(editorContext),
+    });
+
+    await act(async () => {
+      await result.current.runExecution("fresh");
+    });
+
+    expect(mockRunWorkflowExecution).toHaveBeenCalledTimes(1);
+    const callArg = mockRunWorkflowExecution.mock.calls[0][0] as {
+      definition: WorkflowDefinition;
+      cwd: string | undefined;
+      startStepIndex: number;
+    };
+    expect(callArg.definition.steps).toHaveLength(2);
+    expect(callArg.cwd).toBe("/tmp/wsroot");
+    expect(callArg.startStepIndex).toBe(0);
+
+    await waitFor(() => {
+      expect(result.current.progress?.phase).toBe("completed");
+    });
+    expect(mockToast).toHaveBeenCalledWith({ title: "aiChat.workflow.completed" });
+    expect(result.current.pausedState).toBeNull();
+  });
+
+  it("paused outcome stores resumable snapshot and toasts paused", async () => {
+    mockRunWorkflowExecution.mockResolvedValue({
+      outcome: "paused",
+      pausedAtStepIndex: 1,
+      pausedStepId: "s2",
+      stepOutputsById: { s1: "first done" },
+      stepOutputs: ["first done", ""],
+      partialForStep: "in-progress text",
+    } satisfies WorkflowExecutionOutcome);
+
+    const { result } = renderHook(() => useWorkflowRunSession(makeDraft()), {
+      wrapper: createWrapper(editorContext),
+    });
+
+    await act(async () => {
+      await result.current.runExecution("fresh");
+    });
+
+    await waitFor(() => {
+      expect(result.current.pausedState).not.toBeNull();
+    });
+    expect(result.current.pausedState).toMatchObject({
+      pausedStepId: "s2",
+      stepOutputsById: { s1: "first done" },
+      partialForStep: "in-progress text",
+    });
+    expect(result.current.progress?.phase).toBe("paused");
+    expect(mockToast).toHaveBeenCalledWith({ title: "aiChat.workflow.paused" });
+  });
+
+  it("error outcome records lastError and toasts a destructive notice", async () => {
+    mockRunWorkflowExecution.mockResolvedValue({
+      outcome: "error",
+      error: "boom",
+    } satisfies WorkflowExecutionOutcome);
+
+    const { result } = renderHook(() => useWorkflowRunSession(makeDraft()), {
+      wrapper: createWrapper(editorContext),
+    });
+
+    await act(async () => {
+      await result.current.runExecution("fresh");
+    });
+
+    await waitFor(() => {
+      expect(result.current.progress?.phase).toBe("aborted");
+    });
+    expect(result.current.progress?.lastError).toBe("boom");
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "aiChat.workflow.error",
+      variant: "destructive",
+    });
+  });
+});
+
+describe("useWorkflowRunSession - resume", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsTauriDesktop.mockReturnValue(true);
+  });
+
+  it("resume passes startStepIndex/stepOutputs/resumePartial back to runWorkflowExecution", async () => {
+    // First, drive a paused outcome so the hook captures pausedState.
+    mockRunWorkflowExecution.mockResolvedValueOnce({
+      outcome: "paused",
+      pausedAtStepIndex: 1,
+      pausedStepId: "s2",
+      stepOutputsById: { s1: "first" },
+      stepOutputs: ["first", ""],
+      partialForStep: "partial",
+    } satisfies WorkflowExecutionOutcome);
+
+    const { result } = renderHook(() => useWorkflowRunSession(makeDraft()), {
+      wrapper: createWrapper(editorContext),
+    });
+
+    await act(async () => {
+      await result.current.runExecution("fresh");
+    });
+    await waitFor(() => expect(result.current.pausedState).not.toBeNull());
+
+    mockRunWorkflowExecution.mockResolvedValueOnce({
+      outcome: "completed",
+    } satisfies WorkflowExecutionOutcome);
+
+    await act(async () => {
+      await result.current.runExecution("resume");
+    });
+
+    const secondCall = mockRunWorkflowExecution.mock.calls[1][0] as {
+      startStepIndex: number;
+      stepOutputs: string[];
+      resumePartialForCurrentStep: string | undefined;
+    };
+    expect(secondCall.startStepIndex).toBe(1);
+    expect(secondCall.stepOutputs).toEqual(["first", ""]);
+    expect(secondCall.resumePartialForCurrentStep).toBe("partial");
+  });
+
+  it("resume aborts when paused step id is no longer in valid steps", async () => {
+    mockRunWorkflowExecution.mockResolvedValueOnce({
+      outcome: "paused",
+      pausedAtStepIndex: 1,
+      pausedStepId: "s2",
+      stepOutputsById: { s1: "first" },
+      stepOutputs: ["first", ""],
+      partialForStep: "partial",
+    } satisfies WorkflowExecutionOutcome);
+
+    const draft = makeDraft();
+    const { rerender, result } = renderHook(
+      ({ d }: { d: WorkflowDefinition }) => useWorkflowRunSession(d),
+      {
+        wrapper: createWrapper(editorContext),
+        initialProps: { d: draft },
+      },
+    );
+
+    await act(async () => {
+      await result.current.runExecution("fresh");
+    });
+    await waitFor(() => expect(result.current.pausedState).not.toBeNull());
+
+    // User edited the draft and removed `s2`.
+    const editedDraft = makeDraft({
+      steps: [{ id: "s1", title: "Step One", instruction: "do" }],
+    });
+    rerender({ d: editedDraft });
+
+    await act(async () => {
+      await result.current.runExecution("resume");
+    });
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "aiChat.workflow.pausedStepNotFound",
+      variant: "destructive",
+    });
+    // After aborting, pausedState is reset to null.
+    expect(result.current.pausedState).toBeNull();
+  });
+});
+
+describe("useWorkflowRunSession - cleanup and signals", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsTauriDesktop.mockReturnValue(true);
+  });
+
+  it("handlePause aborts the current step controller", async () => {
+    let capturedStepAbort: AbortController | null = null;
+    let resolveExecution: ((value: WorkflowExecutionOutcome) => void) | null = null;
+
+    mockRunWorkflowExecution.mockImplementation(
+      async (params: {
+        createStepAbort: () => AbortController;
+      }): Promise<WorkflowExecutionOutcome> => {
+        capturedStepAbort = params.createStepAbort();
+        return new Promise<WorkflowExecutionOutcome>((resolve) => {
+          resolveExecution = resolve;
+        });
+      },
+    );
+
+    const { result } = renderHook(() => useWorkflowRunSession(makeDraft()), {
+      wrapper: createWrapper(editorContext),
+    });
+
+    let pending: Promise<void> | undefined;
+    act(() => {
+      pending = result.current.runExecution("fresh");
+    });
+    await waitFor(() => expect(capturedStepAbort).not.toBeNull());
+
+    act(() => {
+      result.current.handlePause();
+    });
+
+    expect(capturedStepAbort?.signal.aborted).toBe(true);
+
+    // Drain the promise so the test does not leak.
+    await act(async () => {
+      resolveExecution?.({ outcome: "completed" });
+      await pending;
+    });
+  });
+
+  it("handleStop aborts both workflow and current-step controllers", async () => {
+    let capturedStepAbort: AbortController | null = null;
+    let capturedWorkflowSignal: AbortSignal | null = null;
+    let resolveExecution: ((value: WorkflowExecutionOutcome) => void) | null = null;
+
+    mockRunWorkflowExecution.mockImplementation(
+      async (params: {
+        workflowSignal: AbortSignal;
+        createStepAbort: () => AbortController;
+      }): Promise<WorkflowExecutionOutcome> => {
+        capturedWorkflowSignal = params.workflowSignal;
+        capturedStepAbort = params.createStepAbort();
+        return new Promise<WorkflowExecutionOutcome>((resolve) => {
+          resolveExecution = resolve;
+        });
+      },
+    );
+
+    const { result } = renderHook(() => useWorkflowRunSession(makeDraft()), {
+      wrapper: createWrapper(editorContext),
+    });
+
+    let pending: Promise<void> | undefined;
+    act(() => {
+      pending = result.current.runExecution("fresh");
+    });
+    await waitFor(() => expect(capturedWorkflowSignal).not.toBeNull());
+
+    act(() => {
+      result.current.handleStop();
+    });
+
+    expect(capturedWorkflowSignal?.aborted).toBe(true);
+    expect(capturedStepAbort?.signal.aborted).toBe(true);
+
+    await act(async () => {
+      resolveExecution?.({ outcome: "stopped" });
+      await pending;
+    });
+  });
+
+  it("aborts in-flight controllers on unmount", async () => {
+    let capturedStepAbort: AbortController | null = null;
+    let capturedWorkflowSignal: AbortSignal | null = null;
+    let resolveExecution: ((value: WorkflowExecutionOutcome) => void) | null = null;
+
+    mockRunWorkflowExecution.mockImplementation(
+      async (params: {
+        workflowSignal: AbortSignal;
+        createStepAbort: () => AbortController;
+      }): Promise<WorkflowExecutionOutcome> => {
+        capturedWorkflowSignal = params.workflowSignal;
+        capturedStepAbort = params.createStepAbort();
+        return new Promise<WorkflowExecutionOutcome>((resolve) => {
+          resolveExecution = resolve;
+        });
+      },
+    );
+
+    const { result, unmount } = renderHook(() => useWorkflowRunSession(makeDraft()), {
+      wrapper: createWrapper(editorContext),
+    });
+
+    let pending: Promise<void> | undefined;
+    act(() => {
+      pending = result.current.runExecution("fresh");
+    });
+    await waitFor(() => expect(capturedWorkflowSignal).not.toBeNull());
+
+    unmount();
+
+    expect(capturedWorkflowSignal?.aborted).toBe(true);
+    expect(capturedStepAbort?.signal.aborted).toBe(true);
+
+    // Resolve to avoid leaking the pending promise into the next test.
+    resolveExecution?.({ outcome: "stopped" });
+    await pending;
+  });
+});


### PR DESCRIPTION
Add renderHook-based vitest suites for the hooks listed in #743 to lift
mutation score on `src/hooks/**`:

- useGeneralSettings: load/save lifecycle, theme/locale sync, font-size
  clamping, persistence error handling.
- useAISettings: async load fallbacks, provider/model switching rules,
  connection-test side effects, save/reset flow.
- useMermaidGenerator: state machine (idle → generating → completed/error),
  input validation, AI configuration check, reset.
- useWorkflowDraft: step CRUD, template loading, save validation, JSON
  import/export, saved-definition selection.
- useWorkflowRunSession: validation guards, run outcomes
  (completed/paused/stopped/error), pause/stop signal forwarding,
  unmount abort cleanup.
- useAIChatPanelContentLogic: composition contract — page-title derivation
  forwarded to useAIChat, lifecycle/handler params wired through, branch
  prefill handlers exposed.

All 88 new tests pass; full vitest run (1891 tests) green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive Vitest suites for hooks to improve stability and user-facing behavior: settings loading/saving, AI/chat interactions, diagram generation, workflow drafts, run sessions, and general preferences.
  * Coverage includes message/conversation flows, branch/navigation actions, persistence and error handling, memoization guarantees, import/export UX, execution/resume/abort flows, and UI-facing state transitions and toasts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->