### PR TITLE
ci(mutation-light): expand golden list with 5 stable Phase 1/2 files (#473)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,8 +249,15 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      # Golden list of files with stable mutation scores (Phase 1/2 of Epic #468).
+      # 安定したスコアを持つファイルを段階的に追加し、PR で退行を早めに検知する。
+      # Local scores measured 2026-04-26 with `stryker.config.mutation-changed.mjs`:
+      #   dateUtils.ts                94.03% / useContainerColumns.ts        86.67%
+      #   noteViewHelpers.ts         100.00% / aiChatConversationTitle.ts   100.00%
+      #   aiCostUtils.ts              91.18% / encryption.ts                 96.43%
+      #   mcpServerImportHelpers.ts  100.00% / onboardingState.ts            83.82%
       - name: Run mutation tests (limited scope)
-        run: bun run test:mutation -- --mutate "src/lib/dateUtils.ts,src/hooks/useContainerColumns.ts,src/pages/NoteView/noteViewHelpers.ts"
+        run: bun run test:mutation -- --mutate "src/lib/dateUtils.ts,src/hooks/useContainerColumns.ts,src/pages/NoteView/noteViewHelpers.ts,src/lib/aiChatConversationTitle.ts,src/lib/aiCostUtils.ts,src/lib/encryption.ts,src/lib/mcpServerImportHelpers.ts,src/lib/onboardingState.ts"
 
       - name: Upload mutation report
         if: always()


### PR DESCRIPTION
CI mutation-light の `--mutate` リストに、フェーズ1・2 (#470, #471) で
テストカバレッジが整い高スコアが安定したファイルを追加する。
PR で対象ファイルの退行（survived 増加）を早めに検知できるようにする。

追加ファイルとローカル計測のスコア (2026-04-26, stryker.config.mutation-changed.mjs):
- src/lib/aiChatConversationTitle.ts  100.00%
- src/lib/aiCostUtils.ts                91.18%
- src/lib/encryption.ts                 96.43%
- src/lib/mcpServerImportHelpers.ts   100.00%
- src/lib/onboardingState.ts            83.82%

すべて break 閾値 (70%) と low 閾値 (75%) を上回り、`# errors` も 0。
9 ファイル合計のスコアは 88.55% (433 killed / 52 survived / 4 nocov / 0 errors)。
ローカル所要時間は 5m34s で、CI 上の他ジョブと並列実行のため許容範囲。

その他のフェーズ1・2 候補 (wikiLinkUtils 76.92%, parseStdioArgs 66.67%) は
スコアが境界・以下のため、追加テストでスコアが安定してから別 PR で投入する。

Refs #468, closes #473

https://claude.ai/code/session_01DaxXhP83JmrLWPT8RvWY4R
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration testing coverage with expanded mutation testing across additional source files and documentation of mutation score benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->