### PR TITLE
test: add comprehensive unit tests for hooks, components, and API clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,17 @@ jobs:
 
       - run: bun run test:coverage
 
+      # Workspace package tests are not picked up by the root vitest config,
+      # so run their dedicated configs explicitly. Keep this list in sync with
+      # the `test:run` script in root package.json.
+      # ルートの vitest 設定はワークスペース配下のテストを含まないため、
+      # 各パッケージの vitest.config を明示的に実行する。
+      - name: Run @zedi/shared tests
+        run: bunx vitest run --config packages/shared/vitest.config.ts
+
+      - name: Run @zedi/ui tests
+        run: bunx vitest run --config packages/ui/vitest.config.ts
+
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,14 +100,23 @@ jobs:
 
       # Workspace package tests are not picked up by the root vitest config,
       # so run their dedicated configs explicitly. Keep this list in sync with
-      # the `test:run` script in root package.json.
+      # the `test:run` script in root package.json. server/mcp has its own job
+      # (`mcp-test`); server/hocuspocus is invoked only via `test:run` and not
+      # duplicated here.
       # ルートの vitest 設定はワークスペース配下のテストを含まないため、
-      # 各パッケージの vitest.config を明示的に実行する。
+      # 各パッケージの vitest.config を明示的に実行する。server/mcp は別 job
+      # （`mcp-test`）で動かすためここには含めない。
+      - name: Run admin tests
+        run: bunx vitest run --config admin/vitest.config.ts
+
       - name: Run @zedi/shared tests
         run: bunx vitest run --config packages/shared/vitest.config.ts
 
       - name: Run @zedi/ui tests
         run: bunx vitest run --config packages/ui/vitest.config.ts
+
+      - name: Run @zedi/claude-sidecar tests
+        run: bunx vitest run --config packages/claude-sidecar/vitest.config.ts
 
       - name: Upload coverage report
         if: always()

--- a/admin/src/api/activity.test.ts
+++ b/admin/src/api/activity.test.ts
@@ -28,7 +28,7 @@ describe("listActivity", () => {
     expect(adminFetch).toHaveBeenCalledWith("/api/activity");
   });
 
