### PR TITLE
feat: Add i18n support to admin panel with Japanese and English translations

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -12,9 +12,12 @@
   },
   "dependencies": {
     "@zedi/ui": "workspace:*",
+    "i18next": "^26.0.1",
+    "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-i18next": "^17.0.1",
     "react-router-dom": "^7.13.2"
   },
   "devDependencies": {

--- a/admin/src/components/ConfirmActionDialog.tsx
+++ b/admin/src/components/ConfirmActionDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -71,7 +72,7 @@ export function ConfirmActionDialog({
   onOpenChange,
   title,
   description,
-  confirmLabel = "確認",
+  confirmLabel,
   destructive = false,
   loading = false,
   confirmPhrase,
@@ -79,6 +80,8 @@ export function ConfirmActionDialog({
   onConfirm,
   children,
 }: ConfirmActionDialogProps) {
+  const { t } = useTranslation();
+  const resolvedConfirmLabel = confirmLabel ?? t("common.confirm");
   const [phraseInput, setPhraseInput] = useState("");
 
   // ダイアログ閉じ時に確認フレーズ入力をリセット / Reset phrase input when dialog closes
@@ -116,7 +119,7 @@ export function ConfirmActionDialog({
               <div className="grid gap-2">
                 <Label htmlFor="confirm-phrase-input">
                   {confirmPhraseLabel ??
-                    `確認のため「${confirmPhrase}」を入力してください / Type "${confirmPhrase}" to confirm`}
+                    t("common.confirmPhraseDefault", { phrase: confirmPhrase })}
                 </Label>
                 <Input
                   id="confirm-phrase-input"
@@ -131,7 +134,7 @@ export function ConfirmActionDialog({
         )}
 
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={loading}>キャンセル</AlertDialogCancel>
+          <AlertDialogCancel disabled={loading}>{t("common.cancel")}</AlertDialogCancel>
           <AlertDialogAction
             className={cn(
               destructive && "bg-destructive text-destructive-foreground hover:bg-destructive/90",
@@ -148,7 +151,7 @@ export function ConfirmActionDialog({
               handleConfirm();
             }}
           >
-            {loading ? "処理中..." : confirmLabel}
+            {loading ? t("common.processing") : resolvedConfirmLabel}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/admin/src/i18n/index.ts
+++ b/admin/src/i18n/index.ts
@@ -1,0 +1,72 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+
+// 翻訳をドメインごとに分割（1ファイルあたりのコード量を抑える）
+// Translations are split per domain to keep individual files small.
+import jaCommon from "./locales/ja/common.json";
+import jaNav from "./locales/ja/nav.json";
+import jaAuth from "./locales/ja/auth.json";
+import jaUsers from "./locales/ja/users.json";
+import jaAudit from "./locales/ja/audit.json";
+import jaWikiHealth from "./locales/ja/wikiHealth.json";
+import jaActivityLog from "./locales/ja/activityLog.json";
+import jaAiModels from "./locales/ja/aiModels.json";
+import enCommon from "./locales/en/common.json";
+import enNav from "./locales/en/nav.json";
+import enAuth from "./locales/en/auth.json";
+import enUsers from "./locales/en/users.json";
+import enAudit from "./locales/en/audit.json";
+import enWikiHealth from "./locales/en/wikiHealth.json";
+import enActivityLog from "./locales/en/activityLog.json";
+import enAiModels from "./locales/en/aiModels.json";
+
+const ja = {
+  common: jaCommon,
+  nav: jaNav,
+  auth: jaAuth,
+  users: jaUsers,
+  audit: jaAudit,
+  wikiHealth: jaWikiHealth,
+  activityLog: jaActivityLog,
+  aiModels: jaAiModels,
+};
+
+const en = {
+  common: enCommon,
+  nav: enNav,
+  auth: enAuth,
+  users: enUsers,
+  audit: enAudit,
+  wikiHealth: enWikiHealth,
+  activityLog: enActivityLog,
+  aiModels: enAiModels,
+};
+
+/**
+ * 管理画面用 i18n インスタンス。
+ * 本体アプリと同じ localStorage キー（`zedi-i18next-lng`）を共有して、
+ * 言語設定が両画面間で一貫するようにする。
+ *
+ * Admin i18n instance. Shares the same localStorage key as the main app
+ * (`zedi-i18next-lng`) so language preference stays consistent across surfaces.
+ */
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      ja: { translation: ja },
+      en: { translation: en },
+    },
+    fallbackLng: "ja",
+    interpolation: {
+      escapeValue: false,
+    },
+    detection: {
+      order: ["localStorage", "navigator"],
+      lookupLocalStorage: "zedi-i18next-lng",
+    },
+  });
+
+export default i18n;

--- a/admin/src/i18n/locales/en/activityLog.json
+++ b/admin/src/i18n/locales/en/activityLog.json
@@ -1,0 +1,29 @@
+{
+  "title": "Activity Log",
+  "filters": {
+    "kind": "Kind",
+    "actor": "Actor"
+  },
+  "columns": {
+    "kind": "Kind",
+    "actor": "Actor",
+    "detail": "Detail",
+    "relatedPages": "Related pages",
+    "createdAt": "Recorded at"
+  },
+  "empty": "No activity logs yet.",
+  "showing": "Showing {{shown}} of {{total}}",
+  "kinds": {
+    "clip_ingest": "Clip ingest",
+    "chat_promote": "Chat promote",
+    "lint_run": "Lint run",
+    "wiki_generate": "Wiki generate",
+    "index_build": "Index build",
+    "wiki_schema_update": "Schema update"
+  },
+  "actors": {
+    "user": "User",
+    "ai": "AI",
+    "system": "System"
+  }
+}

--- a/admin/src/i18n/locales/en/aiModels.json
+++ b/admin/src/i18n/locales/en/aiModels.json
@@ -1,0 +1,30 @@
+{
+  "title": "AI Model Management",
+  "syncing": "Syncing...",
+  "syncWithProvider": "Sync with provider",
+  "syncResult": "Sync result:",
+  "syncStat": "Added {{added}} / Deactivated {{deactivated}}",
+  "columns": {
+    "reorder": "Reorder",
+    "provider": "Provider",
+    "modelId": "Model ID",
+    "displayName": "Display name",
+    "tier": "Tier",
+    "active": "Active",
+    "sortOrder": "Order"
+  },
+  "summary": "{{total}} models (active: {{active}})",
+  "dragHint": "Drag to reorder",
+  "displayNameAriaLabel": "Display name for {{modelId}}",
+  "tierAriaLabel": "Tier for {{name}}",
+  "preview": {
+    "title": "Sync preview",
+    "description": "New models will be added, and existing models no longer in scope will be deactivated. Existing models' display names and pricing are not overwritten. Sonnet-family models are added as inactive.",
+    "noChanges": "No changes",
+    "addLabel": "Add: {{name}}",
+    "deactivateLabel": "Deactivate: {{name}}",
+    "inactiveTag": "(inactive)",
+    "errorWarning": "Some providers reported errors. Providers with errors will not be synced.",
+    "confirm": "Run sync (Add {{added}} / Deactivate {{deactivated}})"
+  }
+}

--- a/admin/src/i18n/locales/en/audit.json
+++ b/admin/src/i18n/locales/en/audit.json
@@ -1,0 +1,20 @@
+{
+  "title": "Audit Logs",
+  "filters": {
+    "action": "Filter by action",
+    "from": "From",
+    "to": "To"
+  },
+  "columns": {
+    "createdAt": "Timestamp",
+    "actor": "Actor",
+    "action": "Action",
+    "target": "Target",
+    "diff": "Changes",
+    "ipAddress": "IP"
+  },
+  "empty": "No audit logs.",
+  "actions": {
+    "user.role.update": "User: Role change"
+  }
+}

--- a/admin/src/i18n/locales/en/auth.json
+++ b/admin/src/i18n/locales/en/auth.json
@@ -1,0 +1,7 @@
+{
+  "title": "Zedi Admin",
+  "description": "To log in as an administrator, please sign in to the main app first.",
+  "signInButton": "Sign in to continue",
+  "afterSignIn": "After signing in, return to this page.",
+  "guardLoading": "Loading..."
+}

--- a/admin/src/i18n/locales/en/common.json
+++ b/admin/src/i18n/locales/en/common.json
@@ -1,0 +1,19 @@
+{
+  "cancel": "Cancel",
+  "confirm": "Confirm",
+  "loading": "Loading...",
+  "saving": "Saving...",
+  "processing": "Processing...",
+  "previous": "Previous",
+  "next": "Next",
+  "all": "All",
+  "save": "Save",
+  "delete": "Delete",
+  "reload": "Reload",
+  "running": "Running...",
+  "page": "Page {{page}} / {{count}}",
+  "showingRange": "Showing {{rangeStart}}-{{rangeEnd}} of {{total}}",
+  "showingZero": "Showing 0 of {{total}}",
+  "totalCount": "Total: {{count}}",
+  "confirmPhraseDefault": "Type \"{{phrase}}\" to confirm"
+}

--- a/admin/src/i18n/locales/en/nav.json
+++ b/admin/src/i18n/locales/en/nav.json
@@ -1,0 +1,12 @@
+{
+  "adminPanelTitle": "Zedi Admin",
+  "adminShortTitle": "Admin",
+  "menu": "Menu",
+  "items": {
+    "aiModels": "AI Models",
+    "users": "Users",
+    "auditLogs": "Audit Logs",
+    "wikiHealth": "Wiki Health",
+    "activityLog": "Activity Log"
+  }
+}

--- a/admin/src/i18n/locales/en/users.json
+++ b/admin/src/i18n/locales/en/users.json
@@ -1,0 +1,63 @@
+{
+  "title": "User Management",
+  "statusFilterAriaLabel": "Status filter",
+  "searchEmailPlaceholder": "Search by email",
+  "searchEmailAriaLabel": "Search by email",
+  "columns": {
+    "email": "Email",
+    "name": "Name",
+    "status": "Status",
+    "role": "Role",
+    "pageCount": "Pages",
+    "createdAt": "Created",
+    "actions": "Actions"
+  },
+  "actions": {
+    "restore": "Restore",
+    "suspend": "Suspend",
+    "delete": "Delete"
+  },
+  "states": {
+    "saving": "Saving...",
+    "deleted": "Deleted"
+  },
+  "card": {
+    "reasonPrefix": "Reason: {{reason}}",
+    "pageCount": "Pages: {{count}}"
+  },
+  "row": {
+    "roleAriaLabel": "Role for {{email}}",
+    "suspendedReasonShort": "({{reason}})"
+  },
+  "roleChange": {
+    "title": "Change role",
+    "description": "Change role of {{name}} from \"{{from}}\" to \"{{to}}\"?",
+    "confirm": "Change"
+  },
+  "unsuspend": {
+    "title": "Lift suspension",
+    "description": "Lift the suspension and restore {{name}}'s account?",
+    "confirm": "Restore"
+  },
+  "deleteUser": {
+    "title": "Delete user",
+    "description": "Delete {{name}}. Personal information will be anonymized, and sessions and OAuth links will be removed. This action cannot be undone.",
+    "confirm": "Delete"
+  },
+  "impact": {
+    "title": "Impact:",
+    "notes": "Owned notes: {{count}}",
+    "sessions": "Active sessions: {{count}}",
+    "subscription": "Subscription: {{value}}",
+    "subscriptionActive": "Active",
+    "subscriptionNone": "None",
+    "lastAiUsage": "Last AI usage: {{date}}"
+  },
+  "suspendDialog": {
+    "title": "Suspend user",
+    "description": "Suspend {{name}}. Suspended users lose access to all APIs and existing sessions are invalidated.",
+    "confirm": "Suspend",
+    "reasonLabel": "Reason (optional)",
+    "reasonPlaceholder": "Enter the reason for suspension"
+  }
+}

--- a/admin/src/i18n/locales/en/wikiHealth.json
+++ b/admin/src/i18n/locales/en/wikiHealth.json
@@ -1,0 +1,27 @@
+{
+  "title": "Wiki Health Dashboard",
+  "runLint": "Run lint",
+  "filterRule": "Filter by rule",
+  "emptyAll": "No lint findings. Click \"Run lint\" to start.",
+  "emptyFiltered": "No matching findings.",
+  "columns": {
+    "rule": "Rule",
+    "severity": "Severity",
+    "detail": "Detail",
+    "createdAt": "Detected at",
+    "actions": "Actions"
+  },
+  "pagesRelated": "{{count}} pages related",
+  "resolve": "Resolve",
+  "rules": {
+    "orphan": "Orphan",
+    "ghost_many": "Ghost Excess",
+    "title_similar": "Title Similar",
+    "conflict": "Conflict",
+    "broken_link": "Broken Link",
+    "stale": "Stale"
+  },
+  "detail": {
+    "linkText": "\"{{linkText}}\" ({{count}})"
+  }
+}

--- a/admin/src/i18n/locales/ja/activityLog.json
+++ b/admin/src/i18n/locales/ja/activityLog.json
@@ -1,0 +1,29 @@
+{
+  "title": "活動ログ",
+  "filters": {
+    "kind": "種別 / Kind",
+    "actor": "起点 / Actor"
+  },
+  "columns": {
+    "kind": "種別",
+    "actor": "起点",
+    "detail": "詳細",
+    "relatedPages": "関連ページ",
+    "createdAt": "記録日時"
+  },
+  "empty": "活動ログはまだありません。",
+  "showing": "表示 {{shown}} / 合計 {{total}} 件",
+  "kinds": {
+    "clip_ingest": "クリップ取り込み / Clip ingest",
+    "chat_promote": "Chat → Wiki 昇格 / Chat promote",
+    "lint_run": "Lint 実行 / Lint run",
+    "wiki_generate": "Wiki 生成 / Wiki generate",
+    "index_build": "Index 構築 / Index build",
+    "wiki_schema_update": "スキーマ更新 / Schema update"
+  },
+  "actors": {
+    "user": "ユーザー / User",
+    "ai": "AI",
+    "system": "システム / System"
+  }
+}

--- a/admin/src/i18n/locales/ja/aiModels.json
+++ b/admin/src/i18n/locales/ja/aiModels.json
@@ -1,0 +1,30 @@
+{
+  "title": "AI モデル管理",
+  "syncing": "同期中...",
+  "syncWithProvider": "プロバイダーと同期",
+  "syncResult": "同期結果:",
+  "syncStat": "追加 {{added}} / 無効化 {{deactivated}}",
+  "columns": {
+    "reorder": "並び替え",
+    "provider": "プロバイダー",
+    "modelId": "モデルID",
+    "displayName": "表示名",
+    "tier": "ティア",
+    "active": "有効",
+    "sortOrder": "並び順"
+  },
+  "summary": "{{total}} 件（有効: {{active}}）",
+  "dragHint": "ドラッグで並び替え",
+  "displayNameAriaLabel": "{{modelId}} の表示名",
+  "tierAriaLabel": "{{name}} のティア",
+  "preview": {
+    "title": "同期プレビュー",
+    "description": "新規モデルは追加され、同期対象から外れた既存モデルは非アクティブ化されます。 既存モデルの表示名や料金は上書きされません。Sonnet 系は非アクティブで追加されます。",
+    "noChanges": "変更なし",
+    "addLabel": "追加: {{name}}",
+    "deactivateLabel": "無効化: {{name}}",
+    "inactiveTag": "(非アクティブ)",
+    "errorWarning": "一部プロバイダーでエラーが発生しています。エラーのあるプロバイダーは同期されません。",
+    "confirm": "同期実行（追加 {{added}} / 無効化 {{deactivated}}）"
+  }
+}

--- a/admin/src/i18n/locales/ja/audit.json
+++ b/admin/src/i18n/locales/ja/audit.json
@@ -1,0 +1,20 @@
+{
+  "title": "監査ログ",
+  "filters": {
+    "action": "アクションで絞り込み",
+    "from": "期間（開始）",
+    "to": "期間（終了）"
+  },
+  "columns": {
+    "createdAt": "日時",
+    "actor": "操作者",
+    "action": "アクション",
+    "target": "対象",
+    "diff": "変更内容",
+    "ipAddress": "IP"
+  },
+  "empty": "監査ログはありません。",
+  "actions": {
+    "user.role.update": "ユーザー: ロール変更"
+  }
+}

--- a/admin/src/i18n/locales/ja/auth.json
+++ b/admin/src/i18n/locales/ja/auth.json
@@ -1,0 +1,7 @@
+{
+  "title": "Zedi 管理画面",
+  "description": "管理者としてログインするには、まずメインアプリでサインインしてください。",
+  "signInButton": "サインインして続ける",
+  "afterSignIn": "サインイン後、このページに戻ってきてください。",
+  "guardLoading": "Loading..."
+}

--- a/admin/src/i18n/locales/ja/common.json
+++ b/admin/src/i18n/locales/ja/common.json
@@ -1,0 +1,19 @@
+{
+  "cancel": "キャンセル",
+  "confirm": "確認",
+  "loading": "読み込み中...",
+  "saving": "保存中...",
+  "processing": "処理中...",
+  "previous": "前へ",
+  "next": "次へ",
+  "all": "すべて",
+  "save": "保存",
+  "delete": "削除",
+  "reload": "再読み込み",
+  "running": "実行中...",
+  "page": "{{page}} / {{count}} ページ",
+  "showingRange": "{{rangeStart}}-{{rangeEnd}} 件を表示 / 合計 {{total}} 件",
+  "showingZero": "0 件を表示 / 合計 {{total}} 件",
+  "totalCount": "合計 {{count}} 件",
+  "confirmPhraseDefault": "確認のため「{{phrase}}」を入力してください / Type \"{{phrase}}\" to confirm"
+}

--- a/admin/src/i18n/locales/ja/nav.json
+++ b/admin/src/i18n/locales/ja/nav.json
@@ -1,0 +1,12 @@
+{
+  "adminPanelTitle": "Zedi 管理画面",
+  "adminShortTitle": "管理画面",
+  "menu": "メニュー",
+  "items": {
+    "aiModels": "AI モデル",
+    "users": "ユーザー管理",
+    "auditLogs": "監査ログ",
+    "wikiHealth": "Wiki Health",
+    "activityLog": "活動ログ"
+  }
+}

--- a/admin/src/i18n/locales/ja/users.json
+++ b/admin/src/i18n/locales/ja/users.json
@@ -1,0 +1,63 @@
+{
+  "title": "ユーザー管理",
+  "statusFilterAriaLabel": "ステータスフィルタ",
+  "searchEmailPlaceholder": "メールで検索",
+  "searchEmailAriaLabel": "メールで検索",
+  "columns": {
+    "email": "メール",
+    "name": "名前",
+    "status": "ステータス",
+    "role": "ロール",
+    "pageCount": "ページ数",
+    "createdAt": "作成日",
+    "actions": "操作"
+  },
+  "actions": {
+    "restore": "復活",
+    "suspend": "サスペンド",
+    "delete": "削除"
+  },
+  "states": {
+    "saving": "保存中...",
+    "deleted": "削除済み"
+  },
+  "card": {
+    "reasonPrefix": "理由: {{reason}}",
+    "pageCount": "ページ数: {{count}}"
+  },
+  "row": {
+    "roleAriaLabel": "{{email}} のロール",
+    "suspendedReasonShort": "({{reason}})"
+  },
+  "roleChange": {
+    "title": "ロールを変更",
+    "description": "{{name}} のロールを「{{from}}」から「{{to}}」に変更しますか？",
+    "confirm": "変更する"
+  },
+  "unsuspend": {
+    "title": "サスペンドを解除",
+    "description": "{{name}} のサスペンドを解除し、アカウントを復活させますか？",
+    "confirm": "復活させる"
+  },
+  "deleteUser": {
+    "title": "ユーザーを削除",
+    "description": "{{name}} を削除します。個人情報は匿名化され、セッションと OAuth 連携は削除されます。この操作は元に戻せません。",
+    "confirm": "削除する"
+  },
+  "impact": {
+    "title": "影響範囲:",
+    "notes": "所有ノート: {{count}} 件",
+    "sessions": "アクティブセッション: {{count}} 件",
+    "subscription": "サブスクリプション: {{value}}",
+    "subscriptionActive": "あり (active)",
+    "subscriptionNone": "なし",
+    "lastAiUsage": "最後の AI 使用: {{date}}"
+  },
+  "suspendDialog": {
+    "title": "ユーザーをサスペンド",
+    "description": "{{name}} をサスペンドします。サスペンドされたユーザーはすべての API にアクセスできなくなり、既存セッションも無効化されます。",
+    "confirm": "サスペンド",
+    "reasonLabel": "理由（任意）",
+    "reasonPlaceholder": "サスペンドの理由を入力してください"
+  }
+}

--- a/admin/src/i18n/locales/ja/wikiHealth.json
+++ b/admin/src/i18n/locales/ja/wikiHealth.json
@@ -1,0 +1,27 @@
+{
+  "title": "Wiki Health ダッシュボード",
+  "runLint": "Lint 実行",
+  "filterRule": "ルールで絞り込み",
+  "emptyAll": "Lint findings はありません。「Lint 実行」をクリックしてください。",
+  "emptyFiltered": "該当する findings はありません。",
+  "columns": {
+    "rule": "ルール",
+    "severity": "重要度",
+    "detail": "詳細",
+    "createdAt": "検出日時",
+    "actions": "操作"
+  },
+  "pagesRelated": "{{count}} ページ関連",
+  "resolve": "解決",
+  "rules": {
+    "orphan": "孤立ページ / Orphan",
+    "ghost_many": "Ghost Link 過多 / Ghost Excess",
+    "title_similar": "タイトル類似 / Title Similar",
+    "conflict": "矛盾 / Conflict",
+    "broken_link": "リンク切れ / Broken Link",
+    "stale": "古い情報 / Stale"
+  },
+  "detail": {
+    "linkText": "「{{linkText}}」({{count}} 件)"
+  }
+}

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import "./i18n";
 import "./index.css";
 
 const rootEl = document.getElementById("root");

--- a/admin/src/pages/ActivityLog.tsx
+++ b/admin/src/pages/ActivityLog.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   Badge,
   Button,
@@ -21,24 +22,6 @@ import {
   type ActivityKind,
 } from "@/api/activity";
 import { formatDate } from "@/lib/dateUtils";
-
-/**
- * ルール／起点のラベルマップ。
- * Labels for activity kind and actor.
- */
-const KIND_LABELS: Record<ActivityKind, string> = {
-  clip_ingest: "クリップ取り込み / Clip ingest",
-  chat_promote: "Chat → Wiki 昇格 / Chat promote",
-  lint_run: "Lint 実行 / Lint run",
-  wiki_generate: "Wiki 生成 / Wiki generate",
-  index_build: "Index 構築 / Index build",
-  wiki_schema_update: "スキーマ更新 / Schema update",
-};
-const ACTOR_LABELS: Record<ActivityActor, string> = {
-  user: "ユーザー / User",
-  ai: "AI",
-  system: "システム / System",
-};
 
 const ANY = "__any__";
 const KINDS: ActivityKind[] = [
@@ -82,6 +65,7 @@ function formatDetail(entry: ActivityEntry): string {
  * Admin Activity Log page.
  */
 export default function ActivityLog() {
+  const { t } = useTranslation();
   const [entries, setEntries] = useState<ActivityEntry[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -130,26 +114,26 @@ export default function ActivityLog() {
   return (
     <div>
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="text-lg font-semibold">Activity Log / 活動ログ</h1>
+        <h1 className="text-lg font-semibold">{t("activityLog.title")}</h1>
         <Button type="button" onClick={() => void load()} disabled={loading}>
-          {loading ? "読み込み中..." : "再読み込み"}
+          {loading ? t("common.loading") : t("common.reload")}
         </Button>
       </div>
 
       <div className="mt-4 flex flex-wrap items-end gap-4">
         <div>
           <label htmlFor="activity-kind" className="text-muted-foreground mb-1 block text-xs">
-            種別 / Kind
+            {t("activityLog.filters.kind")}
           </label>
           <Select value={kindFilter ?? ANY} onValueChange={onKind}>
             <SelectTrigger id="activity-kind" className="w-60">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={ANY}>すべて</SelectItem>
+              <SelectItem value={ANY}>{t("common.all")}</SelectItem>
               {KINDS.map((k) => (
                 <SelectItem key={k} value={k}>
-                  {KIND_LABELS[k]}
+                  {t(`activityLog.kinds.${k}`)}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -157,17 +141,17 @@ export default function ActivityLog() {
         </div>
         <div>
           <label htmlFor="activity-actor" className="text-muted-foreground mb-1 block text-xs">
-            起点 / Actor
+            {t("activityLog.filters.actor")}
           </label>
           <Select value={actorFilter ?? ANY} onValueChange={onActor}>
             <SelectTrigger id="activity-actor" className="w-48">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={ANY}>すべて</SelectItem>
+              <SelectItem value={ANY}>{t("common.all")}</SelectItem>
               {ACTORS.map((a) => (
                 <SelectItem key={a} value={a}>
-                  {ACTOR_LABELS[a]}
+                  {t(`activityLog.actors.${a}`)}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -180,29 +164,29 @@ export default function ActivityLog() {
       )}
 
       {loading && entries.length === 0 ? (
-        <p className="text-muted-foreground mt-4">読み込み中...</p>
+        <p className="text-muted-foreground mt-4">{t("common.loading")}</p>
       ) : entries.length === 0 ? (
-        <p className="text-muted-foreground mt-4">活動ログはまだありません。</p>
+        <p className="text-muted-foreground mt-4">{t("activityLog.empty")}</p>
       ) : (
         <div className="mt-4 overflow-x-auto">
           <Table className="border-border min-w-[720px] rounded border">
             <TableHeader>
               <TableRow className="border-border bg-muted/50 hover:bg-transparent">
-                <TableHead className="px-3 py-2">種別</TableHead>
-                <TableHead className="px-3 py-2">起点</TableHead>
-                <TableHead className="px-3 py-2">詳細</TableHead>
-                <TableHead className="px-3 py-2">関連ページ</TableHead>
-                <TableHead className="px-3 py-2">記録日時</TableHead>
+                <TableHead className="px-3 py-2">{t("activityLog.columns.kind")}</TableHead>
+                <TableHead className="px-3 py-2">{t("activityLog.columns.actor")}</TableHead>
+                <TableHead className="px-3 py-2">{t("activityLog.columns.detail")}</TableHead>
+                <TableHead className="px-3 py-2">{t("activityLog.columns.relatedPages")}</TableHead>
+                <TableHead className="px-3 py-2">{t("activityLog.columns.createdAt")}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {entries.map((entry) => (
                 <TableRow key={entry.id} className="border-border align-top">
                   <TableCell className="px-3 py-2">
-                    <Badge variant="outline">{KIND_LABELS[entry.kind]}</Badge>
+                    <Badge variant="outline">{t(`activityLog.kinds.${entry.kind}`)}</Badge>
                   </TableCell>
                   <TableCell className="px-3 py-2">
-                    <Badge variant="secondary">{ACTOR_LABELS[entry.actor]}</Badge>
+                    <Badge variant="secondary">{t(`activityLog.actors.${entry.actor}`)}</Badge>
                   </TableCell>
                   <TableCell className="max-w-md px-3 py-2 text-sm break-words">
                     {formatDetail(entry)}
@@ -218,7 +202,7 @@ export default function ActivityLog() {
             </TableBody>
           </Table>
           <p className="text-muted-foreground mt-2 text-xs">
-            表示 {entries.length} / 合計 {total} 件
+            {t("activityLog.showing", { shown: entries.length, total })}
           </p>
         </div>
       )}

--- a/admin/src/pages/Layout.tsx
+++ b/admin/src/pages/Layout.tsx
@@ -1,5 +1,6 @@
 import { Outlet, Link, useLocation } from "react-router-dom";
 import { Bot, Users, ScrollText, HeartPulse, Activity } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import {
   SidebarProvider,
   Sidebar,
@@ -15,12 +16,12 @@ import {
   SidebarHeader,
 } from "@zedi/ui";
 
-const navLinks = [
-  { to: "/ai-models", label: "AI モデル", icon: Bot },
-  { to: "/users", label: "ユーザー管理", icon: Users },
-  { to: "/audit-logs", label: "監査ログ", icon: ScrollText },
-  { to: "/wiki-health", label: "Wiki Health", icon: HeartPulse },
-  { to: "/activity-log", label: "活動ログ", icon: Activity },
+const NAV_ITEMS = [
+  { to: "/ai-models", labelKey: "nav.items.aiModels", icon: Bot },
+  { to: "/users", labelKey: "nav.items.users", icon: Users },
+  { to: "/audit-logs", labelKey: "nav.items.auditLogs", icon: ScrollText },
+  { to: "/wiki-health", labelKey: "nav.items.wikiHealth", icon: HeartPulse },
+  { to: "/activity-log", labelKey: "nav.items.activityLog", icon: Activity },
 ];
 
 /**
@@ -29,19 +30,21 @@ const navLinks = [
  */
 export default function Layout() {
   const location = useLocation();
+  const { t } = useTranslation();
 
   return (
     <SidebarProvider>
       <Sidebar>
         <SidebarHeader className="border-sidebar-border border-b px-4 py-3">
-          <span className="text-sm font-semibold tracking-tight">Zedi 管理画面</span>
+          <span className="text-sm font-semibold tracking-tight">{t("nav.adminPanelTitle")}</span>
         </SidebarHeader>
         <SidebarContent>
           <SidebarGroup>
-            <SidebarGroupLabel>メニュー</SidebarGroupLabel>
+            <SidebarGroupLabel>{t("nav.menu")}</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {navLinks.map(({ to, label, icon: Icon }) => {
+                {NAV_ITEMS.map(({ to, labelKey, icon: Icon }) => {
+                  const label = t(labelKey);
                   const isActive =
                     location.pathname === to || (to !== "/" && location.pathname.startsWith(to));
                   return (
@@ -63,7 +66,7 @@ export default function Layout() {
       <SidebarInset>
         <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4 md:hidden">
           <SidebarTrigger />
-          <span className="text-sm font-medium">管理画面</span>
+          <span className="text-sm font-medium">{t("nav.adminShortTitle")}</span>
         </header>
         <div className="flex-1 p-4 md:p-6">
           <Outlet />

--- a/admin/src/pages/Login.tsx
+++ b/admin/src/pages/Login.tsx
@@ -1,26 +1,27 @@
 import { Button } from "@zedi/ui";
+import { useTranslation } from "react-i18next";
 
 /**
  * 管理者ログイン案内
  * メインアプリでサインイン後、このドメインに戻るとセッションが有効になる。
+ *
+ * Admin login prompt. Once the user signs in via the main app, returning to
+ * this domain establishes the admin session.
  */
 export default function Login() {
+  const { t } = useTranslation();
   const mainAppUrl = import.meta.env.VITE_MAIN_APP_URL || "https://zedi-note.app";
   const signInUrl = `${mainAppUrl}/sign-in`;
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-slate-900 text-slate-100">
       <div className="max-w-sm text-center">
-        <h1 className="text-xl font-semibold">Zedi 管理画面</h1>
-        <p className="mt-4 text-sm text-slate-400">
-          管理者としてログインするには、まずメインアプリでサインインしてください。
-        </p>
+        <h1 className="text-xl font-semibold">{t("auth.title")}</h1>
+        <p className="mt-4 text-sm text-slate-400">{t("auth.description")}</p>
         <Button asChild size="lg" className="mt-6">
-          <a href={signInUrl}>サインインして続ける</a>
+          <a href={signInUrl}>{t("auth.signInButton")}</a>
         </Button>
-        <p className="mt-4 text-xs text-slate-500">
-          サインイン後、このページに戻ってきてください。
-        </p>
+        <p className="mt-4 text-xs text-slate-500">{t("auth.afterSignIn")}</p>
       </div>
     </div>
   );

--- a/admin/src/pages/ai-models/AiModelCard.tsx
+++ b/admin/src/pages/ai-models/AiModelCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import {
   Button,
   Card,
@@ -21,6 +22,7 @@ interface AiModelCardProps {
 
 /**
  * モバイル用リスト表示（カード形式）。ドラッグ並び替えはなし。
+ * Mobile card view of an AI model row (no drag reorder support).
  */
 export function AiModelCard({
   model: m,
@@ -29,6 +31,7 @@ export function AiModelCard({
   onTierChange,
   onToggleActive,
 }: AiModelCardProps) {
+  const { t } = useTranslation();
   return (
     <Card className={!m.isActive ? "opacity-60" : ""}>
       <CardContent className="p-3">
@@ -50,7 +53,7 @@ export function AiModelCard({
               }
             }}
             className="h-8 text-sm"
-            aria-label={`${m.modelId} の表示名`}
+            aria-label={t("aiModels.displayNameAriaLabel", { modelId: m.modelId })}
           />
         </div>
         <div className="mt-2 flex flex-wrap items-center gap-2">
@@ -60,7 +63,10 @@ export function AiModelCard({
               if (v === "free" || v === "pro") onTierChange(v);
             }}
           >
-            <SelectTrigger className="h-8 w-[100px]" aria-label={`${m.displayName} のティア`}>
+            <SelectTrigger
+              className="h-8 w-[100px]"
+              aria-label={t("aiModels.tierAriaLabel", { name: m.displayName })}
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/admin/src/pages/ai-models/AiModelRow.tsx
+++ b/admin/src/pages/ai-models/AiModelRow.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import {
   Button,
   Input,
@@ -44,6 +45,7 @@ export function AiModelRow({
   onDrop,
   onDragEnd,
 }: AiModelRowProps) {
+  const { t } = useTranslation();
   return (
     <TableRow
       draggable
@@ -73,12 +75,15 @@ export function AiModelRow({
             }
           }}
           className="h-8 min-w-[120px] text-sm"
-          aria-label={`${m.modelId} の表示名`}
+          aria-label={t("aiModels.displayNameAriaLabel", { modelId: m.modelId })}
         />
       </TableCell>
       <TableCell className="px-3 py-2">
         <Select value={m.tierRequired} onValueChange={(v) => onTierChange(v as "free" | "pro")}>
-          <SelectTrigger className="h-8 min-w-[100px]" aria-label={`${m.displayName} のティア`}>
+          <SelectTrigger
+            className="h-8 min-w-[100px]"
+            aria-label={t("aiModels.tierAriaLabel", { name: m.displayName })}
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/admin/src/pages/ai-models/AiModelsContent.tsx
+++ b/admin/src/pages/ai-models/AiModelsContent.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { Button, Table, TableBody, TableHead, TableHeader, TableRow } from "@zedi/ui";
 import type { AiModelAdmin, SyncPreviewResult, SyncResultItem } from "@/api/admin";
 import { AiModelCard } from "./AiModelCard";
@@ -73,6 +74,8 @@ export function AiModelsContent({
   onDrop,
   onDragEnd,
 }: AiModelsContentProps) {
+  const { t } = useTranslation();
+
   function createDisplayNameHandlers(model: AiModelAdmin) {
     return {
       onDisplayNameChange: (value: string) =>
@@ -94,7 +97,7 @@ export function AiModelsContent({
   return (
     <div>
       <div className="flex items-center justify-between gap-4">
-        <h1 className="text-lg font-semibold">AI モデル管理</h1>
+        <h1 className="text-lg font-semibold">{t("aiModels.title")}</h1>
         <Button
           type="button"
           variant="secondary"
@@ -102,7 +105,7 @@ export function AiModelsContent({
           onClick={onPreviewClick}
           disabled={syncing}
         >
-          {syncing ? "同期中..." : "プロバイダーと同期"}
+          {syncing ? t("aiModels.syncing") : t("aiModels.syncWithProvider")}
         </Button>
       </div>
 
@@ -112,10 +115,15 @@ export function AiModelsContent({
 
       {syncResult && (
         <div className="mt-2 rounded bg-slate-800 px-3 py-2 text-sm text-slate-300">
-          <span className="font-medium">同期結果:</span>{" "}
+          <span className="font-medium">{t("aiModels.syncResult")}</span>{" "}
           {syncResult.map((r) => (
             <span key={r.provider} className="mr-3">
-              {r.provider}: {r.error ?? `追加 ${r.upserted} / 無効化 ${r.deactivated ?? 0}`}
+              {r.provider}:{" "}
+              {r.error ??
+                t("aiModels.syncStat", {
+                  added: r.upserted,
+                  deactivated: r.deactivated ?? 0,
+                })}
             </span>
           ))}
         </div>
@@ -134,13 +142,13 @@ export function AiModelsContent({
         <Table className="border-border min-w-[640px] rounded border">
           <TableHeader>
             <TableRow className="border-border bg-muted/50 hover:bg-transparent">
-              <TableHead className="w-8 px-1 py-2" aria-label="並び替え" />
-              <TableHead className="px-3 py-2">プロバイダー</TableHead>
-              <TableHead className="px-3 py-2">モデルID</TableHead>
-              <TableHead className="px-3 py-2">表示名</TableHead>
-              <TableHead className="px-3 py-2">ティア</TableHead>
-              <TableHead className="px-3 py-2">有効</TableHead>
-              <TableHead className="px-3 py-2">並び順</TableHead>
+              <TableHead className="w-8 px-1 py-2" aria-label={t("aiModels.columns.reorder")} />
+              <TableHead className="px-3 py-2">{t("aiModels.columns.provider")}</TableHead>
+              <TableHead className="px-3 py-2">{t("aiModels.columns.modelId")}</TableHead>
+              <TableHead className="px-3 py-2">{t("aiModels.columns.displayName")}</TableHead>
+              <TableHead className="px-3 py-2">{t("aiModels.columns.tier")}</TableHead>
+              <TableHead className="px-3 py-2">{t("aiModels.columns.active")}</TableHead>
+              <TableHead className="px-3 py-2">{t("aiModels.columns.sortOrder")}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -178,8 +186,11 @@ export function AiModelsContent({
       </div>
 
       <p className="mt-2 text-xs text-slate-500">
-        {models.length} 件（有効: {models.filter((m) => m.isActive).length}）
-        <span className="hidden md:inline"> ドラッグで並び替え</span>
+        {t("aiModels.summary", {
+          total: models.length,
+          active: models.filter((m) => m.isActive).length,
+        })}
+        <span className="hidden md:inline"> {t("aiModels.dragHint")}</span>
       </p>
     </div>
   );

--- a/admin/src/pages/ai-models/SyncPreviewModal.tsx
+++ b/admin/src/pages/ai-models/SyncPreviewModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import {
   Button,
   Dialog,
@@ -28,6 +29,7 @@ export function SyncPreviewModal({
   onClose,
   onConfirm,
 }: SyncPreviewModalProps) {
+  const { t } = useTranslation();
   const totalToAdd = previewData?.reduce((sum, r) => sum + (r.toAdd?.length ?? 0), 0) ?? 0;
   const totalToDeactivate =
     previewData?.reduce((sum, r) => sum + (r.toDeactivate?.length ?? 0), 0) ?? 0;
@@ -40,14 +42,13 @@ export function SyncPreviewModal({
         aria-describedby="sync-preview-description"
       >
         <DialogHeader>
-          <DialogTitle id="sync-preview-title">同期プレビュー</DialogTitle>
+          <DialogTitle id="sync-preview-title">{t("aiModels.preview.title")}</DialogTitle>
           <DialogDescription id="sync-preview-description">
-            新規モデルは追加され、同期対象から外れた既存モデルは非アクティブ化されます。
-            既存モデルの表示名や料金は上書きされません。Sonnet 系は非アクティブで追加されます。
+            {t("aiModels.preview.description")}
           </DialogDescription>
         </DialogHeader>
         {loading ? (
-          <p className="text-muted-foreground mt-4">読み込み中...</p>
+          <p className="text-muted-foreground mt-4">{t("common.loading")}</p>
         ) : (
           <>
             <div className="mt-4 space-y-3">
@@ -61,9 +62,11 @@ export function SyncPreviewModal({
                     <ul className="text-muted-foreground mt-1 list-inside list-disc text-sm">
                       {r.toAdd.map((m) => (
                         <li key={m.id}>
-                          追加: {m.displayName}
+                          {t("aiModels.preview.addLabel", { name: m.displayName })}
                           {!m.isActive && (
-                            <span className="ml-1 text-amber-400">(非アクティブ)</span>
+                            <span className="ml-1 text-amber-400">
+                              {t("aiModels.preview.inactiveTag")}
+                            </span>
                           )}
                         </li>
                       ))}
@@ -72,30 +75,35 @@ export function SyncPreviewModal({
                   {r.toDeactivate && r.toDeactivate.length > 0 ? (
                     <ul className="mt-1 list-inside list-disc text-sm text-amber-300">
                       {r.toDeactivate.map((m) => (
-                        <li key={m.id}>無効化: {m.displayName}</li>
+                        <li key={m.id}>
+                          {t("aiModels.preview.deactivateLabel", { name: m.displayName })}
+                        </li>
                       ))}
                     </ul>
                   ) : null}
                   {!r.error &&
                   (r.toAdd?.length ?? 0) === 0 &&
                   (r.toDeactivate?.length ?? 0) === 0 ? (
-                    <p className="text-muted-foreground mt-1 text-sm">変更なし</p>
+                    <p className="text-muted-foreground mt-1 text-sm">
+                      {t("aiModels.preview.noChanges")}
+                    </p>
                   ) : null}
                 </div>
               ))}
             </div>
             <div className="mt-4 flex flex-col gap-2">
               {hasPreviewErrors && (
-                <p className="text-sm text-amber-400">
-                  一部プロバイダーでエラーが発生しています。エラーのあるプロバイダーは同期されません。
-                </p>
+                <p className="text-sm text-amber-400">{t("aiModels.preview.errorWarning")}</p>
               )}
               <DialogFooter>
                 <Button type="button" variant="secondary" onClick={onClose}>
-                  キャンセル
+                  {t("common.cancel")}
                 </Button>
                 <Button type="button" onClick={onConfirm}>
-                  同期実行（追加 {totalToAdd} / 無効化 {totalToDeactivate}）
+                  {t("aiModels.preview.confirm", {
+                    added: totalToAdd,
+                    deactivated: totalToDeactivate,
+                  })}
                 </Button>
               </DialogFooter>
             </div>

--- a/admin/src/pages/ai-models/index.tsx
+++ b/admin/src/pages/ai-models/index.tsx
@@ -7,64 +7,26 @@ import { useAiModelActions } from "./useAiModelActions";
 import { useAiModelsDragReorder } from "./useAiModelsDragReorder";
 
 /**
- *
+ * AI モデル管理ページのコンテナコンポーネント。
+ * Container component for the admin AI models page.
  */
 export default function AiModels() {
-  /**
-   *
-   */
   const { t } = useTranslation();
-  /**
-   *
-   */
   const [models, setModels] = useState<AiModelAdmin[]>([]);
-  /**
-   *
-   */
   const [loading, setLoading] = useState(true);
-  /**
-   *
-   */
   const [error, setError] = useState<string | null>(null);
-  /**
-   *
-   */
   const [syncing, setSyncing] = useState(false);
-  /**
-   *
-   */
   const [syncResult, setSyncResult] = useState<SyncResultItem[] | null>(null);
-  /**
-   *
-   */
   const [previewOpen, setPreviewOpen] = useState(false);
-  /**
-   *
-   */
   const [previewLoading, setPreviewLoading] = useState(false);
-  /**
-   *
-   */
   const [previewData, setPreviewData] = useState<SyncPreviewResult[] | null>(null);
-  /**
-   *
-   */
   const isMountedRef = useRef(true);
-  /**
-   *
-   */
   const originalModelsRef = useRef<AiModelAdmin[]>([]);
 
-  /**
-   *
-   */
   const load = useCallback(async (showLoading = true) => {
     if (showLoading && isMountedRef.current) setLoading(true);
     if (isMountedRef.current) setError(null);
     try {
-      /**
-       *
-       */
       const nextModels = await getAiModels();
       if (!isMountedRef.current) return;
       setModels(nextModels);
@@ -78,9 +40,6 @@ export default function AiModels() {
     }
   }, []);
 
-  /**
-   *
-   */
   const { handleModelUpdate, handleToggleActive, handleTierChange } = useAiModelActions({
     setModels,
     setError,
@@ -88,9 +47,6 @@ export default function AiModels() {
     originalModelsRef,
   });
 
-  /**
-   *
-   */
   const dragReorder = useAiModelsDragReorder({
     models,
     setModels,
@@ -107,17 +63,11 @@ export default function AiModels() {
     };
   }, [load]);
 
-  /**
-   *
-   */
   const handlePreviewClick = useCallback(async () => {
     setPreviewData(null);
     setPreviewLoading(true);
     setError(null);
     try {
-      /**
-       *
-       */
       const results = await previewSyncAiModels();
       if (!isMountedRef.current) return;
       setPreviewData(results);
@@ -131,9 +81,6 @@ export default function AiModels() {
     }
   }, []);
 
-  /**
-   *
-   */
   const handleSyncConfirm = useCallback(() => {
     setPreviewOpen(false);
     setPreviewData(null);

--- a/admin/src/pages/ai-models/index.tsx
+++ b/admin/src/pages/ai-models/index.tsx
@@ -1,26 +1,70 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import type { AiModelAdmin, SyncPreviewResult, SyncResultItem } from "@/api/admin";
 import { getAiModels, previewSyncAiModels, syncAiModels as syncAiModelsApi } from "@/api/admin";
 import { AiModelsContent } from "./AiModelsContent";
 import { useAiModelActions } from "./useAiModelActions";
 import { useAiModelsDragReorder } from "./useAiModelsDragReorder";
 
+/**
+ *
+ */
 export default function AiModels() {
+  /**
+   *
+   */
+  const { t } = useTranslation();
+  /**
+   *
+   */
   const [models, setModels] = useState<AiModelAdmin[]>([]);
+  /**
+   *
+   */
   const [loading, setLoading] = useState(true);
+  /**
+   *
+   */
   const [error, setError] = useState<string | null>(null);
+  /**
+   *
+   */
   const [syncing, setSyncing] = useState(false);
+  /**
+   *
+   */
   const [syncResult, setSyncResult] = useState<SyncResultItem[] | null>(null);
+  /**
+   *
+   */
   const [previewOpen, setPreviewOpen] = useState(false);
+  /**
+   *
+   */
   const [previewLoading, setPreviewLoading] = useState(false);
+  /**
+   *
+   */
   const [previewData, setPreviewData] = useState<SyncPreviewResult[] | null>(null);
+  /**
+   *
+   */
   const isMountedRef = useRef(true);
+  /**
+   *
+   */
   const originalModelsRef = useRef<AiModelAdmin[]>([]);
 
+  /**
+   *
+   */
   const load = useCallback(async (showLoading = true) => {
     if (showLoading && isMountedRef.current) setLoading(true);
     if (isMountedRef.current) setError(null);
     try {
+      /**
+       *
+       */
       const nextModels = await getAiModels();
       if (!isMountedRef.current) return;
       setModels(nextModels);
@@ -34,6 +78,9 @@ export default function AiModels() {
     }
   }, []);
 
+  /**
+   *
+   */
   const { handleModelUpdate, handleToggleActive, handleTierChange } = useAiModelActions({
     setModels,
     setError,
@@ -41,6 +88,9 @@ export default function AiModels() {
     originalModelsRef,
   });
 
+  /**
+   *
+   */
   const dragReorder = useAiModelsDragReorder({
     models,
     setModels,
@@ -57,11 +107,17 @@ export default function AiModels() {
     };
   }, [load]);
 
+  /**
+   *
+   */
   const handlePreviewClick = useCallback(async () => {
     setPreviewData(null);
     setPreviewLoading(true);
     setError(null);
     try {
+      /**
+       *
+       */
       const results = await previewSyncAiModels();
       if (!isMountedRef.current) return;
       setPreviewData(results);
@@ -75,6 +131,9 @@ export default function AiModels() {
     }
   }, []);
 
+  /**
+   *
+   */
   const handleSyncConfirm = useCallback(() => {
     setPreviewOpen(false);
     setPreviewData(null);
@@ -92,8 +151,8 @@ export default function AiModels() {
   if (loading && models.length === 0) {
     return (
       <div>
-        <h1 className="text-lg font-semibold">AI モデル管理</h1>
-        <p className="mt-2 text-slate-400">読み込み中...</p>
+        <h1 className="text-lg font-semibold">{t("aiModels.title")}</h1>
+        <p className="mt-2 text-slate-400">{t("common.loading")}</p>
       </div>
     );
   }

--- a/admin/src/pages/audit-logs/AuditLogsContent.tsx
+++ b/admin/src/pages/audit-logs/AuditLogsContent.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import {
   Button,
   Input,
@@ -39,7 +40,7 @@ interface AuditLogsContentProps {
   onPageChange: (page: number) => void;
 }
 
-/** UI selector sentinel for "すべて" (no filter). */
+/** UI selector sentinel for "all actions" (no filter). */
 const ANY_ACTION = "__any__";
 
 /**
@@ -49,9 +50,7 @@ const ANY_ACTION = "__any__";
  * Only role-change is recorded in Phase 1 (#550); suspend/unsuspend/delete
  * will be added by subsequent issues.
  */
-const KNOWN_ACTIONS: { value: string; label: string }[] = [
-  { value: "user.role.update", label: "ユーザー: ロール変更" },
-];
+const KNOWN_ACTION_VALUES = ["user.role.update"] as const;
 
 /**
  * `action` ごとに before/after を短いサマリに整形する。
@@ -90,6 +89,7 @@ export function AuditLogsContent({
   loading,
   onPageChange,
 }: AuditLogsContentProps) {
+  const { t } = useTranslation();
   const pageCount = Math.max(1, Math.ceil(total / pageSize));
   const hasPreviousPage = page > 0;
   const hasNextPage = page + 1 < pageCount;
@@ -106,7 +106,7 @@ export function AuditLogsContent({
   return (
     <div>
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="text-lg font-semibold">監査ログ</h1>
+        <h1 className="text-lg font-semibold">{t("audit.title")}</h1>
       </div>
 
       <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
@@ -116,17 +116,17 @@ export function AuditLogsContent({
             className="mb-1 block text-xs text-slate-400"
             id="audit-filter-action-label"
           >
-            アクションで絞り込み
+            {t("audit.filters.action")}
           </label>
           <Select value={filters.action ?? ANY_ACTION} onValueChange={handleActionChange}>
             <SelectTrigger id="audit-filter-action" aria-labelledby="audit-filter-action-label">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={ANY_ACTION}>すべて</SelectItem>
-              {KNOWN_ACTIONS.map((a) => (
-                <SelectItem key={a.value} value={a.value}>
-                  {a.label}
+              <SelectItem value={ANY_ACTION}>{t("common.all")}</SelectItem>
+              {KNOWN_ACTION_VALUES.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {t(`audit.actions.${value}`)}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -134,7 +134,7 @@ export function AuditLogsContent({
         </div>
         <div>
           <label htmlFor="audit-filter-from" className="mb-1 block text-xs text-slate-400">
-            期間（開始）
+            {t("audit.filters.from")}
           </label>
           <Input
             id="audit-filter-from"
@@ -145,7 +145,7 @@ export function AuditLogsContent({
         </div>
         <div>
           <label htmlFor="audit-filter-to" className="mb-1 block text-xs text-slate-400">
-            期間（終了）
+            {t("audit.filters.to")}
           </label>
           <Input
             id="audit-filter-to"
@@ -161,21 +161,21 @@ export function AuditLogsContent({
       )}
 
       {loading && logs.length === 0 ? (
-        <p className="mt-4 text-slate-400">読み込み中...</p>
+        <p className="mt-4 text-slate-400">{t("common.loading")}</p>
       ) : logs.length === 0 ? (
-        <p className="mt-4 text-slate-400">監査ログはありません。</p>
+        <p className="mt-4 text-slate-400">{t("audit.empty")}</p>
       ) : (
         <>
           <div className="mt-4 overflow-x-auto">
             <Table className="border-border min-w-[720px] rounded border">
               <TableHeader>
                 <TableRow className="border-border bg-muted/50 hover:bg-transparent">
-                  <TableHead className="px-3 py-2">日時</TableHead>
-                  <TableHead className="px-3 py-2">操作者</TableHead>
-                  <TableHead className="px-3 py-2">アクション</TableHead>
-                  <TableHead className="px-3 py-2">対象</TableHead>
-                  <TableHead className="px-3 py-2">変更内容</TableHead>
-                  <TableHead className="px-3 py-2">IP</TableHead>
+                  <TableHead className="px-3 py-2">{t("audit.columns.createdAt")}</TableHead>
+                  <TableHead className="px-3 py-2">{t("audit.columns.actor")}</TableHead>
+                  <TableHead className="px-3 py-2">{t("audit.columns.action")}</TableHead>
+                  <TableHead className="px-3 py-2">{t("audit.columns.target")}</TableHead>
+                  <TableHead className="px-3 py-2">{t("audit.columns.diff")}</TableHead>
+                  <TableHead className="px-3 py-2">{t("audit.columns.ipAddress")}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -219,13 +219,15 @@ export function AuditLogsContent({
           </div>
 
           <p className="mt-2 text-xs text-slate-500">
-            {total > 0 ? `${rangeStart}-${rangeEnd}` : "0"} 件を表示 / 合計 {total} 件
+            {total > 0
+              ? t("common.showingRange", { rangeStart, rangeEnd, total })
+              : t("common.showingZero", { total })}
           </p>
 
           {total > pageSize && (
             <div className="mt-3 flex items-center justify-between gap-3">
               <span className="text-xs text-slate-500">
-                {page + 1} / {pageCount} ページ
+                {t("common.page", { page: page + 1, count: pageCount })}
               </span>
               <div className="flex items-center gap-2">
                 <Button
@@ -235,7 +237,7 @@ export function AuditLogsContent({
                   onClick={() => onPageChange(page - 1)}
                   disabled={!hasPreviousPage || loading}
                 >
-                  前へ
+                  {t("common.previous")}
                 </Button>
                 <Button
                   type="button"
@@ -244,7 +246,7 @@ export function AuditLogsContent({
                   onClick={() => onPageChange(page + 1)}
                   disabled={!hasNextPage || loading}
                 >
-                  次へ
+                  {t("common.next")}
                 </Button>
               </div>
             </div>

--- a/admin/src/pages/users/SuspendDialog.tsx
+++ b/admin/src/pages/users/SuspendDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Label, Textarea } from "@zedi/ui";
 import type { UserAdmin } from "@/api/admin";
 import { ConfirmActionDialog } from "@/components/ConfirmActionDialog";
@@ -17,6 +18,7 @@ interface SuspendDialogProps {
  * Dialog for entering suspension reason before suspending a user.
  */
 export function SuspendDialog({ user, onClose, onConfirm }: SuspendDialogProps) {
+  const { t } = useTranslation();
   const [reason, setReason] = useState("");
 
   const handleConfirm = () => {
@@ -37,23 +39,21 @@ export function SuspendDialog({ user, onClose, onConfirm }: SuspendDialogProps) 
     <ConfirmActionDialog
       open={user !== null}
       onOpenChange={handleOpenChange}
-      title="ユーザーをサスペンド"
+      title={t("users.suspendDialog.title")}
       description={
-        user
-          ? `${user.name || user.email} をサスペンドします。サスペンドされたユーザーはすべての API にアクセスできなくなり、既存セッションも無効化されます。`
-          : ""
+        user ? t("users.suspendDialog.description", { name: user.name || user.email }) : ""
       }
-      confirmLabel="サスペンド"
+      confirmLabel={t("users.suspendDialog.confirm")}
       destructive
       onConfirm={handleConfirm}
     >
       <div className="grid gap-2">
-        <Label htmlFor="suspend-reason">理由（任意）</Label>
+        <Label htmlFor="suspend-reason">{t("users.suspendDialog.reasonLabel")}</Label>
         <Textarea
           id="suspend-reason"
           value={reason}
           onChange={(e) => setReason(e.target.value)}
-          placeholder="サスペンドの理由を入力してください"
+          placeholder={t("users.suspendDialog.reasonPlaceholder")}
           rows={3}
         />
       </div>

--- a/admin/src/pages/users/UserCard.tsx
+++ b/admin/src/pages/users/UserCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import {
   Badge,
   Button,
@@ -33,6 +34,7 @@ export function UserCard({
   onDelete,
   saving,
 }: UserCardProps) {
+  const { t } = useTranslation();
   return (
     <Card
       className={
@@ -54,7 +56,9 @@ export function UserCard({
         </div>
         <div className="mt-0.5 text-sm text-slate-400">{user.email}</div>
         {user.suspendedReason && (
-          <div className="text-muted-foreground mt-1 text-xs">理由: {user.suspendedReason}</div>
+          <div className="text-muted-foreground mt-1 text-xs">
+            {t("users.card.reasonPrefix", { reason: user.suspendedReason })}
+          </div>
         )}
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <Select
@@ -62,7 +66,10 @@ export function UserCard({
             onValueChange={(v) => onRoleChange(v as UserRole)}
             disabled={saving || user.status !== "active"}
           >
-            <SelectTrigger className="h-8 w-[120px]" aria-label={`${user.email} のロール`}>
+            <SelectTrigger
+              className="h-8 w-[120px]"
+              aria-label={t("users.row.roleAriaLabel", { email: user.email })}
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -71,21 +78,21 @@ export function UserCard({
             </SelectContent>
           </Select>
           <span className="text-xs text-slate-500">
-            ページ数: {user.pageCount.toLocaleString("ja-JP")}
+            {t("users.card.pageCount", { count: user.pageCount.toLocaleString("ja-JP") })}
           </span>
           <span className="text-xs text-slate-500">{formatDate(user.createdAt)}</span>
           {!saving && user.status === "deleted" ? (
-            <span className="text-muted-foreground text-xs">削除済み</span>
+            <span className="text-muted-foreground text-xs">{t("users.states.deleted")}</span>
           ) : (
             !saving && (
               <>
                 {user.status === "suspended" ? (
                   <Button type="button" variant="outline" size="sm" onClick={onUnsuspend}>
-                    復活
+                    {t("users.actions.restore")}
                   </Button>
                 ) : (
                   <Button type="button" variant="destructive" size="sm" onClick={onSuspend}>
-                    サスペンド
+                    {t("users.actions.suspend")}
                   </Button>
                 )}
                 <Button
@@ -95,12 +102,14 @@ export function UserCard({
                   className="text-destructive hover:text-destructive"
                   onClick={onDelete}
                 >
-                  削除
+                  {t("users.actions.delete")}
                 </Button>
               </>
             )
           )}
-          {saving && <span className="text-muted-foreground text-xs">保存中...</span>}
+          {saving && (
+            <span className="text-muted-foreground text-xs">{t("users.states.saving")}</span>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/admin/src/pages/users/UsersContent.tsx
+++ b/admin/src/pages/users/UsersContent.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   Badge,
   Button,
@@ -87,6 +88,7 @@ export function UsersContent({
   onUnsuspend,
   onDelete,
 }: UsersContentProps) {
+  const { t } = useTranslation();
   const pageCount = Math.max(1, Math.ceil(total / pageSize));
   const hasPreviousPage = page > 0;
   const hasNextPage = page + 1 < pageCount;
@@ -99,17 +101,20 @@ export function UsersContent({
   return (
     <div>
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="text-lg font-semibold">ユーザー管理</h1>
+        <h1 className="text-lg font-semibold">{t("users.title")}</h1>
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
           <Select
             value={statusFilter}
             onValueChange={(v) => onStatusFilterChange(v as UserStatus | "all")}
           >
-            <SelectTrigger className="h-9 w-full sm:w-[140px]" aria-label="ステータスフィルタ">
+            <SelectTrigger
+              className="h-9 w-full sm:w-[140px]"
+              aria-label={t("users.statusFilterAriaLabel")}
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">すべて</SelectItem>
+              <SelectItem value="all">{t("common.all")}</SelectItem>
               <SelectItem value="active">active</SelectItem>
               <SelectItem value="suspended">suspended</SelectItem>
               <SelectItem value="deleted">deleted</SelectItem>
@@ -119,9 +124,9 @@ export function UsersContent({
             type="search"
             value={search}
             onChange={(e) => onSearchChange(e.target.value)}
-            placeholder="メールで検索"
+            placeholder={t("users.searchEmailPlaceholder")}
             className="w-full max-w-xs"
-            aria-label="メールで検索"
+            aria-label={t("users.searchEmailAriaLabel")}
           />
         </div>
       </div>
@@ -131,7 +136,7 @@ export function UsersContent({
       )}
 
       {loading && users.length === 0 ? (
-        <p className="mt-4 text-slate-400">読み込み中...</p>
+        <p className="mt-4 text-slate-400">{t("common.loading")}</p>
       ) : (
         <>
           {/* デスクトップ: テーブル */}
@@ -139,13 +144,13 @@ export function UsersContent({
             <Table className="border-border min-w-[480px] rounded border">
               <TableHeader>
                 <TableRow className="border-border bg-muted/50 hover:bg-transparent">
-                  <TableHead className="px-3 py-2">メール</TableHead>
-                  <TableHead className="px-3 py-2">名前</TableHead>
-                  <TableHead className="px-3 py-2">ステータス</TableHead>
-                  <TableHead className="px-3 py-2">ロール</TableHead>
-                  <TableHead className="px-3 py-2">ページ数</TableHead>
-                  <TableHead className="px-3 py-2">作成日</TableHead>
-                  <TableHead className="px-3 py-2">操作</TableHead>
+                  <TableHead className="px-3 py-2">{t("users.columns.email")}</TableHead>
+                  <TableHead className="px-3 py-2">{t("users.columns.name")}</TableHead>
+                  <TableHead className="px-3 py-2">{t("users.columns.status")}</TableHead>
+                  <TableHead className="px-3 py-2">{t("users.columns.role")}</TableHead>
+                  <TableHead className="px-3 py-2">{t("users.columns.pageCount")}</TableHead>
+                  <TableHead className="px-3 py-2">{t("users.columns.createdAt")}</TableHead>
+                  <TableHead className="px-3 py-2">{t("users.columns.actions")}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -163,11 +168,12 @@ export function UsersContent({
                           className="text-muted-foreground ml-1 text-xs"
                           title={u.suspendedReason}
                         >
-                          (
-                          {u.suspendedReason.length > 20
-                            ? `${u.suspendedReason.slice(0, 20)}...`
-                            : u.suspendedReason}
-                          )
+                          {t("users.row.suspendedReasonShort", {
+                            reason:
+                              u.suspendedReason.length > 20
+                                ? `${u.suspendedReason.slice(0, 20)}...`
+                                : u.suspendedReason,
+                          })}
                         </span>
                       )}
                     </TableCell>
@@ -179,7 +185,7 @@ export function UsersContent({
                       >
                         <SelectTrigger
                           className="h-8 min-w-[100px]"
-                          aria-label={`${u.email} のロール`}
+                          aria-label={t("users.row.roleAriaLabel", { email: u.email })}
                         >
                           <SelectValue />
                         </SelectTrigger>
@@ -197,9 +203,13 @@ export function UsersContent({
                     </TableCell>
                     <TableCell className="px-3 py-2">
                       {savingIds.has(u.id) ? (
-                        <span className="text-muted-foreground text-sm">保存中...</span>
+                        <span className="text-muted-foreground text-sm">
+                          {t("users.states.saving")}
+                        </span>
                       ) : u.status === "deleted" ? (
-                        <span className="text-muted-foreground text-sm">削除済み</span>
+                        <span className="text-muted-foreground text-sm">
+                          {t("users.states.deleted")}
+                        </span>
                       ) : (
                         <div className="flex items-center gap-1">
                           {u.status === "suspended" ? (
@@ -209,7 +219,7 @@ export function UsersContent({
                               size="sm"
                               onClick={() => confirm.requestUnsuspend(u)}
                             >
-                              復活
+                              {t("users.actions.restore")}
                             </Button>
                           ) : (
                             <Button
@@ -218,7 +228,7 @@ export function UsersContent({
                               size="sm"
                               onClick={() => setSuspendTarget(u)}
                             >
-                              サスペンド
+                              {t("users.actions.suspend")}
                             </Button>
                           )}
                           <Button
@@ -228,7 +238,7 @@ export function UsersContent({
                             className="text-destructive hover:text-destructive"
                             onClick={() => confirm.requestDelete(u)}
                           >
-                            削除
+                            {t("users.actions.delete")}
                           </Button>
                         </div>
                       )}
@@ -255,13 +265,15 @@ export function UsersContent({
           </div>
 
           <p className="mt-2 text-xs text-slate-500">
-            {total > 0 ? `${rangeStart}-${rangeEnd}` : "0"} 件を表示 / 合計 {total} 件
+            {total > 0
+              ? t("common.showingRange", { rangeStart, rangeEnd, total })
+              : t("common.showingZero", { total })}
           </p>
 
           {total > pageSize && (
             <div className="mt-3 flex items-center justify-between gap-3">
               <span className="text-xs text-slate-500">
-                {page + 1} / {pageCount} ページ
+                {t("common.page", { page: page + 1, count: pageCount })}
               </span>
               <div className="flex items-center gap-2">
                 <Button
@@ -271,7 +283,7 @@ export function UsersContent({
                   onClick={() => onPageChange(page - 1)}
                   disabled={!hasPreviousPage || loading}
                 >
-                  前へ
+                  {t("common.previous")}
                 </Button>
                 <Button
                   type="button"
@@ -280,7 +292,7 @@ export function UsersContent({
                   onClick={() => onPageChange(page + 1)}
                   disabled={!hasNextPage || loading}
                 >
-                  次へ
+                  {t("common.next")}
                 </Button>
               </div>
             </div>
@@ -300,13 +312,17 @@ export function UsersContent({
         onOpenChange={(open) => {
           if (!open) confirm.cancelRoleChange();
         }}
-        title="ロールを変更"
+        title={t("users.roleChange.title")}
         description={
           confirm.roleChangeTarget
-            ? `${confirm.roleChangeTarget.user.name || confirm.roleChangeTarget.user.email} のロールを「${confirm.roleChangeTarget.user.role}」から「${confirm.roleChangeTarget.newRole}」に変更しますか？`
+            ? t("users.roleChange.description", {
+                name: confirm.roleChangeTarget.user.name || confirm.roleChangeTarget.user.email,
+                from: confirm.roleChangeTarget.user.role,
+                to: confirm.roleChangeTarget.newRole,
+              })
             : ""
         }
-        confirmLabel="変更する"
+        confirmLabel={t("users.roleChange.confirm")}
         destructive
         onConfirm={confirm.confirmRoleChange}
       />
@@ -317,13 +333,15 @@ export function UsersContent({
         onOpenChange={(open) => {
           if (!open) confirm.cancelUnsuspend();
         }}
-        title="サスペンドを解除"
+        title={t("users.unsuspend.title")}
         description={
           confirm.unsuspendTarget
-            ? `${confirm.unsuspendTarget.name || confirm.unsuspendTarget.email} のサスペンドを解除し、アカウントを復活させますか？`
+            ? t("users.unsuspend.description", {
+                name: confirm.unsuspendTarget.name || confirm.unsuspendTarget.email,
+              })
             : ""
         }
-        confirmLabel="復活させる"
+        confirmLabel={t("users.unsuspend.confirm")}
         onConfirm={confirm.confirmUnsuspend}
       />
 
@@ -333,13 +351,15 @@ export function UsersContent({
         onOpenChange={(open) => {
           if (!open) confirm.cancelDelete();
         }}
-        title="ユーザーを削除"
+        title={t("users.deleteUser.title")}
         description={
           confirm.deleteTarget
-            ? `${confirm.deleteTarget.user.name || confirm.deleteTarget.user.email} を削除します。個人情報は匿名化され、セッションと OAuth 連携は削除されます。この操作は元に戻せません。`
+            ? t("users.deleteUser.description", {
+                name: confirm.deleteTarget.user.name || confirm.deleteTarget.user.email,
+              })
             : ""
         }
-        confirmLabel="削除する"
+        confirmLabel={t("users.deleteUser.confirm")}
         destructive
         confirmPhrase={confirm.deleteTarget?.user.email}
         loading={confirm.deleteTarget?.loadingImpact}
@@ -347,18 +367,28 @@ export function UsersContent({
       >
         {confirm.deleteTarget?.impact && (
           <div className="rounded border border-yellow-600/40 bg-yellow-900/20 p-3 text-sm">
-            <p className="mb-1 font-medium text-yellow-300">影響範囲:</p>
+            <p className="mb-1 font-medium text-yellow-300">{t("users.impact.title")}</p>
             <ul className="text-muted-foreground list-inside list-disc space-y-0.5">
-              <li>所有ノート: {confirm.deleteTarget.impact.notesCount} 件</li>
-              <li>アクティブセッション: {confirm.deleteTarget.impact.sessionsCount} 件</li>
+              <li>{t("users.impact.notes", { count: confirm.deleteTarget.impact.notesCount })}</li>
               <li>
-                サブスクリプション:{" "}
-                {confirm.deleteTarget.impact.activeSubscription ? "あり (active)" : "なし"}
+                {t("users.impact.sessions", {
+                  count: confirm.deleteTarget.impact.sessionsCount,
+                })}
+              </li>
+              <li>
+                {t("users.impact.subscription", {
+                  value: confirm.deleteTarget.impact.activeSubscription
+                    ? t("users.impact.subscriptionActive")
+                    : t("users.impact.subscriptionNone"),
+                })}
               </li>
               {confirm.deleteTarget.impact.lastAiUsageAt && (
                 <li>
-                  最後の AI 使用:{" "}
-                  {new Date(confirm.deleteTarget.impact.lastAiUsageAt).toLocaleDateString("ja-JP")}
+                  {t("users.impact.lastAiUsage", {
+                    date: new Date(confirm.deleteTarget.impact.lastAiUsageAt).toLocaleDateString(
+                      "ja-JP",
+                    ),
+                  })}
                 </li>
               )}
             </ul>

--- a/admin/src/pages/wiki-health/WikiHealthContent.tsx
+++ b/admin/src/pages/wiki-health/WikiHealthContent.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import {
   Button,
   Select,
@@ -16,18 +17,14 @@ import {
 import type { LintFindingItem, LintRule, LintRunSummaryItem } from "@/api/lint";
 import { formatDate } from "@/lib/dateUtils";
 
-/**
- * ルール名を日本語・英語で表示する。
- * Maps rule name to display label (Japanese / English).
- */
-const RULE_LABELS: Record<LintRule, string> = {
-  orphan: "孤立ページ / Orphan",
-  ghost_many: "Ghost Link 過多 / Ghost Excess",
-  title_similar: "タイトル類似 / Title Similar",
-  conflict: "矛盾 / Conflict",
-  broken_link: "リンク切れ / Broken Link",
-  stale: "古い情報 / Stale",
-};
+const ALL_RULES: LintRule[] = [
+  "orphan",
+  "ghost_many",
+  "title_similar",
+  "conflict",
+  "broken_link",
+  "stale",
+];
 
 /**
  * 重要度に対応する Badge バリアント。
@@ -44,21 +41,7 @@ function severityVariant(severity: string): "default" | "secondary" | "destructi
   }
 }
 
-/**
- * detail オブジェクトからサマリ文字列を生成する。
- * Creates a summary string from a detail object.
- */
-function formatDetail(detail: Record<string, unknown>): string {
-  if (typeof detail.suggestion === "string") return detail.suggestion;
-  if (typeof detail.title === "string") return detail.title;
-  if (typeof detail.linkText === "string") {
-    const count = typeof detail.count === "number" ? detail.count : "?";
-    return `「${detail.linkText}」(${count} 件)`;
-  }
-  return JSON.stringify(detail);
-}
-
-/** UI selector sentinel for "すべて" (no filter). */
+/** UI selector sentinel for "all rules" (no filter). */
 const ANY_RULE = "__any__";
 
 interface WikiHealthContentProps {
@@ -88,7 +71,22 @@ export function WikiHealthContent({
   onRunLint,
   onResolve,
 }: WikiHealthContentProps) {
+  const { t } = useTranslation();
   const filtered = ruleFilter ? findings.filter((f) => f.rule === ruleFilter) : findings;
+
+  /**
+   * detail オブジェクトからサマリ文字列を生成する。
+   * Creates a summary string from a detail object.
+   */
+  const formatDetail = (detail: Record<string, unknown>): string => {
+    if (typeof detail.suggestion === "string") return detail.suggestion;
+    if (typeof detail.title === "string") return detail.title;
+    if (typeof detail.linkText === "string") {
+      const count = typeof detail.count === "number" ? detail.count : "?";
+      return t("wikiHealth.detail.linkText", { linkText: detail.linkText, count });
+    }
+    return JSON.stringify(detail);
+  };
 
   const handleRuleChange = (value: string) => {
     onRuleFilterChange(value === ANY_RULE ? undefined : (value as LintRule));
@@ -97,9 +95,9 @@ export function WikiHealthContent({
   return (
     <div>
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="text-lg font-semibold">Wiki Health ダッシュボード</h1>
+        <h1 className="text-lg font-semibold">{t("wikiHealth.title")}</h1>
         <Button type="button" onClick={onRunLint} disabled={running || loading}>
-          {running ? "実行中..." : "Lint 実行"}
+          {running ? t("common.running") : t("wikiHealth.runLint")}
         </Button>
       </div>
 
@@ -108,7 +106,7 @@ export function WikiHealthContent({
         <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6">
           {summary.map((s) => (
             <div key={s.rule} className="bg-muted/50 rounded border px-3 py-2">
-              <div className="text-muted-foreground text-xs">{RULE_LABELS[s.rule]}</div>
+              <div className="text-muted-foreground text-xs">{t(`wikiHealth.rules.${s.rule}`)}</div>
               <div className="mt-1 text-xl font-bold">{s.count}</div>
             </div>
           ))}
@@ -122,7 +120,7 @@ export function WikiHealthContent({
           className="text-muted-foreground mb-1 block text-xs"
           id="lint-filter-rule-label"
         >
-          ルールで絞り込み
+          {t("wikiHealth.filterRule")}
         </label>
         <Select value={ruleFilter ?? ANY_RULE} onValueChange={handleRuleChange}>
           <SelectTrigger
@@ -133,10 +131,10 @@ export function WikiHealthContent({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={ANY_RULE}>すべて</SelectItem>
-            {(Object.keys(RULE_LABELS) as LintRule[]).map((r) => (
+            <SelectItem value={ANY_RULE}>{t("common.all")}</SelectItem>
+            {ALL_RULES.map((r) => (
               <SelectItem key={r} value={r}>
-                {RULE_LABELS[r]}
+                {t(`wikiHealth.rules.${r}`)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -148,30 +146,28 @@ export function WikiHealthContent({
       )}
 
       {loading && findings.length === 0 ? (
-        <p className="text-muted-foreground mt-4">読み込み中...</p>
+        <p className="text-muted-foreground mt-4">{t("common.loading")}</p>
       ) : filtered.length === 0 ? (
         <p className="text-muted-foreground mt-4">
-          {findings.length === 0
-            ? "Lint findings はありません。「Lint 実行」をクリックしてください。"
-            : "該当する findings はありません。"}
+          {findings.length === 0 ? t("wikiHealth.emptyAll") : t("wikiHealth.emptyFiltered")}
         </p>
       ) : (
         <div className="mt-4 overflow-x-auto">
           <Table className="border-border min-w-[640px] rounded border">
             <TableHeader>
               <TableRow className="border-border bg-muted/50 hover:bg-transparent">
-                <TableHead className="px-3 py-2">ルール</TableHead>
-                <TableHead className="px-3 py-2">重要度</TableHead>
-                <TableHead className="px-3 py-2">詳細</TableHead>
-                <TableHead className="px-3 py-2">検出日時</TableHead>
-                <TableHead className="px-3 py-2">操作</TableHead>
+                <TableHead className="px-3 py-2">{t("wikiHealth.columns.rule")}</TableHead>
+                <TableHead className="px-3 py-2">{t("wikiHealth.columns.severity")}</TableHead>
+                <TableHead className="px-3 py-2">{t("wikiHealth.columns.detail")}</TableHead>
+                <TableHead className="px-3 py-2">{t("wikiHealth.columns.createdAt")}</TableHead>
+                <TableHead className="px-3 py-2">{t("wikiHealth.columns.actions")}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {filtered.map((f) => (
                 <TableRow key={f.id} className="border-border align-top">
                   <TableCell className="px-3 py-2">
-                    <Badge variant="outline">{RULE_LABELS[f.rule]}</Badge>
+                    <Badge variant="outline">{t(`wikiHealth.rules.${f.rule}`)}</Badge>
                   </TableCell>
                   <TableCell className="px-3 py-2">
                     <Badge variant={severityVariant(f.severity)}>{f.severity}</Badge>
@@ -179,7 +175,7 @@ export function WikiHealthContent({
                   <TableCell className="max-w-md px-3 py-2">
                     <div className="text-sm">{formatDetail(f.detail)}</div>
                     <div className="text-muted-foreground mt-1 text-xs">
-                      {f.page_ids.length} ページ関連
+                      {t("wikiHealth.pagesRelated", { count: f.page_ids.length })}
                     </div>
                   </TableCell>
                   <TableCell className="text-muted-foreground px-3 py-2 whitespace-nowrap">
@@ -192,14 +188,16 @@ export function WikiHealthContent({
                       size="sm"
                       onClick={() => onResolve(f.id)}
                     >
-                      解決
+                      {t("wikiHealth.resolve")}
                     </Button>
                   </TableCell>
                 </TableRow>
               ))}
             </TableBody>
           </Table>
-          <p className="text-muted-foreground mt-2 text-xs">合計 {filtered.length} 件</p>
+          <p className="text-muted-foreground mt-2 text-xs">
+            {t("common.totalCount", { count: filtered.length })}
+          </p>
         </div>
       )}
     </div>

--- a/admin/src/test/setup.ts
+++ b/admin/src/test/setup.ts
@@ -1,1 +1,9 @@
 import "@testing-library/jest-dom/vitest";
+
+import i18n from "@/i18n";
+
+// Force JA locale so existing snapshot-style assertions on Japanese strings
+// continue to pass without each test having to set up i18n manually.
+// テスト実行前に日本語へ強制設定し、日本語文字列を直接参照する既存テストを
+// 個別の i18n セットアップなしで通せるようにする。
+await i18n.changeLanguage("ja");

--- a/bun.lock
+++ b/bun.lock
@@ -179,9 +179,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@zedi/ui": "workspace:*",
+        "i18next": "^26.0.1",
+        "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^1.7.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-i18next": "^17.0.1",
         "react-router-dom": "^7.13.2",
       },
       "devDependencies": {


### PR DESCRIPTION
## 概要

管理画面に i18next を使用した多言語対応（日本語・英語）を実装しました。ハードコードされた日本語文字列をすべて翻訳キーに置き換え、言語切り替え機能を追加しました。

## 変更点

- **i18n インフラストラクチャの構築**
  - `admin/src/i18n/index.ts` で i18next を初期化
  - ブラウザ言語検出と localStorage による言語永続化を設定
  - メインアプリと同じ localStorage キー (`zedi-i18next-lng`) を共有

- **翻訳ファイルの追加**
  - 日本語・英語の翻訳ファイルを `admin/src/i18n/locales/{ja,en}/` に追加
  - ドメイン別に分割: `common.json`, `nav.json`, `auth.json`, `users.json`, `audit.json`, `wikiHealth.json`, `activityLog.json`, `aiModels.json`

- **コンポーネントの国際化**
  - `UsersContent.tsx`: ユーザー管理画面のすべてのテキストを翻訳キーに置き換え
  - `WikiHealthContent.tsx`: Wiki Health ダッシュボードのテキストを国際化、`RULE_LABELS` を削除して翻訳キーを使用
  - `ActivityLog.tsx`: 活動ログのテキストを国際化、`KIND_LABELS` と `ACTOR_LABELS` を削除
  - `AuditLogsContent.tsx`: 監査ログのテキストを国際化
  - `AiModelsContent.tsx`, `SyncPreviewModal.tsx`, `AiModelCard.tsx`, `AiModelRow.tsx`: AI モデル管理画面を国際化
  - `Layout.tsx`: ナビゲーションメニューを国際化
  - `Login.tsx`: ログイン画面を国際化
  - `UserCard.tsx`, `SuspendDialog.tsx`: ユーザー関連ダイアログを国際化
  - `ConfirmActionDialog.tsx`: 確認ダイアログのデフォルトラベルを翻訳キーに変更

- **依存関係の追加**
  - `i18next`, `react-i18next`, `i18next-browser-languagedetector` を package.json に追加

- **テスト設定の更新**
  - `admin/src/test/setup.ts` で i18n を初期化し、テスト実行時のデフォルト言語を日本語に設定

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)

## テスト方法

1. 管理画面を開き、各ページ（ユーザー管理、Wiki Health、監査ログなど）が正常に表示されることを確認
2. ブラウザの言語設定を変更して、英語表示に切り替わることを確認
3. localStorage の `zedi-i18next-lng` キーが正しく保存されることを確認
4. メインアプリとの言語設定が同期されることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 翻訳ファイルが完全に揃っている
- [x] メインアプリ

https://claude.ai/code/session_01TVkxK1iyA2p5Jv4qQ4AfKz
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
