### PR TITLE
fix(editor,layout): page heading hierarchy (one h1, body h2+)

### DIFF
--- a/src/components/editor/PageEditor/PageTitleBlock.test.tsx
+++ b/src/components/editor/PageEditor/PageTitleBlock.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PageTitleBlock } from "./PageTitleBlock";
 
@@ -8,6 +8,12 @@ describe("PageTitleBlock", () => {
     it("プレースホルダー「タイトル」が表示される", () => {
       render(<PageTitleBlock title="" onTitleChange={vi.fn()} />);
       expect(screen.getByPlaceholderText("タイトル")).toBeInTheDocument();
+    });
+
+    it("編集時も h1 として扱いアクセシビリティ上の見出し1になる", () => {
+      render(<PageTitleBlock title="編集中タイトル" onTitleChange={vi.fn()} />);
+      const heading = screen.getByRole("heading", { level: 1 });
+      expect(within(heading).getByRole("textbox")).toHaveValue("編集中タイトル");
     });
 
     it("テキストを変更すると onTitleChange が呼ばれる", async () => {

--- a/src/components/editor/PageEditor/PageTitleBlock.tsx
+++ b/src/components/editor/PageEditor/PageTitleBlock.tsx
@@ -68,24 +68,28 @@ export const PageTitleBlock: React.FC<PageTitleBlockProps> = ({
     );
   }
 
+  // 編集タイトルは当該ページの h1。本文は h2 起点（editor）と揃えて 1 ページ 1 見出しにする
+  // Editable page title is the only &lt;h1&gt;; body headings start at h2 in the editor
   return (
     <div ref={titleRef} className="pt-6 pb-2">
-      <input
-        type="text"
-        value={title}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        className={cn(
-          "w-full border-0 bg-transparent text-2xl font-semibold",
-          "placeholder:text-muted-foreground",
-          "focus:outline-none",
-          "min-h-[2.5rem] py-0 leading-tight",
-          errorMessage ? "text-destructive" : "",
-        )}
-        aria-label={placeholder}
-        aria-invalid={Boolean(errorMessage)}
-      />
+      <h1 className="m-0 break-words whitespace-normal">
+        <input
+          type="text"
+          value={title}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className={cn(
+            "w-full border-0 bg-transparent text-2xl font-semibold",
+            "placeholder:text-muted-foreground",
+            "focus:outline-none",
+            "min-h-[2.5rem] py-0 leading-tight",
+            errorMessage ? "text-destructive" : "",
+          )}
+          aria-label={placeholder}
+          aria-invalid={Boolean(errorMessage)}
+        />
+      </h1>
       {errorMessage && (
         <p className="text-destructive mt-1 text-sm" role="alert">
           {errorMessage}

--- a/src/components/editor/TiptapEditor/editorConfig.ts
+++ b/src/components/editor/TiptapEditor/editorConfig.ts
@@ -36,6 +36,7 @@ import {
   SlashSuggestionPlugin,
   type SlashSuggestionState,
 } from "../extensions/slashSuggestionPlugin";
+import { HeadingLevelClamp } from "./headingLevelClampExtension";
 import type { Extension } from "@tiptap/core";
 import type * as Y from "yjs";
 import type { Awareness } from "y-protocols/awareness";
@@ -146,7 +147,8 @@ function createCommonEditorExtensions(options: CommonEditorExtensionsOptions): E
   return [
     StarterKit.configure({
       heading: {
-        levels: [1, 2, 3],
+        // Body top: h2–h4. Page title is the only h1, outside the editor document.
+        levels: [2, 3, 4],
       },
       // Y.js が履歴を管理するためコラボ時は無効
       undoRedo: useCollaboration ? false : undefined,
@@ -157,6 +159,8 @@ function createCommonEditorExtensions(options: CommonEditorExtensionsOptions): E
       // 下で個別に Underline を追加するため StarterKit の underline は無効
       underline: false,
     }),
+    // Legacy h1 + collab: normalize to h2 after each change / 旧 h1 や Y.Doc 取り込みを h2 に揃える
+    HeadingLevelClamp,
     Markdown.configure({
       markedOptions: { gfm: true },
     }),

--- a/src/components/editor/TiptapEditor/editorConfig.ts
+++ b/src/components/editor/TiptapEditor/editorConfig.ts
@@ -147,8 +147,9 @@ function createCommonEditorExtensions(options: CommonEditorExtensionsOptions): E
   return [
     StarterKit.configure({
       heading: {
-        // Body top: h2–h4. Page title is the only h1, outside the editor document.
-        levels: [2, 3, 4],
+        // Body headings span h2–h5 (Markdown `#`/`##`/`###`/`####` map to 2/3/4/5).
+        // The page title is the only h1 and lives outside the editor document.
+        levels: [2, 3, 4, 5],
       },
       // Y.js が履歴を管理するためコラボ時は無効
       undoRedo: useCollaboration ? false : undefined,

--- a/src/components/editor/TiptapEditor/headingLevelClampExtension.test.ts
+++ b/src/components/editor/TiptapEditor/headingLevelClampExtension.test.ts
@@ -16,13 +16,13 @@ describe("HeadingLevelClamp", () => {
     editors.length = 0;
   });
 
-  it("migrates stored heading level 1 to 2 for schema levels 2-4", async () => {
+  it("migrates stored heading level 1 to 2 for schema levels 2-5", async () => {
     const el = document.createElement("div");
     const editor = new Editor({
       element: el,
       extensions: [
         StarterKit.configure({
-          heading: { levels: [2, 3, 4] },
+          heading: { levels: [2, 3, 4, 5] },
         }),
         HeadingLevelClamp,
       ],

--- a/src/components/editor/TiptapEditor/headingLevelClampExtension.test.ts
+++ b/src/components/editor/TiptapEditor/headingLevelClampExtension.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { HeadingLevelClamp } from "./headingLevelClampExtension";
+
+/**
+ * ロード直後、appendTransaction により h1 相当 (level:1) が h2 へ上書きされることを検証する
+ * / Verifies legacy Tiptap JSON (heading level:1) becomes level:2 on load
+ */
+describe("HeadingLevelClamp", () => {
+  const editors: Editor[] = [];
+  afterEach(() => {
+    for (const ed of editors) {
+      ed.destroy();
+    }
+    editors.length = 0;
+  });
+
+  it("migrates stored heading level 1 to 2 for schema levels 2-4", async () => {
+    const el = document.createElement("div");
+    const editor = new Editor({
+      element: el,
+      extensions: [
+        StarterKit.configure({
+          heading: { levels: [2, 3, 4] },
+        }),
+        HeadingLevelClamp,
+      ],
+      content: {
+        type: "doc",
+        content: [
+          { type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "Legacy" }] },
+        ],
+      },
+    });
+    editors.push(editor);
+    await new Promise<void>((resolve) => {
+      queueMicrotask(() => resolve());
+    });
+    const first = editor.state.doc.firstChild;
+    expect(first?.type.name).toBe("heading");
+    expect(first?.attrs.level).toBe(2);
+  });
+});

--- a/src/components/editor/TiptapEditor/headingLevelClampExtension.ts
+++ b/src/components/editor/TiptapEditor/headingLevelClampExtension.ts
@@ -1,0 +1,55 @@
+import { Extension } from "@tiptap/core";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+
+const headingLevelClampKey = new PluginKey("headingLevelClamp");
+
+/**
+ * 本文 h1 相当 (level:1) を h2 へ。初期 doc が appendTransaction を通らないこともあるため
+ * 初回は view マウント直後の queueMicrotask でも反映する
+ * / Body h1 (level:1) → h2. Initial Tiptap content may not run appendTransaction;
+ *     also run once in queueMicrotask after the plugin view is mounted
+ */
+function buildHeadingClampTr(state: EditorState): Transaction | null {
+  const tr = state.tr;
+  let modified = false;
+  state.doc.descendants((node, pos) => {
+    if (node.type.name !== "heading") return;
+    const level = typeof node.attrs.level === "number" ? node.attrs.level : 1;
+    if (level < 2) {
+      tr.setNodeMarkup(pos, undefined, { ...node.attrs, level: 2 });
+      modified = true;
+    }
+  });
+  return modified ? tr : null;
+}
+
+export /**
+ *
+ */
+const HeadingLevelClamp = Extension.create({
+  name: "headingLevelClamp",
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: headingLevelClampKey,
+        view(view) {
+          queueMicrotask(() => {
+            if (view.isDestroyed) return;
+            /**
+             *
+             */
+            const tr = buildHeadingClampTr(view.state);
+            if (tr) {
+              view.dispatch(tr);
+            }
+          });
+          return {};
+        },
+        appendTransaction(_transactions, _oldState, newState) {
+          return buildHeadingClampTr(newState);
+        },
+      }),
+    ];
+  },
+});

--- a/src/components/editor/TiptapEditor/headingLevelClampExtension.ts
+++ b/src/components/editor/TiptapEditor/headingLevelClampExtension.ts
@@ -20,14 +20,20 @@ function buildHeadingClampTr(state: EditorState): Transaction | null {
       tr.setNodeMarkup(pos, undefined, { ...node.attrs, level: 2 });
       modified = true;
     }
+    // headings only contain inline content; no need to scan descendants further
+    return false;
   });
   return modified ? tr : null;
 }
 
-export /**
- *
+/**
+ * 旧 h1（level:1）や Y.Doc から取り込んだ低レベル見出しを h2 にクランプする Tiptap 拡張。
+ * `appendTransaction` で各変更後に正規化し、初回のみ `view` マウント直後の `queueMicrotask` でも反映する。
+ * Tiptap extension that clamps stray heading nodes (level &lt; 2) up to level 2.
+ * Runs on every transaction via `appendTransaction`, plus once on view mount via `queueMicrotask`
+ * because the initial document does not always pass through `appendTransaction`.
  */
-const HeadingLevelClamp = Extension.create({
+export const HeadingLevelClamp = Extension.create({
   name: "headingLevelClamp",
   addProseMirrorPlugins() {
     return [
@@ -36,9 +42,6 @@ const HeadingLevelClamp = Extension.create({
         view(view) {
           queueMicrotask(() => {
             if (view.isDestroyed) return;
-            /**
-             *
-             */
             const tr = buildHeadingClampTr(view.state);
             if (tr) {
               view.dispatch(tr);

--- a/src/components/editor/TiptapEditor/slashCommandItems.ts
+++ b/src/components/editor/TiptapEditor/slashCommandItems.ts
@@ -40,19 +40,19 @@ export const slashCommandItems: SlashCommandItem[] = [
     id: "heading1",
     icon: "Heading1",
     action: (editor, range) =>
-      editor.chain().focus().deleteRange(range).setHeading({ level: 1 }).run(),
+      editor.chain().focus().deleteRange(range).setHeading({ level: 2 }).run(),
   },
   {
     id: "heading2",
     icon: "Heading2",
     action: (editor, range) =>
-      editor.chain().focus().deleteRange(range).setHeading({ level: 2 }).run(),
+      editor.chain().focus().deleteRange(range).setHeading({ level: 3 }).run(),
   },
   {
     id: "heading3",
     icon: "Heading3",
     action: (editor, range) =>
-      editor.chain().focus().deleteRange(range).setHeading({ level: 3 }).run(),
+      editor.chain().focus().deleteRange(range).setHeading({ level: 4 }).run(),
   },
   {
     id: "bulletList",

--- a/src/components/editor/extensions/MarkdownPasteExtension.test.ts
+++ b/src/components/editor/extensions/MarkdownPasteExtension.test.ts
@@ -124,7 +124,7 @@ describe("MarkdownPaste extension", () => {
     const parsedDoc = {
       type: "doc",
       content: [
-        { type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "Hello" }] },
+        { type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "Hello" }] },
       ],
     };
     const { handlePaste, mockEditor } = getHandlePaste({

--- a/src/components/editor/extensions/transformWikiLinksInContent.test.ts
+++ b/src/components/editor/extensions/transformWikiLinksInContent.test.ts
@@ -154,7 +154,7 @@ describe("transformWikiLinksInContent", () => {
       content: [
         {
           type: "heading",
-          attrs: { level: 1 },
+          attrs: { level: 2 },
           content: [{ type: "text", text: "Title with [[Link]]" }],
         },
       ],

--- a/src/components/layout/Header/HeaderLogo.tsx
+++ b/src/components/layout/Header/HeaderLogo.tsx
@@ -2,15 +2,13 @@ import React from "react";
 import { Link } from "react-router-dom";
 
 /**
- *
+ * アプリ名ロゴ。ページの h1 ではないため見出し要素にしない（ブランド用テキスト）
+ * / App brand text in the global header. Not a page &lt;h1&gt;; keep as non-heading
  */
-export /**
- *
- */
-const HeaderLogo: React.FC = () => (
+export const HeaderLogo: React.FC = () => (
   <Link to="/home">
-    <h1 className="from-primary to-primary/70 bg-gradient-to-r bg-clip-text text-2xl font-bold tracking-tight text-transparent transition-opacity hover:opacity-80">
+    <span className="from-primary to-primary/70 bg-gradient-to-r bg-clip-text text-2xl font-bold tracking-tight text-transparent transition-opacity hover:opacity-80">
       Zedi
-    </h1>
+    </span>
   </Link>
 );

--- a/src/index.css
+++ b/src/index.css
@@ -258,6 +258,30 @@
     margin-top: 0;
   }
 
+  .tiptap-editor h4 {
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 1.55;
+    margin: 22px 0 10px;
+    color: hsl(var(--foreground));
+  }
+
+  .tiptap-editor h4:first-child {
+    margin-top: 0;
+  }
+
+  .tiptap-editor h5 {
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.6;
+    margin: 18px 0 8px;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .tiptap-editor h5:first-child {
+    margin-top: 0;
+  }
+
   .tiptap-editor p {
     margin: 0 0 18px;
     line-height: 1.8;

--- a/src/lib/aiChatActionHelpers.test.ts
+++ b/src/lib/aiChatActionHelpers.test.ts
@@ -137,9 +137,10 @@ describe("appendMarkdownToTiptapContent", () => {
       type: "paragraph",
       content: [{ type: "text", text: "Existing" }],
     });
+    // `##` → Tiptap level 3 (body: #/##/### = 2/3/4; page h1 is outside the doc)
     expect(parsed.content[1]).toMatchObject({
       type: "heading",
-      attrs: { level: 2 },
+      attrs: { level: 3 },
     });
     expect(parsed.content[2]).toMatchObject({
       type: "bulletList",

--- a/src/lib/aiChatActionHelpers.test.ts
+++ b/src/lib/aiChatActionHelpers.test.ts
@@ -137,10 +137,11 @@ describe("appendMarkdownToTiptapContent", () => {
       type: "paragraph",
       content: [{ type: "text", text: "Existing" }],
     });
-    // `##` → Tiptap level 3 (body: #/##/### = 2/3/4; page h1 is outside the doc)
+    // `##` → Tiptap level 2 (body: ##/###/####/##### = 2/3/4/5; `# X` stays literal because
+    // the page h1 lives in the title field)
     expect(parsed.content[1]).toMatchObject({
       type: "heading",
-      attrs: { level: 3 },
+      attrs: { level: 2 },
     });
     expect(parsed.content[2]).toMatchObject({
       type: "bulletList",

--- a/src/lib/contentUtils.test.ts
+++ b/src/lib/contentUtils.test.ts
@@ -39,6 +39,22 @@ describe("sanitizeTiptapContent", () => {
     expect(parsed.content[0].content[0].text).toBe("Hello world");
   });
 
+  it("clamps stored heading level 1 to 2 (body top = h2)", () => {
+    const content = JSON.stringify({
+      type: "doc",
+      content: [
+        { type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "Legacy" }] },
+      ],
+    });
+    const result = sanitizeTiptapContent(content);
+    expect(result.hadErrors).toBe(false);
+    const parsed = JSON.parse(result.content) as {
+      content: Array<{ type: string; attrs?: { level: number } }>;
+    };
+    expect(parsed.content[0].type).toBe("heading");
+    expect(parsed.content[0].attrs?.level).toBe(2);
+  });
+
   it("should remove unsupported node types", () => {
     const contentWithUnsupportedNode = JSON.stringify({
       type: "doc",

--- a/src/lib/contentUtils.ts
+++ b/src/lib/contentUtils.ts
@@ -245,6 +245,16 @@ function sanitizeNode(
   // Create a copy of the node
   const sanitizedNode: Record<string, unknown> = { ...node };
 
+  // 本文最上位を h2 に揃え、古い Tiptap JSON（level:1 や欠損＝1 相当）を 2 へ
+  if (nodeType === "heading") {
+    const attrs = { ...((node.attrs as Record<string, unknown> | undefined) ?? {}) };
+    const level = typeof attrs.level === "number" ? attrs.level : 1;
+    if (level < 2) {
+      attrs.level = 2;
+      sanitizedNode.attrs = attrs;
+    }
+  }
+
   // Sanitize marks if present
   if (node.marks && Array.isArray(node.marks)) {
     const sanitizedMarks = (node.marks as Array<Record<string, unknown>>).filter((mark) => {

--- a/src/lib/htmlToTiptap.test.ts
+++ b/src/lib/htmlToTiptap.test.ts
@@ -144,4 +144,17 @@ describe("htmlToTiptapJSON", () => {
     expect(imageNodes.length).toBe(1);
     expect(imageNodes[0]?.attrs).toMatchObject({ src: "https://example.com/fig.webp" });
   });
+
+  // Regression for PR #777 review (Devin): keep <h1> as a heading node so that
+  // editor-time clamping (HeadingLevelClamp / sanitizeTiptapContent) can demote
+  // it to level 2. Dropping <h1> at parse time would silently lose semantics.
+  it("preserves <h1>..<h3> as heading nodes (clamping happens later)", () => {
+    const html = "<h1>Top</h1><h2>Sub</h2><h3>Detail</h3>";
+    const result = htmlToTiptapJSON(html);
+    const headings = result.content?.filter((n) => n.type === "heading") ?? [];
+    expect(headings).toHaveLength(3);
+    expect(headings[0]?.attrs).toMatchObject({ level: 1 });
+    expect(headings[1]?.attrs).toMatchObject({ level: 2 });
+    expect(headings[2]?.attrs).toMatchObject({ level: 3 });
+  });
 });

--- a/src/lib/htmlToTiptap.ts
+++ b/src/lib/htmlToTiptap.ts
@@ -31,7 +31,7 @@ function isClipLinkUriAllowed(url: string | undefined): boolean {
 const extensions = [
   StarterKit.configure({
     heading: {
-      levels: [1, 2, 3],
+      levels: [2, 3, 4],
     },
     codeBlock: false,
     link: false,

--- a/src/lib/htmlToTiptap.ts
+++ b/src/lib/htmlToTiptap.ts
@@ -28,10 +28,17 @@ function isClipLinkUriAllowed(url: string | undefined): boolean {
 // Web クリップ用の最小スキーマ（サーバー `clipAndCreate` と同系）。
 // Table / TaskList 等は含めない — 拡張は別 PR で検討する。
 // generateJSON に Image がないと <img> がドロップされる。
+// 外部 HTML の `<h1>`〜`<h3>` をパース時にドロップしないため、ここでは server 側
+// (`server/api/src/lib/articleExtractor.ts`) と同じ `[1, 2, 3]` を維持する。
+// 取り込み後の正規化（h1 → h2）はエディタ装着時の `HeadingLevelClamp` と
+// `sanitizeTiptapContent` が行う（PR #777）。
+// Keep parsing levels aligned with the server extractor so external `<h1>`〜`<h3>` survive
+// `generateJSON`; client/runtime clamping (HeadingLevelClamp + sanitizeTiptapContent) demotes
+// any level-1 headings to level 2 before they reach the editor body.
 const extensions = [
   StarterKit.configure({
     heading: {
-      levels: [2, 3, 4],
+      levels: [1, 2, 3],
     },
     codeBlock: false,
     link: false,

--- a/src/lib/markdownExport.test.ts
+++ b/src/lib/markdownExport.test.ts
@@ -15,19 +15,44 @@ describe("tiptapToMarkdown", () => {
     expect(md).toContain("Second line");
   });
 
-  it("converts headings with # prefix", () => {
+  // 本文の見出しは body schema 上 h2–h5（level 2–5）で、`#` 1 個の見出しはページタイトル
+  // 入力欄が担う。export ではそれぞれ `##/###/####/#####` を出す。
+  // Body headings span schema levels 2–5; the page h1 lives in the title field, so the
+  // exporter emits `##/###/####/#####` for the four body levels.
+  it("converts body headings (levels 2–5) with matching # prefixes", () => {
     const content = JSON.stringify({
       type: "doc",
       content: [
-        { type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "H1" }] },
         { type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "H2" }] },
         { type: "heading", attrs: { level: 3 }, content: [{ type: "text", text: "H3" }] },
+        { type: "heading", attrs: { level: 4 }, content: [{ type: "text", text: "H4" }] },
+        { type: "heading", attrs: { level: 5 }, content: [{ type: "text", text: "H5" }] },
       ],
     });
     const md = tiptapToMarkdown(content);
-    expect(md).toContain("# H1");
     expect(md).toContain("## H2");
     expect(md).toContain("### H3");
+    expect(md).toContain("#### H4");
+    expect(md).toContain("##### H5");
+  });
+
+  // 旧データに残っている level 1 / 欠損 level は最小の本文見出し `##` にフォールバックさせ、
+  // ページタイトルの `#` と衝突しないようにする。
+  // Legacy heading nodes with level 1 (or a missing level attribute) fall back to `##`,
+  // the minimum body-heading level, so they never collide with the page title's `#`.
+  it("falls back to `##` when level is missing or below 2 (legacy data)", () => {
+    const content = JSON.stringify({
+      type: "doc",
+      content: [
+        { type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "Legacy" }] },
+        { type: "heading", content: [{ type: "text", text: "NoLevel" }] },
+      ],
+    });
+    const md = tiptapToMarkdown(content);
+    expect(md).toContain("## Legacy");
+    expect(md).toContain("## NoLevel");
+    expect(md).not.toMatch(/^# Legacy/m);
+    expect(md).not.toMatch(/^# NoLevel/m);
   });
 
   it("converts bullet list with - markers", () => {

--- a/src/lib/markdownExport.ts
+++ b/src/lib/markdownExport.ts
@@ -42,7 +42,14 @@ Object.assign(nodeHandlers, {
   doc: (n) => convertChildren(n),
   paragraph: (n) => convertChildren(n) + "\n\n",
   heading: (n) => {
-    const level = (n.attrs?.level as number) || 1;
+    // 本文の見出しは body schema 上 h2–h5（level 2–5）。level が欠落している旧データでも
+    // ページタイトルと衝突する `#` 1 個に潰さず、最小の本文見出しレベル `##` にフォールバック
+    // する。これにより `convertMarkdownToTiptapContent` との round-trip が対称に保たれる。
+    // Body headings span schema levels 2–5. If the level attribute is missing on legacy data,
+    // fall back to `##` (the minimum body heading) instead of `#`, which would clash with the
+    // page title and round-trip back to a literal `# X` paragraph in `convertMarkdownToTiptapContent`.
+    const rawLevel = n.attrs?.level;
+    const level = typeof rawLevel === "number" && rawLevel >= 2 ? rawLevel : 2;
     const prefix = "#".repeat(level);
     return `${prefix} ${convertChildren(n)}\n\n`;
   },

--- a/src/lib/markdownToTiptap.test.ts
+++ b/src/lib/markdownToTiptap.test.ts
@@ -28,13 +28,14 @@ describe("convertMarkdownToTiptapContent", () => {
     });
   });
 
-  it("converts ## and ### headings to levels 3 and 4", () => {
-    const result = convertMarkdownToTiptapContent("## Section\n### Sub");
+  it("converts ##, ###, #### headings to levels 3, 4, 5", () => {
+    const result = convertMarkdownToTiptapContent("## Section\n### Sub\n#### Detail");
     const parsed = JSON.parse(result) as {
       content: Array<{ type: string; attrs?: { level: number } }>;
     };
     expect(parsed.content[0]).toMatchObject({ type: "heading", attrs: { level: 3 } });
     expect(parsed.content[1]).toMatchObject({ type: "heading", attrs: { level: 4 } });
+    expect(parsed.content[2]).toMatchObject({ type: "heading", attrs: { level: 5 } });
   });
 
   it("converts bullet list items", () => {

--- a/src/lib/markdownToTiptap.test.ts
+++ b/src/lib/markdownToTiptap.test.ts
@@ -10,7 +10,7 @@ describe("convertMarkdownToTiptapContent", () => {
     expect(parsed.content[0]).toMatchObject({ type: "paragraph" });
   });
 
-  it("converts # heading to heading level 1", () => {
+  it("converts # heading to body top level 2 (not page h1; title is outside the doc)", () => {
     const result = convertMarkdownToTiptapContent("# Title");
     const parsed = JSON.parse(result) as {
       content: Array<{ type: string; attrs?: { level: number }; content?: unknown[] }>;
@@ -18,7 +18,7 @@ describe("convertMarkdownToTiptapContent", () => {
     expect(parsed.content).toHaveLength(1);
     expect(parsed.content[0]).toMatchObject({
       type: "heading",
-      attrs: { level: 1 },
+      attrs: { level: 2 },
     });
     const firstContent = parsed.content[0].content;
     expect(firstContent).toHaveLength(1);
@@ -28,13 +28,13 @@ describe("convertMarkdownToTiptapContent", () => {
     });
   });
 
-  it("converts ## and ### headings", () => {
+  it("converts ## and ### headings to levels 3 and 4", () => {
     const result = convertMarkdownToTiptapContent("## Section\n### Sub");
     const parsed = JSON.parse(result) as {
       content: Array<{ type: string; attrs?: { level: number } }>;
     };
-    expect(parsed.content[0]).toMatchObject({ type: "heading", attrs: { level: 2 } });
-    expect(parsed.content[1]).toMatchObject({ type: "heading", attrs: { level: 3 } });
+    expect(parsed.content[0]).toMatchObject({ type: "heading", attrs: { level: 3 } });
+    expect(parsed.content[1]).toMatchObject({ type: "heading", attrs: { level: 4 } });
   });
 
   it("converts bullet list items", () => {

--- a/src/lib/markdownToTiptap.test.ts
+++ b/src/lib/markdownToTiptap.test.ts
@@ -10,32 +10,34 @@ describe("convertMarkdownToTiptapContent", () => {
     expect(parsed.content[0]).toMatchObject({ type: "paragraph" });
   });
 
-  it("converts # heading to body top level 2 (not page h1; title is outside the doc)", () => {
+  // `# X` は本文 h1 として変換しないため、テキストのまま paragraph として残る。
+  // The page h1 lives in the title field, so `# X` survives verbatim as a paragraph.
+  it("preserves `# X` as a literal paragraph (no heading conversion)", () => {
     const result = convertMarkdownToTiptapContent("# Title");
     const parsed = JSON.parse(result) as {
       content: Array<{ type: string; attrs?: { level: number }; content?: unknown[] }>;
     };
     expect(parsed.content).toHaveLength(1);
     expect(parsed.content[0]).toMatchObject({
-      type: "heading",
-      attrs: { level: 2 },
+      type: "paragraph",
     });
     const firstContent = parsed.content[0].content;
     expect(firstContent).toHaveLength(1);
     expect(firstContent?.[0]).toMatchObject({
       type: "text",
-      text: "Title",
+      text: "# Title",
     });
   });
 
-  it("converts ##, ###, #### headings to levels 3, 4, 5", () => {
-    const result = convertMarkdownToTiptapContent("## Section\n### Sub\n#### Detail");
+  it("converts ##, ###, ####, ##### headings to levels 2, 3, 4, 5", () => {
+    const result = convertMarkdownToTiptapContent("## Section\n### Sub\n#### Detail\n##### Note");
     const parsed = JSON.parse(result) as {
       content: Array<{ type: string; attrs?: { level: number } }>;
     };
-    expect(parsed.content[0]).toMatchObject({ type: "heading", attrs: { level: 3 } });
-    expect(parsed.content[1]).toMatchObject({ type: "heading", attrs: { level: 4 } });
-    expect(parsed.content[2]).toMatchObject({ type: "heading", attrs: { level: 5 } });
+    expect(parsed.content[0]).toMatchObject({ type: "heading", attrs: { level: 2 } });
+    expect(parsed.content[1]).toMatchObject({ type: "heading", attrs: { level: 3 } });
+    expect(parsed.content[2]).toMatchObject({ type: "heading", attrs: { level: 4 } });
+    expect(parsed.content[3]).toMatchObject({ type: "heading", attrs: { level: 5 } });
   });
 
   it("converts bullet list items", () => {

--- a/src/lib/markdownToTiptap.ts
+++ b/src/lib/markdownToTiptap.ts
@@ -1,6 +1,8 @@
 /**
  * Markdown → Tiptap JSON 変換の共通モジュール。
  * wikiGenerator と aiChatActionHelpers の両方で利用。
+ * 見出し: `#/##/###` は body 上で level 2/3/4（h1 はページタイトル用で本文外）に対応する
+ * / Headings: map `#/##/###` to Tiptap levels 2/3/4; the page h1 is the title field, not the doc
  */
 
 import { parseInlineContent, type TiptapTextNode } from "./markdownToTiptapHelpers";
@@ -11,17 +13,32 @@ type TiptapBlockNode = {
   content?: Array<TiptapBlockNode | TiptapTextNode>;
 };
 
+/**
+ *
+ */
 export function convertMarkdownToTiptapContent(markdown: string): string {
+  /**
+   *
+   */
   const normalized = markdown.replace(/\r\n?/g, "\n");
+  /**
+   *
+   */
   const lines = normalized.endsWith("\n")
     ? normalized.slice(0, -1).split("\n")
     : normalized.split("\n");
+  /**
+   *
+   */
   const doc: { type: "doc"; content: TiptapBlockNode[] } = {
     type: "doc",
     content: [],
   };
 
-  for (const line of lines) {
+  for (/**
+   *
+   */
+  const line of lines) {
     if (line.trim() === "") {
       doc.content.push({ type: "paragraph" });
       continue;
@@ -30,7 +47,7 @@ export function convertMarkdownToTiptapContent(markdown: string): string {
     if (line.startsWith("### ")) {
       doc.content.push({
         type: "heading",
-        attrs: { level: 3 },
+        attrs: { level: 4 },
         content: parseInlineContent(line.slice(4)),
       });
       continue;
@@ -39,7 +56,7 @@ export function convertMarkdownToTiptapContent(markdown: string): string {
     if (line.startsWith("## ")) {
       doc.content.push({
         type: "heading",
-        attrs: { level: 2 },
+        attrs: { level: 3 },
         content: parseInlineContent(line.slice(3)),
       });
       continue;
@@ -48,13 +65,16 @@ export function convertMarkdownToTiptapContent(markdown: string): string {
     if (line.startsWith("# ")) {
       doc.content.push({
         type: "heading",
-        attrs: { level: 1 },
+        attrs: { level: 2 },
         content: parseInlineContent(line.slice(2)),
       });
       continue;
     }
 
     if (line.startsWith("- ") || line.startsWith("* ")) {
+      /**
+       *
+       */
       const listItem: TiptapBlockNode = {
         type: "listItem",
         content: [
@@ -65,6 +85,9 @@ export function convertMarkdownToTiptapContent(markdown: string): string {
         ],
       };
 
+      /**
+       *
+       */
       const lastNode = doc.content[doc.content.length - 1];
       if (lastNode?.type === "bulletList") {
         if (!lastNode.content) lastNode.content = [];

--- a/src/lib/markdownToTiptap.ts
+++ b/src/lib/markdownToTiptap.ts
@@ -1,8 +1,8 @@
 /**
  * Markdown → Tiptap JSON 変換の共通モジュール。
  * wikiGenerator と aiChatActionHelpers の両方で利用。
- * 見出し: `#/##/###` は body 上で level 2/3/4（h1 はページタイトル用で本文外）に対応する
- * / Headings: map `#/##/###` to Tiptap levels 2/3/4; the page h1 is the title field, not the doc
+ * 見出し: `#/##/###/####` は body 上で level 2/3/4/5（h1 はページタイトル用で本文外）に対応する
+ * / Headings: map `#/##/###/####` to Tiptap levels 2/3/4/5; the page h1 is the title field, not the doc
  */
 
 import { parseInlineContent, type TiptapTextNode } from "./markdownToTiptapHelpers";
@@ -14,33 +14,34 @@ type TiptapBlockNode = {
 };
 
 /**
+ * Markdown 文字列を Tiptap JSON（`doc`）へ変換し、文字列化して返す。
+ * Convert a Markdown string to a Tiptap `doc` JSON and return its serialized form.
  *
+ * @param markdown - 入力 Markdown / Source Markdown text.
+ * @returns Tiptap doc JSON を `JSON.stringify` した文字列 / Serialized Tiptap doc JSON.
  */
 export function convertMarkdownToTiptapContent(markdown: string): string {
-  /**
-   *
-   */
   const normalized = markdown.replace(/\r\n?/g, "\n");
-  /**
-   *
-   */
   const lines = normalized.endsWith("\n")
     ? normalized.slice(0, -1).split("\n")
     : normalized.split("\n");
-  /**
-   *
-   */
   const doc: { type: "doc"; content: TiptapBlockNode[] } = {
     type: "doc",
     content: [],
   };
 
-  for (/**
-   *
-   */
-  const line of lines) {
+  for (const line of lines) {
     if (line.trim() === "") {
       doc.content.push({ type: "paragraph" });
+      continue;
+    }
+
+    if (line.startsWith("#### ")) {
+      doc.content.push({
+        type: "heading",
+        attrs: { level: 5 },
+        content: parseInlineContent(line.slice(5)),
+      });
       continue;
     }
 
@@ -72,9 +73,6 @@ export function convertMarkdownToTiptapContent(markdown: string): string {
     }
 
     if (line.startsWith("- ") || line.startsWith("* ")) {
-      /**
-       *
-       */
       const listItem: TiptapBlockNode = {
         type: "listItem",
         content: [
@@ -85,9 +83,6 @@ export function convertMarkdownToTiptapContent(markdown: string): string {
         ],
       };
 
-      /**
-       *
-       */
       const lastNode = doc.content[doc.content.length - 1];
       if (lastNode?.type === "bulletList") {
         if (!lastNode.content) lastNode.content = [];

--- a/src/lib/markdownToTiptap.ts
+++ b/src/lib/markdownToTiptap.ts
@@ -1,8 +1,18 @@
 /**
  * Markdown → Tiptap JSON 変換の共通モジュール。
  * wikiGenerator と aiChatActionHelpers の両方で利用。
- * 見出し: `#/##/###/####` は body 上で level 2/3/4/5（h1 はページタイトル用で本文外）に対応する
- * / Headings: map `#/##/###/####` to Tiptap levels 2/3/4/5; the page h1 is the title field, not the doc
+ *
+ * 見出しの方針:
+ * - `# X` は **本文の見出しに変換しない**（ページの h1 はタイトル input が担うため、`# X` を
+ *   書いた行はそのまま `# X` というテキストの paragraph として残す）。これにより、
+ *   `markdownExport.ts` の `"#".repeat(level)` と round-trip が対称になる。
+ * - `## / ### / #### / #####` → Tiptap level 2/3/4/5 にそれぞれ対応する。
+ *
+ * Heading policy:
+ * - `# X` is **not** converted into a body heading; the page h1 lives in the title field, so
+ *   any line starting with `# ` is preserved verbatim as a `# X` paragraph. This keeps the
+ *   import side symmetric with `markdownExport.ts`'s `"#".repeat(level)` output.
+ * - `## / ### / #### / #####` map to Tiptap heading levels 2/3/4/5 respectively.
  */
 
 import { parseInlineContent, type TiptapTextNode } from "./markdownToTiptapHelpers";
@@ -36,10 +46,19 @@ export function convertMarkdownToTiptapContent(markdown: string): string {
       continue;
     }
 
-    if (line.startsWith("#### ")) {
+    if (line.startsWith("##### ")) {
       doc.content.push({
         type: "heading",
         attrs: { level: 5 },
+        content: parseInlineContent(line.slice(6)),
+      });
+      continue;
+    }
+
+    if (line.startsWith("#### ")) {
+      doc.content.push({
+        type: "heading",
+        attrs: { level: 4 },
         content: parseInlineContent(line.slice(5)),
       });
       continue;
@@ -48,7 +67,7 @@ export function convertMarkdownToTiptapContent(markdown: string): string {
     if (line.startsWith("### ")) {
       doc.content.push({
         type: "heading",
-        attrs: { level: 4 },
+        attrs: { level: 3 },
         content: parseInlineContent(line.slice(4)),
       });
       continue;
@@ -57,20 +76,18 @@ export function convertMarkdownToTiptapContent(markdown: string): string {
     if (line.startsWith("## ")) {
       doc.content.push({
         type: "heading",
-        attrs: { level: 3 },
+        attrs: { level: 2 },
         content: parseInlineContent(line.slice(3)),
       });
       continue;
     }
 
-    if (line.startsWith("# ")) {
-      doc.content.push({
-        type: "heading",
-        attrs: { level: 2 },
-        content: parseInlineContent(line.slice(2)),
-      });
-      continue;
-    }
+    // `# X` は本文 h1 として変換しない: ページのタイトル input が h1 を担うため、
+    // 該当行はそのまま `# X` というテキストを含む paragraph として残し、後段の
+    // 既定パラグラフ分岐に委ねる。
+    // `# X` is intentionally NOT converted into a body heading; the page title field is the
+    // canonical h1, so the line falls through to the default paragraph branch and survives
+    // verbatim as a `# X` text paragraph.
 
     if (line.startsWith("- ") || line.startsWith("* ")) {
       const listItem: TiptapBlockNode = {


### PR DESCRIPTION
## 概要

ページエディタ周りの HTML 見出し階層を整理する。グローバルヘッダのロゴを h1 から外し、**ページタイトル（input）を当該画面の唯一の h1** にする。本文の見出しは **h2 起点**（Tiptap level 2–4）とし、`#` / Markdown 取り込みは旧 h1 ノードを h2 へ正規化する。アクセシビリティと「1 ページ 1 つの h1」原則に合わせる。

## 変更点

- **`src/components/layout/Header/HeaderLogo.tsx`**
  - ロゴ「Zedi」を `span` に変更（ブランド用テキスト、ページの h1 ではない）
- **`src/components/editor/PageEditor/PageTitleBlock.tsx`**
  - 編集モードで `<h1><input/></h1>` にラップ；閲覧専用の h1 表示は従来どおり
- **`src/components/editor/TiptapEditor/`**
  - `editorConfig`：`StarterKit` の heading levels を `[2,3,4]`
  - 新規 `headingLevelClampExtension`：`appendTransaction` + 初回 `queueMicrotask` で `level<2` → 2（Y.Doc/旧データ用）
  - `slashCommandItems`：見出し1/2/3 → `setHeading` 2/3/4
- **`src/lib/`**
  - `markdownToTiptap`：`#` / `##` / `###` → Tiptap level 2/3/4
  - `contentUtils`：`sanitizeTiptapContent` で heading `level<2` を 2 に
  - `htmlToTiptap`：クリップ用スキーマの levels を 2–4 に揃え
- **テスト**
  - 上記に合わせて更新。`aiChatActionHelpers.test` の `##` 期待を level 3 に修正

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. フロントで `/pages/:id` を開き、DevTools で `document.querySelectorAll("h1")` が **タイトル用 h1 のみ**（ロゴに h1 が付いていないこと）を確認
2. 本文でスラッシュメニュー「見出し1」を挿入し、DOM が **h2** 相当になることを確認
3. 既存ページに `level:1` 見出しが含まれても、開き直し後に **h2 相当**に正規化されることを確認（可能なら）
4. `bunx vitest run`（該当 `src/components/editor` + `aiChatActionHelpers` 等）が通ることを確認

## チェックリスト

- [x] テストがすべてパスする（ローカルで editor + 関連 lib の vitest を実行）
- [x] Lint エラーがない（pre-commit / lint-staged 済み）
- [ ] 必要に応じてドキュメントを更新した（本 PR ではコード・テストが仕様根拠）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

見た目の意図的な変化は最小（セマンティクス中心）。必要ならアクセシビリティツリーの h1 件数のスクショを追記可。

## 関連 Issue

<!-- 紐づく Issue があれば -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editor now supports heading levels 2–5 for richer in-document structure.

* **Improvements**
  * Page title is properly presented as the primary (h1) heading outside the editor for improved accessibility.
  * Imported or legacy content is automatically normalized so body headings are clamped to start at level 2.
  * Markdown/HTML import and export updated: top-level `#` is preserved as paragraph text; body headings map to `##`–`#####` (levels 2–5).

* **Accessibility**
  * Header/brand text no longer uses a page-level heading, avoiding duplicate h1s.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->