### PR TITLE
chore(deps): bump @hono/node-server to ^2.0.0 in /server/api

### DIFF
--- a/server/api/bun.lock
+++ b/server/api/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1002.0",
         "@aws-sdk/s3-request-presigner": "^3.1002.0",
-        "@hono/node-server": "^1.19.11",
+        "@hono/node-server": "^2.0.0",
         "@mozilla/readability": "^0.6.0",
         "@polar-sh/sdk": "^0.47.0",
         "@react-email/components": "^1.0.11",
@@ -242,7 +242,7 @@
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+    "@hono/node-server": ["@hono/node-server@2.0.0", "", { "peerDependencies": { "hono": "^4" } }, "sha512-n3GfHwwCvHCkGmOwKfxUPOlbfzuO64Sbc5XC4NGPIXxkuOnJrdgExdRKmHfF924r914WRJPT397GdqLvdYTeyQ=="],
 
     "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
 

--- a/server/api/package.json
+++ b/server/api/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1002.0",
     "@aws-sdk/s3-request-presigner": "^3.1002.0",
-    "@hono/node-server": "^1.19.11",
+    "@hono/node-server": "^2.0.0",
     "@mozilla/readability": "^0.6.0",
     "@polar-sh/sdk": "^0.47.0",
     "@react-email/components": "^1.0.11",


### PR DESCRIPTION
## Summary

dependabot #774 が `server/api/package.json` だけを更新して `server/api/bun.lock` を同期せず、CI の `bun install --frozen-lockfile` が `lockfile had changes, but lockfile is frozen` で落ちていたため、その置き換えとして package.json と bun.lock をまとめて更新する。dependabot 設定が `package-ecosystem: npm` のままだと bun.lock が更新されず同様の事象が再発する。

dependabot #774 closes (本PRで置き換え)。

## v2.0.0 のブレイクと影響評価

- **Node.js v18 サポート終了 → v20+ 必須**: `.nvmrc` は v22 系のはずなので影響なし（要確認）。
- **`@hono/node-server/vercel` アダプタ削除**: リポジトリ内未使用。
- **`serve` の public API 互換**: `server/api/src/index.ts` は変更不要。`@hono/node-server/conninfo` の `getConnInfo` も継続利用可能。

## ローカル検証

- `bun install --frozen-lockfile`: ✅ EXIT 0
- `bunx tsc --noEmit` (server/api): ✅ EXIT 0
- `bun run lint`: ✅ 0 errors（warnings のみ、本変更による増減なし）
- `bun run format:check`: ✅ All matched files use Prettier code style

## Test plan

- [ ] CI の API Type Check が緑になること
- [ ] CI の Build / Lint / Type Check / Unit Tests が緑になること
- [ ] Drizzle Migration Check は対象外（スキーマ変更なし）


---
_Generated by [Claude Code](https://claude.ai/code/session_01TQXmJ9uTqJW9JZe8yhrfRj)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server adapter dependency to the latest major version (2.0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->