### PR TITLE
fix: address PR #757 review follow-ups (#764)

### DIFF
--- a/admin/src/pages/users/useConfirmDialogs.test.ts
+++ b/admin/src/pages/users/useConfirmDialogs.test.ts
@@ -59,7 +59,7 @@ describe("useConfirmDialogs - role change", () => {
     expect(result.current.roleChangeTarget).toBeNull();
   });
 
-  it("requestRoleChange → confirm で onRoleChange を呼んで target を null に戻す", () => {
+  it("requestRoleChange → confirm で onRoleChange を呼んで target を null に戻す / requestRoleChange then confirm fires onRoleChange and clears target", () => {
     const { result, onRoleChange } = makeHook();
     act(() => {
       result.current.requestRoleChange(userA, "admin");
@@ -81,7 +81,7 @@ describe("useConfirmDialogs - role change", () => {
     expect(onRoleChange).not.toHaveBeenCalled();
   });
 
-  it("cancel で target を null に戻す", () => {
+  it("cancel で target を null に戻す / cancel clears target", () => {
     const { result } = makeHook();
     act(() => {
       result.current.requestRoleChange(userA, "admin");
@@ -92,7 +92,7 @@ describe("useConfirmDialogs - role change", () => {
 });
 
 describe("useConfirmDialogs - unsuspend", () => {
-  it("request → confirm で onUnsuspend を呼ぶ", () => {
+  it("request → confirm で onUnsuspend を呼ぶ / request then confirm fires onUnsuspend", () => {
     const { result, onUnsuspend } = makeHook();
     act(() => {
       result.current.requestUnsuspend(userA);
@@ -106,7 +106,7 @@ describe("useConfirmDialogs - unsuspend", () => {
     expect(result.current.unsuspendTarget).toBeNull();
   });
 
-  it("cancel で target を null に戻す", () => {
+  it("cancel で target を null に戻す / cancel clears target", () => {
     const { result } = makeHook();
     act(() => {
       result.current.requestUnsuspend(userA);
@@ -121,7 +121,7 @@ describe("useConfirmDialogs - delete with impact", () => {
     vi.mocked(getUserImpact).mockReset();
   });
 
-  it("requestDelete でローディング状態 → impact 取得後に impact 反映", async () => {
+  it("requestDelete でローディング状態 → impact 取得後に impact 反映 / requestDelete shows loading then applies impact once it resolves", async () => {
     vi.mocked(getUserImpact).mockResolvedValueOnce(sampleImpact);
     const { result } = makeHook();
 
@@ -141,7 +141,7 @@ describe("useConfirmDialogs - delete with impact", () => {
     expect(result.current.deleteTarget?.impact).toEqual(sampleImpact);
   });
 
-  it("getUserImpact が失敗したら loadingImpact: false で impact は null のまま", async () => {
+  it("getUserImpact が失敗したら loadingImpact: false で impact は null のまま / when getUserImpact rejects, loadingImpact becomes false and impact stays null", async () => {
     vi.mocked(getUserImpact).mockRejectedValueOnce(new Error("nope"));
     const { result } = makeHook();
 
@@ -203,7 +203,7 @@ describe("useConfirmDialogs - delete with impact", () => {
     expect(result.current.deleteTarget?.loadingImpact).toBe(false);
   });
 
-  it("cancelDelete は requestId をインクリメントし、後から来た resolve を無効化する", async () => {
+  it("cancelDelete は requestId をインクリメントし、後から来た resolve を無効化する / cancelDelete bumps requestId and invalidates a late resolve", async () => {
     let resolveLate: ((v: UserImpact) => void) | null = null;
     vi.mocked(getUserImpact).mockImplementationOnce(
       () =>
@@ -229,7 +229,7 @@ describe("useConfirmDialogs - delete with impact", () => {
     expect(result.current.deleteTarget).toBeNull();
   });
 
-  it("confirmDelete で onDelete を呼んで target を null にする", async () => {
+  it("confirmDelete で onDelete を呼んで target を null にする / confirmDelete fires onDelete and clears target", async () => {
     vi.mocked(getUserImpact).mockResolvedValueOnce(sampleImpact);
     const { result, onDelete } = makeHook();
     act(() => {
@@ -246,7 +246,7 @@ describe("useConfirmDialogs - delete with impact", () => {
     expect(result.current.deleteTarget).toBeNull();
   });
 
-  it("confirmDelete が target なしのときは onDelete を呼ばない", () => {
+  it("confirmDelete が target なしのときは onDelete を呼ばない / confirmDelete without target does not fire onDelete", () => {
     const { result, onDelete } = makeHook();
     act(() => {
       result.current.confirmDelete();

--- a/packages/claude-sidecar/src/handlers/query.test.ts
+++ b/packages/claude-sidecar/src/handlers/query.test.ts
@@ -615,6 +615,72 @@ describe("runQuery", () => {
     ]);
   });
 
+  it("flushes an active tool with tool-use-complete when aborted mid-tool", async () => {
+    // Start a tool, then abort before it finishes — the consumer must still see
+    // tool-use-complete so the start/complete pair stays balanced.
+    // ツール開始後に中断した場合でも tool-use-complete を発火させ、開始/完了対応を保つ。
+    const ac = new AbortController();
+    // Custom iterable: emit tool-use-start, abort, then yield one more event that
+    // the loop should detect-and-break-on rather than process.
+    // tool-use-start を流した直後に abort し、次のイベントでループを抜けるイテラブル。
+    queryMock.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield partial({
+          type: "content_block_start",
+          content_block: { type: "tool_use", name: "Bash", input: '{"command":"sleep 1"}' },
+        }) as unknown as SDKMessage;
+        ac.abort();
+        yield partial({
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "ignored" },
+        }) as unknown as SDKMessage;
+      },
+    });
+
+    await runQuery({
+      id: "q1",
+      prompt: "p",
+      writeLine: (l) => writes.push(l),
+      abortController: ac,
+      tracker,
+    });
+
+    expect(parsed()).toEqual([
+      { type: "tool-use-start", id: "q1", toolName: "Bash", toolInput: '{"command":"sleep 1"}' },
+      { type: "tool-use-complete", id: "q1", toolName: "Bash" },
+      { type: "error", id: "q1", error: "Query aborted", code: "aborted" },
+    ]);
+  });
+
+  it("flushes an active tool with tool-use-complete when the stream throws mid-tool", async () => {
+    // If the SDK iterator throws while a tool is active, emit tool-use-complete before the error.
+    // SDK イテレータがツール処理中に例外を投げた場合でも、エラーの前に tool-use-complete を発火させる。
+    queryMock.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield partial({
+          type: "content_block_start",
+          content_block: { type: "tool_use", name: "Read", input: '{"path":"/x"}' },
+        }) as unknown as SDKMessage;
+        throw new Error("stream blew up");
+      },
+    });
+
+    await runQuery({
+      id: "q1",
+      prompt: "p",
+      writeLine: (l) => writes.push(l),
+      abortController: new AbortController(),
+      tracker,
+    });
+
+    expect(parsed()).toEqual([
+      { type: "tool-use-start", id: "q1", toolName: "Read", toolInput: '{"path":"/x"}' },
+      { type: "tool-use-complete", id: "q1", toolName: "Read" },
+      { type: "error", id: "q1", error: "stream blew up", code: "query_exception" },
+    ]);
+    expect(tracker.snapshot().status).toBe("idle");
+  });
+
   it("emits stream-complete with the aggregated text when the stream ends without a result", async () => {
     queryMock.mockReturnValue(
       makeQueryIterable([

--- a/packages/claude-sidecar/src/handlers/query.ts
+++ b/packages/claude-sidecar/src/handlers/query.ts
@@ -326,6 +326,12 @@ export async function runQuery(params: {
     }
 
     if (abortController.signal.aborted) {
+      // Flush any active tool so downstream consumers see a balanced start/complete pair.
+      // 中断時もアクティブなツールを完了扱いにし、開始/完了の対応関係を保つ。
+      if (activeToolName) {
+        emit({ type: "tool-use-complete", id, toolName: activeToolName });
+        activeToolName = null;
+      }
       emit({
         type: "error",
         id,
@@ -341,6 +347,12 @@ export async function runQuery(params: {
       result: { content: aggregated },
     });
   } catch (err) {
+    // Flush any active tool before reporting the exception so the start/complete pair stays balanced.
+    // 例外発生時もアクティブなツールを完了扱いにし、開始/完了の対応関係を保つ。
+    if (activeToolName) {
+      emit({ type: "tool-use-complete", id, toolName: activeToolName });
+      activeToolName = null;
+    }
     const message = err instanceof Error ? err.message : String(err);
     emit({
       type: "error",

--- a/server/mcp/src/__tests__/tools/index.test.ts
+++ b/server/mcp/src/__tests__/tools/index.test.ts
@@ -16,8 +16,10 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ZediClient } from "../../client/ZediClient.js";
 import { ALL_TOOL_NAMES, registerAllTools } from "../../tools/index.js";
 
-/** Build a fully-mocked ZediClient. Tools call only the methods we register, so types are safe. /
- *  全メソッドをモック化した ZediClient。 */
+/**
+ * Build a fully-mocked ZediClient. Tools call only the methods we register, so types are safe.
+ * 全メソッドをモック化した ZediClient。
+ */
 function createMockClient(): ZediClient {
   return {
     getCurrentUser: vi.fn(),

--- a/src/hooks/useMermaidGenerator.test.ts
+++ b/src/hooks/useMermaidGenerator.test.ts
@@ -47,7 +47,13 @@ afterEach(() => {
 
 describe("useMermaidGenerator", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // `clearAllMocks` only resets call history; implementations set via
+    // `mockImplementation` / `mockResolvedValue` / `mockRejectedValueOnce` would
+    // leak into later tests. `resetAllMocks` also clears those implementations,
+    // so each test starts from a clean baseline.
+    // `clearAllMocks` は呼び出し履歴しかクリアしないため、mockImplementation 等の実装が
+    // 後続テストへ持ち越される。`resetAllMocks` で実装も含めて初期化する。
+    vi.resetAllMocks();
   });
 
   it("starts in idle state with no result/error", () => {
@@ -141,6 +147,24 @@ describe("useMermaidGenerator", () => {
   });
 
   it("generate catches synchronous throws from generateMermaidDiagram and sets error", async () => {
+    // True sync throw: the mock raises before returning a promise so the hook's
+    // try/catch must convert it into an error state.
+    // 真の同期 throw: Promise を返す前に例外を投げ、hook の try/catch でエラー化されることを検証。
+    mockGenerateMermaidDiagram.mockImplementationOnce(() => {
+      throw new Error("network");
+    });
+
+    const { result } = renderHook(() => useMermaidGenerator());
+
+    await act(async () => {
+      await result.current.generate("topic", ["pie"]);
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error?.message).toBe("network");
+  });
+
+  it("generate catches async rejections from generateMermaidDiagram and sets error", async () => {
     mockGenerateMermaidDiagram.mockRejectedValueOnce(new Error("network"));
 
     const { result } = renderHook(() => useMermaidGenerator());


### PR DESCRIPTION
- claude-sidecar: emit `tool-use-complete` on abort/exception paths when a
  tool is still active, keeping start/complete pairs balanced for downstream
  consumers; add regression tests for both paths.
- server/mcp tools test: normalize a malformed `/** ... /` helper comment to
  standard multiline JSDoc.
- useMermaidGenerator tests: switch shared mock reset from `vi.clearAllMocks`
  to `vi.resetAllMocks` so per-test `mockImplementation`/`mockResolvedValue`
  no longer leak between cases.
- useMermaidGenerator tests: realign "synchronous throws" case to use a true
  sync throw, and add a separate async-rejection case so the title matches the
  setup.
- admin useConfirmDialogs tests: add English to Japanese-only `it(...)` titles
  to match the JP/EN bilingual convention.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool lifecycle management to ensure proper event sequencing during abnormal execution terminations.

* **Tests**
  * Enhanced test coverage for error handling scenarios, including abort and exception flows.
  * Improved test isolation with updated mock reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->