### PR TITLE
test: add comprehensive unit tests for query, models, installation, and status handlers

### DIFF
--- a/packages/claude-sidecar/src/handlers/installation.test.ts
+++ b/packages/claude-sidecar/src/handlers/installation.test.ts
@@ -1,0 +1,126 @@
+/**
+ * checkClaudeInstallation のユニットテスト
+ *
+ * - `claudeVersionArgv` のプラットフォーム別分岐
+ * - `Bun.spawn` をモックして 0/非 0 終了・throw 系のシナリオを網羅
+ *
+ * Unit tests for the installation handler. We mock `Bun.spawn` rather than touching the host
+ * file system so the test passes regardless of whether `claude` is on PATH.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { checkClaudeInstallation, claudeVersionArgv } from "./installation";
+
+/** Bun.spawn のテスト用最小スタブ / Minimal stand-in for the bits of Bun.spawn we use. */
+type SpawnStub = {
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  exited: Promise<number>;
+};
+
+/** Build a single-chunk ReadableStream from a string. / 文字列から 1 チャンクのストリームを作る。 */
+function streamOf(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (text.length > 0) controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
+
+/** Replace Bun.spawn for one test; return a vi.fn() spy. / 1 テストの間だけ Bun.spawn を差し替える。 */
+function stubBunSpawn(impl: (argv: string[]) => SpawnStub | Promise<SpawnStub> | never): {
+  spy: ReturnType<typeof vi.fn>;
+} {
+  const spy = vi.fn(impl as (...args: unknown[]) => unknown);
+  // biome / typescript: Bun.spawn の正確な型を入れずに最低限の差し替えを行う。
+  // We intentionally don't import the full Bun typings; the handler only uses {stdout, stderr, exited}.
+  vi.stubGlobal("Bun", {
+    ...((globalThis as { Bun?: unknown }).Bun ?? {}),
+    spawn: spy,
+  });
+  return { spy };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("claudeVersionArgv", () => {
+  it("uses cmd.exe wrapper on win32 (npm shim resolution)", () => {
+    expect(claudeVersionArgv("win32")).toEqual(["cmd.exe", "/c", "claude", "--version"]);
+  });
+
+  it("returns plain claude argv on darwin", () => {
+    expect(claudeVersionArgv("darwin")).toEqual(["claude", "--version"]);
+  });
+
+  it("returns plain claude argv on linux", () => {
+    expect(claudeVersionArgv("linux")).toEqual(["claude", "--version"]);
+  });
+
+  it("defaults to the host process.platform when not provided", () => {
+    expect(claudeVersionArgv()).toEqual(claudeVersionArgv(process.platform));
+  });
+});
+
+describe("checkClaudeInstallation", () => {
+  it("returns installed=true with stdout version string on exit code 0", async () => {
+    const { spy } = stubBunSpawn(() => ({
+      stdout: streamOf("1.2.3 (Claude Code)\n"),
+      stderr: streamOf(""),
+      exited: Promise.resolve(0),
+    }));
+
+    const result = await checkClaudeInstallation();
+
+    expect(result).toEqual({ installed: true, version: "1.2.3 (Claude Code)" });
+    expect(spy).toHaveBeenCalledOnce();
+    const argv = spy.mock.calls[0]?.[0] as string[];
+    expect(argv).toEqual(claudeVersionArgv());
+  });
+
+  it("falls back to stderr when stdout is empty", async () => {
+    // 一部の CLI はバージョンを stderr に書く。 Some CLIs print --version to stderr.
+    stubBunSpawn(() => ({
+      stdout: streamOf(""),
+      stderr: streamOf("claude 9.9.9\n"),
+      exited: Promise.resolve(0),
+    }));
+
+    const result = await checkClaudeInstallation();
+    expect(result).toEqual({ installed: true, version: "claude 9.9.9" });
+  });
+
+  it("returns installed=true with no version when both streams are empty", async () => {
+    stubBunSpawn(() => ({
+      stdout: streamOf(""),
+      stderr: streamOf(""),
+      exited: Promise.resolve(0),
+    }));
+
+    const result = await checkClaudeInstallation();
+    expect(result).toEqual({ installed: true, version: undefined });
+  });
+
+  it("returns installed=false when the CLI exits non-zero", async () => {
+    stubBunSpawn(() => ({
+      stdout: streamOf(""),
+      stderr: streamOf("error: cannot find anthropic auth\n"),
+      exited: Promise.resolve(1),
+    }));
+
+    const result = await checkClaudeInstallation();
+    expect(result).toEqual({ installed: false });
+  });
+
+  it("returns installed=false when spawn throws (CLI not on PATH)", async () => {
+    // PATH に claude が無いと Bun.spawn 自体が throw する。例外は飲み込み false を返す。
+    // When `claude` is not on PATH Bun.spawn throws synchronously; we must catch and report `installed: false`.
+    stubBunSpawn(() => {
+      throw new Error("ENOENT: No such file or directory");
+    });
+
+    const result = await checkClaudeInstallation();
+    expect(result).toEqual({ installed: false });
+  });
+});

--- a/packages/claude-sidecar/src/handlers/installation.ts
+++ b/packages/claude-sidecar/src/handlers/installation.ts
@@ -9,14 +9,18 @@ export interface InstallationCheckResult {
   version?: string;
 }
 
-const CLAUDE = process.platform === "win32" ? "claude.exe" : "claude";
-
-/** argv for `claude --version` (Windows uses `cmd /c` for npm-style shims). / Windows は npm 系シム解決のため cmd 経由 */
-function claudeVersionArgv(): string[] {
-  if (process.platform === "win32") {
+/**
+ * argv for `claude --version` (Windows uses `cmd /c` for npm-style shims).
+ * Windows は npm 系シム解決のため cmd 経由。
+ *
+ * @param platform - Override of `process.platform` for testing. / テスト用に `process.platform` を差し替えるためのオプション。
+ * @internal exported for unit testing only.
+ */
+export function claudeVersionArgv(platform: NodeJS.Platform = process.platform): string[] {
+  if (platform === "win32") {
     return ["cmd.exe", "/c", "claude", "--version"];
   }
-  return [CLAUDE, "--version"];
+  return ["claude", "--version"];
 }
 
 /**

--- a/packages/claude-sidecar/src/handlers/models.test.ts
+++ b/packages/claude-sidecar/src/handlers/models.test.ts
@@ -1,0 +1,114 @@
+/**
+ * listClaudeModels のユニットテスト
+ *
+ * - SDK の `query()` を `vi.mock` で差し替え、`initializationResult` の戻り値を
+ *   `ClaudeModelInfo[]` にマップしていること、`finally` で `q.close()` を必ず呼ぶことを検証する。
+ *
+ * Unit tests for {@link listClaudeModels}. The SDK's `query()` is mocked so the test does
+ * not require a real Claude session.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const queryMock = vi.fn();
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (...args: unknown[]) => queryMock(...args),
+}));
+
+import { listClaudeModels } from "./models";
+
+interface FakeQuery {
+  initializationResult: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+}
+
+/** Build a minimal `Query` stub matching the methods listClaudeModels touches. / 必要メソッドだけのスタブ */
+function fakeQuery(initImpl: () => Promise<unknown> = async () => ({ models: [] })): FakeQuery {
+  return {
+    initializationResult: vi.fn(initImpl),
+    close: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  queryMock.mockReset();
+});
+
+afterEach(() => {
+  queryMock.mockReset();
+});
+
+describe("listClaudeModels", () => {
+  it("requests a minimal plan-mode query (maxTurns:0, permissionMode:'plan')", async () => {
+    const fq = fakeQuery();
+    queryMock.mockReturnValue(fq);
+
+    await listClaudeModels();
+
+    expect(queryMock).toHaveBeenCalledOnce();
+    const arg = queryMock.mock.calls[0]?.[0] as {
+      prompt: string;
+      options: { maxTurns: number; permissionMode: string };
+    };
+    expect(arg.prompt).toBe("");
+    expect(arg.options.maxTurns).toBe(0);
+    expect(arg.options.permissionMode).toBe("plan");
+  });
+
+  it("maps initializationResult.models to ClaudeModelInfo[]", async () => {
+    const fq = fakeQuery(async () => ({
+      models: [
+        {
+          value: "claude-opus-4-7",
+          displayName: "Claude Opus 4.7",
+          description: "Most capable",
+          // 余計なフィールドはマップから落ちる / extra fields must be dropped from the result.
+          extra: "ignored",
+        },
+        {
+          value: "claude-haiku-4-5",
+          displayName: "Claude Haiku 4.5",
+          description: "Fast and cheap",
+        },
+      ],
+    }));
+    queryMock.mockReturnValue(fq);
+
+    const models = await listClaudeModels();
+    expect(models).toEqual([
+      {
+        value: "claude-opus-4-7",
+        displayName: "Claude Opus 4.7",
+        description: "Most capable",
+      },
+      {
+        value: "claude-haiku-4-5",
+        displayName: "Claude Haiku 4.5",
+        description: "Fast and cheap",
+      },
+    ]);
+    expect(fq.initializationResult).toHaveBeenCalledOnce();
+  });
+
+  it("calls q.close() even when initializationResult rejects", async () => {
+    const fq = fakeQuery(() => Promise.reject(new Error("init failed")));
+    queryMock.mockReturnValue(fq);
+
+    await expect(listClaudeModels()).rejects.toThrow("init failed");
+    expect(fq.close).toHaveBeenCalledOnce();
+  });
+
+  it("calls q.close() exactly once on success", async () => {
+    const fq = fakeQuery(async () => ({ models: [] }));
+    queryMock.mockReturnValue(fq);
+
+    await listClaudeModels();
+    expect(fq.close).toHaveBeenCalledOnce();
+  });
+
+  it("returns an empty array when the SDK exposes no models", async () => {
+    const fq = fakeQuery(async () => ({ models: [] }));
+    queryMock.mockReturnValue(fq);
+
+    expect(await listClaudeModels()).toEqual([]);
+  });
+});

--- a/packages/claude-sidecar/src/handlers/query.test.ts
+++ b/packages/claude-sidecar/src/handlers/query.test.ts
@@ -1,0 +1,641 @@
+/**
+ * query.ts のユニットテスト
+ *
+ * - 7 つのストリーム抽出ヘルパ (extract*, is*, emitResultOrError) を表駆動で検証する
+ * - `runQuery` は SDK の `query` をモック化し、stream → SidecarResponse の写像を
+ *   end-to-end で検証する。SDK 自体は触らない。
+ *
+ * Unit tests for the stream-event helpers and the `runQuery` orchestrator. The Claude
+ * Agent SDK is mocked so this suite is hermetic and runs without network access.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  SDKAssistantMessage,
+  SDKMessage,
+  SDKPartialAssistantMessage,
+  SDKResultMessage,
+  SDKToolProgressMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+
+// `runQuery` 内部で SDK の `query()` を呼ぶ箇所をモック化する。
+// Mock the SDK `query()` so runQuery's orchestration is exercised without real network calls.
+const queryMock = vi.fn();
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (...args: unknown[]) => queryMock(...args),
+}));
+
+import {
+  extractAssistantText,
+  extractTextDelta,
+  extractToolUseStart,
+  emitResultOrError,
+  isContentBlockStop,
+  isResultMessage,
+  isSystemInitMessage,
+  isToolProgressMessage,
+  runQuery,
+} from "./query";
+import { QueryActivityTracker } from "./status";
+import type { SidecarResponse } from "../protocol";
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+/** Build a `stream_event` partial-assistant message wrapping a raw event. / 任意イベントをラップした partial 用テストヘルパ */
+function partial(event: unknown): SDKPartialAssistantMessage {
+  return {
+    type: "stream_event",
+    event,
+    parent_tool_use_id: null,
+    uuid: "uuid-partial",
+    session_id: "sess-1",
+  } as unknown as SDKPartialAssistantMessage;
+}
+
+/** Build an SDKAssistantMessage with the given content blocks. / 指定 content の assistant メッセージを作る */
+function assistant(content: unknown[]): SDKAssistantMessage {
+  return {
+    type: "assistant",
+    message: { content } as unknown,
+    parent_tool_use_id: null,
+    uuid: "uuid-assistant",
+    session_id: "sess-1",
+  } as unknown as SDKAssistantMessage;
+}
+
+/** Build a `tool_progress` message. / `tool_progress` テストヘルパ */
+function toolProgress(toolName: string): SDKToolProgressMessage {
+  return {
+    type: "tool_progress",
+    tool_use_id: "tool-1",
+    tool_name: toolName,
+    parent_tool_use_id: null,
+    elapsed_time_seconds: 0.1,
+    uuid: "uuid-tool",
+    session_id: "sess-1",
+  } as unknown as SDKToolProgressMessage;
+}
+
+/** Build a successful `result` message. / 成功 result */
+function resultSuccess(text: string): SDKResultMessage {
+  return {
+    type: "result",
+    subtype: "success",
+    duration_ms: 1,
+    duration_api_ms: 1,
+    is_error: false,
+    num_turns: 1,
+    result: text,
+    stop_reason: "end_turn",
+    total_cost_usd: 0,
+    usage: {} as never,
+    modelUsage: {},
+    permission_denials: [],
+    uuid: "uuid-result",
+    session_id: "sess-1",
+  } as unknown as SDKResultMessage;
+}
+
+/** Build an error `result` message with an explicit `errors` array. / エラー result */
+function resultError(
+  subtype: "error_during_execution" | "error_max_turns",
+  errors: string[],
+): SDKResultMessage {
+  return {
+    type: "result",
+    subtype,
+    duration_ms: 1,
+    duration_api_ms: 1,
+    is_error: true,
+    num_turns: 1,
+    stop_reason: null,
+    total_cost_usd: 0,
+    usage: {} as never,
+    modelUsage: {},
+    permission_denials: [],
+    errors,
+    uuid: "uuid-result",
+    session_id: "sess-1",
+  } as unknown as SDKResultMessage;
+}
+
+/** Wraps an array of SDKMessage into the async-iterable shape `runQuery` expects. / 配列を async-iterable 化する */
+function makeQueryIterable(messages: SDKMessage[]): {
+  [Symbol.asyncIterator](): AsyncIterator<SDKMessage>;
+} {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const m of messages) yield m;
+    },
+  };
+}
+
+// ── helper tests ────────────────────────────────────────────────────────────
+
+describe("extractTextDelta", () => {
+  it("returns the text on a content_block_delta with text_delta", () => {
+    const msg = partial({
+      type: "content_block_delta",
+      delta: { type: "text_delta", text: "hello" },
+    });
+    expect(extractTextDelta(msg)).toBe("hello");
+  });
+
+  it("returns null when event is not content_block_delta", () => {
+    expect(extractTextDelta(partial({ type: "content_block_start" }))).toBeNull();
+  });
+
+  it("returns null when delta is not a text_delta", () => {
+    const msg = partial({
+      type: "content_block_delta",
+      delta: { type: "input_json_delta", partial_json: "{}" },
+    });
+    expect(extractTextDelta(msg)).toBeNull();
+  });
+
+  it("returns null when event is missing", () => {
+    expect(extractTextDelta(partial(undefined))).toBeNull();
+  });
+
+  it("returns null when text is not a string", () => {
+    const msg = partial({
+      type: "content_block_delta",
+      delta: { type: "text_delta", text: 123 },
+    });
+    expect(extractTextDelta(msg)).toBeNull();
+  });
+});
+
+describe("extractToolUseStart", () => {
+  it("extracts {name, input} when input is a string", () => {
+    const msg = partial({
+      type: "content_block_start",
+      content_block: { type: "tool_use", name: "Read", input: '{"path":"x"}' },
+    });
+    expect(extractToolUseStart(msg)).toEqual({ name: "Read", input: '{"path":"x"}' });
+  });
+
+  it("JSON-stringifies non-string input", () => {
+    const msg = partial({
+      type: "content_block_start",
+      content_block: { type: "tool_use", name: "Bash", input: { command: "ls" } },
+    });
+    expect(extractToolUseStart(msg)).toEqual({
+      name: "Bash",
+      input: JSON.stringify({ command: "ls" }),
+    });
+  });
+
+  it("falls back to 'unknown' when name is missing", () => {
+    const msg = partial({
+      type: "content_block_start",
+      content_block: { type: "tool_use", input: "x" },
+    });
+    expect(extractToolUseStart(msg)).toEqual({ name: "unknown", input: "x" });
+  });
+
+  it("returns null when content_block is not a tool_use", () => {
+    const msg = partial({
+      type: "content_block_start",
+      content_block: { type: "text", text: "" },
+    });
+    expect(extractToolUseStart(msg)).toBeNull();
+  });
+
+  it("returns null when event type is wrong", () => {
+    expect(extractToolUseStart(partial({ type: "content_block_stop" }))).toBeNull();
+  });
+});
+
+describe("isContentBlockStop", () => {
+  it("returns true only for content_block_stop events", () => {
+    expect(isContentBlockStop(partial({ type: "content_block_stop" }))).toBe(true);
+    expect(isContentBlockStop(partial({ type: "content_block_delta" }))).toBe(false);
+    expect(isContentBlockStop(partial(undefined))).toBe(false);
+  });
+});
+
+describe("isToolProgressMessage", () => {
+  it("identifies tool_progress messages", () => {
+    expect(isToolProgressMessage(toolProgress("Bash"))).toBe(true);
+  });
+
+  it("rejects other message types", () => {
+    expect(isToolProgressMessage(assistant([]) as unknown as SDKMessage)).toBe(false);
+    expect(isToolProgressMessage(resultSuccess("ok"))).toBe(false);
+  });
+});
+
+describe("extractAssistantText", () => {
+  it("concatenates every text block in order", () => {
+    const text = extractAssistantText(
+      assistant([
+        { type: "text", text: "hello " },
+        { type: "tool_use", name: "Read", input: {} },
+        { type: "text", text: "world" },
+      ]),
+    );
+    expect(text).toBe("hello world");
+  });
+
+  it("returns an empty string when content is missing", () => {
+    expect(extractAssistantText(assistant(undefined as unknown as unknown[]))).toBe("");
+  });
+
+  it("ignores non-text blocks", () => {
+    const text = extractAssistantText(
+      assistant([
+        { type: "tool_use", name: "Read", input: {} },
+        { type: "tool_result", content: "foo" },
+      ]),
+    );
+    expect(text).toBe("");
+  });
+});
+
+describe("isResultMessage", () => {
+  it("matches success and error result subtypes", () => {
+    expect(isResultMessage(resultSuccess("x"))).toBe(true);
+    expect(isResultMessage(resultError("error_during_execution", []))).toBe(true);
+  });
+
+  it("rejects non-result messages", () => {
+    expect(isResultMessage(toolProgress("x") as unknown as SDKMessage)).toBe(false);
+  });
+});
+
+describe("isSystemInitMessage", () => {
+  it("matches a system message with subtype: init", () => {
+    expect(isSystemInitMessage({ type: "system", subtype: "init" } as unknown as SDKMessage)).toBe(
+      true,
+    );
+  });
+
+  it("rejects non-init system messages", () => {
+    expect(isSystemInitMessage({ type: "system", subtype: "other" } as unknown as SDKMessage)).toBe(
+      false,
+    );
+  });
+
+  it("rejects messages of other types", () => {
+    expect(isSystemInitMessage(resultSuccess("x"))).toBe(false);
+  });
+});
+
+describe("emitResultOrError", () => {
+  it("emits stream-complete with msg.result on success", () => {
+    const calls: SidecarResponse[] = [];
+    emitResultOrError("q1", resultSuccess("final"), "agg", (r) => calls.push(r));
+    expect(calls).toEqual([{ type: "stream-complete", id: "q1", result: { content: "final" } }]);
+  });
+
+  it("falls back to aggregated text when msg.result is missing", () => {
+    const calls: SidecarResponse[] = [];
+    const msg = resultSuccess("");
+    // Simulate the SDK returning nullish `result` (e.g. older SDK versions).
+    // 古い SDK で result が null/undefined になるパスを模擬する。
+    (msg as { result?: string | null }).result = null;
+    emitResultOrError("q1", msg, "from-stream", (r) => calls.push(r));
+    expect(calls).toEqual([
+      { type: "stream-complete", id: "q1", result: { content: "from-stream" } },
+    ]);
+  });
+
+  it("joins error array with '; ' on error subtypes", () => {
+    const calls: SidecarResponse[] = [];
+    emitResultOrError("q1", resultError("error_during_execution", ["one", "two"]), "", (r) =>
+      calls.push(r),
+    );
+    expect(calls).toEqual([
+      {
+        type: "error",
+        id: "q1",
+        error: "one; two",
+        code: "error_during_execution",
+      },
+    ]);
+  });
+
+  it("falls back to a generic message when errors[] is empty", () => {
+    const calls: SidecarResponse[] = [];
+    emitResultOrError("q1", resultError("error_max_turns", []), "", (r) => calls.push(r));
+    expect(calls).toEqual([
+      {
+        type: "error",
+        id: "q1",
+        error: "Claude Code finished with subtype error_max_turns",
+        code: "error_max_turns",
+      },
+    ]);
+  });
+});
+
+// ── runQuery integration ────────────────────────────────────────────────────
+
+describe("runQuery", () => {
+  let writes: string[];
+  let tracker: QueryActivityTracker;
+
+  beforeEach(() => {
+    writes = [];
+    tracker = new QueryActivityTracker();
+    queryMock.mockReset();
+  });
+
+  afterEach(() => {
+    queryMock.mockReset();
+  });
+
+  /** Parse the JSONL writes into an array of SidecarResponse objects. / writeLine の出力を JSON にして返す */
+  function parsed(): SidecarResponse[] {
+    return writes.map((line) => JSON.parse(line.trim()) as SidecarResponse);
+  }
+
+  it("forwards default tools and options to the SDK and emits a stream-complete on success", async () => {
+    const messages: SDKMessage[] = [
+      // text delta -> stream-chunk
+      partial({
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "hi" },
+      }) as unknown as SDKMessage,
+      resultSuccess("hi"),
+    ];
+    queryMock.mockReturnValue(makeQueryIterable(messages));
+
+    const ac = new AbortController();
+    await runQuery({
+      id: "q1",
+      prompt: "say hi",
+      writeLine: (l) => writes.push(l),
+      abortController: ac,
+      tracker,
+    });
+
+    expect(queryMock).toHaveBeenCalledOnce();
+    const opts = queryMock.mock.calls[0]?.[0] as {
+      prompt: string;
+      options: Record<string, unknown>;
+    };
+    expect(opts.prompt).toBe("say hi");
+    expect(opts.options.allowedTools).toEqual(["Read", "Write", "Bash", "WebSearch"]);
+    expect(opts.options.maxTurns).toBe(25);
+    expect(opts.options.permissionMode).toBe("acceptEdits");
+    expect(opts.options.includePartialMessages).toBe(true);
+    expect(opts.options.mcpServers).toBeUndefined();
+
+    expect(parsed()).toEqual([
+      { type: "stream-chunk", id: "q1", content: "hi" },
+      { type: "stream-complete", id: "q1", result: { content: "hi" } },
+    ]);
+    // tracker は finally で end されるので最終的に idle に戻る / tracker ends in finally → idle
+    expect(tracker.snapshot().status).toBe("idle");
+  });
+
+  it("appends the mcp__* permission when mcpServers are provided", async () => {
+    queryMock.mockReturnValue(makeQueryIterable([resultSuccess("done")]));
+
+    await runQuery({
+      id: "q1",
+      prompt: "mcp",
+      mcpServers: { z: { command: "/bin/z" } },
+      writeLine: (l) => writes.push(l),
+      abortController: new AbortController(),
+      tracker,
+    });
+
+    const opts = queryMock.mock.calls[0]?.[0] as { options: { allowedTools: string[] } };
+    expect(opts.options.allowedTools).toEqual(["Read", "Write", "Bash", "WebSearch", "mcp__*"]);
+  });
+
+  it("respects an explicit allowedTools override", async () => {
+    queryMock.mockReturnValue(makeQueryIterable([resultSuccess("done")]));
+
+    await runQuery({
+      id: "q1",
+      prompt: "p",
+      allowedTools: ["Bash"],
+      writeLine: (l) => writes.push(l),
+      abortController: new AbortController(),
+      tracker,
+    });
+
+    const opts = queryMock.mock.calls[0]?.[0] as { options: { allowedTools: string[] } };
+    expect(opts.options.allowedTools).toEqual(["Bash"]);
+  });
+
+  it("emits tool-use-start and tool-use-complete around a tool block", async () => {
+    queryMock.mockReturnValue(
+      makeQueryIterable([
+        partial({
+          type: "content_block_start",
+          content_block: { type: "tool_use", name: "Read", input: '{"path":"a"}' },
+        }) as unknown as SDKMessage,
+        partial({ type: "content_block_stop" }) as unknown as SDKMessage,
+        resultSuccess("ok"),
+      ]),
+    );
+
+    await runQuery({
+      id: "q1",
+      prompt: "p",
+      writeLine: (l) => writes.push(l),
+      abortController: new AbortController(),
+      tracker,
+    });
+
+    expect(parsed()).toEqual([
+      { type: "tool-use-start", id: "q1", toolName: "Read", toolInput: '{"path":"a"}' },
+      { type: "tool-use-complete", id: "q1", toolName: "Read" },
+      { type: "stream-complete", id: "q1", result: { content: "ok" } },
+    ]);
+  });
+
+  it("aggregates text deltas before falling back to assistant slicing", async () => {
+    // partial deltas が "Hello " を集約した後、assistant は "Hello world" を持つ。
+    // 残りの " world" のみが新しい delta として出力されるはず。
+    // After "Hello " is aggregated via deltas, the assistant message contains
+    // "Hello world"; only the trailing " world" should be emitted as a new chunk.
+    queryMock.mockReturnValue(
+      makeQueryIterable([
+        partial({
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "Hello " },
+        }) as unknown as SDKMessage,
+        assistant([{ type: "text", text: "Hello world" }]) as unknown as SDKMessage,
+        resultSuccess("Hello world"),
+      ]),
+    );
+
+    await runQuery({
+      id: "q1",
+      prompt: "p",
+      writeLine: (l) => writes.push(l),
+      abortController: new AbortController(),
+      tracker,
+    });
+
+    expect(parsed()).toEqual([
+      { type: "stream-chunk", id: "q1", content: "Hello " },
+      { type: "stream-chunk", id: "q1", content: "world" },
+      { type: "stream-complete", id: "q1", result: { content: "Hello world" } },
+    ]);
+  });
+
+  it("starts a new tool when tool_progress reports a different tool, completing the previous one", async () => {
+    queryMock.mockReturnValue(
+      makeQueryIterable([
+        toolProgress("ToolA") as unknown as SDKMessage,
+        toolProgress("ToolA") as unknown as SDKMessage,
+        toolProgress("ToolB") as unknown as SDKMessage,
+        resultSuccess(""),
+      ]),
+    );
+
+    await runQuery({
+      id: "q1",
+      prompt: "p",
+      writeLine: (l) => writes.push(l),
+      abortController: new AbortController(),
+      tracker,
+    });
+
+    expect(parsed()).toEqual([
+      { type: "tool-use-start", id: "q1", toolName: "ToolA", toolInput: "" },
+      { type: "tool-use-complete", id: "q1", toolName: "ToolA" },
+      { type: "tool-use-start", id: "q1", toolName: "ToolB", toolInput: "" },
+      { type: "tool-use-complete", id: "q1", toolName: "ToolB" },
+      { type: "stream-complete", id: "q1", result: { content: "" } },
+    ]);
+  });
+
+  it("emits mcp-status when system init carries non-empty mcp_servers", async () => {
+    queryMock.mockReturnValue(
+      makeQueryIterable([
+        {
+          type: "system",
+          subtype: "init",
+          mcp_servers: [
+            {
+              name: "zedi",
+              status: "connected",
+              tools: [{ name: "search", description: "Find" }],
+            },
+            { name: "broken", status: "error", error: "boom" },
+          ],
+        } as unknown as SDKMessage,
+        resultSuccess(""),
+      ]),
+    );
+
+    await runQuery({
+      id: "q1",
+      prompt: "p",
+      writeLine: (l) => writes.push(l),
+      abortController: new AbortController(),
+      tracker,
+    });
+
+    const responses = parsed();
+    expect(responses[0]).toEqual({
+      type: "mcp-status",
+      id: "q1",
+      servers: [
+        {
+          name: "zedi",
+          status: "connected",
+          error: undefined,
+          tools: [{ name: "search", description: "Find" }],
+        },
+        { name: "broken", status: "error", error: "boom", tools: undefined },
+      ],
+    });
+  });
+
+  it("converts a result error into an error response", async () => {
+    queryMock.mockReturnValue(
+      makeQueryIterable([resultError("error_max_turns", ["limit reached"])]),
+    );
+
+    await runQuery({
+      id: "q1",
+      prompt: "p",
+      writeLine: (l) => writes.push(l),
+      abortController: new AbortController(),
+      tracker,
+    });
+
+    expect(parsed()).toEqual([
+      { type: "error", id: "q1", error: "limit reached", code: "error_max_turns" },
+    ]);
+  });
+
+  it("catches synchronous SDK exceptions and emits a query_exception error", async () => {
+    queryMock.mockImplementation(() => {
+      throw new Error("SDK exploded");
+    });
+
+    await runQuery({
+      id: "q1",
+      prompt: "p",
+      writeLine: (l) => writes.push(l),
+      abortController: new AbortController(),
+      tracker,
+    });
+
+    expect(parsed()).toEqual([
+      { type: "error", id: "q1", error: "SDK exploded", code: "query_exception" },
+    ]);
+    expect(tracker.snapshot().status).toBe("idle");
+  });
+
+  it("emits an aborted error when the abort signal is fired before the result arrives", async () => {
+    const ac = new AbortController();
+    // Trigger abort before iteration begins so the loop sees it on the first message.
+    // 反復開始前に abort して、最初のメッセージでループを抜けるようにする。
+    ac.abort();
+    queryMock.mockReturnValue(
+      makeQueryIterable([
+        partial({
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "x" },
+        }) as unknown as SDKMessage,
+      ]),
+    );
+
+    await runQuery({
+      id: "q1",
+      prompt: "p",
+      writeLine: (l) => writes.push(l),
+      abortController: ac,
+      tracker,
+    });
+
+    expect(parsed()).toEqual([
+      { type: "error", id: "q1", error: "Query aborted", code: "aborted" },
+    ]);
+  });
+
+  it("emits stream-complete with the aggregated text when the stream ends without a result", async () => {
+    queryMock.mockReturnValue(
+      makeQueryIterable([
+        partial({
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "partial" },
+        }) as unknown as SDKMessage,
+      ]),
+    );
+
+    await runQuery({
+      id: "q1",
+      prompt: "p",
+      writeLine: (l) => writes.push(l),
+      abortController: new AbortController(),
+      tracker,
+    });
+
+    expect(parsed()).toEqual([
+      { type: "stream-chunk", id: "q1", content: "partial" },
+      { type: "stream-complete", id: "q1", result: { content: "partial" } },
+    ]);
+  });
+});

