### PR TITLE
test(P3): cover agentSlashCommands and slashSuggestionPlugin (#744)

### DIFF
--- a/src/components/editor/extensions/slashSuggestionPlugin.test.ts
+++ b/src/components/editor/extensions/slashSuggestionPlugin.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for the `/` slash suggestion ProseMirror plugin.
+ * `/` スラッシュサジェスト用 ProseMirror プラグインのテスト。
+ *
+ * The plugin tracks slash queries triggered at the start of a line or after a
+ * space, and notifies subscribers when its state changes. These tests build a
+ * minimal ProseMirror schema + state and feed transactions directly so we can
+ * pin the trigger conditions without a full Tiptap editor.
+ * 行頭またはスペース直後の `/` を検知する。最小スキーマ + 直接トランザクション
+ * 適用でトリガ条件を固定する。
+ */
+
+import type { Plugin } from "@tiptap/pm/state";
+import { EditorState, TextSelection } from "@tiptap/pm/state";
+import { Schema } from "@tiptap/pm/model";
+import { describe, expect, it, vi } from "vitest";
+import {
+  SlashSuggestionPlugin,
+  slashSuggestionPluginKey,
+  type SlashSuggestionState,
+} from "./slashSuggestionPlugin";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: {
+      group: "block",
+      content: "text*",
+      toDOM: () => ["p", 0],
+    },
+    text: { group: "inline" },
+  },
+});
+
+/**
+ * Pulls the bare ProseMirror plugin out of the Tiptap extension wrapper so we
+ * can install it on a hand-built `EditorState`.
+ * Tiptap 拡張ラッパーから素の ProseMirror プラグインを取り出す。
+ */
+function getPlugin(onStateChange?: (s: SlashSuggestionState) => void): Plugin {
+  const extension = SlashSuggestionPlugin.configure({ onStateChange });
+  const addPlugins = extension.config.addProseMirrorPlugins;
+  if (!addPlugins) throw new Error("addProseMirrorPlugins missing");
+  // Tiptap stores extension options on `this.options` inside the method.
+  // 拡張内部の `this.options` 経由で onStateChange を渡す必要がある。
+  const plugins = addPlugins.call({ options: { onStateChange } } as never);
+  return plugins[0];
+}
+
+/**
+ * Creates an editor state seeded with `text` inside a single paragraph and a
+ * collapsed cursor at the end of that text.
+ * 1 段落のみのドキュメントを生成し、キャレットを末尾に置く。
+ */
+function makeState(text: string, plugin: Plugin): EditorState {
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, text ? [schema.text(text)] : []),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [plugin] });
+  // 段落内末尾にキャレットを置く: pos 1 が段落 open、pos 1+text.length が末尾。
+  // Place the caret at the end of the paragraph (pos 1 + text length).
+  const tr = state.tr.setSelection(TextSelection.create(state.doc, 1 + text.length));
+  return state.apply(tr);
+}
+
+describe("slashSuggestionPlugin — initial state", () => {
+  it("initialises with no active suggestion", () => {
+    const plugin = getPlugin();
+    const state = makeState("", plugin);
+    const pluginState = slashSuggestionPluginKey.getState(state);
+    expect(pluginState).toEqual({
+      active: false,
+      query: "",
+      range: null,
+      decorations: expect.any(Object),
+    });
+  });
+});
+
+describe("slashSuggestionPlugin — activation triggers", () => {
+  it("activates on `/` at the start of a line", () => {
+    const onStateChange = vi.fn();
+    const plugin = getPlugin(onStateChange);
+    const state = makeState("/", plugin);
+    const pluginState = slashSuggestionPluginKey.getState(state);
+
+    expect(pluginState?.active).toBe(true);
+    expect(pluginState?.query).toBe("");
+    // `/` 自体は pos 1〜2 の範囲。range はメニュー削除に再利用される。
+    // The slash itself sits at positions 1..2; range is later used to delete it.
+    expect(pluginState?.range).toEqual({ from: 1, to: 2 });
+    expect(onStateChange).toHaveBeenCalledWith(pluginState);
+  });
+
+  it("captures the query text after `/`", () => {
+    const plugin = getPlugin();
+    const state = makeState("/analyze", plugin);
+    const pluginState = slashSuggestionPluginKey.getState(state);
+
+    expect(pluginState?.active).toBe(true);
+    expect(pluginState?.query).toBe("analyze");
+    expect(pluginState?.range).toEqual({ from: 1, to: 9 });
+  });
+
+  it("activates on a `/` preceded by a space mid-line", () => {
+    const plugin = getPlugin();
+    const state = makeState("hi /run", plugin);
+    const pluginState = slashSuggestionPluginKey.getState(state);
+
+    expect(pluginState?.active).toBe(true);
+    expect(pluginState?.query).toBe("run");
+    // "hi " (3 chars) → `/` at pos 4, query ends at pos 8.
+    // 行頭ではなくスペース直後の `/` も同様に検知する。
+    expect(pluginState?.range).toEqual({ from: 4, to: 8 });
+  });
+
+  it("preserves spaces inside the query so multi-token args stay active", () => {
+    // `/analyze path/to/file` のような入力を維持する設計（コードコメント参照）。
+    // Multi-word args after the command must keep the menu open.
+    const plugin = getPlugin();
+    const state = makeState("/analyze src/foo.ts", plugin);
+    const pluginState = slashSuggestionPluginKey.getState(state);
+
+    expect(pluginState?.active).toBe(true);
+    expect(pluginState?.query).toBe("analyze src/foo.ts");
+  });
+});
+
+describe("slashSuggestionPlugin — non-trigger inputs", () => {
+  it("does not activate when `/` is embedded in a word", () => {
+    const plugin = getPlugin();
+    const state = makeState("foo/bar", plugin);
+    const pluginState = slashSuggestionPluginKey.getState(state);
+    expect(pluginState?.active).toBe(false);
+  });
+
+  it("does not activate without any `/`", () => {
+    const plugin = getPlugin();
+    const state = makeState("plain text", plugin);
+    const pluginState = slashSuggestionPluginKey.getState(state);
+    expect(pluginState?.active).toBe(false);
+  });
+});
+
+describe("slashSuggestionPlugin — deactivation", () => {
+  it("deactivates when the selection becomes a non-empty range", () => {
+    const onStateChange = vi.fn();
+    const plugin = getPlugin(onStateChange);
+
+    // 1) Activate with `/foo`.
+    let state = makeState("/foo", plugin);
+    expect(slashSuggestionPluginKey.getState(state)?.active).toBe(true);
+    onStateChange.mockClear();
+
+    // 2) Expand the selection to a range; the plugin must turn off.
+    const tr = state.tr.setSelection(TextSelection.create(state.doc, 1, 5));
+    state = state.apply(tr);
+    const pluginState = slashSuggestionPluginKey.getState(state);
+    expect(pluginState?.active).toBe(false);
+    expect(pluginState?.range).toBeNull();
+    expect(pluginState?.query).toBe("");
+    expect(onStateChange).toHaveBeenCalledWith(pluginState);
+  });
+
+  it("stays inactive when a non-empty selection is applied from an inactive state", () => {
+    const onStateChange = vi.fn();
+    const plugin = getPlugin(onStateChange);
+
+    let state = makeState("hello", plugin);
+    expect(slashSuggestionPluginKey.getState(state)?.active).toBe(false);
+    onStateChange.mockClear();
+
+    const tr = state.tr.setSelection(TextSelection.create(state.doc, 1, 4));
+    state = state.apply(tr);
+    expect(slashSuggestionPluginKey.getState(state)?.active).toBe(false);
+    // 既に inactive のため通知しない（不要な再描画を避ける）。
+    // No notification when already inactive — avoids redundant re-renders.
+    expect(onStateChange).not.toHaveBeenCalled();
+  });
+
+  it("turns off when the user types past the slash trigger and the regex no longer matches", () => {
+    const plugin = getPlugin();
+
+    // Active first.
+    let state = makeState("/foo", plugin);
+    expect(slashSuggestionPluginKey.getState(state)?.active).toBe(true);
+
+    // Replace the entire paragraph contents with text that no longer matches.
+    // 段落全体を非トリガなテキストに差し替える（pos 1〜5 が段落内 4 文字 + 末尾位置）。
+    const tr = state.tr.replaceWith(1, 5, schema.text("plain"));
+    state = state.apply(tr);
+    expect(slashSuggestionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("explicit close meta clears the active state and notifies subscribers", () => {
+    const onStateChange = vi.fn();
+    const plugin = getPlugin(onStateChange);
+
+    let state = makeState("/foo", plugin);
+    expect(slashSuggestionPluginKey.getState(state)?.active).toBe(true);
+    onStateChange.mockClear();
+
+    const tr = state.tr.setMeta(slashSuggestionPluginKey, { close: true });
+    state = state.apply(tr);
+    const pluginState = slashSuggestionPluginKey.getState(state);
+    expect(pluginState).toEqual({
+      active: false,
+      query: "",
+      range: null,
+      decorations: expect.any(Object),
+    });
+    expect(onStateChange).toHaveBeenCalledWith(pluginState);
+  });
+});
+
+describe("slashSuggestionPlugin — decorations", () => {
+  it("creates a single decoration over the slash range when active", () => {
+    const plugin = getPlugin();
+    const state = makeState("/run", plugin);
+    const pluginState = slashSuggestionPluginKey.getState(state);
+    expect(pluginState?.active).toBe(true);
+
+    // DecorationSet.find returns all decorations overlapping the document.
+    // 装飾が `/run` 範囲（pos 1〜5）を覆っていることを確認する。
+    const decos = pluginState?.decorations.find(0, state.doc.content.size) ?? [];
+    expect(decos).toHaveLength(1);
+    expect(decos[0].from).toBe(1);
+    expect(decos[0].to).toBe(5);
+  });
+
+  it("returns an empty decoration set when inactive", () => {
+    const plugin = getPlugin();
+    const state = makeState("plain", plugin);
+    const pluginState = slashSuggestionPluginKey.getState(state);
+    expect(pluginState?.active).toBe(false);
+    const decos = pluginState?.decorations.find(0, state.doc.content.size) ?? [];
+    expect(decos).toHaveLength(0);
+  });
+});
+
+describe("slashSuggestionPlugin — extension wiring", () => {
+  it("declares the expected extension name", () => {
+    expect(SlashSuggestionPlugin.name).toBe("slashSuggestion");
+  });
+
+  it("exposes a default options object with no callback", () => {
+    const ext = SlashSuggestionPlugin.configure();
+    expect(ext.options.onStateChange).toBeUndefined();
+  });
+});

--- a/src/lib/agentSlashCommands/agentSlashEditorText.test.ts
+++ b/src/lib/agentSlashCommands/agentSlashEditorText.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for plain-text / selection-text helpers used by agent slash commands.
+ * エージェントスラッシュ用のテキスト取得ヘルパーのテスト。
+ */
+
+import type { Editor } from "@tiptap/core";
+import { describe, expect, it, vi } from "vitest";
+import { getEditorPlainText, getEditorSelectionText } from "./agentSlashEditorText";
+
+describe("getEditorPlainText", () => {
+  it("requests text from Tiptap with a newline block separator", () => {
+    const getText = vi.fn(() => "line1\nline2");
+    const editor = { getText } as unknown as Editor;
+
+    expect(getEditorPlainText(editor)).toBe("line1\nline2");
+    expect(getText).toHaveBeenCalledWith({ blockSeparator: "\n" });
+  });
+
+  it("returns whatever Tiptap returns, including empty strings", () => {
+    const editor = { getText: vi.fn(() => "") } as unknown as Editor;
+    expect(getEditorPlainText(editor)).toBe("");
+  });
+});
+
+describe("getEditorSelectionText", () => {
+  it("returns empty when the selection is collapsed", () => {
+    const textBetween = vi.fn();
+    const editor = {
+      state: {
+        selection: { from: 5, to: 5 },
+        doc: { textBetween },
+      },
+    } as unknown as Editor;
+
+    expect(getEditorSelectionText(editor)).toBe("");
+    // 折りたたみ選択では textBetween を呼ばない（不要な計算を避ける）。
+    // No call to textBetween for a collapsed selection — avoids wasted work.
+    expect(textBetween).not.toHaveBeenCalled();
+  });
+
+  it("delegates to doc.textBetween with a newline block separator and U+FFFC leaf marker", () => {
+    const textBetween = vi.fn(() => "abc");
+    const editor = {
+      state: {
+        selection: { from: 2, to: 7 },
+        doc: { textBetween },
+      },
+    } as unknown as Editor;
+
+    expect(getEditorSelectionText(editor)).toBe("abc");
+    // U+FFFC (object replacement char) はノード代替の標準プレースホルダ。
+    // U+FFFC is the standard placeholder used for node replacements in ProseMirror.
+    expect(textBetween).toHaveBeenCalledWith(2, 7, "\n", "￼");
+  });
+});

--- a/src/lib/agentSlashCommands/buildAgentSlashPrompt.test.ts
+++ b/src/lib/agentSlashCommands/buildAgentSlashPrompt.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Dispatcher-level tests for `buildAgentSlashPrompt` and Claude option policy.
+ * `buildAgentSlashPrompt` 振り分けと Claude 実行ポリシーのテスト。
+ */
+
+import type { Editor } from "@tiptap/core";
+import { describe, expect, it, vi } from "vitest";
+import { buildAgentSlashPrompt, getAgentSlashClaudeOptions } from "./buildAgentSlashPrompt";
+import type { AgentSlashCommandId } from "./types";
+
+/**
+ * Minimal editor mock used only by `agent-explain` / `agent-summarize` paths
+ * when captures are not supplied. Other branches do not touch the editor.
+ * `agent-explain` / `agent-summarize` 以外の分岐ではエディタを触らない。
+ */
+function makeMockEditor(opts: { plainText?: string; selectionText?: string }): Editor {
+  return {
+    getText: vi.fn(() => opts.plainText ?? ""),
+    state: {
+      selection: { from: 0, to: opts.selectionText ? opts.selectionText.length : 0 },
+      doc: {
+        textBetween: vi.fn(() => opts.selectionText ?? ""),
+      },
+    },
+  } as unknown as Editor;
+}
+
+describe("buildAgentSlashPrompt — command dispatch", () => {
+  // Editor が必要になる分岐は限定的。args の前後空白は trim される契約。
+  // Only explain/summarize touch the editor; args are trimmed by contract.
+
+  it.each([
+    ["agent-analyze", "  src/lib.ts  ", "Target path (relative to workspace): src/lib.ts"],
+    ["agent-run", "  echo hi  ", "Command: echo hi"],
+    ["agent-research", "  graphs  ", "Topic: graphs"],
+    ["agent-review", "  src/x.ts  ", "Target path: src/x.ts"],
+    ["agent-test", "  src/x.test.ts  ", "Focus path or pattern: src/x.test.ts"],
+  ] as const)("dispatches %s and forwards trimmed args", (id, args, needle) => {
+    const editor = makeMockEditor({});
+    const out = buildAgentSlashPrompt(id as AgentSlashCommandId, args, editor);
+    expect(out).toContain(needle);
+  });
+
+  it("dispatches agent-git-summary regardless of args", () => {
+    const editor = makeMockEditor({});
+    const out = buildAgentSlashPrompt("agent-git-summary", "ignored args", editor);
+    expect(out).toContain("git log -n 20 --oneline");
+  });
+
+  it("dispatches agent-explain and forwards the captured selection", () => {
+    const editor = makeMockEditor({});
+    const out = buildAgentSlashPrompt("agent-explain", "", editor, {
+      selectionText: "snippet",
+    });
+    expect(out).toContain("Selection:");
+    expect(out).toContain("snippet");
+    expect(editor.state.doc.textBetween).not.toHaveBeenCalled();
+  });
+
+  it("dispatches agent-summarize and forwards the captured plain text", () => {
+    const editor = makeMockEditor({});
+    const out = buildAgentSlashPrompt("agent-summarize", "", editor, {
+      plainText: "body",
+    });
+    expect(out).toContain("Note text:\nbody");
+    expect(editor.getText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the live editor when captures are absent (explain)", () => {
+    const editor = makeMockEditor({ selectionText: "live" });
+    const out = buildAgentSlashPrompt("agent-explain", "", editor);
+    expect(out).toContain("live");
+    expect(editor.state.doc.textBetween).toHaveBeenCalled();
+  });
+
+  it("falls back to the live editor when captures are absent (summarize)", () => {
+    const editor = makeMockEditor({ plainText: "live body" });
+    const out = buildAgentSlashPrompt("agent-summarize", "", editor);
+    expect(out).toContain("live body");
+    expect(editor.getText).toHaveBeenCalled();
+  });
+
+  it("throws on an unknown command id (defensive exhaustiveness check)", () => {
+    const editor = makeMockEditor({});
+    // 型に存在しない id を渡したケースのフェイルセーフ。
+    // Defensive guard for an id that bypassed the type system.
+    expect(() =>
+      buildAgentSlashPrompt("agent-unknown" as unknown as AgentSlashCommandId, "", editor),
+    ).toThrow(/Unhandled agent slash command/);
+  });
+});
+
+describe("getAgentSlashClaudeOptions", () => {
+  it.each([
+    ["agent-analyze", 20, ["Read"]],
+    ["agent-explain", 8, []],
+    ["agent-git-summary", 10, ["Bash"]],
+    ["agent-research", 20, ["WebSearch", "Read"]],
+    ["agent-review", 20, ["Read"]],
+    ["agent-run", 12, ["Bash"]],
+    ["agent-summarize", 16, []],
+    ["agent-test", 18, ["Bash", "Read"]],
+  ] as const)("returns the policy for %s", (id, maxTurns, allowedTools) => {
+    const opts = getAgentSlashClaudeOptions(id as AgentSlashCommandId);
+    expect(opts.maxTurns).toBe(maxTurns);
+    expect(opts.allowedTools).toEqual(allowedTools);
+  });
+
+  it("throws on an unknown command id (defensive exhaustiveness check)", () => {
+    expect(() =>
+      getAgentSlashClaudeOptions("agent-unknown" as unknown as AgentSlashCommandId),
+    ).toThrow(/Unhandled agent slash command/);
+  });
+});

--- a/src/lib/agentSlashCommands/buildAgentSlashPromptParts.test.ts
+++ b/src/lib/agentSlashCommands/buildAgentSlashPromptParts.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Per-command prompt builder tests for agent slash commands.
+ * エージェントスラッシュ各コマンドのプロンプト生成テスト。
+ */
+
+import type { Editor } from "@tiptap/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildAnalyzePrompt,
+  buildExplainPrompt,
+  buildGitSummaryPrompt,
+  buildResearchPrompt,
+  buildReviewPrompt,
+  buildRunPrompt,
+  buildSummarizePrompt,
+  buildTestPrompt,
+} from "./buildAgentSlashPromptParts";
+
+/**
+ * Builds a minimal mock editor that satisfies the calls made by the
+ * prompt-builder helpers (`getText` and selection-aware `textBetween`).
+ * プロンプトビルダから呼ばれる API のみを満たす最小モックを返す。
+ */
+function makeMockEditor(opts: {
+  /** Plain text returned from `editor.getText`. / `editor.getText` の戻り値 */
+  plainText?: string;
+  /** Selection range for `state.selection`. / `state.selection` の範囲 */
+  selection?: { from: number; to: number };
+  /** Selection text returned by `doc.textBetween`. / `doc.textBetween` の戻り値 */
+  selectionText?: string;
+}): Editor {
+  const sel = opts.selection ?? { from: 0, to: 0 };
+  return {
+    getText: vi.fn(() => opts.plainText ?? ""),
+    state: {
+      selection: sel,
+      doc: {
+        textBetween: vi.fn(() => opts.selectionText ?? ""),
+      },
+    },
+  } as unknown as Editor;
+}
+
+describe("buildAnalyzePrompt", () => {
+  it("includes the workspace path when args are provided", () => {
+    const out = buildAnalyzePrompt("src/lib/foo.ts");
+    expect(out).toContain("Target path (relative to workspace): src/lib/foo.ts");
+    expect(out).toContain("Analyze the code at the given path");
+  });
+
+  it("falls back to inference message when args are empty", () => {
+    const out = buildAnalyzePrompt("");
+    expect(out).toContain("No path was given");
+    expect(out).not.toContain("Target path (relative to workspace):");
+  });
+});
+
+describe("buildGitSummaryPrompt", () => {
+  it("instructs to run git log and summarize in Japanese", () => {
+    const out = buildGitSummaryPrompt();
+    expect(out).toContain("git log -n 20 --oneline");
+    expect(out).toContain("Bash");
+    expect(out).toContain("Japanese");
+  });
+});
+
+describe("buildRunPrompt", () => {
+  it("includes the command when args are provided", () => {
+    const out = buildRunPrompt("ls -la");
+    expect(out).toContain("Command: ls -la");
+    expect(out).toContain("Bash");
+  });
+
+  it("asks the user to provide a command when args are empty", () => {
+    const out = buildRunPrompt("");
+    expect(out).toContain("No command was given");
+  });
+});
+
+describe("buildResearchPrompt", () => {
+  it("includes the topic when args are provided", () => {
+    const out = buildResearchPrompt("Tiptap performance");
+    expect(out).toContain("Topic: Tiptap performance");
+    expect(out).toContain("WebSearch");
+  });
+
+  it("asks the user to specify a topic when args are empty", () => {
+    const out = buildResearchPrompt("");
+    expect(out).toContain("No topic was given");
+  });
+});
+
+describe("buildReviewPrompt", () => {
+  it("includes the target path when args are provided", () => {
+    const out = buildReviewPrompt("src/components/Foo.tsx");
+    expect(out).toContain("Target path: src/components/Foo.tsx");
+    expect(out).toContain("code review");
+  });
+
+  it("asks for a default when args are empty", () => {
+    const out = buildReviewPrompt("");
+    expect(out).toContain("No path was given");
+  });
+});
+
+describe("buildTestPrompt", () => {
+  it("includes the focus path when args are provided", () => {
+    const out = buildTestPrompt("src/lib/foo.test.ts");
+    expect(out).toContain("Focus path or pattern: src/lib/foo.test.ts");
+    expect(out).toContain("bun run test:run");
+  });
+
+  it("falls back to default test script when args are empty", () => {
+    const out = buildTestPrompt("");
+    expect(out).toContain("No path");
+    expect(out).toContain("default test script");
+  });
+});
+
+describe("buildExplainPrompt", () => {
+  it("uses the captured selection text when provided", () => {
+    const editor = makeMockEditor({});
+    const out = buildExplainPrompt(editor, { selectionText: "captured snippet" });
+    expect(out).toContain("Selection:");
+    expect(out).toContain("captured snippet");
+    // captures.selectionText が優先されるため editor 取得は呼ばれない
+    // editor accessors should not be called when captures provide the selection.
+    expect(editor.getText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to live editor selection when captures are absent", () => {
+    const editor = makeMockEditor({
+      selection: { from: 1, to: 8 },
+      selectionText: "live sel",
+    });
+    const out = buildExplainPrompt(editor);
+    expect(out).toContain("Selection:");
+    expect(out).toContain("live sel");
+    expect(editor.state.doc.textBetween).toHaveBeenCalled();
+  });
+
+  it("instructs the user to select text when no selection is available", () => {
+    const editor = makeMockEditor({ selection: { from: 4, to: 4 } });
+    const out = buildExplainPrompt(editor);
+    expect(out).toContain("No selection");
+  });
+});
+
+describe("buildSummarizePrompt", () => {
+  it("uses the captured plain text when provided", () => {
+    const editor = makeMockEditor({});
+    const out = buildSummarizePrompt(editor, { plainText: "note body" });
+    expect(out).toContain("Note text:\nnote body");
+    expect(editor.getText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to live editor text when captures are absent", () => {
+    const editor = makeMockEditor({ plainText: "live body" });
+    const out = buildSummarizePrompt(editor);
+    expect(out).toContain("Note text:\nlive body");
+    expect(editor.getText).toHaveBeenCalledWith({ blockSeparator: "\n" });
+  });
+
+  it("reports an empty note when there is no text", () => {
+    const editor = makeMockEditor({ plainText: "" });
+    const out = buildSummarizePrompt(editor);
+    expect(out).toContain("The note appears empty.");
+    expect(out).not.toContain("Note text:");
+  });
+
+  it("truncates very large note text and marks it as truncated", () => {
+    const huge = "x".repeat(13000);
+    const editor = makeMockEditor({ plainText: huge });
+    const out = buildSummarizePrompt(editor);
+    expect(out).toContain("…(truncated)");
+    // 12000 文字 + "\n\n…(truncated)" のみが本文として残る。
+    // Exactly 12000 chars from the original should be included before the truncation marker.
+    const slice = out.split("Note text:\n")[1] ?? "";
+    expect(slice.startsWith("x".repeat(12000))).toBe(true);
+    expect(slice.length).toBeLessThan(huge.length);
+  });
+});

--- a/src/lib/agentSlashCommands/buildAgentSlashPromptParts.test.ts
+++ b/src/lib/agentSlashCommands/buildAgentSlashPromptParts.test.ts
@@ -123,9 +123,11 @@ describe("buildExplainPrompt", () => {
     const out = buildExplainPrompt(editor, { selectionText: "captured snippet" });
     expect(out).toContain("Selection:");
     expect(out).toContain("captured snippet");
-    // captures.selectionText が優先されるため editor 取得は呼ばれない
-    // editor accessors should not be called when captures provide the selection.
-    expect(editor.getText).not.toHaveBeenCalled();
+    // /explain のフォールバックは getEditorSelectionText → doc.textBetween。
+    // captures.selectionText がある場合はこちらが呼ばれないことを固定する。
+    // /explain falls back via getEditorSelectionText → doc.textBetween, so
+    // pin that the document accessor is skipped when captures provide the text.
+    expect(editor.state.doc.textBetween).not.toHaveBeenCalled();
   });
 
   it("falls back to live editor selection when captures are absent", () => {

--- a/src/lib/agentSlashCommands/executeAgentSlashCommand.test.ts
+++ b/src/lib/agentSlashCommands/executeAgentSlashCommand.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for the high-level orchestration of one slash-agent execution.
+ * スラッシュエージェント 1 回分のオーケストレーションテスト。
+ */
+
+import type { Editor } from "@tiptap/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/claudeCode/runQueryToCompletion", () => ({
+  runClaudeQueryToCompletion: vi.fn(),
+}));
+
+vi.mock("./buildAgentSlashPrompt", () => ({
+  buildAgentSlashPrompt: vi.fn(() => "PROMPT"),
+  getAgentSlashClaudeOptions: vi.fn(() => ({ maxTurns: 5, allowedTools: ["Read"] })),
+  getEditorPlainText: vi.fn(() => "PLAIN"),
+  getEditorSelectionText: vi.fn(() => ""),
+}));
+
+vi.mock("./insertSlashAgentMarkdown", () => ({
+  insertSlashAgentMarkdownAt: vi.fn(),
+}));
+
+vi.mock("./insertPosition", () => ({
+  readSlashAgentInsertPosition: vi.fn(() => "cursor"),
+}));
+
+vi.mock("./slashAgentSelectionCache", () => ({
+  clearLastSlashAgentSelection: vi.fn(),
+  getLastSlashAgentSelection: vi.fn(() => ""),
+}));
+
+import { runClaudeQueryToCompletion } from "@/lib/claudeCode/runQueryToCompletion";
+import {
+  buildAgentSlashPrompt,
+  getAgentSlashClaudeOptions,
+  getEditorSelectionText,
+} from "./buildAgentSlashPrompt";
+import { executeAgentSlashCommand } from "./executeAgentSlashCommand";
+import {
+  getSlashAgentCommandHook,
+  registerSlashAgentCommandHook,
+  type SlashAgentCommandHook,
+} from "./hook";
+import { readSlashAgentInsertPosition } from "./insertPosition";
+import { insertSlashAgentMarkdownAt } from "./insertSlashAgentMarkdown";
+import {
+  clearLastSlashAgentSelection,
+  getLastSlashAgentSelection,
+} from "./slashAgentSelectionCache";
+
+/**
+ * Builds a fluent editor mock with traceable chain calls and a mutable cursor.
+ * チェーン呼び出しを追跡できるエディタモックを構築する。
+ */
+function makeMockEditor(opts: { cursorAfterDelete?: number } = {}): {
+  editor: Editor;
+  deleteRange: ReturnType<typeof vi.fn>;
+  insertContentAt: ReturnType<typeof vi.fn>;
+} {
+  const deleteRange = vi.fn();
+  const insertContentAt = vi.fn();
+
+  const chainObj: {
+    focus: () => typeof chainObj;
+    deleteRange: (range: unknown) => typeof chainObj;
+    insertContentAt: (pos: number, content: unknown) => typeof chainObj;
+    run: () => boolean;
+  } = {
+    focus() {
+      return chainObj;
+    },
+    deleteRange(range) {
+      deleteRange(range);
+      return chainObj;
+    },
+    insertContentAt(pos, content) {
+      insertContentAt(pos, content);
+      return chainObj;
+    },
+    run() {
+      return true;
+    },
+  };
+
+  const editor = {
+    chain: vi.fn(() => chainObj),
+    state: {
+      selection: { from: opts.cursorAfterDelete ?? 12 },
+    },
+  } as unknown as Editor;
+
+  return { editor, deleteRange, insertContentAt };
+}
+
+beforeEach(() => {
+  vi.mocked(runClaudeQueryToCompletion).mockReset();
+  vi.mocked(buildAgentSlashPrompt).mockClear();
+  vi.mocked(getAgentSlashClaudeOptions).mockClear();
+  vi.mocked(getEditorSelectionText).mockReset().mockReturnValue("");
+  vi.mocked(insertSlashAgentMarkdownAt).mockReset();
+  vi.mocked(readSlashAgentInsertPosition).mockReset().mockReturnValue("cursor");
+  vi.mocked(clearLastSlashAgentSelection).mockReset();
+  vi.mocked(getLastSlashAgentSelection).mockReset().mockReturnValue("");
+});
+
+afterEach(() => {
+  registerSlashAgentCommandHook(null);
+});
+
+describe("executeAgentSlashCommand — hook short-circuit", () => {
+  it("uses hook output without calling Claude", async () => {
+    const hook: SlashAgentCommandHook = vi.fn(() => ({ markdown: "from-hook" }));
+    registerSlashAgentCommandHook(hook);
+
+    const { editor, deleteRange } = makeMockEditor({ cursorAfterDelete: 17 });
+
+    const result = await executeAgentSlashCommand({
+      commandId: "agent-analyze",
+      query: "analyze src/foo.ts",
+      editor,
+      range: { from: 4, to: 10 },
+    });
+
+    expect(result).toBeNull();
+    expect(hook).toHaveBeenCalledTimes(1);
+    expect(deleteRange).toHaveBeenCalledWith({ from: 4, to: 10 });
+    // Claude 経路に進まないこと。
+    // The Claude pipeline must not run when the hook resolves.
+    expect(runClaudeQueryToCompletion).not.toHaveBeenCalled();
+    expect(insertSlashAgentMarkdownAt).toHaveBeenCalledWith(editor, 17, "from-hook", "cursor");
+  });
+
+  it("returns the hook's error message when the hook throws", async () => {
+    registerSlashAgentCommandHook(() => {
+      throw new Error("hook boom");
+    });
+
+    const { editor, deleteRange } = makeMockEditor();
+
+    const result = await executeAgentSlashCommand({
+      commandId: "agent-analyze",
+      query: "analyze x",
+      editor,
+      range: { from: 0, to: 5 },
+    });
+
+    expect(result).toBe("hook boom");
+    // 失敗時はエディタを変更しない（範囲削除も Claude 呼び出しもしない）。
+    // On failure no editor mutation and no Claude call should happen.
+    expect(deleteRange).not.toHaveBeenCalled();
+    expect(runClaudeQueryToCompletion).not.toHaveBeenCalled();
+  });
+
+  it("falls through to Claude when the hook returns null", async () => {
+    registerSlashAgentCommandHook(() => null);
+    vi.mocked(runClaudeQueryToCompletion).mockResolvedValue({ ok: true, content: "claude-result" });
+
+    const { editor } = makeMockEditor();
+
+    const result = await executeAgentSlashCommand({
+      commandId: "agent-analyze",
+      query: "analyze src/foo.ts",
+      editor,
+      range: { from: 0, to: 5 },
+    });
+
+    expect(result).toBeNull();
+    expect(runClaudeQueryToCompletion).toHaveBeenCalledTimes(1);
+    expect(insertSlashAgentMarkdownAt).toHaveBeenCalledWith(
+      editor,
+      expect.any(Number),
+      "claude-result",
+      "cursor",
+    );
+  });
+});
+
+describe("executeAgentSlashCommand — Claude execution path", () => {
+  it("forwards the resolved args + selection captures to the prompt builder", async () => {
+    vi.mocked(runClaudeQueryToCompletion).mockResolvedValue({ ok: true, content: "ok" });
+    vi.mocked(getEditorSelectionText).mockReturnValue("live-sel");
+
+    const { editor } = makeMockEditor();
+
+    await executeAgentSlashCommand({
+      commandId: "agent-analyze",
+      query: "analyze src/foo.ts",
+      editor,
+      range: { from: 0, to: 5 },
+    });
+
+    expect(buildAgentSlashPrompt).toHaveBeenCalledWith("agent-analyze", "src/foo.ts", editor, {
+      selectionText: "live-sel",
+      plainText: "PLAIN",
+    });
+  });
+
+  it("merges claudeCwd into the Claude options when provided", async () => {
+    vi.mocked(runClaudeQueryToCompletion).mockResolvedValue({ ok: true, content: "ok" });
+
+    const { editor } = makeMockEditor();
+    const signal = new AbortController().signal;
+
+    await executeAgentSlashCommand({
+      commandId: "agent-run",
+      query: "run echo",
+      editor,
+      range: { from: 0, to: 3 },
+      signal,
+      claudeCwd: "/tmp/work",
+    });
+
+    const [prompt, opts, passedSignal] = vi.mocked(runClaudeQueryToCompletion).mock.calls[0];
+    expect(prompt).toBe("PROMPT");
+    expect(opts).toEqual({ maxTurns: 5, allowedTools: ["Read"], cwd: "/tmp/work" });
+    expect(passedSignal).toBe(signal);
+  });
+
+  it("does not include cwd when claudeCwd is omitted", async () => {
+    vi.mocked(runClaudeQueryToCompletion).mockResolvedValue({ ok: true, content: "ok" });
+
+    const { editor } = makeMockEditor();
+
+    await executeAgentSlashCommand({
+      commandId: "agent-run",
+      query: "run echo",
+      editor,
+      range: { from: 0, to: 3 },
+    });
+
+    const opts = vi.mocked(runClaudeQueryToCompletion).mock.calls[0][1];
+    expect(opts).toEqual({ maxTurns: 5, allowedTools: ["Read"] });
+    expect((opts as Record<string, unknown>).cwd).toBeUndefined();
+  });
+
+  it("inserts the Claude content at the post-delete cursor with the chosen position", async () => {
+    vi.mocked(runClaudeQueryToCompletion).mockResolvedValue({ ok: true, content: "## Result" });
+    vi.mocked(readSlashAgentInsertPosition).mockReturnValue("end");
+
+    const { editor } = makeMockEditor({ cursorAfterDelete: 99 });
+
+    await executeAgentSlashCommand({
+      commandId: "agent-analyze",
+      query: "analyze x",
+      editor,
+      range: { from: 0, to: 5 },
+    });
+
+    expect(insertSlashAgentMarkdownAt).toHaveBeenCalledWith(editor, 99, "## Result", "end");
+  });
+
+  it("inserts a paragraph with the error and returns the message on failure", async () => {
+    vi.mocked(runClaudeQueryToCompletion).mockResolvedValue({ ok: false, error: "boom" });
+
+    const { editor, insertContentAt } = makeMockEditor({ cursorAfterDelete: 25 });
+
+    const result = await executeAgentSlashCommand({
+      commandId: "agent-analyze",
+      query: "analyze x",
+      editor,
+      range: { from: 0, to: 5 },
+    });
+
+    expect(result).toBe("boom");
+    expect(insertContentAt).toHaveBeenCalledWith(25, {
+      type: "paragraph",
+      content: [{ type: "text", text: "Claude Code: boom" }],
+    });
+    // 失敗時は Markdown 挿入経路を通らないこと。
+    // The Markdown-insert path must not run on failure.
+    expect(insertSlashAgentMarkdownAt).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the cached selection for /explain when the live selection is empty", async () => {
+    vi.mocked(runClaudeQueryToCompletion).mockResolvedValue({ ok: true, content: "ok" });
+    vi.mocked(getEditorSelectionText).mockReturnValue("");
+    vi.mocked(getLastSlashAgentSelection).mockReturnValue("cached");
+
+    const { editor } = makeMockEditor();
+
+    await executeAgentSlashCommand({
+      commandId: "agent-explain",
+      query: "explain",
+      editor,
+      range: { from: 0, to: 7 },
+    });
+
+    expect(buildAgentSlashPrompt).toHaveBeenCalledWith("agent-explain", "", editor, {
+      selectionText: "cached",
+      plainText: "PLAIN",
+    });
+    // 成功時は /explain のキャッシュをクリアする。
+    // On success the /explain selection cache is cleared.
+    expect(clearLastSlashAgentSelection).toHaveBeenCalledWith(editor);
+  });
+
+  it("does not consult the /explain selection cache for other commands", async () => {
+    vi.mocked(runClaudeQueryToCompletion).mockResolvedValue({ ok: true, content: "ok" });
+    vi.mocked(getEditorSelectionText).mockReturnValue("");
+
+    const { editor } = makeMockEditor();
+
+    await executeAgentSlashCommand({
+      commandId: "agent-summarize",
+      query: "summarize",
+      editor,
+      range: { from: 0, to: 9 },
+    });
+
+    expect(getLastSlashAgentSelection).not.toHaveBeenCalled();
+    expect(clearLastSlashAgentSelection).not.toHaveBeenCalled();
+  });
+
+  it("hook short-circuit clears the /explain cache too", async () => {
+    registerSlashAgentCommandHook(() => ({ markdown: "from-hook" }));
+
+    const { editor } = makeMockEditor();
+
+    await executeAgentSlashCommand({
+      commandId: "agent-explain",
+      query: "explain",
+      editor,
+      range: { from: 0, to: 5 },
+    });
+
+    expect(clearLastSlashAgentSelection).toHaveBeenCalledWith(editor);
+  });
+
+  it("returns the resolved hook from the registry on each invocation", () => {
+    const hook: SlashAgentCommandHook = vi.fn(() => null);
+    registerSlashAgentCommandHook(hook);
+    expect(getSlashAgentCommandHook()).toBe(hook);
+  });
+});

--- a/src/lib/agentSlashCommands/executeAgentSlashCommand.test.ts
+++ b/src/lib/agentSlashCommands/executeAgentSlashCommand.test.ts
@@ -167,12 +167,11 @@ describe("executeAgentSlashCommand — hook short-circuit", () => {
 
     expect(result).toBeNull();
     expect(runClaudeQueryToCompletion).toHaveBeenCalledTimes(1);
-    expect(insertSlashAgentMarkdownAt).toHaveBeenCalledWith(
-      editor,
-      expect.any(Number),
-      "claude-result",
-      "cursor",
-    );
+    // makeMockEditor() の既定で state.selection.from = 12 になるため、
+    // 挿入位置はその固定値を期待する（曖昧な expect.any(Number) を避ける）。
+    // The default mock editor has state.selection.from = 12, so pin it
+    // exactly instead of accepting any number.
+    expect(insertSlashAgentMarkdownAt).toHaveBeenCalledWith(editor, 12, "claude-result", "cursor");
   });
 });
 

--- a/src/lib/agentSlashCommands/hook.test.ts
+++ b/src/lib/agentSlashCommands/hook.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the global slash-agent command hook registry.
+ * グローバルなスラッシュエージェントフック登録のテスト。
+ */
+
+import type { Editor } from "@tiptap/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getSlashAgentCommandHook,
+  registerSlashAgentCommandHook,
+  type SlashAgentCommandHook,
+} from "./hook";
+
+afterEach(() => {
+  // 共有モジュール状態を必ずリセットする（テスト間の漏れ防止）。
+  // Always reset shared module state to prevent cross-test bleed.
+  registerSlashAgentCommandHook(null);
+});
+
+describe("registerSlashAgentCommandHook / getSlashAgentCommandHook", () => {
+  it("returns null when no hook is registered", () => {
+    expect(getSlashAgentCommandHook()).toBeNull();
+  });
+
+  it("registers the supplied hook and exposes it via the getter", () => {
+    const hook: SlashAgentCommandHook = vi.fn(() => null);
+    registerSlashAgentCommandHook(hook);
+    expect(getSlashAgentCommandHook()).toBe(hook);
+  });
+
+  it("clears the registered hook when null is passed", () => {
+    const hook: SlashAgentCommandHook = vi.fn(() => null);
+    registerSlashAgentCommandHook(hook);
+    registerSlashAgentCommandHook(null);
+    expect(getSlashAgentCommandHook()).toBeNull();
+  });
+
+  it("replaces the previous hook on re-registration", () => {
+    const first: SlashAgentCommandHook = vi.fn(() => null);
+    const second: SlashAgentCommandHook = vi.fn(() => null);
+    registerSlashAgentCommandHook(first);
+    registerSlashAgentCommandHook(second);
+    expect(getSlashAgentCommandHook()).toBe(second);
+  });
+
+  it("invokes the registered hook with the supplied context", async () => {
+    const hook: SlashAgentCommandHook = vi.fn(() => ({ markdown: "from-hook" }));
+    registerSlashAgentCommandHook(hook);
+    const editor = {} as Editor;
+    const result = await getSlashAgentCommandHook()?.({
+      commandId: "agent-analyze",
+      args: "src/x",
+      query: "analyze src/x",
+      editor,
+    });
+    expect(hook).toHaveBeenCalledWith({
+      commandId: "agent-analyze",
+      args: "src/x",
+      query: "analyze src/x",
+      editor,
+    });
+    expect(result).toEqual({ markdown: "from-hook" });
+  });
+});

--- a/src/lib/agentSlashCommands/insertPosition.test.ts
+++ b/src/lib/agentSlashCommands/insertPosition.test.ts
@@ -72,26 +72,42 @@ describe("writeSlashAgentInsertPosition", () => {
 
 describe("readSlashAgentInsertPosition — non-browser environment", () => {
   // jsdom 上で window を一時的に消し、SSR 経路の早期 return を確認する。
-  // Temporarily delete window to exercise the SSR early return.
+  // また `delete window` が黙って失敗するケース（globalThis.window が
+  // non-configurable）でも誤検知しないように、localStorage への
+  // アクセス自体が発生していないことも合わせて検証する。
+  // Temporarily delete window to exercise the SSR early return. Because
+  // `delete window` may silently fail in some jsdom builds (the property is
+  // non-configurable), also assert that localStorage was never touched —
+  // that pins the contract that the early-return path actually ran.
   let originalWindow: typeof globalThis.window | undefined;
+  let getItemSpy: ReturnType<typeof vi.spyOn>;
+  let setItemSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     originalWindow = globalThis.window;
     // @ts-expect-error -- intentional removal for SSR coverage
     delete (globalThis as { window?: unknown }).window;
+    getItemSpy = vi.spyOn(Storage.prototype, "getItem");
+    setItemSpy = vi.spyOn(Storage.prototype, "setItem");
   });
 
   afterEach(() => {
+    getItemSpy.mockRestore();
+    setItemSpy.mockRestore();
     if (originalWindow !== undefined) {
       (globalThis as { window?: typeof globalThis.window }).window = originalWindow;
     }
   });
 
-  it("defaults to 'cursor' when window is undefined", () => {
+  it("defaults to 'cursor' without touching localStorage when window is undefined", () => {
     expect(readSlashAgentInsertPosition()).toBe("cursor");
+    // SSR 経路が確かに走ったことを localStorage 非アクセスで担保する。
+    // Asserts the SSR branch actually executed (no localStorage access).
+    expect(getItemSpy).not.toHaveBeenCalled();
   });
 
-  it("writeSlashAgentInsertPosition is a no-op when window is undefined", () => {
+  it("writeSlashAgentInsertPosition is a no-op without touching localStorage", () => {
     expect(() => writeSlashAgentInsertPosition("end")).not.toThrow();
+    expect(setItemSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/agentSlashCommands/insertPosition.test.ts
+++ b/src/lib/agentSlashCommands/insertPosition.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the insert-position localStorage helpers.
+ * 挿入位置を localStorage に保持するヘルパーのテスト。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readSlashAgentInsertPosition, writeSlashAgentInsertPosition } from "./insertPosition";
+
+const STORAGE_KEY = "zedi.slashAgent.insertPosition";
+
+describe("readSlashAgentInsertPosition", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("defaults to 'cursor' when no value is stored", () => {
+    expect(readSlashAgentInsertPosition()).toBe("cursor");
+  });
+
+  it("returns 'end' when 'end' is stored", () => {
+    window.localStorage.setItem(STORAGE_KEY, "end");
+    expect(readSlashAgentInsertPosition()).toBe("end");
+  });
+
+  it("returns 'cursor' when an unknown value is stored", () => {
+    // 仕様外の値は cursor にフォールバック（前向きに壊れない）。
+    // Unknown values fall back to 'cursor' (forward-compatible).
+    window.localStorage.setItem(STORAGE_KEY, "middle");
+    expect(readSlashAgentInsertPosition()).toBe("cursor");
+  });
+
+  it("returns 'cursor' when localStorage.getItem throws", () => {
+    const spy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+    try {
+      expect(readSlashAgentInsertPosition()).toBe("cursor");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("writeSlashAgentInsertPosition", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("persists 'end' under the canonical key", () => {
+    writeSlashAgentInsertPosition("end");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("end");
+  });
+
+  it("persists 'cursor' under the canonical key", () => {
+    writeSlashAgentInsertPosition("cursor");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("cursor");
+  });
+
+  it("swallows quota / private-mode errors silently", () => {
+    const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    try {
+      // 例外が外に漏れないことを契約として固定する。
+      // Pin the contract that errors do not propagate.
+      expect(() => writeSlashAgentInsertPosition("end")).not.toThrow();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("readSlashAgentInsertPosition — non-browser environment", () => {
+  // jsdom 上で window を一時的に消し、SSR 経路の早期 return を確認する。
+  // Temporarily delete window to exercise the SSR early return.
+  let originalWindow: typeof globalThis.window | undefined;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+    // @ts-expect-error -- intentional removal for SSR coverage
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  afterEach(() => {
+    if (originalWindow !== undefined) {
+      (globalThis as { window?: typeof globalThis.window }).window = originalWindow;
+    }
+  });
+
+  it("defaults to 'cursor' when window is undefined", () => {
+    expect(readSlashAgentInsertPosition()).toBe("cursor");
+  });
+
+  it("writeSlashAgentInsertPosition is a no-op when window is undefined", () => {
+    expect(() => writeSlashAgentInsertPosition("end")).not.toThrow();
+  });
+});

--- a/src/lib/agentSlashCommands/insertPosition.test.ts
+++ b/src/lib/agentSlashCommands/insertPosition.test.ts
@@ -85,7 +85,6 @@ describe("readSlashAgentInsertPosition — non-browser environment", () => {
 
   beforeEach(() => {
     originalWindow = globalThis.window;
-    // @ts-expect-error -- intentional removal for SSR coverage
     delete (globalThis as { window?: unknown }).window;
     getItemSpy = vi.spyOn(Storage.prototype, "getItem");
     setItemSpy = vi.spyOn(Storage.prototype, "setItem");

--- a/src/lib/agentSlashCommands/insertSlashAgentMarkdown.test.ts
+++ b/src/lib/agentSlashCommands/insertSlashAgentMarkdown.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for inserting Markdown returned by Claude into the Tiptap editor.
+ * Claude が返した Markdown を Tiptap に挿入する処理のテスト。
+ */
+
+import type { Editor } from "@tiptap/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/markdownToTiptap", () => ({
+  convertMarkdownToTiptapContent: vi.fn(),
+}));
+
+import { convertMarkdownToTiptapContent } from "@/lib/markdownToTiptap";
+import { insertSlashAgentMarkdownAt } from "./insertSlashAgentMarkdown";
+
+/**
+ * Builds a fluent chain spy that captures `insertContentAt` arguments.
+ * `insertContentAt` の呼び出しを記録するチェーンスパイを構築する。
+ */
+function makeChainSpy(): {
+  chain: () => {
+    focus: () => { insertContentAt: ReturnType<typeof vi.fn> };
+  };
+  insertContentAt: ReturnType<typeof vi.fn>;
+} {
+  const insertContentAt = vi.fn(() => ({ run: vi.fn() }));
+  const chain = vi.fn(() => ({
+    focus: vi.fn(() => ({ insertContentAt })),
+  }));
+  return { chain, insertContentAt };
+}
+
+/**
+ * Builds an editor mock with a fluent chain and a doc of the given size.
+ * 指定サイズの doc とチェーンスパイを持つエディタモックを返す。
+ */
+function makeMockEditor(docSize: number): {
+  editor: Editor;
+  insertContentAt: ReturnType<typeof vi.fn>;
+} {
+  const { chain, insertContentAt } = makeChainSpy();
+  const editor = {
+    chain,
+    state: {
+      doc: { content: { size: docSize } },
+    },
+  } as unknown as Editor;
+  return { editor, insertContentAt };
+}
+
+beforeEach(() => {
+  vi.mocked(convertMarkdownToTiptapContent).mockReset();
+});
+
+describe("insertSlashAgentMarkdownAt", () => {
+  it("inserts converted content at the cursor position when position='cursor'", () => {
+    const fakeJson = JSON.stringify({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "hi" }] }],
+    });
+    vi.mocked(convertMarkdownToTiptapContent).mockReturnValue(fakeJson);
+
+    const { editor, insertContentAt } = makeMockEditor(100);
+    insertSlashAgentMarkdownAt(editor, 7, "**hi**", "cursor");
+
+    expect(convertMarkdownToTiptapContent).toHaveBeenCalledWith("**hi**");
+    expect(insertContentAt).toHaveBeenCalledTimes(1);
+    expect(insertContentAt).toHaveBeenCalledWith(7, [
+      { type: "paragraph", content: [{ type: "text", text: "hi" }] },
+    ]);
+  });
+
+  it("inserts at the document end when position='end'", () => {
+    const fakeJson = JSON.stringify({
+      type: "doc",
+      content: [{ type: "paragraph" }],
+    });
+    vi.mocked(convertMarkdownToTiptapContent).mockReturnValue(fakeJson);
+
+    const { editor, insertContentAt } = makeMockEditor(42);
+    insertSlashAgentMarkdownAt(editor, 7, "any", "end");
+
+    expect(insertContentAt).toHaveBeenCalledWith(42, [{ type: "paragraph" }]);
+  });
+
+  it("trims whitespace and substitutes a placeholder for empty results", () => {
+    vi.mocked(convertMarkdownToTiptapContent).mockReturnValue(
+      JSON.stringify({ type: "doc", content: [] }),
+    );
+
+    const { editor } = makeMockEditor(10);
+    insertSlashAgentMarkdownAt(editor, 0, "   \n  ", "cursor");
+
+    // 空白のみの結果は "(empty result)" に置換され、ユーザに変換不能を示す。
+    // Whitespace-only results are replaced with "(empty result)" so the user notices.
+    expect(convertMarkdownToTiptapContent).toHaveBeenCalledWith("(empty result)");
+  });
+
+  it("handles missing content array by inserting an empty list (no crash)", () => {
+    // content が無いケースでも例外にならず、空配列で挿入する契約。
+    // When `content` is missing, fall back to `[]` instead of throwing.
+    vi.mocked(convertMarkdownToTiptapContent).mockReturnValue(JSON.stringify({ type: "doc" }));
+
+    const { editor, insertContentAt } = makeMockEditor(10);
+    insertSlashAgentMarkdownAt(editor, 3, "x", "cursor");
+
+    expect(insertContentAt).toHaveBeenCalledWith(3, []);
+  });
+
+  it("falls back to a plain paragraph when conversion JSON cannot be parsed", () => {
+    vi.mocked(convertMarkdownToTiptapContent).mockReturnValue("not-json{");
+
+    const { editor, insertContentAt } = makeMockEditor(10);
+    insertSlashAgentMarkdownAt(editor, 5, "raw text", "cursor");
+
+    expect(insertContentAt).toHaveBeenCalledWith(5, [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "raw text" }],
+      },
+    ]);
+  });
+
+  it("falls back with the placeholder text when an empty input cannot be parsed either", () => {
+    // 空入力 + パース失敗の合成ケース：プレースホルダがフォールバック段落に入る。
+    // Empty input + parse failure: the placeholder text seeds the fallback paragraph.
+    vi.mocked(convertMarkdownToTiptapContent).mockReturnValue("not-json{");
+
+    const { editor, insertContentAt } = makeMockEditor(10);
+    insertSlashAgentMarkdownAt(editor, 0, "", "cursor");
+
+    expect(insertContentAt).toHaveBeenCalledWith(0, [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "(empty result)" }],
+      },
+    ]);
+  });
+});

--- a/src/lib/agentSlashCommands/slashAgentSelectionCache.test.ts
+++ b/src/lib/agentSlashCommands/slashAgentSelectionCache.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for the per-editor selection cache used by `/explain`.
+ * `/explain` 用に選択テキストを保持するキャッシュのテスト。
+ */
+
+import type { Editor } from "@tiptap/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  clearLastSlashAgentSelection,
+  getLastSlashAgentSelection,
+  rememberSlashAgentSelection,
+} from "./slashAgentSelectionCache";
+
+/**
+ * Builds an editor mock whose `state.selection` and `doc.textBetween` reflect
+ * the supplied range/text. WeakMap lookups need a real, stable object identity.
+ * 範囲とテキストを反映するエディタモックを作る（WeakMap キーには安定オブジェクトが必要）。
+ */
+function makeMockEditor(opts: { from: number; to: number; text?: string }): Editor {
+  return {
+    state: {
+      selection: { from: opts.from, to: opts.to },
+      doc: { textBetween: vi.fn(() => opts.text ?? "") },
+    },
+  } as unknown as Editor;
+}
+
+describe("slashAgentSelectionCache", () => {
+  it("returns empty when nothing is cached", () => {
+    const editor = makeMockEditor({ from: 0, to: 0 });
+    expect(getLastSlashAgentSelection(editor)).toBe("");
+  });
+
+  it("does not cache when the selection is collapsed", () => {
+    const editor = makeMockEditor({ from: 4, to: 4, text: "ignored" });
+    rememberSlashAgentSelection(editor);
+    expect(getLastSlashAgentSelection(editor)).toBe("");
+    // 折りたたみ選択では textBetween を呼ばないこと。
+    // textBetween must not be called for a collapsed selection.
+    expect(editor.state.doc.textBetween).not.toHaveBeenCalled();
+  });
+
+  it("caches the selection text for the next read", () => {
+    const editor = makeMockEditor({ from: 1, to: 6, text: "hello" });
+    rememberSlashAgentSelection(editor);
+    expect(getLastSlashAgentSelection(editor)).toBe("hello");
+    expect(editor.state.doc.textBetween).toHaveBeenCalledWith(1, 6, "\n", "￼");
+  });
+
+  it("overwrites the cached value with the most recent non-empty selection", () => {
+    const editor = makeMockEditor({ from: 1, to: 4, text: "old" });
+    rememberSlashAgentSelection(editor);
+    expect(getLastSlashAgentSelection(editor)).toBe("old");
+
+    (editor as unknown as { state: { selection: { from: number; to: number } } }).state.selection =
+      { from: 5, to: 9 };
+    (editor.state.doc.textBetween as ReturnType<typeof vi.fn>).mockReturnValueOnce("new");
+    rememberSlashAgentSelection(editor);
+    expect(getLastSlashAgentSelection(editor)).toBe("new");
+  });
+
+  it("scopes cached selections per editor instance", () => {
+    const a = makeMockEditor({ from: 1, to: 3, text: "A" });
+    const b = makeMockEditor({ from: 2, to: 7, text: "B" });
+    rememberSlashAgentSelection(a);
+    rememberSlashAgentSelection(b);
+    expect(getLastSlashAgentSelection(a)).toBe("A");
+    expect(getLastSlashAgentSelection(b)).toBe("B");
+  });
+
+  it("clears the cache for a single editor without affecting others", () => {
+    const a = makeMockEditor({ from: 1, to: 3, text: "A" });
+    const b = makeMockEditor({ from: 2, to: 7, text: "B" });
+    rememberSlashAgentSelection(a);
+    rememberSlashAgentSelection(b);
+
+    clearLastSlashAgentSelection(a);
+    expect(getLastSlashAgentSelection(a)).toBe("");
+    expect(getLastSlashAgentSelection(b)).toBe("B");
+  });
+});


### PR DESCRIPTION
Adds unit tests for 8 of 11 files in `src/lib/agentSlashCommands/`
(plus the existing `parseAgentSlashQuery.test.ts`, totalling 9/11) and
a ProseMirror-state-driven test for `slashSuggestionPlugin`.

- Table-driven coverage of all 8 `buildAgentSlashPrompt` branches and
  the per-command tool/policy map.
- Editor-mock based tests for `getEditorPlainText` /
  `getEditorSelectionText`, the `/explain` selection cache, the global
  hook registry, the localStorage insert-position helpers (incl. SSR
  fallback), and Markdown insertion fallbacks.
- Mocked-collaborator integration tests for `executeAgentSlashCommand`
  covering hook short-circuit, hook errors, Claude success/failure, the
  cwd merge, and the `/explain` cache lifecycle.
- Minimal-schema ProseMirror state harness for
  `slashSuggestionPlugin`: activation triggers, deactivation paths,
  decoration ranges, and explicit close meta.

All assertions use exact-string / key-phrase checks (no snapshots) so
mutations are caught.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for slash suggestions (activation/deactivation rules and decorations), editor plain/selection text helpers, agent slash prompt builders, command execution flow (hooks, fallback behaviors, and insertion positions), hook registry behavior, insert-position persistence (including SSR), markdown insertion fallbacks, and selection caching for /explain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->