### PR TITLE
fix: prevent autosave from racing soft delete (issue #768)

### DIFF
--- a/src/components/editor/PageEditor/useEditorAutoSave.test.ts
+++ b/src/components/editor/PageEditor/useEditorAutoSave.test.ts
@@ -336,6 +336,94 @@ describe("useEditorAutoSave", () => {
     });
   });
 
+  describe("cancelPendingSave (issue #768)", () => {
+    it("デバウンス中に cancelPendingSave を呼ぶと onSave / syncWikiLinks がもう走らない / pending debounce is cleared so onSave never fires", async () => {
+      const syncWikiLinks = vi.fn().mockResolvedValue(undefined);
+      const onSave = vi.fn().mockResolvedValue(true);
+      const onSaveContentOnly = vi.fn().mockResolvedValue(true);
+
+      const { result } = renderHook(() =>
+        useEditorAutoSave({
+          pageId,
+          debounceMs: 500,
+          onSave,
+          onSaveContentOnly,
+          syncWikiLinks,
+        }),
+      );
+
+      act(() => {
+        result.current.saveChanges("My Title", "{}");
+      });
+
+      act(() => {
+        result.current.cancelPendingSave();
+      });
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(onSave).not.toHaveBeenCalled();
+      expect(onSaveContentOnly).not.toHaveBeenCalled();
+      expect(syncWikiLinks).not.toHaveBeenCalled();
+    });
+
+    it("cancelPendingSave 後にアンマウントしても unmount flush で onSave / syncWikiLinks が呼ばれない / unmount flush is suppressed after cancelPendingSave", async () => {
+      const syncWikiLinks = vi.fn().mockResolvedValue(undefined);
+      const onSave = vi.fn().mockResolvedValue(true);
+      const onSaveContentOnly = vi.fn().mockResolvedValue(true);
+
+      const { result, unmount } = renderHook(() =>
+        useEditorAutoSave({
+          pageId,
+          debounceMs: 500,
+          onSave,
+          onSaveContentOnly,
+          syncWikiLinks,
+        }),
+      );
+
+      act(() => {
+        result.current.saveChanges("My Title", "{}");
+      });
+
+      act(() => {
+        result.current.cancelPendingSave();
+      });
+
+      unmount();
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(onSave).not.toHaveBeenCalled();
+      expect(onSaveContentOnly).not.toHaveBeenCalled();
+      expect(syncWikiLinks).not.toHaveBeenCalled();
+    });
+
+    it("保留中の保存が無いときに cancelPendingSave を呼んでも安全（no-op） / cancelPendingSave is safe to call when nothing is pending", () => {
+      const onSave = vi.fn().mockResolvedValue(true);
+      const { result } = renderHook(() =>
+        useEditorAutoSave({
+          pageId,
+          debounceMs: 500,
+          onSave,
+          onSaveContentOnly: vi.fn().mockResolvedValue(true),
+          syncWikiLinks: vi.fn().mockResolvedValue(undefined),
+        }),
+      );
+
+      expect(() => {
+        act(() => {
+          result.current.cancelPendingSave();
+        });
+      }).not.toThrow();
+      expect(onSave).not.toHaveBeenCalled();
+    });
+  });
+
   describe("保存成功時の linkedPages 無効化（3.5）", () => {
     it("onSaveSuccess で queryClient.invalidateQueries が linkedPages の queryKey で1回呼ばれる", async () => {
       const queryClient = new QueryClient();

--- a/src/components/editor/PageEditor/useEditorAutoSave.test.ts
+++ b/src/components/editor/PageEditor/useEditorAutoSave.test.ts
@@ -403,6 +403,62 @@ describe("useEditorAutoSave", () => {
       expect(syncWikiLinks).not.toHaveBeenCalled();
     });
 
+    it("shouldBlockSave で content-only 経路が保留中でも cancelPendingSave で抑止される / content-only debounce branch is also cleared (CodeRabbit feedback)", async () => {
+      // CodeRabbit のレビュー指摘: 既存のキャンセル系テストは shouldBlockSave=false の
+      // フル保存経路しか走らせていなかったため、`onSaveContentOnly` を expect しても
+      // vacuous（そもそも呼ばれない）。`shouldBlockSave=true` を立てて content-only
+      // 経路の `pendingRef` も同じ `cancelPendingSave` で確実に消えることを検証する。
+      //
+      // CodeRabbit: the prior cancellation tests only exercised the full-save
+      // branch, so asserting `onSaveContentOnly` was vacuous. This case enables
+      // `shouldBlockSave` to schedule the content-only debounce path and asserts
+      // `cancelPendingSave` clears that pendingRef too.
+      const syncWikiLinks = vi.fn().mockResolvedValue(undefined);
+      const onSave = vi.fn().mockResolvedValue(true);
+      const onSaveContentOnly = vi.fn().mockResolvedValue(true);
+
+      const { result, unmount } = renderHook(() =>
+        useEditorAutoSave({
+          pageId,
+          debounceMs: 500,
+          shouldBlockSave: true,
+          onSave,
+          onSaveContentOnly,
+          syncWikiLinks,
+        }),
+      );
+
+      act(() => {
+        result.current.saveChanges("My Title", "{}");
+      });
+
+      act(() => {
+        result.current.cancelPendingSave();
+      });
+
+      // 単に時間を進めても content-only 経路の onSaveContentOnly は呼ばれない。
+      // Advancing timers must not flush the content-only branch.
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(onSaveContentOnly).not.toHaveBeenCalled();
+      expect(onSave).not.toHaveBeenCalled();
+      expect(syncWikiLinks).not.toHaveBeenCalled();
+
+      // unmount flush も走らない（pendingRef が null のため）。
+      // The unmount flush must also stay silent (pendingRef is null).
+      unmount();
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(onSaveContentOnly).not.toHaveBeenCalled();
+      expect(onSave).not.toHaveBeenCalled();
+      expect(syncWikiLinks).not.toHaveBeenCalled();
+    });
+
     it("保留中の保存が無いときに cancelPendingSave を呼んでも安全（no-op） / cancelPendingSave is safe to call when nothing is pending", () => {
       const onSave = vi.fn().mockResolvedValue(true);
       const { result } = renderHook(() =>

--- a/src/components/editor/PageEditor/useEditorAutoSave.ts
+++ b/src/components/editor/PageEditor/useEditorAutoSave.ts
@@ -24,6 +24,18 @@ interface UseEditorAutoSaveOptions {
 
 interface UseEditorAutoSaveReturn {
   saveChanges: (title: string, content: string, forceBlockTitle?: boolean) => void;
+  /**
+   * 保留中の debounce 保存とアンマウント時 flush をキャンセルする。
+   * `usePageDeletion` がページ削除を発火する直前に呼ぶことで、
+   * unmount flush の `updatePage` が論理削除を上書きして「無題のページ」が
+   * 復活するレース (issue #768) を防ぐ。
+   *
+   * Cancel any pending debounced save and suppress the unmount flush.
+   * Called by `usePageDeletion` immediately before firing
+   * `deletePageMutation.mutate`, so the unmount flush's `updatePage` cannot
+   * race the soft delete and resurrect the row (issue #768).
+   */
+  cancelPendingSave: () => void;
   lastSaved: number | null;
   isSaving: boolean;
   isSyncingLinks: boolean;
@@ -192,8 +204,17 @@ export function useEditorAutoSave({
     ],
   );
 
+  const cancelPendingSave = useCallback(() => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+      saveTimeoutRef.current = null;
+    }
+    pendingRef.current = null;
+  }, []);
+
   return {
     saveChanges,
+    cancelPendingSave,
     lastSaved,
     isSaving,
     isSyncingLinks,

--- a/src/components/editor/PageEditor/usePageDeletion.test.ts
+++ b/src/components/editor/PageEditor/usePageDeletion.test.ts
@@ -260,13 +260,23 @@ describe("usePageDeletion - cancelPendingSave 順序 (issue #768)", () => {
     expect(callOrder).toEqual(["cancel", "mutate"]);
   });
 
-  it("handleDelete (明示削除) も mutate より先に cancelPendingSave を呼ぶ", () => {
+  it("handleDelete (明示削除) は mutate → onSuccess の順で cancelPendingSave を呼ぶ (Codex P2: 失敗時の保留保存を保護)", () => {
+    // Codex P2 レビューの観点: `handleDelete` は他のハンドラと違い `onError`
+    // でエディタに残るため、mutate 前に cancelPendingSave すると失敗時に
+    // 保留中の編集が落ちる。`onSuccess` の中でだけキャンセルする実装を
+    // 順序検証する。
+    //
+    // Codex P2: unlike other deletion paths, `handleDelete`'s `onError`
+    // keeps the user on the editor, so cancelling before the mutation
+    // would silently drop their queued autosave. Verify cancellation
+    // only happens inside `onSuccess`.
     const callOrder: string[] = [];
     mockCancelPendingSave.mockImplementation(() => {
       callOrder.push("cancel");
     });
-    mockMutate.mockImplementation(() => {
+    mockMutate.mockImplementation((_id: string, opts?: { onSuccess?: () => void }) => {
       callOrder.push("mutate");
+      opts?.onSuccess?.();
     });
 
     const { result } = renderHook(() =>
@@ -281,7 +291,36 @@ describe("usePageDeletion - cancelPendingSave 順序 (issue #768)", () => {
 
     act(() => result.current.handleDelete());
 
-    expect(callOrder).toEqual(["cancel", "mutate"]);
+    expect(callOrder).toEqual(["mutate", "cancel"]);
+    expect(mockNavigate).toHaveBeenCalledWith("/home");
+  });
+
+  it("handleDelete: 削除失敗時は cancelPendingSave を呼ばず保留保存を保持する (Codex P2)", () => {
+    // 失敗ブランチではエディタに残るので、保留中の autosave は触らない。
+    // On the failure branch the user stays on the editor, so the pending
+    // autosave must remain intact.
+    mockMutate.mockImplementation((_id: string, opts?: { onError?: (e: Error) => void }) => {
+      opts?.onError?.(new Error("network down"));
+    });
+
+    const { result } = renderHook(() =>
+      usePageDeletion({
+        currentPageId: "page-1",
+        title: "foo",
+        content: NON_EMPTY_CONTENT,
+        shouldBlockSave: false,
+        cancelPendingSave: mockCancelPendingSave,
+      }),
+    );
+
+    act(() => result.current.handleDelete());
+
+    expect(mockCancelPendingSave).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "削除に失敗しました",
+      variant: "destructive",
+    });
   });
 
   it("削除に至らないキャンセルパス (handleCancelDelete) では cancelPendingSave を呼ばない", () => {

--- a/src/components/editor/PageEditor/usePageDeletion.test.ts
+++ b/src/components/editor/PageEditor/usePageDeletion.test.ts
@@ -10,10 +10,11 @@ import { usePageDeletion } from "./usePageDeletion";
  * (`handleOpenDuplicatePage`) used by the duplicate-title warning.
  */
 
-const { mockNavigate, mockMutate, mockToast } = vi.hoisted(() => ({
+const { mockNavigate, mockMutate, mockToast, mockCancelPendingSave } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockMutate: vi.fn(),
   mockToast: vi.fn(),
+  mockCancelPendingSave: vi.fn(),
 }));
 
 vi.mock("react-router-dom", () => ({
@@ -52,6 +53,7 @@ describe("usePageDeletion.handleOpenDuplicatePage", () => {
         title: "foo",
         content: NON_EMPTY_CONTENT,
         shouldBlockSave: true,
+        cancelPendingSave: mockCancelPendingSave,
       }),
     );
 
@@ -69,6 +71,7 @@ describe("usePageDeletion.handleOpenDuplicatePage", () => {
         title: "foo",
         content: EMPTY_CONTENT,
         shouldBlockSave: true,
+        cancelPendingSave: mockCancelPendingSave,
       }),
     );
 
@@ -89,6 +92,7 @@ describe("usePageDeletion.handleOpenDuplicatePage", () => {
         title: "foo",
         content: NON_EMPTY_CONTENT,
         shouldBlockSave: true,
+        cancelPendingSave: mockCancelPendingSave,
       }),
     );
 
@@ -107,6 +111,7 @@ describe("usePageDeletion.handleOpenDuplicatePage", () => {
         title: "foo",
         content: NON_EMPTY_CONTENT,
         shouldBlockSave: true,
+        cancelPendingSave: mockCancelPendingSave,
       }),
     );
 
@@ -128,6 +133,7 @@ describe("usePageDeletion.handleOpenDuplicatePage", () => {
         title: "foo",
         content: NON_EMPTY_CONTENT,
         shouldBlockSave: true,
+        cancelPendingSave: mockCancelPendingSave,
       }),
     );
 
@@ -146,6 +152,7 @@ describe("usePageDeletion.handleOpenDuplicatePage", () => {
         title: "foo",
         content: NON_EMPTY_CONTENT,
         shouldBlockSave: true,
+        cancelPendingSave: mockCancelPendingSave,
       }),
     );
 
@@ -157,5 +164,141 @@ describe("usePageDeletion.handleOpenDuplicatePage", () => {
 
     // 最終 navigate は /home であるべき
     expect(mockNavigate).toHaveBeenLastCalledWith("/home");
+  });
+});
+
+/**
+ * Issue #768: 削除前に保留中の autosave をキャンセルすることで、
+ * unmount flush の `updatePage` が論理削除を上書きして「無題のページ」が
+ * 復活するレースを防ぐ。各削除パスで `cancelPendingSave` が
+ * `deletePageMutation.mutate` よりも先に呼ばれることを順序検証する。
+ *
+ * Issue #768: cancelling the pending autosave before deletion prevents the
+ * unmount flush's `updatePage` from racing the soft delete and resurrecting
+ * an "untitled page" row. These tests assert that for each deletion path
+ * `cancelPendingSave` runs *before* `deletePageMutation.mutate`.
+ */
+describe("usePageDeletion - cancelPendingSave 順序 (issue #768)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("handleOpenDuplicatePage (空コンテンツ) は mutate より先に cancelPendingSave を呼ぶ", () => {
+    const callOrder: string[] = [];
+    mockCancelPendingSave.mockImplementation(() => {
+      callOrder.push("cancel");
+    });
+    mockMutate.mockImplementation(() => {
+      callOrder.push("mutate");
+    });
+
+    const { result } = renderHook(() =>
+      usePageDeletion({
+        currentPageId: "dup-id",
+        title: "foo",
+        content: EMPTY_CONTENT,
+        shouldBlockSave: true,
+        cancelPendingSave: mockCancelPendingSave,
+      }),
+    );
+
+    act(() => result.current.handleOpenDuplicatePage("target-id"));
+
+    expect(callOrder).toEqual(["cancel", "mutate"]);
+  });
+
+  it("handleBack (タイトル空・コンテンツ無し) は mutate より先に cancelPendingSave を呼ぶ", () => {
+    const callOrder: string[] = [];
+    mockCancelPendingSave.mockImplementation(() => {
+      callOrder.push("cancel");
+    });
+    mockMutate.mockImplementation(() => {
+      callOrder.push("mutate");
+    });
+
+    const { result } = renderHook(() =>
+      usePageDeletion({
+        currentPageId: "page-1",
+        title: "",
+        content: EMPTY_CONTENT,
+        shouldBlockSave: false,
+        cancelPendingSave: mockCancelPendingSave,
+      }),
+    );
+
+    act(() => result.current.handleBack());
+
+    expect(callOrder).toEqual(["cancel", "mutate"]);
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "タイトルが未入力のため、ページを削除しました",
+    });
+  });
+
+  it("handleConfirmDelete は mutate より先に cancelPendingSave を呼ぶ", () => {
+    const callOrder: string[] = [];
+    mockCancelPendingSave.mockImplementation(() => {
+      callOrder.push("cancel");
+    });
+    mockMutate.mockImplementation(() => {
+      callOrder.push("mutate");
+    });
+
+    const { result } = renderHook(() =>
+      usePageDeletion({
+        currentPageId: "page-1",
+        title: "",
+        content: NON_EMPTY_CONTENT,
+        shouldBlockSave: false,
+        cancelPendingSave: mockCancelPendingSave,
+      }),
+    );
+
+    // 確認ダイアログを開いてから confirm
+    act(() => result.current.handleBack());
+    act(() => result.current.handleConfirmDelete());
+
+    expect(callOrder).toEqual(["cancel", "mutate"]);
+  });
+
+  it("handleDelete (明示削除) も mutate より先に cancelPendingSave を呼ぶ", () => {
+    const callOrder: string[] = [];
+    mockCancelPendingSave.mockImplementation(() => {
+      callOrder.push("cancel");
+    });
+    mockMutate.mockImplementation(() => {
+      callOrder.push("mutate");
+    });
+
+    const { result } = renderHook(() =>
+      usePageDeletion({
+        currentPageId: "page-1",
+        title: "foo",
+        content: NON_EMPTY_CONTENT,
+        shouldBlockSave: false,
+        cancelPendingSave: mockCancelPendingSave,
+      }),
+    );
+
+    act(() => result.current.handleDelete());
+
+    expect(callOrder).toEqual(["cancel", "mutate"]);
+  });
+
+  it("削除に至らないキャンセルパス (handleCancelDelete) では cancelPendingSave を呼ばない", () => {
+    const { result } = renderHook(() =>
+      usePageDeletion({
+        currentPageId: "page-1",
+        title: "",
+        content: NON_EMPTY_CONTENT,
+        shouldBlockSave: false,
+        cancelPendingSave: mockCancelPendingSave,
+      }),
+    );
+
+    act(() => result.current.handleBack()); // opens dialog only
+    act(() => result.current.handleCancelDelete());
+
+    expect(mockCancelPendingSave).not.toHaveBeenCalled();
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 });

--- a/src/components/editor/PageEditor/usePageDeletion.ts
+++ b/src/components/editor/PageEditor/usePageDeletion.ts
@@ -9,6 +9,18 @@ interface UsePageDeletionOptions {
   title: string;
   content: string;
   shouldBlockSave: boolean;
+  /**
+   * 削除発火直前に呼ぶ、保留中 autosave のキャンセル関数。
+   * `useEditorAutoSave.cancelPendingSave` を渡す想定。issue #768 のレース
+   * （unmount flush の `updatePage` が論理削除を上書きして「無題のページ」
+   * が復活する）を防ぐために必須。
+   *
+   * Cancel any pending autosave before firing a delete. Pass
+   * `useEditorAutoSave.cancelPendingSave`. Required to prevent the issue
+   * #768 race where the unmount flush's `updatePage` overwrites the soft
+   * delete and resurrects an "untitled page" row.
+   */
+  cancelPendingSave: () => void;
 }
 
 interface UsePageDeletionReturn {
@@ -40,6 +52,7 @@ export function usePageDeletion({
   title,
   content,
   shouldBlockSave,
+  cancelPendingSave,
 }: UsePageDeletionOptions): UsePageDeletionReturn {
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -53,6 +66,11 @@ export function usePageDeletion({
 
   const handleDelete = useCallback(() => {
     if (currentPageId) {
+      // issue #768: 削除発火前に保留中の autosave をキャンセルして、
+      // unmount flush の updatePage が論理削除を上書きしないようにする。
+      // issue #768: cancel any pending autosave before firing the delete so
+      // the unmount flush's updatePage cannot overwrite the soft delete.
+      cancelPendingSave();
       deletePageMutation.mutate(currentPageId, {
         onSuccess: () => {
           toast({
@@ -68,7 +86,7 @@ export function usePageDeletion({
         },
       });
     }
-  }, [currentPageId, deletePageMutation, navigate, toast]);
+  }, [currentPageId, deletePageMutation, navigate, toast, cancelPendingSave]);
 
   const handleBack = useCallback(() => {
     const hasContent = isContentNotEmpty(content);
@@ -94,6 +112,9 @@ export function usePageDeletion({
         return;
       }
 
+      // issue #768: 削除発火前に保留中の autosave をキャンセル。
+      // issue #768: cancel any pending autosave before firing the delete.
+      cancelPendingSave();
       // コンテンツがない場合はそのまま削除
       deletePageMutation.mutate(currentPageId);
       if (shouldDeleteForDuplicate) {
@@ -107,10 +128,22 @@ export function usePageDeletion({
       }
     }
     navigate("/home");
-  }, [navigate, currentPageId, title, content, deletePageMutation, shouldBlockSave, toast]);
+  }, [
+    navigate,
+    currentPageId,
+    title,
+    content,
+    deletePageMutation,
+    shouldBlockSave,
+    toast,
+    cancelPendingSave,
+  ]);
 
   const handleConfirmDelete = useCallback(() => {
     if (currentPageId) {
+      // issue #768: 削除発火前に保留中の autosave をキャンセル。
+      // issue #768: cancel any pending autosave before firing the delete.
+      cancelPendingSave();
       deletePageMutation.mutate(currentPageId);
       toast({
         title: `${deleteReason}を削除しました`,
@@ -120,7 +153,15 @@ export function usePageDeletion({
     navigate(pendingNavTarget);
     // 次回に備えてデフォルトに戻す / reset to default for next invocation
     setPendingNavTarget("/home");
-  }, [currentPageId, deletePageMutation, deleteReason, navigate, pendingNavTarget, toast]);
+  }, [
+    currentPageId,
+    deletePageMutation,
+    deleteReason,
+    navigate,
+    pendingNavTarget,
+    toast,
+    cancelPendingSave,
+  ]);
 
   const handleCancelDelete = useCallback(() => {
     setDeleteConfirmOpen(false);
@@ -149,6 +190,9 @@ export function usePageDeletion({
         return;
       }
 
+      // issue #768: 削除発火前に保留中の autosave をキャンセル。
+      // issue #768: cancel any pending autosave before firing the delete.
+      cancelPendingSave();
       // コンテンツがない場合はそのまま削除して遷移
       // Otherwise delete immediately and navigate to the existing page.
       deletePageMutation.mutate(currentPageId);
@@ -157,7 +201,7 @@ export function usePageDeletion({
       });
       navigate(targetPath);
     },
-    [currentPageId, content, deletePageMutation, navigate, toast],
+    [currentPageId, content, deletePageMutation, navigate, toast, cancelPendingSave],
   );
 
   return {

--- a/src/components/editor/PageEditor/usePageDeletion.ts
+++ b/src/components/editor/PageEditor/usePageDeletion.ts
@@ -66,13 +66,19 @@ export function usePageDeletion({
 
   const handleDelete = useCallback(() => {
     if (currentPageId) {
-      // issue #768: 削除発火前に保留中の autosave をキャンセルして、
-      // unmount flush の updatePage が論理削除を上書きしないようにする。
-      // issue #768: cancel any pending autosave before firing the delete so
-      // the unmount flush's updatePage cannot overwrite the soft delete.
-      cancelPendingSave();
+      // issue #768 + Codex P2: 他のハンドラと違い、`handleDelete` の `onError`
+      // ではユーザーがエディタに残るため、削除失敗時に保留中の autosave を
+      // 落とすと最近の編集が失われる。そのため `cancelPendingSave` は削除が
+      // 成功して `/home` に遷移する直前（`onSuccess` 内）でのみ呼ぶ。
+      //
+      // issue #768 + Codex P2: unlike the other handlers, `handleDelete`'s
+      // `onError` keeps the user on the editor, so cancelling the pending
+      // autosave before the mutation would silently drop their queued edits
+      // on a failed delete. Cancel only inside `onSuccess`, just before
+      // navigating away (and the unmount flush).
       deletePageMutation.mutate(currentPageId, {
         onSuccess: () => {
+          cancelPendingSave();
           toast({
             title: "ページを削除しました",
           });

--- a/src/components/editor/PageEditor/usePageDeletion.ts
+++ b/src/components/editor/PageEditor/usePageDeletion.ts
@@ -44,8 +44,29 @@ interface UsePageDeletionReturn {
 }
 
 /**
- * Hook for page deletion logic
- * Handles delete confirmation, back navigation with cleanup
+ * ページ削除フロー（明示削除・戻る・タイトル空・タイトル重複）の状態と
+ * ハンドラを束ねるフック。確認ダイアログの開閉、削除理由の保持、削除後の
+ * 遷移先決定、トースト表示までを管理する。
+ *
+ * issue #768: 削除を発火する前に呼び出し側 (`useEditorAutoSave`) の
+ * `cancelPendingSave` を必ず実行し、保留中の autosave debounce と unmount
+ * flush を抑止する。これにより `updatePage` が論理削除を上書きして
+ * 「無題のページ」が `/home` に復活するレースを防ぐ。`handleDelete` だけは
+ * `onError` でユーザーがエディタに残るため、保留中の編集を落とさないよう
+ * `onSuccess` 内（navigate 直前）でのみキャンセルする。
+ *
+ * Hook bundling page deletion flows (explicit delete, back navigation,
+ * empty-title cleanup, duplicate-title cleanup): manages confirmation
+ * dialog state, the deletion reason, post-delete navigation target, and
+ * toasts.
+ *
+ * issue #768: each deletion path invokes the caller-supplied
+ * `cancelPendingSave` (from `useEditorAutoSave`) to clear pending autosave
+ * debounces and suppress the unmount flush, preventing the race where
+ * `updatePage` overwrites the soft delete and an "untitled" row reappears
+ * on `/home`. `handleDelete` is the exception: its `onError` keeps the user
+ * on the editor, so cancellation is deferred to `onSuccess` (just before
+ * `navigate`) to avoid silently dropping queued edits on a failed delete.
  */
 export function usePageDeletion({
   currentPageId,

--- a/src/components/editor/PageEditor/usePageEditorAutoSaveWithMutation.ts
+++ b/src/components/editor/PageEditor/usePageEditorAutoSaveWithMutation.ts
@@ -31,6 +31,7 @@ export function usePageEditorAutoSaveWithMutation({
 
   const {
     saveChanges,
+    cancelPendingSave,
     lastSaved: autoSaveLastSaved,
     isSyncingLinks,
   } = useEditorAutoSave({
@@ -67,5 +68,5 @@ export function usePageEditorAutoSaveWithMutation({
     },
   });
 
-  return { saveChanges, lastSaved: autoSaveLastSaved, isSyncingLinks };
+  return { saveChanges, cancelPendingSave, lastSaved: autoSaveLastSaved, isSyncingLinks };
 }

--- a/src/components/editor/PageEditor/usePageEditorStateAndSync.ts
+++ b/src/components/editor/PageEditor/usePageEditorStateAndSync.ts
@@ -33,12 +33,14 @@ function usePageEditorDeletionAndNav(
   content: string,
   sourceUrl: string,
   shouldBlockSave: boolean,
+  cancelPendingSave: () => void,
 ) {
   const deletion = usePageDeletion({
     currentPageId,
     title,
     content,
     shouldBlockSave,
+    cancelPendingSave,
   });
   const { handleExportMarkdown, handleCopyMarkdown } = useMarkdownExport(title, content, sourceUrl);
   usePageEditorKeyboard({ onBack: deletion.handleBack });
@@ -129,6 +131,17 @@ export function usePageEditorStateAndSync() {
     usePageEditorWikiCollab(resetWikiBase, collaboration);
 
   const {
+    saveChanges,
+    cancelPendingSave,
+    lastSaved: autoSaveLastSaved,
+    isSyncingLinks,
+  } = usePageEditorAutoSaveWithMutation({
+    currentPageId,
+    shouldBlockSave,
+    updateLastSaved,
+  });
+
+  const {
     deleteConfirmOpen,
     deleteReason,
     setDeleteConfirmOpen,
@@ -139,17 +152,14 @@ export function usePageEditorStateAndSync() {
     handleOpenDuplicatePage,
     handleExportMarkdown,
     handleCopyMarkdown,
-  } = usePageEditorDeletionAndNav(currentPageId, title, content, sourceUrl, shouldBlockSave);
-
-  const {
-    saveChanges,
-    lastSaved: autoSaveLastSaved,
-    isSyncingLinks,
-  } = usePageEditorAutoSaveWithMutation({
+  } = usePageEditorDeletionAndNav(
     currentPageId,
+    title,
+    content,
+    sourceUrl,
     shouldBlockSave,
-    updateLastSaved,
-  });
+    cancelPendingSave,
+  );
 
   const { displayLastSaved, pendingInitialContent, setPendingInitialContent } =
     useDisplayLastSavedAndPending(autoSaveLastSaved, lastSaved);

--- a/src/lib/pageRepository/StorageAdapterPageRepository.ts
+++ b/src/lib/pageRepository/StorageAdapterPageRepository.ts
@@ -254,6 +254,16 @@ export class StorageAdapterPageRepository {
   ): Promise<void> {
     const existing = await this.adapter.getPage(pageId);
     if (!existing) return;
+    // issue #768 safety net: 論理削除済みページに対する update は no-op。
+    // 現在の `adapter.getPage` は `isDeleted: true` を null として返すので
+    // 上の早期 return で実質カバーされているが、将来 `getPage` が tombstone も
+    // 返す仕様に変わったときに削除済み行を復活させないための明示ガード。
+    //
+    // issue #768 safety net: skip updates targeting a soft-deleted page.
+    // Today `adapter.getPage` already filters out `isDeleted: true` rows so
+    // the early return above covers it, but this explicit guard keeps the
+    // contract intact if `getPage` ever starts surfacing tombstones.
+    if (existing.isDeleted) return;
     const now = Date.now();
     const meta: PageMetadata = {
       ...existing,


### PR DESCRIPTION
## 概要

ページ削除時に保留中の autosave をキャンセルして、unmount flush の `updatePage` が論理削除を上書きするレース条件を防ぐ。

## 変更点

- `useEditorAutoSave` に `cancelPendingSave()` メソッドを追加。保留中の debounce 保存とアンマウント時 flush をキャンセルする
- `usePageDeletion` が削除を発火する直前に `cancelPendingSave()` を呼び出すよう修正（全削除パスで実施）
- `usePageEditorStateAndSync` で `cancelPendingSave` を `usePageDeletion` に渡すよう修正
- `StorageAdapterPageRepository.updatePage()` に安全ネット追加：論理削除済みページへの update は no-op に
- 包括的なテストを追加：
  - `useEditorAutoSave` の `cancelPendingSave` 動作確認（debounce キャンセル、unmount flush 抑制、no-op 安全性）
  - `usePageDeletion` の全削除パスで `cancelPendingSave` が `mutate` より先に呼ばれることを順序検証

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## テスト方法

自動テストで完全にカバーされています：

1. `useEditorAutoSave.test.ts` の新規テスト 3 件：
   - debounce 中の `cancelPendingSave` で onSave が走らないことを確認
   - `cancelPendingSave` 後のアンマウント flush が抑制されることを確認
   - 保留中の保存がないときの no-op 安全性を確認

2. `usePageDeletion.test.ts` の新規テスト 5 件：
   - `handleOpenDuplicatePage`、`handleBack`、`handleConfirmDelete`、`handleDelete` の各削除パスで `cancelPendingSave` が `mutate` より先に呼ばれることを順序検証
   - キャンセルパス (`handleCancelDelete`) では `cancelPendingSave` が呼ばれないことを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #768

https://claude.ai/code/session_01WE1NLZbYwDG4qkAaSGqoP7
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented pending autosaves from being applied during or after page deletion to avoid unintended overwrites.
  * Stopped updates on pages that are already deleted to avoid resurrecting removed content.

* **New Features**
  * Exposed a cancel-pending-autosave mechanism so deletions and navigations no longer trigger late saves.

* **Tests**
  * Added tests verifying cancellation behavior and correct call order around deletion flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->