### PR TITLE
test(P4): add coverage for src/stores/ and storage layer (#745)

### DIFF
--- a/src/lib/pageRepository.test.ts
+++ b/src/lib/pageRepository.test.ts
@@ -69,28 +69,34 @@ function createInMemoryRepository(
       return [...store.pages.values()].filter((p) => !p.isDeleted);
     },
     async getPagesSummary(_userId) {
-      return [...store.pages.values()].map<PageSummary>((p) => ({
-        id: p.id,
-        ownerUserId: p.ownerUserId,
-        noteId: p.noteId,
-        title: p.title,
-        contentPreview: p.contentPreview,
-        thumbnailUrl: p.thumbnailUrl,
-        sourceUrl: p.sourceUrl,
-        createdAt: p.createdAt,
-        updatedAt: p.updatedAt,
-        isDeleted: p.isDeleted,
-      }));
+      return [...store.pages.values()]
+        .filter((p) => !p.isDeleted)
+        .map<PageSummary>((p) => ({
+          id: p.id,
+          ownerUserId: p.ownerUserId,
+          noteId: p.noteId,
+          title: p.title,
+          contentPreview: p.contentPreview,
+          thumbnailUrl: p.thumbnailUrl,
+          sourceUrl: p.sourceUrl,
+          createdAt: p.createdAt,
+          updatedAt: p.updatedAt,
+          isDeleted: p.isDeleted,
+        }));
     },
     async getPagesByIds(_userId, ids) {
-      return ids.map((id) => store.pages.get(id)).filter((p): p is Page => Boolean(p));
+      return ids
+        .map((id) => store.pages.get(id))
+        .filter((p): p is Page => p !== undefined && !p.isDeleted);
     },
     async getPageByTitle(_userId, title) {
-      return [...store.pages.values()].find((p) => p.title === title) ?? null;
+      return [...store.pages.values()].find((p) => p.title === title && !p.isDeleted) ?? null;
     },
     async checkDuplicateTitle(_userId, title, excludePageId) {
       return (
-        [...store.pages.values()].find((p) => p.title === title && p.id !== excludePageId) ?? null
+        [...store.pages.values()].find(
+          (p) => p.title === title && p.id !== excludePageId && !p.isDeleted,
+        ) ?? null
       );
     },
     async updatePage(_userId, pageId, updates) {
@@ -105,9 +111,14 @@ function createInMemoryRepository(
       await fireMutate();
     },
     async searchPages(_userId, query) {
-      return [...store.pages.values()].filter((p) =>
-        p.title.toLowerCase().includes(query.toLowerCase()),
-      );
+      const normalized = query.toLowerCase().trim();
+      if (!normalized) return [];
+      return [...store.pages.values()].filter((p) => {
+        if (p.isDeleted) return false;
+        return (
+          p.title.toLowerCase().includes(normalized) || p.content.toLowerCase().includes(normalized)
+        );
+      });
     },
     async addLink(sourceId, targetId, linkType: LinkType = "wiki") {
       if (
@@ -281,6 +292,45 @@ describe("IPageRepository contract", () => {
 
     await repo.deletePage("u1", page.id);
     expect(await repo.getPage("u1", page.id)).toBeNull();
+  });
+
+  it("read methods consistently hide soft-deleted pages", async () => {
+    // モックの soft-delete 挙動が read 系全体で一貫しているかを担保する。
+    // gemini-code-assist のレビューで指摘されたモック内一貫性のリグレッション防止。
+    //
+    // Pin the mock's soft-delete contract across every read path so tests that
+    // exercise deletion paths get consistent results. Regression guard for the
+    // gemini-code-assist review feedback.
+    const alive = await repo.createPage("u1", "Alive");
+    const tombstone = await repo.createPage("u1", "Tombstone");
+    await repo.deletePage("u1", tombstone.id);
+
+    expect((await repo.getPages("u1")).map((p) => p.id)).toEqual([alive.id]);
+    expect((await repo.getPagesSummary("u1")).map((p) => p.id)).toEqual([alive.id]);
+    expect((await repo.getPagesByIds("u1", [alive.id, tombstone.id])).map((p) => p.id)).toEqual([
+      alive.id,
+    ]);
+    expect(await repo.getPageByTitle("u1", "Tombstone")).toBeNull();
+    expect(await repo.checkDuplicateTitle("u1", "Tombstone")).toBeNull();
+  });
+
+  it("searchPages mirrors pageStore semantics: title+content, trim, hide deleted", async () => {
+    // gemini-code-assist のレビュー対応: 実装側 (pageStore.searchPages) の
+    // 「title+content の部分一致」「空クエリは []」「論理削除は除外」をモックも遵守する。
+    //
+    // Address gemini-code-assist review: the mock now matches `pageStore.searchPages`
+    // — title+content match, blank queries return [], soft-deleted pages excluded.
+    await repo.createPage("u1", "Hello", "alpha body");
+    await repo.createPage("u1", "World", "beta body");
+    const trashed = await repo.createPage("u1", "Trash", "alpha trashed");
+    await repo.deletePage("u1", trashed.id);
+
+    expect((await repo.searchPages("u1", "alpha")).map((p) => p.title)).toEqual(["Hello"]);
+    expect((await repo.searchPages("u1", "BODY")).map((p) => p.title).sort()).toEqual([
+      "Hello",
+      "World",
+    ]);
+    expect(await repo.searchPages("u1", "   ")).toEqual([]);
   });
 
   it("link methods default linkType to 'wiki' (issue #725 Phase 1)", async () => {

--- a/src/lib/pageRepository.test.ts
+++ b/src/lib/pageRepository.test.ts
@@ -450,16 +450,16 @@ function createMockAdapter(): StorageAdapter {
   };
 }
 
-function createMockApi(): ApiClient {
+function createMockApi(): Partial<ApiClient> {
   return {
     deletePage: vi.fn(),
     createPage: vi.fn(),
-  } as unknown as ApiClient;
+  };
 }
 
 describe("StorageAdapterPageRepository (production) satisfies IPageRepository", () => {
   let adapter: ReturnType<typeof createMockAdapter>;
-  let api: ApiClient;
+  let api: Partial<ApiClient>;
   let repo: IPageRepository;
 
   beforeEach(() => {
@@ -467,12 +467,15 @@ describe("StorageAdapterPageRepository (production) satisfies IPageRepository", 
     api = createMockApi();
     // 型レベルで `IPageRepository` を満たすかをここで強制する。
     // Compile-time assertion that the production class satisfies the interface.
-    repo = new StorageAdapterPageRepository(adapter, api);
+    repo = new StorageAdapterPageRepository(adapter, api as ApiClient);
   });
 
-  it("delegates createPage (guest) to adapter.upsertPage", async () => {
+  it("delegates createPage (guest) to adapter.upsertPage and skips api.createPage", async () => {
     await repo.createPage("local-user", "Hello");
     expect(adapter.upsertPage).toHaveBeenCalledOnce();
+    // CodeRabbit のレビュー対応: ゲスト経路で API が呼ばれない不変条件をガード。
+    // Guard the guest-path invariant: API must not be invoked for `local-user`.
+    expect(api.createPage).not.toHaveBeenCalled();
   });
 
   it("delegates getPage to adapter.getPage", async () => {

--- a/src/lib/pageRepository.test.ts
+++ b/src/lib/pageRepository.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { IPageRepository, CreatePageOptions, PageRepositoryOptions } from "./pageRepository";
+import type { Page, PageSummary, Link, GhostLink, LinkType } from "@/types/page";
+
+/**
+ * `pageRepository.ts` は型のみのインターフェース層であり、ランタイムロジックを
+ * 持たない。本テストは「インターフェースを満たす実装が、各 method を 1:1 で
+ * 下位ストア (=adapter) に委譲する」という契約をスパイで検証する。
+ *
+ * Concrete adapters (e.g. `StorageAdapterPageRepository`) carry their own
+ * behaviour tests; here we only verify the interface contract — every method
+ * exists, has the documented signature, and delegates verbatim.
+ *
+ * `pageRepository.ts` is a types-only module with no runtime behaviour. This
+ * test pins the contract: any implementation must expose every documented
+ * method and forward arguments to its underlying store.
+ */
+
+interface PageStoreLike {
+  pages: Map<string, Page>;
+  links: Link[];
+  ghostLinks: GhostLink[];
+}
+
+function makeStore(): PageStoreLike {
+  return { pages: new Map(), links: [], ghostLinks: [] };
+}
+
+/**
+ * 最小の `IPageRepository` 実装。各 method は store にしか触らず、CRUD と link
+ * 系は spy 越しに呼び出し回数を検証できる。
+ *
+ * Minimal repository implementation that delegates each method straight to a
+ * mutable store map; we then spy on it to verify delegation in tests.
+ */
+function createInMemoryRepository(
+  store: PageStoreLike,
+  options?: PageRepositoryOptions,
+): IPageRepository {
+  const fireMutate = async (): Promise<void> => {
+    if (options?.onMutate) await options.onMutate();
+  };
+
+  const repo: IPageRepository = {
+    async createPage(userId, title = "", content = "", opts) {
+      const id = `id-${store.pages.size + 1}`;
+      const now = Date.now();
+      const page: Page = {
+        id,
+        ownerUserId: userId,
+        noteId: null,
+        title,
+        content,
+        thumbnailUrl: opts?.thumbnailUrl ?? undefined,
+        sourceUrl: opts?.sourceUrl ?? undefined,
+        createdAt: now,
+        updatedAt: now,
+        isDeleted: false,
+      };
+      store.pages.set(id, page);
+      await fireMutate();
+      return page;
+    },
+    async getPage(_userId, pageId) {
+      const p = store.pages.get(pageId);
+      return p && !p.isDeleted ? p : null;
+    },
+    async getPages(_userId) {
+      return [...store.pages.values()].filter((p) => !p.isDeleted);
+    },
+    async getPagesSummary(_userId) {
+      return [...store.pages.values()].map<PageSummary>((p) => ({
+        id: p.id,
+        ownerUserId: p.ownerUserId,
+        noteId: p.noteId,
+        title: p.title,
+        contentPreview: p.contentPreview,
+        thumbnailUrl: p.thumbnailUrl,
+        sourceUrl: p.sourceUrl,
+        createdAt: p.createdAt,
+        updatedAt: p.updatedAt,
+        isDeleted: p.isDeleted,
+      }));
+    },
+    async getPagesByIds(_userId, ids) {
+      return ids.map((id) => store.pages.get(id)).filter((p): p is Page => Boolean(p));
+    },
+    async getPageByTitle(_userId, title) {
+      return [...store.pages.values()].find((p) => p.title === title) ?? null;
+    },
+    async checkDuplicateTitle(_userId, title, excludePageId) {
+      return (
+        [...store.pages.values()].find((p) => p.title === title && p.id !== excludePageId) ?? null
+      );
+    },
+    async updatePage(_userId, pageId, updates) {
+      const p = store.pages.get(pageId);
+      if (!p) return;
+      store.pages.set(pageId, { ...p, ...updates, updatedAt: Date.now() });
+      await fireMutate();
+    },
+    async deletePage(_userId, pageId) {
+      const p = store.pages.get(pageId);
+      if (p) store.pages.set(pageId, { ...p, isDeleted: true });
+      await fireMutate();
+    },
+    async searchPages(_userId, query) {
+      return [...store.pages.values()].filter((p) =>
+        p.title.toLowerCase().includes(query.toLowerCase()),
+      );
+    },
+    async addLink(sourceId, targetId, linkType: LinkType = "wiki") {
+      if (
+        store.links.some(
+          (l) => l.sourceId === sourceId && l.targetId === targetId && l.linkType === linkType,
+        )
+      ) {
+        return;
+      }
+      store.links.push({ sourceId, targetId, linkType, createdAt: Date.now() });
+    },
+    async removeLink(sourceId, targetId, linkType: LinkType = "wiki") {
+      store.links = store.links.filter(
+        (l) => !(l.sourceId === sourceId && l.targetId === targetId && l.linkType === linkType),
+      );
+    },
+    async getOutgoingLinks(pageId, linkType: LinkType = "wiki") {
+      return store.links
+        .filter((l) => l.sourceId === pageId && l.linkType === linkType)
+        .map((l) => l.targetId);
+    },
+    async getBacklinks(pageId, linkType: LinkType = "wiki") {
+      return store.links
+        .filter((l) => l.targetId === pageId && l.linkType === linkType)
+        .map((l) => l.sourceId);
+    },
+    async getLinks(_userId) {
+      return [...store.links];
+    },
+    async addGhostLink(linkText, sourcePageId, linkType: LinkType = "wiki") {
+      if (
+        store.ghostLinks.some(
+          (g) =>
+            g.linkText === linkText && g.sourcePageId === sourcePageId && g.linkType === linkType,
+        )
+      ) {
+        return;
+      }
+      store.ghostLinks.push({
+        linkText,
+        sourcePageId,
+        linkType,
+        createdAt: Date.now(),
+      });
+    },
+    async removeGhostLink(linkText, sourcePageId, linkType: LinkType = "wiki") {
+      store.ghostLinks = store.ghostLinks.filter(
+        (g) =>
+          !(g.linkText === linkText && g.sourcePageId === sourcePageId && g.linkType === linkType),
+      );
+    },
+    async getGhostLinkSources(linkText, linkType: LinkType = "wiki") {
+      return store.ghostLinks
+        .filter((g) => g.linkText === linkText && g.linkType === linkType)
+        .map((g) => g.sourcePageId);
+    },
+    async getGhostLinks(_userId) {
+      return [...store.ghostLinks];
+    },
+    async getGhostLinksBySourcePage(sourcePageId, linkType: LinkType = "wiki") {
+      return store.ghostLinks
+        .filter((g) => g.sourcePageId === sourcePageId && g.linkType === linkType)
+        .map((g) => g.linkText);
+    },
+    async promoteGhostLink(userId, linkText) {
+      const sources = await repo.getGhostLinkSources(linkText, "wiki");
+      if (sources.length < 2) return null;
+      const created = await repo.createPage(userId, linkText, "");
+      for (const sourceId of sources) {
+        await repo.addLink(sourceId, created.id, "wiki");
+        await repo.removeGhostLink(linkText, sourceId, "wiki");
+      }
+      return created;
+    },
+  };
+
+  return repo;
+}
+
+describe("IPageRepository contract", () => {
+  let store: PageStoreLike;
+  let repo: IPageRepository;
+
+  beforeEach(() => {
+    store = makeStore();
+    repo = createInMemoryRepository(store);
+  });
+
+  it("exposes every documented method as a function", () => {
+    const required = [
+      "createPage",
+      "getPage",
+      "getPages",
+      "getPagesSummary",
+      "getPagesByIds",
+      "getPageByTitle",
+      "checkDuplicateTitle",
+      "updatePage",
+      "deletePage",
+      "searchPages",
+      "addLink",
+      "removeLink",
+      "getOutgoingLinks",
+      "getBacklinks",
+      "getLinks",
+      "addGhostLink",
+      "removeGhostLink",
+      "getGhostLinkSources",
+      "getGhostLinks",
+      "getGhostLinksBySourcePage",
+      "promoteGhostLink",
+    ] as const;
+
+    for (const name of required) {
+      expect(typeof (repo as unknown as Record<string, unknown>)[name]).toBe("function");
+    }
+  });
+
+  it("createPage stores a Page and respects CreatePageOptions", async () => {
+    const options: CreatePageOptions = {
+      sourceUrl: "https://example.com",
+      thumbnailUrl: "https://thumb.example.com/x.png",
+    };
+    const page = await repo.createPage("user-1", "Title", "body", options);
+
+    expect(page.title).toBe("Title");
+    expect(page.ownerUserId).toBe("user-1");
+    expect(page.sourceUrl).toBe(options.sourceUrl);
+    expect(page.thumbnailUrl).toBe(options.thumbnailUrl);
+    expect(store.pages.size).toBe(1);
+  });
+
+  it("read methods return what the underlying store contains", async () => {
+    await repo.createPage("u1", "Alpha");
+    await repo.createPage("u1", "Bravo");
+
+    const all = await repo.getPages("u1");
+    expect(all.map((p) => p.title).sort()).toEqual(["Alpha", "Bravo"]);
+
+    const byTitle = await repo.getPageByTitle("u1", "Alpha");
+    expect(byTitle?.title).toBe("Alpha");
+
+    const ids = all.map((p) => p.id);
+    const byIds = await repo.getPagesByIds("u1", ids);
+    expect(byIds).toHaveLength(2);
+
+    const summaries = await repo.getPagesSummary("u1");
+    expect(summaries).toHaveLength(2);
+    // contentPreview / thumbnailUrl は省略されていてよいが、必須キーは存在する
+    // contentPreview / thumbnailUrl may be omitted, but required keys are present
+    for (const s of summaries) {
+      expect(s).toHaveProperty("id");
+      expect(s).toHaveProperty("title");
+      expect(s).toHaveProperty("noteId");
+    }
+  });
+
+  it("checkDuplicateTitle excludes the given page id", async () => {
+    const a = await repo.createPage("u1", "Same");
+    await repo.createPage("u1", "Same");
+
+    const dup = await repo.checkDuplicateTitle("u1", "Same", a.id);
+    expect(dup).not.toBeNull();
+    expect(dup?.id).not.toBe(a.id);
+  });
+
+  it("updatePage merges fields and deletePage soft-deletes", async () => {
+    const page = await repo.createPage("u1", "Old");
+    await repo.updatePage("u1", page.id, { title: "New" });
+    expect((await repo.getPage("u1", page.id))?.title).toBe("New");
+
+    await repo.deletePage("u1", page.id);
+    expect(await repo.getPage("u1", page.id)).toBeNull();
+  });
+
+  it("link methods default linkType to 'wiki' (issue #725 Phase 1)", async () => {
+    await repo.addLink("a", "b");
+    await repo.addLink("a", "c", "tag");
+
+    expect(await repo.getOutgoingLinks("a")).toEqual(["b"]);
+    expect(await repo.getOutgoingLinks("a", "tag")).toEqual(["c"]);
+    expect(await repo.getBacklinks("b")).toEqual(["a"]);
+
+    const all = await repo.getLinks("u1");
+    expect(all.map((l) => l.linkType).sort()).toEqual(["tag", "wiki"]);
+
+    await repo.removeLink("a", "b");
+    expect(await repo.getOutgoingLinks("a")).toEqual([]);
+    // タグ側は削除されないことを確認 / tag-typed edge survives wiki removal
+    expect(await repo.getOutgoingLinks("a", "tag")).toEqual(["c"]);
+  });
+
+  it("ghost link methods support linkType scoping and source listing", async () => {
+    await repo.addGhostLink("Topic", "p1");
+    await repo.addGhostLink("Topic", "p2");
+    await repo.addGhostLink("Topic", "p3", "tag");
+
+    expect((await repo.getGhostLinkSources("Topic")).sort()).toEqual(["p1", "p2"]);
+    expect(await repo.getGhostLinkSources("Topic", "tag")).toEqual(["p3"]);
+    expect(await repo.getGhostLinksBySourcePage("p1")).toEqual(["Topic"]);
+
+    const all = await repo.getGhostLinks("u1");
+    expect(all).toHaveLength(3);
+
+    await repo.removeGhostLink("Topic", "p1");
+    expect((await repo.getGhostLinkSources("Topic")).sort()).toEqual(["p2"]);
+  });
+
+  it("promoteGhostLink only promotes when 2+ wiki ghosts exist", async () => {
+    expect(await repo.promoteGhostLink("u1", "Solo")).toBeNull();
+
+    await repo.addGhostLink("Pair", "p1");
+    await repo.addGhostLink("Pair", "p2");
+    const created = await repo.promoteGhostLink("u1", "Pair");
+    expect(created).not.toBeNull();
+    expect(created?.title).toBe("Pair");
+
+    expect(await repo.getGhostLinkSources("Pair")).toEqual([]);
+    const out1 = await repo.getOutgoingLinks("p1");
+    const out2 = await repo.getOutgoingLinks("p2");
+    expect(out1).toContain(created?.id);
+    expect(out2).toContain(created?.id);
+  });
+
+  it("delegates each mutation through the same wrapped object (spy contract)", async () => {
+    const wrapped = createInMemoryRepository(makeStore());
+    const spy = {
+      createPage: vi.spyOn(wrapped, "createPage"),
+      updatePage: vi.spyOn(wrapped, "updatePage"),
+      deletePage: vi.spyOn(wrapped, "deletePage"),
+      addLink: vi.spyOn(wrapped, "addLink"),
+      addGhostLink: vi.spyOn(wrapped, "addGhostLink"),
+    };
+
+    const p = await wrapped.createPage("u1", "T");
+    await wrapped.updatePage("u1", p.id, { title: "T2" });
+    await wrapped.addLink(p.id, "other");
+    await wrapped.addGhostLink("ghost", p.id);
+    await wrapped.deletePage("u1", p.id);
+
+    expect(spy.createPage).toHaveBeenCalledWith("u1", "T");
+    expect(spy.updatePage).toHaveBeenCalledWith("u1", p.id, { title: "T2" });
+    expect(spy.addLink).toHaveBeenCalledWith(p.id, "other");
+    expect(spy.addGhostLink).toHaveBeenCalledWith("ghost", p.id);
+    expect(spy.deletePage).toHaveBeenCalledWith("u1", p.id);
+  });
+});
+
+describe("PageRepositoryOptions.onMutate", () => {
+  it("fires after each mutating method in implementations that wire it up", async () => {
+    const onMutate = vi.fn();
+    const r = createInMemoryRepository(makeStore(), { onMutate });
+
+    const page = await r.createPage("u1", "T");
+    await r.updatePage("u1", page.id, { title: "T2" });
+    await r.deletePage("u1", page.id);
+
+    // 3 mutations × 1 callback each = 3 invocations
+    expect(onMutate).toHaveBeenCalledTimes(3);
+  });
+
+  it("is optional: implementations may skip the callback", async () => {
+    const r = createInMemoryRepository(makeStore());
+    await expect(r.createPage("u1", "T")).resolves.toBeDefined();
+  });
+});

--- a/src/lib/pageRepository.test.ts
+++ b/src/lib/pageRepository.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { IPageRepository, CreatePageOptions, PageRepositoryOptions } from "./pageRepository";
 import type { Page, PageSummary, Link, GhostLink, LinkType } from "@/types/page";
+import { StorageAdapterPageRepository } from "./pageRepository/StorageAdapterPageRepository";
+import type { StorageAdapter } from "./storageAdapter/StorageAdapter";
+import type { ApiClient } from "./api/apiClient";
 
 /**
  * `pageRepository.ts` は型のみのインターフェース層であり、ランタイムロジックを
@@ -129,11 +132,13 @@ function createInMemoryRepository(
         return;
       }
       store.links.push({ sourceId, targetId, linkType, createdAt: Date.now() });
+      await fireMutate();
     },
     async removeLink(sourceId, targetId, linkType: LinkType = "wiki") {
       store.links = store.links.filter(
         (l) => !(l.sourceId === sourceId && l.targetId === targetId && l.linkType === linkType),
       );
+      await fireMutate();
     },
     async getOutgoingLinks(pageId, linkType: LinkType = "wiki") {
       return store.links
@@ -163,12 +168,14 @@ function createInMemoryRepository(
         linkType,
         createdAt: Date.now(),
       });
+      await fireMutate();
     },
     async removeGhostLink(linkText, sourcePageId, linkType: LinkType = "wiki") {
       store.ghostLinks = store.ghostLinks.filter(
         (g) =>
           !(g.linkText === linkText && g.sourcePageId === sourcePageId && g.linkType === linkType),
       );
+      await fireMutate();
     },
     async getGhostLinkSources(linkText, linkType: LinkType = "wiki") {
       return store.ghostLinks
@@ -406,17 +413,109 @@ describe("IPageRepository contract", () => {
   });
 });
 
+/**
+ * 実プロダクションの `StorageAdapterPageRepository` が `IPageRepository` を満たし、
+ * かつ adapter / API へ正しく委譲することを spy で確認するスモーク層。
+ * CodeRabbit のレビュー対応: in-memory モックだけだと実装側の reg を見逃すため、
+ * 実装に直接アンカーした薄い契約スイートを置く（網羅検証は
+ * `pageRepository/StorageAdapterPageRepository.test.ts` 側）。
+ *
+ * Smoke layer that anchors `IPageRepository` contract assertions to the real
+ * runtime implementation so adapter regressions surface here too. Exhaustive
+ * delegation tests live alongside the implementation
+ * (`pageRepository/StorageAdapterPageRepository.test.ts`); this block exists so
+ * the interface file's test suite catches contract drift in the production class.
+ */
+function createMockAdapter(): StorageAdapter {
+  return {
+    getAllPages: vi.fn().mockResolvedValue([]),
+    getPage: vi.fn().mockResolvedValue(null),
+    upsertPage: vi.fn().mockResolvedValue(undefined),
+    deletePage: vi.fn().mockResolvedValue(undefined),
+    getYDocState: vi.fn().mockResolvedValue(null),
+    saveYDocState: vi.fn().mockResolvedValue(undefined),
+    getYDocVersion: vi.fn().mockResolvedValue(0),
+    getLinks: vi.fn().mockResolvedValue([]),
+    getBacklinks: vi.fn().mockResolvedValue([]),
+    saveLinks: vi.fn().mockResolvedValue(undefined),
+    getGhostLinks: vi.fn().mockResolvedValue([]),
+    saveGhostLinks: vi.fn().mockResolvedValue(undefined),
+    searchPages: vi.fn().mockResolvedValue([]),
+    updateSearchIndex: vi.fn().mockResolvedValue(undefined),
+    getLastSyncTime: vi.fn().mockResolvedValue(0),
+    setLastSyncTime: vi.fn().mockResolvedValue(undefined),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    resetDatabase: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockApi(): ApiClient {
+  return {
+    deletePage: vi.fn(),
+    createPage: vi.fn(),
+  } as unknown as ApiClient;
+}
+
+describe("StorageAdapterPageRepository (production) satisfies IPageRepository", () => {
+  let adapter: ReturnType<typeof createMockAdapter>;
+  let api: ApiClient;
+  let repo: IPageRepository;
+
+  beforeEach(() => {
+    adapter = createMockAdapter();
+    api = createMockApi();
+    // 型レベルで `IPageRepository` を満たすかをここで強制する。
+    // Compile-time assertion that the production class satisfies the interface.
+    repo = new StorageAdapterPageRepository(adapter, api);
+  });
+
+  it("delegates createPage (guest) to adapter.upsertPage", async () => {
+    await repo.createPage("local-user", "Hello");
+    expect(adapter.upsertPage).toHaveBeenCalledOnce();
+  });
+
+  it("delegates getPage to adapter.getPage", async () => {
+    await repo.getPage("local-user", "p1");
+    expect(adapter.getPage).toHaveBeenCalledWith("p1");
+  });
+
+  it("delegates addLink to adapter.saveLinks (defaulting linkType to 'wiki')", async () => {
+    await repo.addLink("a", "b");
+    expect(adapter.getLinks).toHaveBeenCalledWith("a", "wiki");
+    expect(adapter.saveLinks).toHaveBeenCalledOnce();
+    const call = (adapter.saveLinks as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[2]).toBe("wiki");
+  });
+
+  it("delegates deletePage (auth) to adapter.deletePage and api.deletePage", async () => {
+    await repo.deletePage("auth-user", "p1");
+    expect(adapter.deletePage).toHaveBeenCalledWith("p1");
+    expect(api.deletePage).toHaveBeenCalledWith("p1");
+  });
+});
+
 describe("PageRepositoryOptions.onMutate", () => {
-  it("fires after each mutating method in implementations that wire it up", async () => {
+  it("fires after every mutating method (CRUD + link/ghost link paths)", async () => {
+    // CodeRabbit のレビュー対応: onMutate は CRUD だけでなく link/ghost link
+    // 系の mutation でも発火する契約。書き込み経路全体でリグレッションを検出できる。
+    //
+    // Address CodeRabbit feedback: `onMutate` is fired on every mutating path
+    // (page CRUD + link / ghost link writes), so a regression on any of them
+    // is caught here.
     const onMutate = vi.fn();
     const r = createInMemoryRepository(makeStore(), { onMutate });
 
     const page = await r.createPage("u1", "T");
     await r.updatePage("u1", page.id, { title: "T2" });
+    await r.addLink(page.id, "target");
+    await r.removeLink(page.id, "target");
+    await r.addGhostLink("Ghost", page.id);
+    await r.removeGhostLink("Ghost", page.id);
     await r.deletePage("u1", page.id);
 
-    // 3 mutations × 1 callback each = 3 invocations
-    expect(onMutate).toHaveBeenCalledTimes(3);
+    // 7 mutations (create / update / addLink / removeLink / addGhost / removeGhost / delete)
+    expect(onMutate).toHaveBeenCalledTimes(7);
   });
 
   it("is optional: implementations may skip the callback", async () => {

--- a/src/lib/storage/index.test.ts
+++ b/src/lib/storage/index.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from "vitest";
+import {
+  getStorageProvider,
+  isProviderConfigured,
+  getSettingsForUpload,
+  isStorageConfiguredForUpload,
+  type StorageProviderContext,
+} from "./index";
+import { GyazoProvider } from "./providers/GyazoProvider";
+import { GitHubProvider } from "./providers/GitHubProvider";
+import { GoogleDriveProvider } from "./providers/GoogleDriveProvider";
+import { S3Provider } from "./providers/S3Provider";
+import type { StorageSettings, StorageProviderConfig, StorageProviderType } from "@/types/storage";
+
+const ctx: StorageProviderContext = {
+  getToken: async () => "fake-token",
+  baseUrl: "https://api.example.com",
+};
+
+function settings(
+  provider: StorageProviderType | "cloudflare-r2",
+  config: StorageProviderConfig = {},
+  overrides: Partial<StorageSettings> = {},
+): StorageSettings {
+  return {
+    provider: provider as StorageProviderType,
+    config,
+    isConfigured: true,
+    preferDefaultStorage: false,
+    ...overrides,
+  };
+}
+
+describe("getStorageProvider factory", () => {
+  describe("s3 (default storage)", () => {
+    it("returns an S3Provider when context.getToken is supplied", () => {
+      const provider = getStorageProvider(settings("s3"), ctx);
+      expect(provider).toBeInstanceOf(S3Provider);
+    });
+
+    it("throws when context is missing", () => {
+      expect(() => getStorageProvider(settings("s3"))).toThrow(/getToken が必要です/);
+    });
+
+    it("throws when context.getToken is missing", () => {
+      expect(() =>
+        getStorageProvider(settings("s3"), {
+          // 型を維持するため明示的に未定義を渡す
+          // explicitly pass undefined to keep the type contract
+          getToken: undefined as unknown as StorageProviderContext["getToken"],
+        }),
+      ).toThrow(/getToken が必要です/);
+    });
+
+    it("treats legacy 'cloudflare-r2' as 's3' (mutation: legacy migration branch)", () => {
+      const provider = getStorageProvider(settings("cloudflare-r2"), ctx);
+      expect(provider).toBeInstanceOf(S3Provider);
+    });
+  });
+
+  describe("gyazo", () => {
+    it("returns a GyazoProvider when token is configured", () => {
+      const provider = getStorageProvider(settings("gyazo", { gyazoAccessToken: "tok" }));
+      expect(provider).toBeInstanceOf(GyazoProvider);
+    });
+
+    it("throws when gyazoAccessToken is missing", () => {
+      expect(() => getStorageProvider(settings("gyazo", {}))).toThrow(
+        /Gyazo Access Token が設定されていません/,
+      );
+    });
+  });
+
+  describe("github", () => {
+    it("returns a GitHubProvider when repository + token are present", () => {
+      const provider = getStorageProvider(
+        settings("github", {
+          githubRepository: "owner/repo",
+          githubToken: "tok",
+          githubBranch: "main",
+          githubPath: "images",
+        }),
+      );
+      expect(provider).toBeInstanceOf(GitHubProvider);
+    });
+
+    it("throws when repository is missing", () => {
+      expect(() => getStorageProvider(settings("github", { githubToken: "tok" }))).toThrow(
+        /GitHub の設定が不完全です/,
+      );
+    });
+
+    it("throws when token is missing", () => {
+      expect(() =>
+        getStorageProvider(settings("github", { githubRepository: "owner/repo" })),
+      ).toThrow(/GitHub の設定が不完全です/);
+    });
+  });
+
+  describe("google-drive", () => {
+    it("returns a GoogleDriveProvider when clientId + accessToken are set", () => {
+      const provider = getStorageProvider(
+        settings("google-drive", {
+          googleDriveClientId: "id",
+          googleDriveClientSecret: "secret",
+          googleDriveAccessToken: "access",
+          googleDriveRefreshToken: "refresh",
+          googleDriveFolderId: "folder",
+        }),
+      );
+      expect(provider).toBeInstanceOf(GoogleDriveProvider);
+    });
+
+    it("falls back to empty strings when optional clientSecret/refreshToken are missing", () => {
+      const provider = getStorageProvider(
+        settings("google-drive", {
+          googleDriveClientId: "id",
+          googleDriveAccessToken: "access",
+        }),
+      );
+      expect(provider).toBeInstanceOf(GoogleDriveProvider);
+    });
+
+    it("throws when clientId is missing", () => {
+      expect(() =>
+        getStorageProvider(settings("google-drive", { googleDriveAccessToken: "access" })),
+      ).toThrow(/Google Drive の設定が不完全です/);
+    });
+
+    it("throws when accessToken is missing", () => {
+      expect(() =>
+        getStorageProvider(settings("google-drive", { googleDriveClientId: "id" })),
+      ).toThrow(/Google Drive の設定が不完全です/);
+    });
+  });
+
+  it("throws on an unknown provider", () => {
+    // any-cast で未知 provider をシミュレート / cast to simulate an unknown provider
+    expect(() =>
+      getStorageProvider(settings("totally-unknown" as unknown as StorageProviderType)),
+    ).toThrow(/Unknown storage provider/);
+  });
+});
+
+describe("isProviderConfigured", () => {
+  it.each([
+    ["gyazo", { gyazoAccessToken: "tok" }, true],
+    ["gyazo", {}, false],
+    ["github", { githubRepository: "o/r", githubToken: "t" }, true],
+    ["github", { githubRepository: "o/r" }, false],
+    ["github", { githubToken: "t" }, false],
+    ["google-drive", { googleDriveClientId: "id", googleDriveAccessToken: "ac" }, true],
+    ["google-drive", { googleDriveClientId: "id" }, false],
+    ["google-drive", { googleDriveAccessToken: "ac" }, false],
+    ["s3", {}, true],
+  ] as const)("(%s, %o) → %s", (provider, config, expected) => {
+    expect(isProviderConfigured(provider as StorageProviderType, config)).toBe(expected);
+  });
+
+  it("returns false for an unknown provider", () => {
+    expect(isProviderConfigured("nope" as unknown as StorageProviderType, {})).toBe(false);
+  });
+});
+
+describe("getSettingsForUpload", () => {
+  it("returns s3 defaults when preferDefaultStorage is undefined (default branch)", () => {
+    const out = getSettingsForUpload({
+      provider: "gyazo",
+      config: { gyazoAccessToken: "tok" },
+      isConfigured: true,
+    });
+    expect(out).toEqual({
+      provider: "s3",
+      config: {},
+      isConfigured: true,
+    });
+  });
+
+  it("returns s3 defaults when preferDefaultStorage is true", () => {
+    const out = getSettingsForUpload({
+      provider: "github",
+      config: { githubRepository: "o/r", githubToken: "t" },
+      isConfigured: true,
+      preferDefaultStorage: true,
+    });
+    expect(out.provider).toBe("s3");
+    expect(out.config).toEqual({});
+  });
+
+  it("preserves the original settings when preferDefaultStorage is false", () => {
+    const original: StorageSettings = {
+      provider: "gyazo",
+      config: { gyazoAccessToken: "tok" },
+      isConfigured: true,
+      preferDefaultStorage: false,
+    };
+    expect(getSettingsForUpload(original)).toBe(original);
+  });
+});
+
+describe("isStorageConfiguredForUpload", () => {
+  it("returns true when default storage is preferred", () => {
+    expect(
+      isStorageConfiguredForUpload({
+        provider: "s3",
+        config: {},
+        isConfigured: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      isStorageConfiguredForUpload({
+        provider: "gyazo",
+        config: {},
+        isConfigured: true,
+        preferDefaultStorage: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for s3 when external storage is preferred (s3 cannot be 'external')", () => {
+    expect(
+      isStorageConfiguredForUpload({
+        provider: "s3",
+        config: {},
+        isConfigured: true,
+        preferDefaultStorage: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for an external provider only when its config is complete", () => {
+    expect(
+      isStorageConfiguredForUpload({
+        provider: "gyazo",
+        config: { gyazoAccessToken: "tok" },
+        isConfigured: true,
+        preferDefaultStorage: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      isStorageConfiguredForUpload({
+        provider: "gyazo",
+        config: {},
+        isConfigured: true,
+        preferDefaultStorage: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/stores/aiChatStore.test.ts
+++ b/src/stores/aiChatStore.test.ts
@@ -186,6 +186,11 @@ describe("aiChatStore", () => {
       expect(state.isOpen).toBe(true);
       expect(state.contextEnabled).toBe(false);
       expect(state.selectedModel).toEqual(model);
+      // CodeRabbit のレビュー対応: 揮発フィールドが rehydrate で蘇らないことを明示確認。
+      // Pin volatile fields explicitly so the test name matches its assertions.
+      expect(state.activeConversationId).toBeNull();
+      expect(state.isStreaming).toBe(false);
+      expect(state.showConversationList).toBe(false);
     });
   });
 });

--- a/src/stores/aiChatStore.test.ts
+++ b/src/stores/aiChatStore.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act } from "@testing-library/react";
+import { useAIChatStore } from "./aiChatStore";
+
+const INITIAL_STATE = {
+  isOpen: false,
+  activeConversationId: null,
+  isStreaming: false,
+  contextEnabled: true,
+  showConversationList: false,
+  selectedModel: null,
+} as const;
+
+/**
+ * 各テストの前に zustand state と localStorage をリセットする。persist は
+ * 同じ key (`ai-chat-storage`) に書き込むため、明示クリアしないと前テストの
+ * 永続値が次テストの初期値になってしまう。
+ *
+ * Reset zustand state and localStorage before each test. Without explicit
+ * clearing, persisted state from a previous test bleeds into the next one.
+ */
+function resetStore(): void {
+  act(() => {
+    useAIChatStore.setState(INITIAL_STATE);
+  });
+}
+
+describe("aiChatStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetStore();
+  });
+
+  it("starts with the documented default state", () => {
+    expect(useAIChatStore.getState()).toMatchObject(INITIAL_STATE);
+  });
+
+  describe("panel actions", () => {
+    it("togglePanel flips isOpen", () => {
+      useAIChatStore.getState().togglePanel();
+      expect(useAIChatStore.getState().isOpen).toBe(true);
+
+      useAIChatStore.getState().togglePanel();
+      expect(useAIChatStore.getState().isOpen).toBe(false);
+    });
+
+    it("openPanel / closePanel set absolute states", () => {
+      useAIChatStore.getState().openPanel();
+      expect(useAIChatStore.getState().isOpen).toBe(true);
+
+      useAIChatStore.getState().closePanel();
+      expect(useAIChatStore.getState().isOpen).toBe(false);
+
+      // 二重 close でも false のまま / closing twice stays false
+      useAIChatStore.getState().closePanel();
+      expect(useAIChatStore.getState().isOpen).toBe(false);
+    });
+  });
+
+  describe("conversation + streaming", () => {
+    it("setActiveConversation accepts ids and null", () => {
+      useAIChatStore.getState().setActiveConversation("conv-1");
+      expect(useAIChatStore.getState().activeConversationId).toBe("conv-1");
+
+      useAIChatStore.getState().setActiveConversation(null);
+      expect(useAIChatStore.getState().activeConversationId).toBeNull();
+    });
+
+    it("setStreaming toggles streaming flag", () => {
+      useAIChatStore.getState().setStreaming(true);
+      expect(useAIChatStore.getState().isStreaming).toBe(true);
+
+      useAIChatStore.getState().setStreaming(false);
+      expect(useAIChatStore.getState().isStreaming).toBe(false);
+    });
+
+    it("toggleConversationList flips list visibility", () => {
+      useAIChatStore.getState().toggleConversationList();
+      expect(useAIChatStore.getState().showConversationList).toBe(true);
+
+      useAIChatStore.getState().toggleConversationList();
+      expect(useAIChatStore.getState().showConversationList).toBe(false);
+    });
+  });
+
+  describe("toggleContext", () => {
+    it("starts enabled and flips on each call", () => {
+      expect(useAIChatStore.getState().contextEnabled).toBe(true);
+
+      useAIChatStore.getState().toggleContext();
+      expect(useAIChatStore.getState().contextEnabled).toBe(false);
+
+      useAIChatStore.getState().toggleContext();
+      expect(useAIChatStore.getState().contextEnabled).toBe(true);
+    });
+  });
+
+  describe("setSelectedModel", () => {
+    it("stores a model selection and clears with null", () => {
+      const model = {
+        id: "openai:gpt-4o-mini",
+        provider: "openai" as const,
+        model: "gpt-4o-mini",
+        displayName: "GPT-4o mini",
+        inputCostUnits: 1,
+        outputCostUnits: 2,
+      };
+
+      useAIChatStore.getState().setSelectedModel(model);
+      expect(useAIChatStore.getState().selectedModel).toEqual(model);
+
+      useAIChatStore.getState().setSelectedModel(null);
+      expect(useAIChatStore.getState().selectedModel).toBeNull();
+    });
+  });
+
+  describe("persist + partialize", () => {
+    /**
+     * `partialize` は `isOpen` / `contextEnabled` / `selectedModel` のみを
+     * localStorage に書く契約。アクティブ会話やストリーミング状態は永続化しない
+     * (UI 立ち上げ直後にゾンビ "streaming" になるのを避けるため)。
+     *
+     * The store is contracted to persist only `isOpen` / `contextEnabled` /
+     * `selectedModel`. Volatile UI state stays in memory.
+     */
+    it("only persists the partialized fields", () => {
+      const model = {
+        id: "anthropic:claude-haiku",
+        provider: "anthropic" as const,
+        model: "claude-haiku",
+        displayName: "Claude Haiku",
+      };
+
+      useAIChatStore.getState().openPanel();
+      useAIChatStore.getState().toggleContext(); // → false
+      useAIChatStore.getState().setSelectedModel(model);
+      // 揮発キー: これらは partialize で除外されるので localStorage に出ない
+      // volatile keys: excluded by partialize, must not be in localStorage
+      useAIChatStore.getState().setActiveConversation("conv-X");
+      useAIChatStore.getState().setStreaming(true);
+      useAIChatStore.getState().toggleConversationList();
+
+      const raw = localStorage.getItem("ai-chat-storage");
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw as string) as {
+        state: Record<string, unknown>;
+      };
+
+      expect(parsed.state).toEqual({
+        isOpen: true,
+        contextEnabled: false,
+        selectedModel: model,
+      });
+      expect(parsed.state).not.toHaveProperty("activeConversationId");
+      expect(parsed.state).not.toHaveProperty("isStreaming");
+      expect(parsed.state).not.toHaveProperty("showConversationList");
+    });
+
+    it("rehydrate restores persisted fields without resurrecting volatile ones", async () => {
+      const model = {
+        id: "openai:gpt-4o",
+        provider: "openai" as const,
+        model: "gpt-4o",
+        displayName: "GPT-4o",
+      };
+
+      localStorage.setItem(
+        "ai-chat-storage",
+        JSON.stringify({
+          version: 1,
+          state: {
+            isOpen: true,
+            contextEnabled: false,
+            selectedModel: model,
+            // 永続化されてはいけないフィールドが万一 localStorage にあっても、
+            // partialize されるので rehydrate 後に取り込まれない…はずが、zustand
+            // の persist はそのまま反映してしまう。partialize は書き込み側のみ。
+            // ここでは契約として「書き込み時に partialize される」ことを担保する。
+          },
+        }),
+      );
+
+      await useAIChatStore.persist.rehydrate();
+
+      const state = useAIChatStore.getState();
+      expect(state.isOpen).toBe(true);
+      expect(state.contextEnabled).toBe(false);
+      expect(state.selectedModel).toEqual(model);
+    });
+  });
+});

--- a/src/stores/aiChatStore.test.ts
+++ b/src/stores/aiChatStore.test.ts
@@ -156,7 +156,7 @@ describe("aiChatStore", () => {
       expect(parsed.state).not.toHaveProperty("showConversationList");
     });
 
-    it("rehydrate restores persisted fields without resurrecting volatile ones", async () => {
+    it("rehydrate restores persisted fields and leaves unspecified volatile fields at defaults", async () => {
       const model = {
         id: "openai:gpt-4o",
         provider: "openai" as const,

--- a/src/stores/pageStore.test.ts
+++ b/src/stores/pageStore.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act } from "@testing-library/react";
+import { usePageStore } from "./pageStore";
+
+/**
+ * pageStore はゲストセッション向けの zustand + persist ストア。
+ * 各テストで `setState` でリセットし、localStorage も明示的にクリアする。
+ *
+ * pageStore is the zustand + persist guest store. Reset state via `setState`
+ * and clear localStorage between tests so persisted data does not leak.
+ */
+function resetStore(): void {
+  act(() => {
+    usePageStore.setState({ pages: [], links: [], ghostLinks: [] });
+  });
+}
+
+describe("pageStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetStore();
+  });
+
+  describe("createPage", () => {
+    it("creates a personal page with default empty title and content", () => {
+      const before = Date.now() - 1;
+      const page = usePageStore.getState().createPage();
+
+      expect(page.id).toBeTruthy();
+      expect(page.title).toBe("");
+      expect(page.content).toBe("");
+      expect(page.ownerUserId).toBe("local-user");
+      expect(page.noteId).toBeNull();
+      expect(page.isDeleted).toBe(false);
+      expect(page.createdAt).toBeGreaterThan(before);
+      expect(page.updatedAt).toBe(page.createdAt);
+
+      expect(usePageStore.getState().pages).toHaveLength(1);
+      expect(usePageStore.getState().pages[0]).toEqual(page);
+    });
+
+    it("prepends newly created pages to the list", () => {
+      const first = usePageStore.getState().createPage("first");
+      const second = usePageStore.getState().createPage("second");
+
+      const ids = usePageStore.getState().pages.map((p) => p.id);
+      expect(ids).toEqual([second.id, first.id]);
+    });
+
+    it("persists created pages to localStorage", () => {
+      usePageStore.getState().createPage("Persisted", "body");
+
+      const raw = localStorage.getItem("zedi-pages");
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw as string) as { state: { pages: Array<{ title: string }> } };
+      expect(parsed.state.pages[0].title).toBe("Persisted");
+    });
+  });
+
+  describe("updatePage", () => {
+    it("merges updates and bumps updatedAt", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date(1_000_000));
+        const page = usePageStore.getState().createPage("orig", "body");
+        vi.setSystemTime(new Date(2_000_000));
+
+        usePageStore.getState().updatePage(page.id, { title: "updated" });
+
+        const stored = usePageStore.getState().getPage(page.id);
+        expect(stored?.title).toBe("updated");
+        expect(stored?.content).toBe("body");
+        expect(stored?.updatedAt).toBe(2_000_000);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("is a no-op for an unknown id", () => {
+      const page = usePageStore.getState().createPage("orig");
+      const before = usePageStore.getState().pages;
+
+      usePageStore.getState().updatePage("missing", { title: "x" });
+
+      expect(usePageStore.getState().pages).toEqual(before);
+      expect(usePageStore.getState().getPage(page.id)?.title).toBe("orig");
+    });
+  });
+
+  describe("deletePage", () => {
+    it("marks the page as deleted and drops attached links", () => {
+      const a = usePageStore.getState().createPage("A");
+      const b = usePageStore.getState().createPage("B");
+      const c = usePageStore.getState().createPage("C");
+
+      usePageStore.getState().addLink(a.id, b.id);
+      usePageStore.getState().addLink(c.id, a.id);
+      usePageStore.getState().addLink(b.id, c.id);
+
+      usePageStore.getState().deletePage(a.id);
+
+      const state = usePageStore.getState();
+      expect(state.pages.find((p) => p.id === a.id)?.isDeleted).toBe(true);
+      // a を含むリンクは消え、b → c のリンクだけ残る
+      // links touching a are removed; b → c survives
+      expect(state.links).toEqual([
+        expect.objectContaining({ sourceId: b.id, targetId: c.id, linkType: "wiki" }),
+      ]);
+    });
+
+    it("hides deleted pages from getPage / getPageByTitle", () => {
+      const page = usePageStore.getState().createPage("Hidden");
+      usePageStore.getState().deletePage(page.id);
+
+      expect(usePageStore.getState().getPage(page.id)).toBeUndefined();
+      expect(usePageStore.getState().getPageByTitle("Hidden")).toBeUndefined();
+    });
+  });
+
+  describe("getPage / getPageByTitle", () => {
+    it("returns undefined for a missing id", () => {
+      expect(usePageStore.getState().getPage("missing")).toBeUndefined();
+    });
+
+    it("getPageByTitle is case-insensitive and trims whitespace", () => {
+      const page = usePageStore.getState().createPage("Hello World");
+      expect(usePageStore.getState().getPageByTitle("  hello world  ")?.id).toBe(page.id);
+      expect(usePageStore.getState().getPageByTitle("HELLO WORLD")?.id).toBe(page.id);
+    });
+  });
+
+  describe("addLink / removeLink", () => {
+    it("adds a wiki link by default and de-duplicates repeat inserts", () => {
+      usePageStore.getState().addLink("a", "b");
+      usePageStore.getState().addLink("a", "b");
+
+      expect(usePageStore.getState().links).toEqual([
+        expect.objectContaining({ sourceId: "a", targetId: "b", linkType: "wiki" }),
+      ]);
+    });
+
+    it("treats wiki and tag edges on the same pair as distinct rows (issue #725)", () => {
+      usePageStore.getState().addLink("a", "b", "wiki");
+      usePageStore.getState().addLink("a", "b", "tag");
+
+      expect(usePageStore.getState().links).toHaveLength(2);
+      const types = usePageStore.getState().links.map((l) => l.linkType);
+      expect(types.sort()).toEqual(["tag", "wiki"]);
+    });
+
+    it("removeLink only deletes rows of the matching linkType", () => {
+      usePageStore.getState().addLink("a", "b", "wiki");
+      usePageStore.getState().addLink("a", "b", "tag");
+
+      usePageStore.getState().removeLink("a", "b", "wiki");
+
+      expect(usePageStore.getState().links).toEqual([
+        expect.objectContaining({ sourceId: "a", targetId: "b", linkType: "tag" }),
+      ]);
+    });
+  });
+
+  describe("getOutgoingLinks / getBacklinks", () => {
+    it("filters by linkType (default 'wiki')", () => {
+      usePageStore.getState().addLink("a", "b", "wiki");
+      usePageStore.getState().addLink("a", "c", "wiki");
+      usePageStore.getState().addLink("a", "d", "tag");
+
+      expect(usePageStore.getState().getOutgoingLinks("a").sort()).toEqual(["b", "c"]);
+      expect(usePageStore.getState().getOutgoingLinks("a", "tag")).toEqual(["d"]);
+    });
+
+    it("getBacklinks returns sources pointing at the page", () => {
+      usePageStore.getState().addLink("p1", "target");
+      usePageStore.getState().addLink("p2", "target");
+      usePageStore.getState().addLink("p3", "other");
+
+      expect(usePageStore.getState().getBacklinks("target").sort()).toEqual(["p1", "p2"]);
+      expect(usePageStore.getState().getBacklinks("other")).toEqual(["p3"]);
+    });
+  });
+
+  describe("ghost links", () => {
+    it("addGhostLink de-duplicates and supports linkType scoping", () => {
+      usePageStore.getState().addGhostLink("Topic", "p1");
+      usePageStore.getState().addGhostLink("Topic", "p1");
+      usePageStore.getState().addGhostLink("Topic", "p1", "tag");
+
+      expect(usePageStore.getState().ghostLinks).toHaveLength(2);
+    });
+
+    it("removeGhostLink only deletes the matching (text, source, type) tuple", () => {
+      usePageStore.getState().addGhostLink("Topic", "p1");
+      usePageStore.getState().addGhostLink("Topic", "p2");
+
+      usePageStore.getState().removeGhostLink("Topic", "p1");
+
+      expect(usePageStore.getState().ghostLinks).toEqual([
+        expect.objectContaining({ linkText: "Topic", sourcePageId: "p2", linkType: "wiki" }),
+      ]);
+    });
+
+    it("getGhostLinkSources collects pages by linkText + linkType", () => {
+      usePageStore.getState().addGhostLink("Topic", "p1");
+      usePageStore.getState().addGhostLink("Topic", "p2");
+      usePageStore.getState().addGhostLink("Topic", "p3", "tag");
+
+      expect(usePageStore.getState().getGhostLinkSources("Topic").sort()).toEqual(["p1", "p2"]);
+      expect(usePageStore.getState().getGhostLinkSources("Topic", "tag")).toEqual(["p3"]);
+    });
+
+    it("promoteGhostLink only promotes when 2+ sources exist for the wiki bucket", () => {
+      usePageStore.getState().addGhostLink("Solo", "p1");
+      expect(usePageStore.getState().promoteGhostLink("Solo")).toBeNull();
+
+      usePageStore.getState().addGhostLink("Pair", "p1");
+      usePageStore.getState().addGhostLink("Pair", "p2");
+
+      const promoted = usePageStore.getState().promoteGhostLink("Pair");
+      expect(promoted).not.toBeNull();
+      expect(promoted?.title).toBe("Pair");
+
+      const state = usePageStore.getState();
+      // ゴーストは消費され、各ソースから新ページへの実リンクが張られる
+      // ghosts consumed; real links from each source to the promoted page exist
+      expect(state.ghostLinks.find((g) => g.linkText === "Pair")).toBeUndefined();
+      const targets = state.links.filter((l) => l.targetId === promoted?.id).map((l) => l.sourceId);
+      expect(targets.sort()).toEqual(["p1", "p2"]);
+    });
+
+    it("promoteGhostLink ignores tag-only ghosts (issue #725 Phase 1)", () => {
+      usePageStore.getState().addGhostLink("Tagged", "p1", "tag");
+      usePageStore.getState().addGhostLink("Tagged", "p2", "tag");
+
+      expect(usePageStore.getState().promoteGhostLink("Tagged")).toBeNull();
+      expect(usePageStore.getState().pages).toHaveLength(0);
+    });
+  });
+
+  describe("searchPages", () => {
+    beforeEach(() => {
+      usePageStore.getState().createPage("Hello World", "first body");
+      usePageStore.getState().createPage("Other", "contains hello");
+      usePageStore.getState().createPage("Trash", "ignored");
+    });
+
+    it("returns title and content matches case-insensitively", () => {
+      const results = usePageStore.getState().searchPages("HELLO");
+      expect(results.map((p) => p.title).sort()).toEqual(["Hello World", "Other"]);
+    });
+
+    it("returns [] for a blank query", () => {
+      expect(usePageStore.getState().searchPages("   ")).toEqual([]);
+    });
+
+    it("excludes soft-deleted pages from search results", () => {
+      const target = usePageStore.getState().getPageByTitle("Hello World");
+      if (!target) throw new Error("fixture page missing");
+      usePageStore.getState().deletePage(target.id);
+
+      const results = usePageStore.getState().searchPages("hello");
+      expect(results.map((p) => p.title)).toEqual(["Other"]);
+    });
+  });
+
+  describe("persist migrate", () => {
+    /**
+     * persist の `migrate` は zustand 内部から呼ばれる private 関数なので、ここでは
+     * 永続化キーに古いバージョンの payload を直接書き、ストアを `rehydrate` で
+     * 再水和して結果を確認する。
+     *
+     * `migrate` is invoked internally by zustand. We seed localStorage with an
+     * older-versioned payload and trigger `rehydrate()` to validate the upgrade.
+     */
+    it("backfills missing noteId to null (v1 → v2)", async () => {
+      localStorage.setItem(
+        "zedi-pages",
+        JSON.stringify({
+          version: 1,
+          state: {
+            pages: [
+              {
+                id: "old-1",
+                ownerUserId: "local-user",
+                title: "Legacy",
+                content: "",
+                createdAt: 1,
+                updatedAt: 1,
+                isDeleted: false,
+              },
+            ],
+            links: [],
+            ghostLinks: [],
+          },
+        }),
+      );
+
+      await usePageStore.persist.rehydrate();
+
+      const page = usePageStore.getState().pages.find((p) => p.id === "old-1");
+      expect(page?.noteId).toBeNull();
+    });
+
+    it("backfills missing linkType to 'wiki' for links and ghost links (v2 → v3)", async () => {
+      localStorage.setItem(
+        "zedi-pages",
+        JSON.stringify({
+          version: 2,
+          state: {
+            pages: [],
+            links: [{ sourceId: "a", targetId: "b", createdAt: 1 }],
+            ghostLinks: [{ linkText: "X", sourcePageId: "a", createdAt: 1 }],
+          },
+        }),
+      );
+
+      await usePageStore.persist.rehydrate();
+
+      const state = usePageStore.getState();
+      expect(state.links[0].linkType).toBe("wiki");
+      expect(state.ghostLinks[0].linkType).toBe("wiki");
+    });
+  });
+});


### PR DESCRIPTION
- pageStore: ゲスト CRUD / リンク / ゴーストリンク / 永続化 + v1→v2→v3 マイグレーション
- aiChatStore: 全 action と partialize された永続キーの契約
- storage/index: factory 全分岐 + cloudflare-r2 → s3 レガシー migration / アップロード設定
- pageRepository: IPageRepository 契約テスト + onMutate コールバック

Closes #745.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites covering page repository behavior (CRUD, soft-delete, listing, search, links/ghost-links and promotion), storage provider selection and upload settings, AI chat state persistence and UI toggles, and page store actions/persistence including migration scenarios and link/ghost-link edge cases to improve stability and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->