-  it("kind / actor / from / to / limit / offset を querystring に詰める", async () => {
+  it("kind / actor / from / to / limit / offset を querystring に詰める / packs kind/actor/from/to/limit/offset into querystring", async () => {
     vi.mocked(adminFetch).mockResolvedValueOnce(
       new Response(JSON.stringify({ entries: [], total: 0, limit: 10 }), { status: 200 }),
     );

--- a/admin/src/api/activity.test.ts
+++ b/admin/src/api/activity.test.ts
@@ -1,0 +1,118 @@
+/**
+ * activity API クライアントのテスト（adminFetch をモック）。
+ * Tests for the activity API client (adminFetch mocked).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { listActivity } from "./activity";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return {
+    ...actual,
+    adminFetch: vi.fn(),
+  };
+});
+
+const { adminFetch } = await import("./client");
+
+describe("listActivity", () => {
+  beforeEach(() => {
+    vi.mocked(adminFetch).mockReset();
+  });
+
+  it("パラメータ無しなら /api/activity を呼ぶ / hits /api/activity without params", async () => {
+    vi.mocked(adminFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ entries: [], total: 0, limit: 50 }), { status: 200 }),
+    );
+    await listActivity();
+    expect(adminFetch).toHaveBeenCalledWith("/api/activity");
+  });
+
+  it("kind / actor / from / to / limit / offset を querystring に詰める", async () => {
+    vi.mocked(adminFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ entries: [], total: 0, limit: 10 }), { status: 200 }),
+    );
+
+    await listActivity({
+      kind: "lint_run",
+      actor: "ai",
+      from: "2026-01-01T00:00:00Z",
+      to: "2026-02-01T00:00:00Z",
+      limit: 10,
+      offset: 20,
+    });
+
+    const calledWith = vi.mocked(adminFetch).mock.calls[0]?.[0];
+    expect(calledWith).toContain("/api/activity?");
+    const qs = new URLSearchParams((calledWith as string).split("?")[1] ?? "");
+    expect(qs.get("kind")).toBe("lint_run");
+    expect(qs.get("actor")).toBe("ai");
+    expect(qs.get("from")).toBe("2026-01-01T00:00:00Z");
+    expect(qs.get("to")).toBe("2026-02-01T00:00:00Z");
+    expect(qs.get("limit")).toBe("10");
+    expect(qs.get("offset")).toBe("20");
+  });
+
+  it("limit=0 は数値として扱う（offset 同様）/ accepts numeric 0 for limit and offset", async () => {
+    vi.mocked(adminFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ entries: [], total: 0, limit: 0 }), { status: 200 }),
+    );
+
+    await listActivity({ limit: 0, offset: 0 });
+    const calledWith = vi.mocked(adminFetch).mock.calls[0]?.[0] as string;
+    const qs = new URLSearchParams(calledWith.split("?")[1] ?? "");
+    expect(qs.get("limit")).toBe("0");
+    expect(qs.get("offset")).toBe("0");
+  });
+
+  it("undefined のキーは付けない / omits keys when undefined", async () => {
+    vi.mocked(adminFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ entries: [], total: 0, limit: 0 }), { status: 200 }),
+    );
+
+    await listActivity({ kind: "clip_ingest" });
+    const calledWith = vi.mocked(adminFetch).mock.calls[0]?.[0] as string;
+    const qs = new URLSearchParams(calledWith.split("?")[1] ?? "");
+    expect(qs.get("kind")).toBe("clip_ingest");
+    expect(qs.get("actor")).toBeNull();
+    expect(qs.get("from")).toBeNull();
+    expect(qs.get("limit")).toBeNull();
+    expect(qs.get("offset")).toBeNull();
+  });
+
+  it("200 なら ActivityListResponse を返す / returns ActivityListResponse on success", async () => {
+    const body = {
+      entries: [
+        {
+          id: "a1",
+          kind: "lint_run" as const,
+          actor: "system" as const,
+          target_page_ids: [],
+          detail: null,
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      total: 1,
+      limit: 50,
+    };
+    vi.mocked(adminFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(body), { status: 200 }),
+    );
+
+    await expect(listActivity()).resolves.toEqual(body);
+  });
+
+  it("!res.ok なら getErrorMessage 由来の Error を投げる / throws when response is not ok", async () => {
+    vi.mocked(adminFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "Forbidden" }), { status: 403 }),
+    );
+    await expect(listActivity()).rejects.toThrow("Forbidden");
+  });
+
+  it("body が空でも fallback メッセージで Error を投げる / throws fallback when body is empty", async () => {
+    vi.mocked(adminFetch).mockResolvedValueOnce(
+      new Response(null, { status: 500, statusText: "" }),
+    );
+    await expect(listActivity()).rejects.toThrow("Failed to fetch activity entries");
+  });
+});

--- a/admin/src/api/client.test.ts
+++ b/admin/src/api/client.test.ts
@@ -53,14 +53,12 @@ describe("getErrorMessage", () => {
 });
 
 describe("adminFetch", () => {
-  const originalFetch = globalThis.fetch;
-
   beforeEach(() => {
-    globalThis.fetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("ok", { status: 200 })));
   });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    vi.unstubAllGlobals();
   });
 
   it("credentials: include を必ず指定する / always sets credentials: 'include'", async () => {

--- a/admin/src/api/client.test.ts
+++ b/admin/src/api/client.test.ts
@@ -1,0 +1,108 @@
+/**
+ * adminFetch / getErrorMessage の単体テスト。
+ * Unit tests for adminFetch / getErrorMessage.
+ *
+ * `adminFetch` は global の `fetch` をモックして検証し、
+ * `getErrorMessage` は `Response` を直接組み立てて分岐を網羅する。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { adminFetch, getErrorMessage } from "./client";
+
+describe("getErrorMessage", () => {
+  it("レスポンス JSON の message を trim して返す / returns trimmed message from JSON body", async () => {
+    const res = new Response(JSON.stringify({ message: "  Boom  " }), { status: 500 });
+    await expect(getErrorMessage(res, "fallback")).resolves.toBe("Boom");
+  });
+
+  it("message が無い場合は statusText を使う / falls back to statusText when message is missing", async () => {
+    const res = new Response(JSON.stringify({ other: "x" }), {
+      status: 503,
+      statusText: "Service Unavailable",
+    });
+    await expect(getErrorMessage(res, "fallback")).resolves.toBe("Service Unavailable");
+  });
+
+  it("body が JSON でない場合も statusText に倒す / uses statusText when body is not JSON", async () => {
+    const res = new Response("not-json-body", {
+      status: 502,
+      statusText: "Bad Gateway",
+    });
+    await expect(getErrorMessage(res, "fallback")).resolves.toBe("Bad Gateway");
+  });
+
+  it("message が空白だけのとき fallback を返す / returns fallback when message is blank", async () => {
+    const res = new Response(JSON.stringify({ message: "   " }), {
+      status: 500,
+      statusText: "",
+    });
+    await expect(getErrorMessage(res, "fallback")).resolves.toBe("fallback");
+  });
+
+  it("message が文字列以外なら無視して statusText / fallback を使う / ignores non-string message", async () => {
+    const res = new Response(JSON.stringify({ message: 42 }), {
+      status: 500,
+      statusText: "",
+    });
+    await expect(getErrorMessage(res, "fallback")).resolves.toBe("fallback");
+  });
+
+  it("statusText も空のとき fallback を返す / returns fallback when both message and statusText are empty", async () => {
+    const res = new Response(null, { status: 500, statusText: "" });
+    await expect(getErrorMessage(res, "fallback")).resolves.toBe("fallback");
+  });
+});
+
+describe("adminFetch", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("credentials: include を必ず指定する / always sets credentials: 'include'", async () => {
+    await adminFetch("/api/foo");
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/foo",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+
+  it("body があるとき Content-Type: application/json を付与する / sets JSON content-type when body is present", async () => {
+    await adminFetch("/api/foo", { method: "POST", body: JSON.stringify({ a: 1 }) });
+    const call = vi.mocked(globalThis.fetch).mock.calls[0];
+    const init = call?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("FormData の場合は Content-Type を勝手に付けない / does not override Content-Type for FormData body", async () => {
+    const fd = new FormData();
+    fd.append("k", "v");
+    await adminFetch("/api/foo", { method: "POST", body: fd });
+    const call = vi.mocked(globalThis.fetch).mock.calls[0];
+    const init = call?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get("Content-Type")).toBeNull();
+  });
+
+  it("呼び出し側で Content-Type を指定したらそのまま使う / preserves caller-supplied Content-Type", async () => {
+    await adminFetch("/api/foo", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: "hi",
+    });
+    const call = vi.mocked(globalThis.fetch).mock.calls[0];
+    const init = call?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get("Content-Type")).toBe("text/plain");
+  });
+
+  it("先頭に / が無いパスでも / を付ける / normalises path without leading slash", async () => {
+    await adminFetch("api/foo");
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/foo", expect.any(Object));
+  });
+});

--- a/admin/src/api/lint.test.ts
+++ b/admin/src/api/lint.test.ts
@@ -1,0 +1,107 @@
+/**
+ * lint API クライアントのテスト（adminFetch をモック）。
+ * Tests for the lint API client (adminFetch mocked).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runLint, getLintFindings, resolveLintFinding } from "./lint";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return {
+    ...actual,
+    adminFetch: vi.fn(),
+  };
+});
+
+const { adminFetch } = await import("./client");
+
+describe("runLint", () => {
+  beforeEach(() => {
+    vi.mocked(adminFetch).mockReset();
+  });
+
+  it("POST /api/lint/run を呼んで結果を返す / posts to /api/lint/run", async () => {
+    vi.mocked(adminFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ summary: [{ rule: "orphan", count: 2 }], total: 2 }), {
+        status: 200,
+      }),
+    );
+    const result = await runLint();
+    expect(result.total).toBe(2);
+    expect(result.summary[0]).toEqual({ rule: "orphan", count: 2 });
+    expect(adminFetch).toHaveBeenCalledWith("/api/lint/run", { method: "POST" });
+  });
+
+  it("!res.ok なら fallback で Error を投げる / throws on failure", async () => {
+    vi.mocked(adminFetch).mockResolvedValueOnce(
+      new Response(null, { status: 500, statusText: "" }),
+    );
+    await expect(runLint()).rejects.toThrow("Failed to run lint");
+  });
+});
+
+describe("getLintFindings", () => {
+  beforeEach(() => {
+    vi.mocked(adminFetch).mockReset();
+  });
+
+  it("findings と total を返す / returns findings and total", async () => {
+    const findings = [
+      {
+        id: "f1",
+        rule: "orphan" as const,
+        severity: "warn" as const,
+        page_ids: ["p1"],
+        detail: { reason: "no inbound link" },
+        created_at: "2026-01-01T00:00:00Z",
+        resolved_at: null,
+      },
+    ];
+    vi.mocked(adminFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ findings, total: 1 }), { status: 200 }),
+    );
+    const out = await getLintFindings();
+    expect(out).toEqual({ findings, total: 1 });
+    expect(adminFetch).toHaveBeenCalledWith("/api/lint/findings");
+  });
+
+  it("!res.ok なら body の message でエラーになる / surfaces server error message", async () => {
+    vi.mocked(adminFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "Forbidden" }), { status: 403 }),
+    );
+    await expect(getLintFindings()).rejects.toThrow("Forbidden");
+  });
+});
+
+describe("resolveLintFinding", () => {
+  beforeEach(() => {
+    vi.mocked(adminFetch).mockReset();
+  });
+
+  it("id を URL エンコードして POST する / encodes id and POSTs", async () => {
+    const finding = {
+      id: "lint:1/2",
+      rule: "ghost_many" as const,
+      severity: "info" as const,
+      page_ids: [],
+      detail: {},
+      created_at: "2026-01-01T00:00:00Z",
+      resolved_at: "2026-01-02T00:00:00Z",
+    };
+    vi.mocked(adminFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ finding }), { status: 200 }),
+    );
+    const out = await resolveLintFinding("lint:1/2");
+    expect(out.finding).toEqual(finding);
+    expect(adminFetch).toHaveBeenCalledWith("/api/lint/findings/lint%3A1%2F2/resolve", {
+      method: "POST",
+    });
+  });
+
+  it("!res.ok なら fallback で Error を投げる / throws on failure", async () => {
+    vi.mocked(adminFetch).mockResolvedValueOnce(
+      new Response(null, { status: 500, statusText: "" }),
+    );
+    await expect(resolveLintFinding("x")).rejects.toThrow("Failed to resolve finding");
+  });
+});

--- a/admin/src/lib/dateUtils.test.ts
+++ b/admin/src/lib/dateUtils.test.ts
@@ -1,0 +1,24 @@
+/**
+ * formatDate のテスト。
+ * Tests for formatDate.
+ */
+import { describe, it, expect } from "vitest";
+import { formatDate } from "./dateUtils";
+
+describe("formatDate", () => {
+  it("ISO 8601 を YYYY/MM/DD（ja-JP）に整形する / formats ISO date in ja-JP locale", () => {
+    expect(formatDate("2026-04-25T01:23:45Z")).toBe("2026/04/25");
+  });
+
+  it("月日が 1 桁でも 0 埋めされる / zero-pads single-digit month/day", () => {
+    expect(formatDate("2026-01-02T00:00:00Z")).toBe("2026/01/02");
+  });
+
+  it("不正な日付文字列はそのまま返す / returns input as-is for invalid date", () => {
+    expect(formatDate("not-a-date")).toBe("not-a-date");
+  });
+
+  it("空文字も入力をそのまま返す / returns empty input as-is", () => {
+    expect(formatDate("")).toBe("");
+  });
+});

--- a/admin/src/pages/ai-models/useAiModelActions.test.ts
+++ b/admin/src/pages/ai-models/useAiModelActions.test.ts
@@ -1,0 +1,283 @@
+/**
+ * useAiModelActions のテスト。
+ * - 楽観的更新 → 失敗時 rollback / optimistic update with rollback
+ * - mounted ref が false の間は state 更新しない / no state mutation when unmounted
+ *
+ * Tests for useAiModelActions.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useAiModelActions } from "./useAiModelActions";
+import type { AiModelAdmin } from "@/api/admin";
+
+vi.mock("@/api/admin", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/admin")>();
+  return {
+    ...actual,
+    patchAiModel: vi.fn(),
+  };
+});
+
+const { patchAiModel } = await import("@/api/admin");
+
+const baseModel: AiModelAdmin = {
+  id: "openai:gpt-4",
+  provider: "openai",
+  modelId: "gpt-4",
+  displayName: "GPT-4",
+  tierRequired: "pro",
+  inputCostUnits: 100,
+  outputCostUnits: 100,
+  isActive: true,
+  sortOrder: 0,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+interface Refs {
+  models: AiModelAdmin[];
+  setModels: ReturnType<typeof vi.fn>;
+  setError: ReturnType<typeof vi.fn>;
+  isMountedRef: { current: boolean };
+  originalModelsRef: { current: AiModelAdmin[] };
+}
+
+function createRefs(initial: AiModelAdmin[] = [baseModel]): Refs {
+  // setState 互換の更新関数を受け付け、内部配列を更新する
+  // Accepts either next-state value or updater fn (matches React.SetStateAction)
+  let models = initial;
+  const setModels = vi.fn(
+    (updater: AiModelAdmin[] | ((prev: AiModelAdmin[]) => AiModelAdmin[])) => {
+      models =
+        typeof updater === "function"
+          ? (updater as (p: AiModelAdmin[]) => AiModelAdmin[])(models)
+          : updater;
+    },
+  );
+  return {
+    get models() {
+      return models;
+    },
+    setModels,
+    setError: vi.fn(),
+    isMountedRef: { current: true },
+    originalModelsRef: { current: [...initial] },
+  };
+}
+
+describe("useAiModelActions.handleModelUpdate", () => {
+  beforeEach(() => {
+    vi.mocked(patchAiModel).mockReset();
+  });
+
+  it("成功時: 楽観的更新 → originalModelsRef も更新される / optimistic update + originalModelsRef sync", async () => {
+    vi.mocked(patchAiModel).mockResolvedValueOnce({ ...baseModel, displayName: "GPT-4 Updated" });
+    const refs = createRefs();
+    const { result } = renderHook(() =>
+      useAiModelActions({
+        setModels: refs.setModels as never,
+        setError: refs.setError as never,
+        isMountedRef: refs.isMountedRef as never,
+        originalModelsRef: refs.originalModelsRef as never,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleModelUpdate(baseModel, { displayName: "GPT-4 Updated" });
+    });
+
+    // setError(null) で先に reset されている
+    expect(refs.setError).toHaveBeenCalledWith(null);
+    // setModels が楽観的更新で 1 回呼ばれる
+    expect(refs.setModels).toHaveBeenCalledTimes(1);
+    expect(refs.models[0]?.displayName).toBe("GPT-4 Updated");
+    // originalModelsRef も更新される
+    expect(refs.originalModelsRef.current[0]?.displayName).toBe("GPT-4 Updated");
+  });
+
+  it("失敗時: rollback して setError に message を渡す / rollbacks and surfaces error", async () => {
+    vi.mocked(patchAiModel).mockRejectedValueOnce(new Error("nope"));
+    const refs = createRefs();
+    const { result } = renderHook(() =>
+      useAiModelActions({
+        setModels: refs.setModels as never,
+        setError: refs.setError as never,
+        isMountedRef: refs.isMountedRef as never,
+        originalModelsRef: refs.originalModelsRef as never,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleModelUpdate(baseModel, { displayName: "broken" });
+    });
+
+    // 楽観的更新（1回目） + rollback（2回目）= 2 回呼ばれる
+    expect(refs.setModels).toHaveBeenCalledTimes(2);
+    // rollback 後は元の値に戻っている
+    expect(refs.models[0]?.displayName).toBe("GPT-4");
+    expect(refs.setError).toHaveBeenLastCalledWith("nope");
+    // 例外オブジェクトが Error 以外でも対応する別ケースは下のテスト
+  });
+
+  it("Error 以外を投げたとき String() 化して setError する / stringifies non-Error throws", async () => {
+    vi.mocked(patchAiModel).mockRejectedValueOnce("oops");
+    const refs = createRefs();
+    const { result } = renderHook(() =>
+      useAiModelActions({
+        setModels: refs.setModels as never,
+        setError: refs.setError as never,
+        isMountedRef: refs.isMountedRef as never,
+        originalModelsRef: refs.originalModelsRef as never,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleModelUpdate(baseModel, { displayName: "x" });
+    });
+    expect(refs.setError).toHaveBeenLastCalledWith("oops");
+  });
+
+  it("isMountedRef が false なら早期 return（成功前にアンマウント）/ short-circuits before any state update if unmounted", async () => {
+    const refs = createRefs();
+    refs.isMountedRef.current = false;
+
+    const { result } = renderHook(() =>
+      useAiModelActions({
+        setModels: refs.setModels as never,
+        setError: refs.setError as never,
+        isMountedRef: refs.isMountedRef as never,
+        originalModelsRef: refs.originalModelsRef as never,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleModelUpdate(baseModel, { displayName: "x" });
+    });
+
+    expect(refs.setError).not.toHaveBeenCalled();
+    expect(refs.setModels).not.toHaveBeenCalled();
+    expect(patchAiModel).not.toHaveBeenCalled();
+  });
+
+  it("失敗 + アンマウント済みなら rollback も skip する / skips rollback if unmounted between request and failure", async () => {
+    let resolveReject: (() => void) | null = null;
+    vi.mocked(patchAiModel).mockReturnValueOnce(
+      new Promise((_, reject) => {
+        resolveReject = () => reject(new Error("late"));
+      }) as never,
+    );
+    const refs = createRefs();
+    const { result } = renderHook(() =>
+      useAiModelActions({
+        setModels: refs.setModels as never,
+        setError: refs.setError as never,
+        isMountedRef: refs.isMountedRef as never,
+        originalModelsRef: refs.originalModelsRef as never,
+      }),
+    );
+
+    let pending: Promise<void>;
+    await act(async () => {
+      pending = result.current.handleModelUpdate(baseModel, { displayName: "x" });
+    });
+
+    // 楽観的更新（1回目）は走った後にアンマウント
+    expect(refs.setModels).toHaveBeenCalledTimes(1);
+    refs.isMountedRef.current = false;
+
+    await act(async () => {
+      resolveReject?.();
+      await pending;
+    });
+
+    // rollback は呼ばれず、setModels は依然 1 回のまま
+    expect(refs.setModels).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useAiModelActions.handleToggleActive", () => {
+  beforeEach(() => {
+    vi.mocked(patchAiModel).mockReset();
+  });
+
+  it("originalModel が無いと何もしない / no-op when original model is missing", async () => {
+    vi.mocked(patchAiModel).mockResolvedValueOnce(baseModel);
+    const refs = createRefs();
+    refs.originalModelsRef.current = [];
+    const { result } = renderHook(() =>
+      useAiModelActions({
+        setModels: refs.setModels as never,
+        setError: refs.setError as never,
+        isMountedRef: refs.isMountedRef as never,
+        originalModelsRef: refs.originalModelsRef as never,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleToggleActive(baseModel);
+    });
+
+    expect(patchAiModel).not.toHaveBeenCalled();
+  });
+
+  it("isActive を反転して PATCH する / toggles isActive based on current value", async () => {
+    vi.mocked(patchAiModel).mockResolvedValueOnce({ ...baseModel, isActive: false });
+    const refs = createRefs();
+    const { result } = renderHook(() =>
+      useAiModelActions({
+        setModels: refs.setModels as never,
+        setError: refs.setError as never,
+        isMountedRef: refs.isMountedRef as never,
+        originalModelsRef: refs.originalModelsRef as never,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleToggleActive(baseModel);
+    });
+
+    expect(patchAiModel).toHaveBeenCalledWith(baseModel.id, { isActive: false });
+  });
+});
+
+describe("useAiModelActions.handleTierChange", () => {
+  beforeEach(() => {
+    vi.mocked(patchAiModel).mockReset();
+  });
+
+  it("同じ tier なら no-op / skips when tier is unchanged", async () => {
+    const refs = createRefs();
+    const { result } = renderHook(() =>
+      useAiModelActions({
+        setModels: refs.setModels as never,
+        setError: refs.setError as never,
+        isMountedRef: refs.isMountedRef as never,
+        originalModelsRef: refs.originalModelsRef as never,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleTierChange(baseModel, "pro");
+    });
+
+    expect(patchAiModel).not.toHaveBeenCalled();
+  });
+
+  it("tier を変更して PATCH する / sends new tier", async () => {
+    vi.mocked(patchAiModel).mockResolvedValueOnce({ ...baseModel, tierRequired: "free" });
+    const refs = createRefs();
+    const { result } = renderHook(() =>
+      useAiModelActions({
+        setModels: refs.setModels as never,
+        setError: refs.setError as never,
+        isMountedRef: refs.isMountedRef as never,
+        originalModelsRef: refs.originalModelsRef as never,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleTierChange(baseModel, "free");
+    });
+
+    expect(patchAiModel).toHaveBeenCalledWith(baseModel.id, { tierRequired: "free" });
+  });
+});

--- a/admin/src/pages/ai-models/useAiModelsDragReorder.test.ts
+++ b/admin/src/pages/ai-models/useAiModelsDragReorder.test.ts
@@ -1,0 +1,278 @@
+/**
+ * useAiModelsDragReorder のテスト。
+ * - 並び替えと永続化の楽観的更新 / optimistic reorder + persist
+ * - エラー時の load() による recovery / load() recovery on failure
+ *
+ * Tests for useAiModelsDragReorder.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useAiModelsDragReorder } from "./useAiModelsDragReorder";
+import type { AiModelAdmin } from "@/api/admin";
+
+vi.mock("@/api/admin", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/admin")>();
+  return {
+    ...actual,
+    patchAiModelsBulk: vi.fn(),
+  };
+});
+
+const { patchAiModelsBulk } = await import("@/api/admin");
+
+const makeModel = (id: string, sortOrder: number): AiModelAdmin => ({
+  id,
+  provider: "openai",
+  modelId: id,
+  displayName: id.toUpperCase(),
+  tierRequired: "pro",
+  inputCostUnits: 100,
+  outputCostUnits: 100,
+  isActive: true,
+  sortOrder,
+  createdAt: "2026-01-01T00:00:00Z",
+});
+
+type LoadFn = (showLoading?: boolean) => Promise<void>;
+
+interface Args {
+  models: AiModelAdmin[];
+  setModels: ReturnType<typeof vi.fn>;
+  setError: ReturnType<typeof vi.fn>;
+  isMountedRef: { current: boolean };
+  load: LoadFn & ReturnType<typeof vi.fn>;
+}
+
+function createArgs(models: AiModelAdmin[]): Args {
+  // `load` の型は (showLoading?: boolean) => Promise<void> なので、
+  // Mock の汎用シグネチャを LoadFn にキャストして型エラーを回避する。
+  // Cast vi.fn() to LoadFn so the hook's `load` prop type is satisfied.
+  const load = vi.fn().mockResolvedValue(undefined) as ReturnType<typeof vi.fn> & LoadFn;
+  return {
+    models,
+    setModels: vi.fn(),
+    setError: vi.fn(),
+    isMountedRef: { current: true },
+    load,
+  };
+}
+
+function makeDragEvent(payload: Record<string, string> = {}) {
+  const data = new Map<string, string>(Object.entries(payload));
+  return {
+    preventDefault: vi.fn(),
+    dataTransfer: {
+      effectAllowed: "",
+      dropEffect: "",
+      setData: (k: string, v: string) => data.set(k, v),
+      getData: (k: string) => data.get(k) ?? "",
+    },
+  } as unknown as React.DragEvent;
+}
+
+describe("useAiModelsDragReorder.handleReorder", () => {
+  beforeEach(() => {
+    vi.mocked(patchAiModelsBulk).mockReset();
+  });
+
+  it("配列を並び替えて sortOrder を採番し直し、API を呼ぶ / reorders and persists with re-numbered sortOrder", async () => {
+    vi.mocked(patchAiModelsBulk).mockResolvedValueOnce({ updated: 3, models: [] });
+    const models = [makeModel("a", 0), makeModel("b", 1), makeModel("c", 2)];
+    const args = createArgs(models);
+
+    const { result } = renderHook(() =>
+      useAiModelsDragReorder({
+        models: args.models,
+        setModels: args.setModels as never,
+        setError: args.setError as never,
+        isMountedRef: args.isMountedRef as never,
+        load: args.load,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleDragStart;
+      // 0 → 2 の入れ替え（a を末尾に） / move "a" to the end
+      await (result.current as unknown as { handleReorder: typeof result.current.handleDrop }); // 型回避
+    });
+
+    // 直接 handleReorder を呼べないため hook 内部の handleDrop 経由で再現
+    // a → c 上にドロップで 0 → 2 を発火
+    const ev = makeDragEvent({ "text/plain": "a" });
+    await act(async () => {
+      result.current.handleDrop(ev, "c");
+      // microtask 1 周
+      await Promise.resolve();
+    });
+
+    // 楽観的に setModels が呼ばれている
+    expect(args.setModels).toHaveBeenCalledTimes(1);
+    const updater = args.setModels.mock.calls[0]?.[0] as AiModelAdmin[];
+    expect(updater.map((m) => m.id)).toEqual(["b", "c", "a"]);
+    expect(updater.map((m) => m.sortOrder)).toEqual([0, 1, 2]);
+    expect(patchAiModelsBulk).toHaveBeenCalledWith([
+      { id: "b", sortOrder: 0 },
+      { id: "c", sortOrder: 1 },
+      { id: "a", sortOrder: 2 },
+    ]);
+  });
+
+  it("API が失敗したら load(false) で再取得し、setError にメッセージを渡す / falls back to load() and surfaces error", async () => {
+    vi.mocked(patchAiModelsBulk).mockRejectedValueOnce(new Error("server-down"));
+    const args = createArgs([makeModel("a", 0), makeModel("b", 1)]);
+
+    const { result } = renderHook(() =>
+      useAiModelsDragReorder({
+        models: args.models,
+        setModels: args.setModels as never,
+        setError: args.setError as never,
+        isMountedRef: args.isMountedRef as never,
+        load: args.load,
+      }),
+    );
+
+    await act(async () => {
+      result.current.handleDrop(makeDragEvent({ "text/plain": "a" }), "b");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(args.load).toHaveBeenCalledWith(false);
+    expect(args.setError).toHaveBeenLastCalledWith("server-down");
+  });
+
+  it("失敗時に既にアンマウントなら load も setError も呼ばない / skip recovery when unmounted", async () => {
+    let rejectFn: (() => void) | null = null;
+    vi.mocked(patchAiModelsBulk).mockReturnValueOnce(
+      new Promise((_, reject) => {
+        rejectFn = () => reject(new Error("late"));
+      }) as never,
+    );
+    const args = createArgs([makeModel("a", 0), makeModel("b", 1)]);
+
+    const { result } = renderHook(() =>
+      useAiModelsDragReorder({
+        models: args.models,
+        setModels: args.setModels as never,
+        setError: args.setError as never,
+        isMountedRef: args.isMountedRef as never,
+        load: args.load,
+      }),
+    );
+
+    await act(async () => {
+      result.current.handleDrop(makeDragEvent({ "text/plain": "a" }), "b");
+      await Promise.resolve();
+    });
+
+    args.isMountedRef.current = false;
+    await act(async () => {
+      rejectFn?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(args.load).not.toHaveBeenCalled();
+    expect(args.setError).toHaveBeenCalledTimes(1); // 楽観的更新時の null reset のみ
+    expect(args.setError).toHaveBeenCalledWith(null);
+  });
+
+  it("fromIndex === toIndex の場合は何もしない / no-op when index is the same", async () => {
+    const args = createArgs([makeModel("a", 0)]);
+    const { result } = renderHook(() =>
+      useAiModelsDragReorder({
+        models: args.models,
+        setModels: args.setModels as never,
+        setError: args.setError as never,
+        isMountedRef: args.isMountedRef as never,
+        load: args.load,
+      }),
+    );
+
+    await act(async () => {
+      result.current.handleDrop(makeDragEvent({ "text/plain": "a" }), "a");
+      await Promise.resolve();
+    });
+
+    expect(args.setModels).not.toHaveBeenCalled();
+    expect(patchAiModelsBulk).not.toHaveBeenCalled();
+  });
+});
+
+describe("useAiModelsDragReorder drag state", () => {
+  it("handleDragStart で draggedId を設定し、dataTransfer に id を入れる", () => {
+    const args = createArgs([makeModel("a", 0)]);
+    const { result } = renderHook(() =>
+      useAiModelsDragReorder({
+        models: args.models,
+        setModels: args.setModels as never,
+        setError: args.setError as never,
+        isMountedRef: args.isMountedRef as never,
+        load: args.load,
+      }),
+    );
+
+    const ev = makeDragEvent();
+    act(() => {
+      result.current.handleDragStart(ev, "a");
+    });
+
+    expect(result.current.draggedId).toBe("a");
+    expect(ev.dataTransfer.effectAllowed).toBe("move");
+    expect(ev.dataTransfer.getData("text/plain")).toBe("a");
+    expect(JSON.parse(ev.dataTransfer.getData("application/json"))).toEqual({ id: "a" });
+  });
+
+  it("handleDragOver で dragOverId を設定し preventDefault を呼ぶ", () => {
+    const args = createArgs([makeModel("a", 0)]);
+    const { result } = renderHook(() =>
+      useAiModelsDragReorder({
+        models: args.models,
+        setModels: args.setModels as never,
+        setError: args.setError as never,
+        isMountedRef: args.isMountedRef as never,
+        load: args.load,
+      }),
+    );
+
+    const ev = makeDragEvent();
+    act(() => {
+      result.current.handleDragOver(ev, "a");
+    });
+
+    expect(ev.preventDefault).toHaveBeenCalled();
+    expect(ev.dataTransfer.dropEffect).toBe("move");
+    expect(result.current.dragOverId).toBe("a");
+  });
+
+  it("handleDragEnd / handleDragLeave で id 状態がクリアされる", () => {
+    const args = createArgs([makeModel("a", 0)]);
+    const { result } = renderHook(() =>
+      useAiModelsDragReorder({
+        models: args.models,
+        setModels: args.setModels as never,
+        setError: args.setError as never,
+        isMountedRef: args.isMountedRef as never,
+        load: args.load,
+      }),
+    );
+
+    act(() => {
+      result.current.handleDragStart(makeDragEvent(), "a");
+      result.current.handleDragOver(makeDragEvent(), "a");
+    });
+    expect(result.current.draggedId).toBe("a");
+
+    act(() => {
+      result.current.handleDragEnd();
+    });
+    expect(result.current.draggedId).toBeNull();
+    expect(result.current.dragOverId).toBeNull();
+
+    act(() => {
+      result.current.handleDragOver(makeDragEvent(), "a");
+      result.current.handleDragLeave();
+    });
+    expect(result.current.dragOverId).toBeNull();
+  });
+});

--- a/admin/src/pages/ai-models/useAiModelsDragReorder.test.ts
+++ b/admin/src/pages/ai-models/useAiModelsDragReorder.test.ts
@@ -193,7 +193,7 @@ describe("useAiModelsDragReorder.handleReorder", () => {
 });
 
 describe("useAiModelsDragReorder drag state", () => {
-  it("handleDragStart で draggedId を設定し、dataTransfer に id を入れる", () => {
+  it("handleDragStart で draggedId を設定し、dataTransfer に id を入れる / sets draggedId and writes id to dataTransfer", () => {
     const args = createArgs([makeModel("a", 0)]);
     const { result } = renderHook(() =>
       useAiModelsDragReorder({
@@ -216,7 +216,7 @@ describe("useAiModelsDragReorder drag state", () => {
     expect(JSON.parse(ev.dataTransfer.getData("application/json"))).toEqual({ id: "a" });
   });
 
-  it("handleDragOver で dragOverId を設定し preventDefault を呼ぶ", () => {
+  it("handleDragOver で dragOverId を設定し preventDefault を呼ぶ / sets dragOverId and calls preventDefault", () => {
     const args = createArgs([makeModel("a", 0)]);
     const { result } = renderHook(() =>
       useAiModelsDragReorder({
@@ -238,7 +238,7 @@ describe("useAiModelsDragReorder drag state", () => {
     expect(result.current.dragOverId).toBe("a");
   });
 
-  it("handleDragEnd / handleDragLeave で id 状態がクリアされる", () => {
+  it("handleDragEnd / handleDragLeave で id 状態がクリアされる / clears drag id state on drag end/leave", () => {
     const args = createArgs([makeModel("a", 0)]);
     const { result } = renderHook(() =>
       useAiModelsDragReorder({

--- a/admin/src/pages/ai-models/useAiModelsDragReorder.test.ts
+++ b/admin/src/pages/ai-models/useAiModelsDragReorder.test.ts
@@ -90,18 +90,11 @@ describe("useAiModelsDragReorder.handleReorder", () => {
       }),
     );
 
+    // handleReorder は内部関数なので handleDrop 経由で 0 → 2 の移動を発火する
+    // (a を末尾に動かす)。
+    // Trigger handleReorder via handleDrop (drop "a" onto "c" => move to end).
     await act(async () => {
-      await result.current.handleDragStart;
-      // 0 → 2 の入れ替え（a を末尾に） / move "a" to the end
-      await (result.current as unknown as { handleReorder: typeof result.current.handleDrop }); // 型回避
-    });
-
-    // 直接 handleReorder を呼べないため hook 内部の handleDrop 経由で再現
-    // a → c 上にドロップで 0 → 2 を発火
-    const ev = makeDragEvent({ "text/plain": "a" });
-    await act(async () => {
-      result.current.handleDrop(ev, "c");
-      // microtask 1 周
+      result.current.handleDrop(makeDragEvent({ "text/plain": "a" }), "c");
       await Promise.resolve();
     });
 

--- a/admin/src/pages/users/useConfirmDialogs.test.ts
+++ b/admin/src/pages/users/useConfirmDialogs.test.ts
@@ -179,6 +179,7 @@ describe("useConfirmDialogs - delete with impact", () => {
     expect(result.current.deleteTarget?.user.id).toBe(userA.id);
 
     // ユーザー B に切り替えてから古い request A を resolve しても、状態は B のまま
+    // Even if old request A resolves after switching to user B, the state stays on B.
     act(() => {
       result.current.requestDelete(userB);
     });
@@ -188,12 +189,12 @@ describe("useConfirmDialogs - delete with impact", () => {
       resolveA?.({ ...sampleImpact, notesCount: 999 });
       await Promise.resolve();
     });
-    // A の結果は反映されない
+    // A の結果は反映されない / A's resolved result must not be applied.
     expect(result.current.deleteTarget?.user.id).toBe(userB.id);
     expect(result.current.deleteTarget?.impact).toBeNull();
     expect(result.current.deleteTarget?.loadingImpact).toBe(true);
 
-    // B の resolve はちゃんと反映される
+    // B の resolve はちゃんと反映される / B's resolve still propagates correctly.
     await act(async () => {
       resolveB?.(sampleImpact);
       await Promise.resolve();
@@ -220,7 +221,7 @@ describe("useConfirmDialogs - delete with impact", () => {
     });
     expect(result.current.deleteTarget).toBeNull();
 
-    // resolve しても deleteTarget は null のまま
+    // resolve しても deleteTarget は null のまま / late resolve does not revive deleteTarget.
     await act(async () => {
       resolveLate?.(sampleImpact);
       await Promise.resolve();

--- a/admin/src/pages/users/useConfirmDialogs.test.ts
+++ b/admin/src/pages/users/useConfirmDialogs.test.ts
@@ -1,0 +1,255 @@
+/**
+ * useConfirmDialogs のテスト。
+ * - 各 dialog の request → confirm / cancel ライフサイクル
+ * - getUserImpact の race 対策（requestId）/ guard against stale impact responses
+ *
+ * Tests for useConfirmDialogs.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useConfirmDialogs } from "./useConfirmDialogs";
+import type { UserAdmin, UserImpact } from "@/api/admin";
+
+vi.mock("@/api/admin", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/admin")>();
+  return {
+    ...actual,
+    getUserImpact: vi.fn(),
+  };
+});
+
+const { getUserImpact } = await import("@/api/admin");
+
+const userA: UserAdmin = {
+  id: "user-a",
+  email: "a@example.com",
+  name: "User A",
+  role: "user",
+  status: "active",
+  suspendedAt: null,
+  suspendedReason: null,
+  suspendedBy: null,
+  createdAt: "2026-01-01T00:00:00Z",
+  pageCount: 0,
+};
+
+const userB: UserAdmin = { ...userA, id: "user-b", email: "b@example.com", name: "User B" };
+
+const sampleImpact: UserImpact = {
+  notesCount: 3,
+  sessionsCount: 1,
+  activeSubscription: false,
+  lastAiUsageAt: null,
+};
+
+function makeHook() {
+  const onRoleChange = vi.fn();
+  const onUnsuspend = vi.fn();
+  const onDelete = vi.fn();
+  const result = renderHook(() => useConfirmDialogs(onRoleChange, onUnsuspend, onDelete));
+  return { ...result, onRoleChange, onUnsuspend, onDelete };
+}
+
+describe("useConfirmDialogs - role change", () => {
+  it("同じロールへの変更は target を立てない / no-op when role is unchanged", () => {
+    const { result } = makeHook();
+    act(() => {
+      result.current.requestRoleChange(userA, "user");
+    });
+    expect(result.current.roleChangeTarget).toBeNull();
+  });
+
+  it("requestRoleChange → confirm で onRoleChange を呼んで target を null に戻す", () => {
+    const { result, onRoleChange } = makeHook();
+    act(() => {
+      result.current.requestRoleChange(userA, "admin");
+    });
+    expect(result.current.roleChangeTarget).toEqual({ user: userA, newRole: "admin" });
+
+    act(() => {
+      result.current.confirmRoleChange();
+    });
+    expect(onRoleChange).toHaveBeenCalledWith(userA, "admin");
+    expect(result.current.roleChangeTarget).toBeNull();
+  });
+
+  it("confirm が target なしのときは何もしない / confirm without target is a no-op", () => {
+    const { result, onRoleChange } = makeHook();
+    act(() => {
+      result.current.confirmRoleChange();
+    });
+    expect(onRoleChange).not.toHaveBeenCalled();
+  });
+
+  it("cancel で target を null に戻す", () => {
+    const { result } = makeHook();
+    act(() => {
+      result.current.requestRoleChange(userA, "admin");
+      result.current.cancelRoleChange();
+    });
+    expect(result.current.roleChangeTarget).toBeNull();
+  });
+});
+
+describe("useConfirmDialogs - unsuspend", () => {
+  it("request → confirm で onUnsuspend を呼ぶ", () => {
+    const { result, onUnsuspend } = makeHook();
+    act(() => {
+      result.current.requestUnsuspend(userA);
+    });
+    expect(result.current.unsuspendTarget).toEqual(userA);
+
+    act(() => {
+      result.current.confirmUnsuspend();
+    });
+    expect(onUnsuspend).toHaveBeenCalledWith(userA);
+    expect(result.current.unsuspendTarget).toBeNull();
+  });
+
+  it("cancel で target を null に戻す", () => {
+    const { result } = makeHook();
+    act(() => {
+      result.current.requestUnsuspend(userA);
+      result.current.cancelUnsuspend();
+    });
+    expect(result.current.unsuspendTarget).toBeNull();
+  });
+});
+
+describe("useConfirmDialogs - delete with impact", () => {
+  beforeEach(() => {
+    vi.mocked(getUserImpact).mockReset();
+  });
+
+  it("requestDelete でローディング状態 → impact 取得後に impact 反映", async () => {
+    vi.mocked(getUserImpact).mockResolvedValueOnce(sampleImpact);
+    const { result } = makeHook();
+
+    act(() => {
+      result.current.requestDelete(userA);
+    });
+
+    expect(result.current.deleteTarget).toEqual({
+      user: userA,
+      impact: null,
+      loadingImpact: true,
+    });
+
+    await waitFor(() => {
+      expect(result.current.deleteTarget?.loadingImpact).toBe(false);
+    });
+    expect(result.current.deleteTarget?.impact).toEqual(sampleImpact);
+  });
+
+  it("getUserImpact が失敗したら loadingImpact: false で impact は null のまま", async () => {
+    vi.mocked(getUserImpact).mockRejectedValueOnce(new Error("nope"));
+    const { result } = makeHook();
+
+    act(() => {
+      result.current.requestDelete(userA);
+    });
+    await waitFor(() => {
+      expect(result.current.deleteTarget?.loadingImpact).toBe(false);
+    });
+    expect(result.current.deleteTarget?.impact).toBeNull();
+  });
+
+  it("古い request の resolve は新しい target を上書きしない / stale resolve is ignored", async () => {
+    let resolveA: ((v: UserImpact) => void) | null = null;
+    let resolveB: ((v: UserImpact) => void) | null = null;
+    vi.mocked(getUserImpact)
+      .mockImplementationOnce(
+        () =>
+          new Promise<UserImpact>((resolve) => {
+            resolveA = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<UserImpact>((resolve) => {
+            resolveB = resolve;
+          }),
+      );
+
+    const { result } = makeHook();
+
+    act(() => {
+      result.current.requestDelete(userA);
+    });
+    expect(result.current.deleteTarget?.user.id).toBe(userA.id);
+
+    // ユーザー B に切り替えてから古い request A を resolve しても、状態は B のまま
+    act(() => {
+      result.current.requestDelete(userB);
+    });
+    expect(result.current.deleteTarget?.user.id).toBe(userB.id);
+
+    await act(async () => {
+      resolveA?.({ ...sampleImpact, notesCount: 999 });
+      await Promise.resolve();
+    });
+    // A の結果は反映されない
+    expect(result.current.deleteTarget?.user.id).toBe(userB.id);
+    expect(result.current.deleteTarget?.impact).toBeNull();
+    expect(result.current.deleteTarget?.loadingImpact).toBe(true);
+
+    // B の resolve はちゃんと反映される
+    await act(async () => {
+      resolveB?.(sampleImpact);
+      await Promise.resolve();
+    });
+    expect(result.current.deleteTarget?.impact).toEqual(sampleImpact);
+    expect(result.current.deleteTarget?.loadingImpact).toBe(false);
+  });
+
+  it("cancelDelete は requestId をインクリメントし、後から来た resolve を無効化する", async () => {
+    let resolveLate: ((v: UserImpact) => void) | null = null;
+    vi.mocked(getUserImpact).mockImplementationOnce(
+      () =>
+        new Promise<UserImpact>((resolve) => {
+          resolveLate = resolve;
+        }),
+    );
+
+    const { result } = makeHook();
+    act(() => {
+      result.current.requestDelete(userA);
+    });
+    act(() => {
+      result.current.cancelDelete();
+    });
+    expect(result.current.deleteTarget).toBeNull();
+
+    // resolve しても deleteTarget は null のまま
+    await act(async () => {
+      resolveLate?.(sampleImpact);
+      await Promise.resolve();
+    });
+    expect(result.current.deleteTarget).toBeNull();
+  });
+
+  it("confirmDelete で onDelete を呼んで target を null にする", async () => {
+    vi.mocked(getUserImpact).mockResolvedValueOnce(sampleImpact);
+    const { result, onDelete } = makeHook();
+    act(() => {
+      result.current.requestDelete(userA);
+    });
+    await waitFor(() => {
+      expect(result.current.deleteTarget?.loadingImpact).toBe(false);
+    });
+
+    act(() => {
+      result.current.confirmDelete();
+    });
+    expect(onDelete).toHaveBeenCalledWith(userA);
+    expect(result.current.deleteTarget).toBeNull();
+  });
+
+  it("confirmDelete が target なしのときは onDelete を呼ばない", () => {
+    const { result, onDelete } = makeHook();
+    act(() => {
+      result.current.confirmDelete();
+    });
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/admin/vitest.config.ts
+++ b/admin/vitest.config.ts
@@ -2,6 +2,11 @@ import path from "path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  // Anchor `include` / `setupFiles` to admin/ so the config also works when
+  // invoked from the workspace root (`vitest run --config admin/vitest.config.ts`).
+  // ルート（`vitest run --config admin/vitest.config.ts`）から呼ばれた場合も
+  // `include` / `setupFiles` が admin/ 配下を指すよう root を固定する。
+  root: __dirname,
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "format:check": "prettier --check .",
     "preview": "vite preview",
     "test": "vitest",
-    "test:run": "vitest run && vitest run --config packages/shared/vitest.config.ts && vitest run --config packages/claude-sidecar/vitest.config.ts && vitest run --config server/hocuspocus/vitest.config.ts && vitest run --config server/mcp/vitest.config.ts",
+    "test:run": "vitest run && vitest run --config packages/shared/vitest.config.ts && vitest run --config packages/ui/vitest.config.ts && vitest run --config packages/claude-sidecar/vitest.config.ts && vitest run --config server/hocuspocus/vitest.config.ts && vitest run --config server/mcp/vitest.config.ts",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "format:check": "prettier --check .",
     "preview": "vite preview",
     "test": "vitest",
-    "test:run": "vitest run && vitest run --config packages/shared/vitest.config.ts && vitest run --config packages/ui/vitest.config.ts && vitest run --config packages/claude-sidecar/vitest.config.ts && vitest run --config server/hocuspocus/vitest.config.ts && vitest run --config server/mcp/vitest.config.ts",
+    "test:run": "vitest run && vitest run --config packages/shared/vitest.config.ts && vitest run --config packages/ui/vitest.config.ts && vitest run --config packages/claude-sidecar/vitest.config.ts && vitest run --config server/hocuspocus/vitest.config.ts && vitest run --config server/mcp/vitest.config.ts && vitest run --config admin/vitest.config.ts",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,10 @@
     "./hooks/use-toast": "./src/hooks/use-toast.ts",
     "./components/sonner": "./src/components/sonner.tsx"
   },
+  "scripts": {
+    "test": "vitest --config vitest.config.ts",
+    "test:run": "vitest run --config vitest.config.ts"
+  },
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/ui/src/components/sidebar/SidebarProvider.test.tsx
+++ b/packages/ui/src/components/sidebar/SidebarProvider.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * SidebarProvider のテスト。
+ * - 初期値（cookie / defaultOpen）の解決
+ * - open/close の cookie 永続化
+ * - controlled モード（open prop / onOpenChange）
+ * - キーボードショートカット（Ctrl/Meta + b）
+ *
+ * Tests for SidebarProvider.
+ */
+import * as React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { SidebarProvider } from "./SidebarProvider";
+import { useSidebar } from "./useSidebar";
+import { SIDEBAR_COOKIE_NAME, SIDEBAR_KEYBOARD_SHORTCUT } from "./sidebarConstants";
+
+function clearCookies(): void {
+  for (const part of document.cookie.split(";")) {
+    const name = part.split("=")[0]?.trim();
+    if (name) document.cookie = `${name}=; path=/; max-age=0`;
+  }
+}
+
+interface ProbeProps {
+  onCtx?: (ctx: ReturnType<typeof useSidebar>) => void;
+}
+
+function Probe({ onCtx }: ProbeProps): React.JSX.Element {
+  const ctx = useSidebar();
+  onCtx?.(ctx);
+  return (
+    <div>
+      <span data-testid="state">{ctx.state}</span>
+      <span data-testid="open">{String(ctx.open)}</span>
+      <button type="button" data-testid="toggle" onClick={ctx.toggleSidebar}>
+        toggle
+      </button>
+    </div>
+  );
+}
+
+describe("SidebarProvider initial state", () => {
+  beforeEach(() => {
+    clearCookies();
+  });
+
+  it("Cookie が無ければ defaultOpen に従う / falls back to defaultOpen", () => {
+    render(
+      <SidebarProvider defaultOpen={false}>
+        <Probe />
+      </SidebarProvider>,
+    );
+    expect(screen.getByTestId("open").textContent).toBe("false");
+    expect(screen.getByTestId("state").textContent).toBe("collapsed");
+  });
+
+  it("Cookie の値が defaultOpen より優先される / cookie wins over defaultOpen", () => {
+    document.cookie = `${SIDEBAR_COOKIE_NAME}=true; path=/`;
+    render(
+      <SidebarProvider defaultOpen={false}>
+        <Probe />
+      </SidebarProvider>,
+    );
+    expect(screen.getByTestId("open").textContent).toBe("true");
+    expect(screen.getByTestId("state").textContent).toBe("expanded");
+  });
+});
+
+describe("SidebarProvider toggle / cookie persistence", () => {
+  beforeEach(() => {
+    clearCookies();
+  });
+
+  it("toggleSidebar で開閉が切り替わり cookie に永続化される", () => {
+    render(
+      <SidebarProvider defaultOpen={false}>
+        <Probe />
+      </SidebarProvider>,
+    );
+    expect(screen.getByTestId("open").textContent).toBe("false");
+
+    act(() => {
+      screen.getByTestId("toggle").click();
+    });
+
+    expect(screen.getByTestId("open").textContent).toBe("true");
+    expect(document.cookie).toContain(`${SIDEBAR_COOKIE_NAME}=true`);
+  });
+});
+
+describe("SidebarProvider controlled mode", () => {
+  beforeEach(() => {
+    clearCookies();
+  });
+
+  it("open prop で controlled になり、toggle は onOpenChange を呼ぶ", () => {
+    const onOpenChange = vi.fn();
+    function Wrapper(): React.JSX.Element {
+      const [open, setOpen] = React.useState(true);
+      return (
+        <SidebarProvider
+          open={open}
+          onOpenChange={(v) => {
+            onOpenChange(v);
+            setOpen(v);
+          }}
+        >
+          <Probe />
+        </SidebarProvider>
+      );
+    }
+    render(<Wrapper />);
+    expect(screen.getByTestId("open").textContent).toBe("true");
+
+    act(() => {
+      screen.getByTestId("toggle").click();
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(screen.getByTestId("open").textContent).toBe("false");
+  });
+});
+
+describe("SidebarProvider keyboard shortcut", () => {
+  beforeEach(() => {
+    clearCookies();
+  });
+
+  function dispatchShortcut(modifier: "ctrl" | "meta", target?: HTMLElement): KeyboardEvent {
+    const evt = new KeyboardEvent("keydown", {
+      key: SIDEBAR_KEYBOARD_SHORTCUT,
+      ctrlKey: modifier === "ctrl",
+      metaKey: modifier === "meta",
+      bubbles: true,
+      cancelable: true,
+    });
+    (target ?? window).dispatchEvent(evt);
+    return evt;
+  }
+
+  it("Ctrl+B でトグルされ preventDefault される", () => {
+    render(
+      <SidebarProvider defaultOpen={false}>
+        <Probe />
+      </SidebarProvider>,
+    );
+    let evt: KeyboardEvent | undefined;
+    act(() => {
+      evt = dispatchShortcut("ctrl");
+    });
+    expect(screen.getByTestId("open").textContent).toBe("true");
+    expect(evt?.defaultPrevented).toBe(true);
+  });
+
+  it("Meta+B でも動作する / works with Meta key as well", () => {
+    render(
+      <SidebarProvider defaultOpen={false}>
+        <Probe />
+      </SidebarProvider>,
+    );
+    act(() => {
+      dispatchShortcut("meta");
+    });
+    expect(screen.getByTestId("open").textContent).toBe("true");
+  });
+
+  it("INPUT にフォーカス中はショートカットを無視する / ignores shortcut while typing in inputs", () => {
+    render(
+      <SidebarProvider defaultOpen={false}>
+        <input data-testid="input" />
+        <Probe />
+      </SidebarProvider>,
+    );
+
+    const input = screen.getByTestId("input") as HTMLInputElement;
+    input.focus();
+
+    act(() => {
+      const evt = new KeyboardEvent("keydown", {
+        key: SIDEBAR_KEYBOARD_SHORTCUT,
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      input.dispatchEvent(evt);
+    });
+
+    expect(screen.getByTestId("open").textContent).toBe("false");
+  });
+
+  it("contenteditable 要素でも無視する / ignores shortcut on contenteditable", () => {
+    render(
+      <SidebarProvider defaultOpen={false}>
+        <div data-testid="editor" contentEditable />
+        <Probe />
+      </SidebarProvider>,
+    );
+
+    const editor = screen.getByTestId("editor");
+    act(() => {
+      const evt = new KeyboardEvent("keydown", {
+        key: SIDEBAR_KEYBOARD_SHORTCUT,
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(evt);
+    });
+
+    expect(screen.getByTestId("open").textContent).toBe("false");
+  });
+});

--- a/packages/ui/src/components/sidebar/sidebarConstants.test.ts
+++ b/packages/ui/src/components/sidebar/sidebarConstants.test.ts
@@ -1,0 +1,67 @@
+/**
+ * sidebarConstants の Cookie パースロジックをテストする。
+ * Tests for the cookie parsing logic in sidebarConstants.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  readSidebarOpenFromCookie,
+  SIDEBAR_COOKIE_NAME,
+  SIDEBAR_COOKIE_MAX_AGE,
+  SIDEBAR_KEYBOARD_SHORTCUT,
+  SIDEBAR_WIDTH,
+  SIDEBAR_WIDTH_ICON,
+  SIDEBAR_WIDTH_MOBILE,
+} from "./sidebarConstants";
+
+function clearCookies(): void {
+  for (const part of document.cookie.split(";")) {
+    const name = part.split("=")[0]?.trim();
+    if (name) document.cookie = `${name}=; path=/; max-age=0`;
+  }
+}
+
+describe("sidebarConstants - module exports", () => {
+  it("Cookie 名と max-age（7 日）/ exposes name and 7-day max-age", () => {
+    expect(SIDEBAR_COOKIE_NAME).toBe("sidebar:state");
+    expect(SIDEBAR_COOKIE_MAX_AGE).toBe(60 * 60 * 24 * 7);
+  });
+
+  it("ショートカットキーとレイアウト幅の定数 / exposes shortcut and layout widths", () => {
+    expect(SIDEBAR_KEYBOARD_SHORTCUT).toBe("b");
+    expect(SIDEBAR_WIDTH).toBe("14rem");
+    expect(SIDEBAR_WIDTH_MOBILE).toBe("18rem");
+    expect(SIDEBAR_WIDTH_ICON).toBe("3rem");
+  });
+});
+
+describe("readSidebarOpenFromCookie", () => {
+  beforeEach(() => {
+    clearCookies();
+  });
+
+  it("Cookie 未設定なら null / returns null when cookie is not set", () => {
+    expect(readSidebarOpenFromCookie()).toBeNull();
+  });
+
+  it("`sidebar:state=true` のとき true / returns true when set to 'true'", () => {
+    document.cookie = `${SIDEBAR_COOKIE_NAME}=true; path=/`;
+    expect(readSidebarOpenFromCookie()).toBe(true);
+  });
+
+  it("`sidebar:state=false` のとき false / returns false when set to 'false'", () => {
+    document.cookie = `${SIDEBAR_COOKIE_NAME}=false; path=/`;
+    expect(readSidebarOpenFromCookie()).toBe(false);
+  });
+
+  it("値が `true`/`false` 以外のときは null / returns null for other values", () => {
+    document.cookie = `${SIDEBAR_COOKIE_NAME}=open; path=/`;
+    expect(readSidebarOpenFromCookie()).toBeNull();
+  });
+
+  it("空白付きの Cookie 並びでも正しく解釈する / handles whitespace-separated cookies", () => {
+    document.cookie = `other=1; path=/`;
+    document.cookie = `${SIDEBAR_COOKIE_NAME}=true; path=/`;
+    document.cookie = `another=2; path=/`;
+    expect(readSidebarOpenFromCookie()).toBe(true);
+  });
+});

--- a/packages/ui/src/hooks/use-mobile.test.tsx
+++ b/packages/ui/src/hooks/use-mobile.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * useIsMobile のテスト。
+ * - matchMedia の subscribe / snapshot を介して値が更新されること
+ * - breakpoint 定数の妥当性
+ *
+ * Tests for useIsMobile.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { MOBILE_BREAKPOINT, useIsMobile } from "./use-mobile";
+
+interface MockMql {
+  matches: boolean;
+  listeners: Set<(e: MediaQueryListEvent) => void>;
+}
+
+function installMatchMedia(initialMatches: boolean): { mql: MockMql; restore: () => void } {
+  const mql: MockMql = { matches: initialMatches, listeners: new Set() };
+  const original = window.matchMedia;
+  window.matchMedia = vi.fn().mockImplementation(() => ({
+    get matches() {
+      return mql.matches;
+    },
+    media: "",
+    onchange: null,
+    addEventListener: (_evt: string, listener: (e: MediaQueryListEvent) => void) => {
+      mql.listeners.add(listener);
+    },
+    removeEventListener: (_evt: string, listener: (e: MediaQueryListEvent) => void) => {
+      mql.listeners.delete(listener);
+    },
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  return {
+    mql,
+    restore: () => {
+      window.matchMedia = original;
+    },
+  };
+}
+
+describe("MOBILE_BREAKPOINT", () => {
+  it("Tailwind の md (768) と一致 / matches Tailwind md breakpoint", () => {
+    expect(MOBILE_BREAKPOINT).toBe(768);
+  });
+});
+
+describe("useIsMobile", () => {
+  let cleanup: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanup = null;
+  });
+
+  afterEach(() => {
+    cleanup?.();
+  });
+
+  it("初回スナップショットが false なら false を返す / returns initial snapshot value", () => {
+    const { mql, restore } = installMatchMedia(false);
+    cleanup = restore;
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+    expect(mql.listeners.size).toBeGreaterThan(0);
+  });
+
+  it("初回スナップショットが true なら true を返す / returns true when viewport is mobile", () => {
+    const { restore } = installMatchMedia(true);
+    cleanup = restore;
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it("media query 変化で値が更新される / updates on media query change", () => {
+    const { mql, restore } = installMatchMedia(false);
+    cleanup = restore;
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      mql.matches = true;
+      mql.listeners.forEach((l) => l({ matches: true } as MediaQueryListEvent));
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("アンマウント時に listener が解除される / unsubscribes on unmount", () => {
+    const { mql, restore } = installMatchMedia(false);
+    cleanup = restore;
+    const { unmount } = renderHook(() => useIsMobile());
+    expect(mql.listeners.size).toBe(1);
+    unmount();
+    expect(mql.listeners.size).toBe(0);
+  });
+});

--- a/packages/ui/src/hooks/use-toast.test.ts
+++ b/packages/ui/src/hooks/use-toast.test.ts
@@ -1,0 +1,151 @@
+/**
+ * use-toast のテスト。
+ * - reducer の state 遷移（ADD / UPDATE / DISMISS / REMOVE）
+ * - useToast フックの subscription / dispatch 経路
+ *
+ * Tests for the use-toast module.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { reducer, toast, useToast } from "./use-toast";
+
+type State = ReturnType<typeof reducer>;
+type Toast = State["toasts"][number];
+
+const makeToast = (id: string, overrides: Partial<Toast> = {}): Toast =>
+  ({
+    id,
+    open: true,
+    title: id,
+    ...overrides,
+  }) as Toast;
+
+describe("use-toast reducer", () => {
+  it("ADD_TOAST は配列の先頭に追加し、TOAST_LIMIT(=1) で切り詰める", () => {
+    const after = reducer({ toasts: [] }, { type: "ADD_TOAST", toast: makeToast("a") });
+    expect(after.toasts).toHaveLength(1);
+    expect(after.toasts[0]?.id).toBe("a");
+
+    const second = reducer(after, { type: "ADD_TOAST", toast: makeToast("b") });
+    // 上限 1 件で切り詰められる
+    expect(second.toasts).toHaveLength(1);
+    expect(second.toasts[0]?.id).toBe("b");
+  });
+
+  it("UPDATE_TOAST は同じ id の toast をマージする / merges fields by id", () => {
+    const initial: State = { toasts: [makeToast("a", { title: "old" })] };
+    const after = reducer(initial, {
+      type: "UPDATE_TOAST",
+      toast: { id: "a", title: "new" } as Partial<Toast>,
+    });
+    expect(after.toasts[0]?.title).toBe("new");
+  });
+
+  it("DISMISS_TOAST(id) は対象を open:false にする / closes only the targeted toast", () => {
+    const initial: State = {
+      toasts: [makeToast("a"), makeToast("b")],
+    };
+    const after = reducer(initial, { type: "DISMISS_TOAST", toastId: "a" });
+    const a = after.toasts.find((t) => t.id === "a");
+    const b = after.toasts.find((t) => t.id === "b");
+    expect(a?.open).toBe(false);
+    expect(b?.open).toBe(true);
+  });
+
+  it("DISMISS_TOAST(undefined) は全 toast を open:false にする / closes all toasts", () => {
+    const initial: State = {
+      toasts: [makeToast("a"), makeToast("b")],
+    };
+    const after = reducer(initial, { type: "DISMISS_TOAST" });
+    expect(after.toasts.every((t) => t.open === false)).toBe(true);
+  });
+
+  it("REMOVE_TOAST(id) は配列から該当 toast を消す / removes toast by id", () => {
+    const initial: State = { toasts: [makeToast("a"), makeToast("b")] };
+    const after = reducer(initial, { type: "REMOVE_TOAST", toastId: "a" });
+    expect(after.toasts).toHaveLength(1);
+    expect(after.toasts[0]?.id).toBe("b");
+  });
+
+  it("REMOVE_TOAST(undefined) は配列を空にする / clears all toasts", () => {
+    const initial: State = { toasts: [makeToast("a"), makeToast("b")] };
+    const after = reducer(initial, { type: "REMOVE_TOAST" });
+    expect(after.toasts).toHaveLength(0);
+  });
+});
+
+describe("toast() / useToast()", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    // 永続している memoryState を空にするために dismiss + REMOVE 動作を待つ
+    // Reset memoryState by dispatching dismiss/remove via the public API.
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.dismiss();
+    });
+  });
+
+  it("toast() を呼ぶと subscriber に新しい toast が伝播される / emits new toast to subscribers", () => {
+    const { result } = renderHook(() => useToast());
+    expect(result.current.toasts).toHaveLength(0);
+
+    act(() => {
+      toast({ title: "Hello" });
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0]?.title).toBe("Hello");
+    expect(result.current.toasts[0]?.open).toBe(true);
+  });
+
+  it("dismiss() で open: false に変わる / dismiss flips open to false", () => {
+    const { result } = renderHook(() => useToast());
+
+    let id = "";
+    act(() => {
+      id = toast({ title: "Hello" }).id;
+    });
+
+    act(() => {
+      result.current.dismiss(id);
+    });
+
+    expect(result.current.toasts[0]?.open).toBe(false);
+  });
+
+  it("toast().update() が subscriber に伝播 / update propagates to subscribers", () => {
+    const { result } = renderHook(() => useToast());
+
+    let api: ReturnType<typeof toast> | null = null;
+    act(() => {
+      api = toast({ title: "old" });
+    });
+
+    act(() => {
+      api?.update({
+        ...(result.current.toasts[0] as Toast),
+        title: "new",
+      });
+    });
+
+    expect(result.current.toasts[0]?.title).toBe("new");
+  });
+
+  it("onOpenChange(false) で dismiss されたかのように open:false になる / onOpenChange(false) triggers dismiss", () => {
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      toast({ title: "x" });
+    });
+    const created = result.current.toasts[0];
+    expect(created?.open).toBe(true);
+
+    act(() => {
+      created?.onOpenChange?.(false);
+    });
+    expect(result.current.toasts[0]?.open).toBe(false);
+  });
+});

--- a/packages/ui/src/hooks/use-toast.test.ts
+++ b/packages/ui/src/hooks/use-toast.test.ts
@@ -80,13 +80,16 @@ describe("toast() / useToast()", () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
-    // 永続している memoryState を空にするために dismiss + REMOVE 動作を待つ
-    // Reset memoryState by dispatching dismiss/remove via the public API.
+    // memoryState はモジュール singleton なのでテスト間で共有される。
+    // dismiss → REMOVE_TOAST(=TOAST_REMOVE_DELAY 後) を待ってから real timer に戻す。
+    // memoryState is a module-level singleton; dismiss + advance fake timers so
+    // the queued REMOVE_TOAST clears toasts before switching back to real timers.
     const { result } = renderHook(() => useToast());
     act(() => {
       result.current.dismiss();
+      vi.advanceTimersByTime(1_000_000);
     });
+    vi.useRealTimers();
   });
 
   it("toast() を呼ぶと subscriber に新しい toast が伝播される / emits new toast to subscribers", () => {

--- a/packages/ui/src/test/setup.ts
+++ b/packages/ui/src/test/setup.ts
@@ -1,0 +1,26 @@
+import "@testing-library/jest-dom/vitest";
+
+/**
+ * jsdom does not implement `window.matchMedia`. Provide a minimal stub so
+ * hooks like `useIsMobile` can call it during tests. Individual tests can
+ * override this with `vi.fn()` to assert subscription / change behaviour.
+ *
+ * jsdom には `window.matchMedia` が無いため、`useIsMobile` などが落ちないよう
+ * 最小限のスタブを差し込む。挙動を検証するテストは個別に上書きする。
+ */
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,28 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+
+/**
+ * Vitest config for `@zedi/ui` package.
+ * - Uses jsdom for DOM-touching hooks/components (sidebar, toast, mobile detection).
+ * - Aligns React/react-dom with the workspace root so Radix and our package use the same instance.
+ *
+ * `@zedi/ui` パッケージ用の vitest 設定。
+ * - DOM を触るフック・コンポーネント（sidebar, toast, モバイル判定）のため jsdom を使う。
+ * - Radix と本パッケージが同一 React インスタンスを共有するよう、ワークスペースルートの react を参照する。
+ */
+export default defineConfig({
+  root: import.meta.dirname,
+  resolve: {
+    alias: {
+      react: path.resolve(import.meta.dirname, "../../node_modules/react"),
+      "react-dom": path.resolve(import.meta.dirname, "../../node_modules/react-dom"),
+    },
+    dedupe: ["react", "react-dom"],
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: [path.resolve(import.meta.dirname, "src/test/setup.ts")],
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
## 概要

複数のパッケージにわたる包括的なユニットテストスイートを追加しました。admin パッケージの hooks・API クライアント、UI パッケージのコンポーネント・hooks、および共通ユーティリティ関数をカバーしています。

## 変更点

- **admin パッケージ**
  - `useAiModelActions.test.ts`: AI モデル更新の楽観的更新と失敗時ロールバック、アンマウント時の状態更新スキップをテスト
  - `useAiModelsDragReorder.test.ts`: ドラッグ&ドロップによる並び替えと永続化、エラー時の復旧をテスト
  - `useConfirmDialogs.test.ts`: 確認ダイアログのライフサイクル、race condition 対策（requestId）をテスト
  - `activity.test.ts`: activity API クライアントのクエリパラメータ処理をテスト
  - `client.test.ts`: `adminFetch` と `getErrorMessage` のエラーハンドリングをテスト
  - `lint.test.ts`: lint API クライアントの各エンドポイントをテスト
  - `dateUtils.test.ts`: 日付フォーマット関数をテスト

- **UI パッケージ**
  - `SidebarProvider.test.tsx`: Cookie 永続化、controlled モード、キーボードショートカット（Ctrl/Meta+B）をテスト
  - `use-toast.test.ts`: reducer の状態遷移（ADD/UPDATE/DISMISS/REMOVE）と subscriber パターンをテスト
  - `use-mobile.test.tsx`: matchMedia の subscribe と breakpoint 定数をテスト
  - `sidebarConstants.test.ts`: Cookie パースロジックと定数値をテスト

- **ビルド・CI 設定**
  - `packages/ui/vitest.config.ts`: UI パッケージ用の vitest 設定（jsdom、React インスタンス共有）
  - `packages/ui/src/test/setup.ts`: jsdom の `window.matchMedia` スタブ
  - `package.json` と `.github/workflows/ci.yml`: ワークスペースパッケージのテスト実行設定を追加

## 変更の種類

- [x] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

すべてのテストは CI で自動実行されます：

```bash
# ルートで全テスト実行
bun run test:run

# または個別パッケージ
bun run -w ui test:run
bun run -w admin test:run
```

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] CI 設定を更新した
- [x] コミットメッセージが Conventional Commits に従っている

## 補足

- 各テストは日本語と英語のコメントで意図を明記しています
- 楽観的更新、race condition、アンマウント時の状態管理など、実装の複雑な部分を重点的にカバーしています
- UI パッケージのテストは jsdom 環境で実行され、Radix UI との共存を確認しています

https://claude.ai/code/session_01JBSVNxfV2iDJJCThZvS6S5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage across admin and UI: API clients, hooks, pages, drag/reorder flows, dialogs, toast, sidebar, and date formatting.

* **Chores**
  * CI now runs package-scoped test suites.
  * Added Vitest configs and test setup for admin and UI packages; updated test scripts to include package runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->