### PR TITLE
Disable JSDoc auto-fixer to prevent empty stub generation

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -100,16 +100,27 @@ export default tseslint.config(
             ClassDeclaration: true,
             ArrowFunctionExpression: true,
           },
+          // `publicOnly` は `require` 配下にのみ作用するため、`contexts` 側は明示的に
+          // `ExportNamedDeclaration` 配下のセレクタへ絞り、未 export の内部宣言で
+          // 警告が出ないようにする。
+          // `publicOnly` only filters the `require` targets, so we scope custom
+          // contexts to children of `ExportNamedDeclaration` to avoid warning
+          // on internal, non-exported declarations.
           contexts: [
-            "TSTypeAliasDeclaration",
-            "TSInterfaceDeclaration",
-            "TSEnumDeclaration",
-            "VariableDeclaration",
+            "ExportNamedDeclaration > TSTypeAliasDeclaration",
+            "ExportNamedDeclaration > TSInterfaceDeclaration",
+            "ExportNamedDeclaration > TSEnumDeclaration",
+            "ExportNamedDeclaration > VariableDeclaration",
           ],
         },
       ],
       "jsdoc/require-description": ["warn", { descriptionStyle: "body" }],
-      "jsdoc/no-blank-block-descriptions": "error",
+      // `jsdoc/require-jsdoc` が `warn` であるのに、空 description を `error` にすると
+      // 「JSDoc を書き始めた人ほどブロックされる」逆インセンティブになるため warn に統一する。
+      // Align severity with `jsdoc/require-jsdoc` (`warn`); making blank
+      // descriptions `error` would penalise contributors who start writing JSDoc
+      // more than those who skip it entirely.
+      "jsdoc/no-blank-block-descriptions": "warn",
       "tsdoc/syntax": "warn",
 
       // --- 可読性・複雑度 ---

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -81,10 +81,18 @@ export default tseslint.config(
       "no-console": "off", // 下の override で src のみ有効
 
       // --- TSDoc / JSDoc（export されたものにコメント必須、現時点は warning のみ） ---
+      // 空 JSDoc スタブの自動挿入を防ぐため `enableFixer: false` を指定する。
+      // `--fix` で空 description のブロックを生成すると `jsdoc/no-blank-block-descriptions`
+      // と矛盾し、レビューでもノイズとして繰り返し指摘されるため、警告のみ残し手動で記述する運用とする。
+      // Disable the auto-fixer so `--fix` does not insert empty JSDoc stubs.
+      // The auto-inserted blocks conflict with `jsdoc/no-blank-block-descriptions`
+      // and were repeatedly flagged as noise during review; we keep the warning
+      // but require contributors to write descriptions manually.
       "jsdoc/require-jsdoc": [
         "warn",
         {
           publicOnly: true,
+          enableFixer: false,
           require: {
             FunctionDeclaration: true,
             FunctionExpression: true,


### PR DESCRIPTION
## 概要

`jsdoc/require-jsdoc` ルールの自動修正機能を無効化し、空の JSDoc スタブが自動生成されるのを防ぎます。

## 変更点

- `eslint.config.js` の `jsdoc/require-jsdoc` ルール設定に `enableFixer: false` を追加
- 自動生成される空の JSDoc ブロックが `jsdoc/no-blank-block-descriptions` ルールと矛盾するのを防止
- JSDoc コメントは警告として表示されますが、手動で記述する運用に統一

## 変更の種類

- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `eslint --fix` を実行して、JSDoc スタブが自動生成されないことを確認
2. `eslint` を実行して、JSDoc 記述が必要な箇所で警告が表示されることを確認
3. 既存の lint ルールが正常に動作することを確認

## チェックリスト

- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

https://claude.ai/code/session_01N2vkvwoGwNJmn4prnW3scP
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint configuration to prevent conflicting auto-fix behaviors in code quality validation rules, ensuring consistency in documentation enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->