--- a/packages/claude-sidecar/src/handlers/query.ts
+++ b/packages/claude-sidecar/src/handlers/query.ts
@@ -21,7 +21,13 @@ export type WriteLine = (line: string) => void;
 
 const DEFAULT_TOOLS = ["Read", "Write", "Bash", "WebSearch"] as const;
 
-function extractTextDelta(msg: SDKPartialAssistantMessage): string | null {
+/**
+ * Extracts a text delta from a `content_block_delta` stream event.
+ * `content_block_delta` ストリームイベントからテキスト delta を取り出す。
+ *
+ * @internal exported for unit testing only.
+ */
+export function extractTextDelta(msg: SDKPartialAssistantMessage): string | null {
   const ev = msg.event as unknown as Record<string, unknown> | undefined;
   if (!ev || typeof ev !== "object") return null;
   if (ev.type !== "content_block_delta") return null;
@@ -34,8 +40,10 @@ function extractTextDelta(msg: SDKPartialAssistantMessage): string | null {
 /**
  * Detects a tool_use content_block_start from a stream event.
  * ストリームイベントから tool_use の content_block_start を検出する。
+ *
+ * @internal exported for unit testing only.
  */
-function extractToolUseStart(
+export function extractToolUseStart(
   msg: SDKPartialAssistantMessage,
 ): { name: string; input: string } | null {
   const ev = msg.event as unknown as Record<string, unknown> | undefined;
@@ -51,17 +59,31 @@ function extractToolUseStart(
 /**
  * Detects a content_block_stop from a stream event (to mark tool use complete).
  * ストリームイベントから content_block_stop を検出する。
+ *
+ * @internal exported for unit testing only.
  */
-function isContentBlockStop(msg: SDKPartialAssistantMessage): boolean {
+export function isContentBlockStop(msg: SDKPartialAssistantMessage): boolean {
   const ev = msg.event as { type?: string } | undefined;
   return ev?.type === "content_block_stop";
 }
 
-function isToolProgressMessage(msg: SDKMessage): msg is SDKToolProgressMessage {
+/**
+ * Type guard for `tool_progress` messages emitted by the SDK.
+ * SDK が送出する `tool_progress` メッセージかを判定する型ガード。
+ *
+ * @internal exported for unit testing only.
+ */
+export function isToolProgressMessage(msg: SDKMessage): msg is SDKToolProgressMessage {
   return typeof msg === "object" && msg !== null && "type" in msg && msg.type === "tool_progress";
 }
 
-function extractAssistantText(msg: SDKAssistantMessage): string {
+/**
+ * Concatenates text blocks contained in an assistant message.
+ * assistant メッセージ内のテキストブロックを連結する。
+ *
+ * @internal exported for unit testing only.
+ */
+export function extractAssistantText(msg: SDKAssistantMessage): string {
   const message = msg.message as { content?: unknown };
   const content = message.content;
   if (!Array.isArray(content)) return "";
@@ -80,15 +102,23 @@ function extractAssistantText(msg: SDKAssistantMessage): string {
   return out;
 }
 
-function isResultMessage(msg: SDKMessage): msg is SDKResultMessage {
+/**
+ * Type guard for SDK `result` messages.
+ * SDK の `result` メッセージかを判定する型ガード。
+ *
+ * @internal exported for unit testing only.
+ */
+export function isResultMessage(msg: SDKMessage): msg is SDKResultMessage {
   return typeof msg === "object" && msg !== null && "type" in msg && msg.type === "result";
 }
 
 /**
  * Checks if a message is a system init message containing MCP server status.
  * system init メッセージ（MCP サーバーステータスを含む）かどうかを判定する。
+ *
+ * @internal exported for unit testing only.
  */
-function isSystemInitMessage(msg: SDKMessage): boolean {
+export function isSystemInitMessage(msg: SDKMessage): boolean {
   return (
     typeof msg === "object" &&
     msg !== null &&
@@ -102,8 +132,10 @@ function isSystemInitMessage(msg: SDKMessage): boolean {
 /**
  * Emits stream-complete on success or error line on failure.
  * 成功時は stream-complete、失敗時は error 行を出す。
+ *
+ * @internal exported for unit testing only.
  */
-function emitResultOrError(
+export function emitResultOrError(
   id: string,
   msg: SDKResultMessage,
   aggregated: string,

--- a/packages/claude-sidecar/src/handlers/status.test.ts
+++ b/packages/claude-sidecar/src/handlers/status.test.ts
@@ -1,0 +1,84 @@
+/**
+ * QueryActivityTracker のユニットテスト
+ *
+ * - start / end / clearAll の Set ベースの状態追跡
+ * - snapshot() の status / activeQueryIds が常に正しい形になること
+ *
+ * Unit tests for the {@link QueryActivityTracker} state machine.
+ */
+import { describe, expect, it } from "vitest";
+import { QueryActivityTracker } from "./status";
+
+describe("QueryActivityTracker", () => {
+  it("starts empty with status 'idle'", () => {
+    const tracker = new QueryActivityTracker();
+    const snap = tracker.snapshot();
+    expect(snap.status).toBe("idle");
+    expect(snap.activeQueryIds).toEqual([]);
+  });
+
+  it("transitions to 'processing' after start()", () => {
+    const tracker = new QueryActivityTracker();
+    tracker.start("q-1");
+    const snap = tracker.snapshot();
+    expect(snap.status).toBe("processing");
+    expect(snap.activeQueryIds).toEqual(["q-1"]);
+  });
+
+  it("returns to 'idle' after every running query ends", () => {
+    const tracker = new QueryActivityTracker();
+    tracker.start("q-1");
+    tracker.start("q-2");
+    tracker.end("q-1");
+    expect(tracker.snapshot().status).toBe("processing");
+    expect(tracker.snapshot().activeQueryIds).toEqual(["q-2"]);
+    tracker.end("q-2");
+    expect(tracker.snapshot()).toEqual({ status: "idle", activeQueryIds: [] });
+  });
+
+  it("dedupes duplicate start() calls (Set semantics)", () => {
+    // 重複 start でも 1 ID として扱う / Duplicate `start()` calls collapse to a single id.
+    const tracker = new QueryActivityTracker();
+    tracker.start("q-1");
+    tracker.start("q-1");
+    expect(tracker.snapshot().activeQueryIds).toEqual(["q-1"]);
+    tracker.end("q-1");
+    expect(tracker.snapshot().status).toBe("idle");
+  });
+
+  it("end() on an unknown id is a no-op", () => {
+    // 未知の ID を end() しても例外にならず状態も変えない / Unknown end() must not throw or mutate state.
+    const tracker = new QueryActivityTracker();
+    tracker.start("q-1");
+    expect(() => tracker.end("does-not-exist")).not.toThrow();
+    expect(tracker.snapshot().activeQueryIds).toEqual(["q-1"]);
+  });
+
+  it("clearAll() empties active ids without aborting controllers", () => {
+    // shutdown 用: 状態だけクリアし、AbortController には触れない / clearAll only clears tracked ids.
+    const tracker = new QueryActivityTracker();
+    tracker.start("a");
+    tracker.start("b");
+    tracker.clearAll();
+    expect(tracker.snapshot()).toEqual({ status: "idle", activeQueryIds: [] });
+  });
+
+  it("snapshot() returns an isolated array (mutation safety)", () => {
+    // 返却された配列を改変しても内部状態には影響しないこと / Returned array must be a copy.
+    const tracker = new QueryActivityTracker();
+    tracker.start("q-1");
+    const snap = tracker.snapshot();
+    snap.activeQueryIds.push("rogue");
+    expect(tracker.snapshot().activeQueryIds).toEqual(["q-1"]);
+  });
+
+  it("preserves insertion order of active query ids", () => {
+    // Set の挿入順を保つことに依存するクライアントがあるため、順序保証を明示する。
+    // Some clients depend on insertion order, so we explicitly assert it.
+    const tracker = new QueryActivityTracker();
+    tracker.start("third");
+    tracker.start("first");
+    tracker.start("second");
+    expect(tracker.snapshot().activeQueryIds).toEqual(["third", "first", "second"]);
+  });
+});

--- a/server/mcp/src/__tests__/tools/index.test.ts
+++ b/server/mcp/src/__tests__/tools/index.test.ts
@@ -1,0 +1,133 @@
+/**
+ * tools/index.ts のユニットテスト
+ *
+ * `server.test.ts` は MCP クライアント経由で end-to-end の挙動を見ているのに対し、
+ * このテストは `registerAllTools` と `ALL_TOOL_NAMES` のメタ情報の整合性を直接検証する。
+ *
+ * - `ALL_TOOL_NAMES` は重複なく zedi_ 接頭辞のみで構成されること
+ * - `registerAllTools(server, client)` は `ALL_TOOL_NAMES` の各要素を 1 度ずつ登録すること
+ * - 既存ツール定義の一覧と完全に一致すること（追加・削除のたぶん漏れを検知する）
+ *
+ * Unit tests for the registry contract: `registerAllTools` registers exactly the tools
+ * advertised in `ALL_TOOL_NAMES`. Catches silent additions or removals.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZediClient } from "../../client/ZediClient.js";
+import { ALL_TOOL_NAMES, registerAllTools } from "../../tools/index.js";
+
+/** Build a fully-mocked ZediClient. Tools call only the methods we register, so types are safe. /
+ *  全メソッドをモック化した ZediClient。 */
+function createMockClient(): ZediClient {
+  return {
+    getCurrentUser: vi.fn(),
+    listPages: vi.fn(),
+    getPageContent: vi.fn(),
+    createPage: vi.fn(),
+    updatePageContent: vi.fn(),
+    deletePage: vi.fn(),
+    listNotes: vi.fn(),
+    getNote: vi.fn(),
+    createNote: vi.fn(),
+    updateNote: vi.fn(),
+    deleteNote: vi.fn(),
+    addPageToNote: vi.fn(),
+    removePageFromNote: vi.fn(),
+    reorderNotePages: vi.fn(),
+    listNotePages: vi.fn(),
+    listNoteMembers: vi.fn(),
+    addNoteMember: vi.fn(),
+    updateNoteMember: vi.fn(),
+    removeNoteMember: vi.fn(),
+    search: vi.fn(),
+    clipUrl: vi.fn(),
+  };
+}
+
+/** Captures registerTool calls so we can assert which tools were registered. / 登録呼び出しを記録するスタブ */
+function createServerStub(): {
+  server: Pick<McpServer, "registerTool">;
+  registered: string[];
+} {
+  const registered: string[] = [];
+  const server = {
+    registerTool: ((name: string) => {
+      registered.push(name);
+      // Real `registerTool` returns a `RegisteredTool`, but tools/index.ts does not
+      // consume the return value, so a no-op stub is sufficient.
+      // 実装の戻り値は `RegisteredTool` だが、tools/index.ts は無視するため空 object を返す。
+      return {} as unknown;
+    }) as unknown as McpServer["registerTool"],
+  };
+  return { server: server as Pick<McpServer, "registerTool">, registered };
+}
+
+describe("ALL_TOOL_NAMES", () => {
+  it("contains no duplicates", () => {
+    const set = new Set(ALL_TOOL_NAMES);
+    expect(set.size).toBe(ALL_TOOL_NAMES.length);
+  });
+
+  it("uses the zedi_ prefix consistently", () => {
+    for (const name of ALL_TOOL_NAMES) {
+      expect(name).toMatch(/^zedi_[a-z0-9_]+$/);
+    }
+  });
+
+  it("includes the canonical user / pages / notes / search / clip surface", () => {
+    // 仕様凍結のため必須ツールを明示的に列挙する。/ Lock the canonical surface in tests so silent removals are caught.
+    const required = [
+      "zedi_get_current_user",
+      "zedi_list_pages",
+      "zedi_get_page",
+      "zedi_create_page",
+      "zedi_update_page_content",
+      "zedi_delete_page",
+      "zedi_list_notes",
+      "zedi_get_note",
+      "zedi_create_note",
+      "zedi_update_note",
+      "zedi_delete_note",
+      "zedi_list_note_pages",
+      "zedi_add_page_to_note",
+      "zedi_remove_page_from_note",
+      "zedi_reorder_note_pages",
+      "zedi_list_note_members",
+      "zedi_add_note_member",
+      "zedi_update_note_member",
+      "zedi_remove_note_member",
+      "zedi_search",
+      "zedi_clip_url",
+    ];
+    for (const name of required) {
+      expect(ALL_TOOL_NAMES).toContain(name);
+    }
+  });
+});
+
+describe("registerAllTools", () => {
+  it("registers exactly the tools listed in ALL_TOOL_NAMES (no extras, no missing)", () => {
+    const { server, registered } = createServerStub();
+    registerAllTools(server as unknown as McpServer, createMockClient());
+
+    expect(registered.sort()).toEqual([...ALL_TOOL_NAMES].sort());
+  });
+
+  it("registers each tool exactly once (no double registration)", () => {
+    const { server, registered } = createServerStub();
+    registerAllTools(server as unknown as McpServer, createMockClient());
+
+    const counts = new Map<string, number>();
+    for (const name of registered) counts.set(name, (counts.get(name) ?? 0) + 1);
+    for (const [name, count] of counts) {
+      expect(count, `tool ${name} should be registered once`).toBe(1);
+    }
+  });
+
+  it("registers ALL_TOOL_NAMES.length tools total", () => {
+    const { server, registered } = createServerStub();
+    registerAllTools(server as unknown as McpServer, createMockClient());
+
+    expect(registered).toHaveLength(ALL_TOOL_NAMES.length);
+  });
+});

--- a/server/mcp/src/__tests__/tools/index.test.ts
+++ b/server/mcp/src/__tests__/tools/index.test.ts
@@ -75,7 +75,19 @@ describe("ALL_TOOL_NAMES", () => {
   });
 
   it("includes the canonical user / pages / notes / search / clip surface", () => {
-    // 仕様凍結のため必須ツールを明示的に列挙する。/ Lock the canonical surface in tests so silent removals are caught.
+    // この list は意図的に `ALL_TOOL_NAMES` を二重化している。`registerAllTools` 側のテストは
+    // 「実装と `ALL_TOOL_NAMES` がズレないこと」しか保証しないので、両方を一括で消した
+    // (= 公開 API 縮退) 場合は検出できない。ここで仕様として固定したい一群のツール名を
+    // ハードコードしておくことで、その縮退を CI で確実に止める。新規ツール追加時にこの
+    // list の更新は不要 (`>=` 関係)、ただし既存ツールの削除/改名時は意図的な仕様変更として
+    // この list も併せて更新すること。
+    //
+    // This list intentionally duplicates `ALL_TOOL_NAMES`. The `registerAllTools` test only
+    // guarantees the registry stays consistent with `ALL_TOOL_NAMES`; if both were dropped
+    // together (i.e. a silent public-API regression) it would still pass. Locking the
+    // canonical surface here forces any tool removal/rename to be an explicit edit to this
+    // list, surfacing it in code review. Adding a new tool does NOT require touching this
+    // list (it's a "must contain" check, not an equality check).
     const required = [
       "zedi_get_current_user",
       "zedi_list_pages",


### PR DESCRIPTION
## 概要

複数のハンドラーモジュールに対する包括的なユニットテストスイートを追加しました。SDK のモック化により、ネットワークアクセスなしで動作する堅牢なテストを実現しています。

## 変更点

- **`packages/claude-sidecar/src/handlers/query.test.ts`** (新規): `runQuery` オーケストレーターと 7 つのストリーム抽出ヘルパー関数の表駆動テスト (641 行)
  - `extractTextDelta`, `extractToolUseStart`, `isContentBlockStop`, `isToolProgressMessage`, `extractAssistantText`, `isResultMessage`, `isSystemInitMessage`, `emitResultOrError` を検証
  - `runQuery` の end-to-end 動作を SDK モック化で検証（テキスト集約、ツール使用、エラーハンドリング、中止処理など）

- **`server/mcp/src/__tests__/tools/index.test.ts`** (新規): ツール登録メタデータの整合性テスト (133 行)
  - `ALL_TOOL_NAMES` に重複がなく、`zedi_` 接頭辞で統一されていることを検証
  - `registerAllTools` が `ALL_TOOL_NAMES` の各要素を正確に 1 度ずつ登録することを確認
  - 既存ツール定義との完全一致を保証（追加・削除漏れを検知）

- **`packages/claude-sidecar/src/handlers/installation.test.ts`** (新規): インストール確認ハンドラーのテスト (126 行)
  - `claudeVersionArgv` のプラットフォーム別分岐 (win32/darwin/linux) を検証
  - `Bun.spawn` をモック化し、終了コード 0/非 0、例外スロー、stdout/stderr フォールバックなどのシナリオをカバー

- **`packages/claude-sidecar/src/handlers/models.test.ts`** (新規): モデルリスト取得のテスト (114 行)
  - SDK `query()` のモック化により、初期化結果の `models` フィールドを `ClaudeModelInfo[]` にマップすることを検証
  - `finally` ブロックで `q.close()` が必ず呼ばれることを確認

- **`packages/claude-sidecar/src/handlers/status.test.ts`** (新規): クエリアクティビティトラッカーの状態機械テスト (84 行)
  - `start()` / `end()` / `clearAll()` による Set ベースの状態追跡を検証
  - `snapshot()` の `status` / `activeQueryIds` が常に正しい形になることを確認
  - 挿入順序保証、重複排除、ミューテーション安全性を検証

- **`packages/claude-sidecar/src/handlers/query.ts`** (修正): テスト用に 7 つのヘルパー関数を `export` に変更
  - `extractTextDelta`, `extractToolUseStart`, `isContentBlockStop`, `isToolProgressMessage`, `extractAssistantText`, `isResultMessage`, `isSystemInitMessage` に JSDoc コメント追加

- **`packages/claude-sidecar/src/handlers/installation.ts`** (修正): `claudeVersionArgv` を `export` に変更し、テスト用に `platform` パラメータを追加

## 変

https://claude.ai/code/session_01QqA7osjj26a4ZRNMiJB1rW
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
