### PR TITLE
Align slash menu heading levels with body schema (h2–h5)

### DIFF
--- a/src/components/editor/TiptapEditor/slashCommandItems.test.ts
+++ b/src/components/editor/TiptapEditor/slashCommandItems.test.ts
@@ -1,6 +1,6 @@
 /**
- * slashCommandItems: filtering and platform-gated availability.
- * slashCommandItems: フィルタリングとプラットフォーム依存の可用性判定。
+ * slashCommandItems: filtering, platform-gated availability, and heading-level alignment.
+ * slashCommandItems: フィルタリング、プラットフォーム依存の可用性判定、見出しレベル整合。
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -81,8 +81,48 @@ describe("slashCommandItems platform gating", () => {
     const ids = filtered.map((i) => i.id);
 
     expect(ids).toContain("paragraph");
-    expect(ids).toContain("heading1");
+    expect(ids).toContain("heading2");
     expect(ids).toContain("table");
     expect(ids).toContain("mermaid");
+  });
+});
+
+describe("slashCommandItems heading entries", () => {
+  /**
+   * Slash menu の見出し ID は実 level と 1:1 で対応していなければならない
+   * (PR #777 で本文 schema が `levels: [2, 3, 4, 5]` に変わったため)。
+   * Slash menu heading IDs must map 1:1 to the real schema level
+   * (the body editor restricts headings to `levels: [2, 3, 4, 5]` since PR #777).
+   */
+  it("exposes heading2 through heading5 with matching levels and no legacy heading1", () => {
+    const ids = slashCommandItems.map((i) => i.id);
+
+    expect(ids).not.toContain("heading1");
+    expect(ids).toContain("heading2");
+    expect(ids).toContain("heading3");
+    expect(ids).toContain("heading4");
+    expect(ids).toContain("heading5");
+
+    const captured: { level?: number } = {};
+    const chain = {
+      focus: () => chain,
+      deleteRange: () => chain,
+      setHeading: (attrs: { level: number }) => {
+        captured.level = attrs.level;
+        return chain;
+      },
+      run: () => true,
+    };
+    const editorStub = {
+      chain: () => chain,
+    } as unknown as Editor;
+
+    for (const level of [2, 3, 4, 5] as const) {
+      const item = slashCommandItems.find((i) => i.id === `heading${level}`);
+      expect(item).toBeDefined();
+      captured.level = undefined;
+      item?.action(editorStub, { from: 0, to: 0 });
+      expect(captured.level).toBe(level);
+    }
   });
 });

--- a/src/components/editor/TiptapEditor/slashCommandItems.ts
+++ b/src/components/editor/TiptapEditor/slashCommandItems.ts
@@ -37,22 +37,32 @@ export const slashCommandItems: SlashCommandItem[] = [
     action: (editor, range) => editor.chain().focus().deleteRange(range).setParagraph().run(),
   },
   {
-    id: "heading1",
-    icon: "Heading1",
-    action: (editor, range) =>
-      editor.chain().focus().deleteRange(range).setHeading({ level: 2 }).run(),
-  },
-  {
+    // ページタイトル input が h1 を担うため、本文 schema は `levels: [2, 3, 4, 5]`。
+    // ID とラベルは実 level に揃える。
+    // The page title input owns the only h1; the body schema allows levels 2–5,
+    // so each slash item's id matches the level it inserts.
     id: "heading2",
     icon: "Heading2",
     action: (editor, range) =>
-      editor.chain().focus().deleteRange(range).setHeading({ level: 3 }).run(),
+      editor.chain().focus().deleteRange(range).setHeading({ level: 2 }).run(),
   },
   {
     id: "heading3",
     icon: "Heading3",
     action: (editor, range) =>
+      editor.chain().focus().deleteRange(range).setHeading({ level: 3 }).run(),
+  },
+  {
+    id: "heading4",
+    icon: "Heading4",
+    action: (editor, range) =>
       editor.chain().focus().deleteRange(range).setHeading({ level: 4 }).run(),
+  },
+  {
+    id: "heading5",
+    icon: "Heading5",
+    action: (editor, range) =>
+      editor.chain().focus().deleteRange(range).setHeading({ level: 5 }).run(),
   },
   {
     id: "bulletList",

--- a/src/components/editor/TiptapEditor/slashSuggestionIcons.tsx
+++ b/src/components/editor/TiptapEditor/slashSuggestionIcons.tsx
@@ -6,9 +6,10 @@
 import type { FC, SVGProps } from "react";
 import {
   Pilcrow,
-  Heading1,
   Heading2,
   Heading3,
+  Heading4,
+  Heading5,
   List,
   ListOrdered,
   CheckSquare,
@@ -35,9 +36,10 @@ import type { AgentSlashCommandId } from "@/lib/agentSlashCommands/types";
 /** Map icon name string → Lucide component / アイコン名 → Lucide コンポーネント */
 export const slashMenuIconMap: Record<string, FC<SVGProps<SVGSVGElement>>> = {
   Pilcrow,
-  Heading1,
   Heading2,
   Heading3,
+  Heading4,
+  Heading5,
   List,
   ListOrdered,
   CheckSquare,

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -83,20 +83,25 @@
       "description": "Body text",
       "aliases": "paragraph,p,text"
     },
-    "heading1": {
-      "title": "Heading 1",
-      "description": "Large heading",
-      "aliases": "heading1,h1,heading"
-    },
     "heading2": {
       "title": "Heading 2",
-      "description": "Medium heading",
+      "description": "Large heading",
       "aliases": "heading2,h2,heading"
     },
     "heading3": {
       "title": "Heading 3",
-      "description": "Small heading",
+      "description": "Medium heading",
       "aliases": "heading3,h3,heading"
+    },
+    "heading4": {
+      "title": "Heading 4",
+      "description": "Small heading",
+      "aliases": "heading4,h4,heading"
+    },
+    "heading5": {
+      "title": "Heading 5",
+      "description": "Smallest heading",
+      "aliases": "heading5,h5,heading"
     },
     "bulletList": {
       "title": "Bullet list",

--- a/src/i18n/locales/ja/editor.json
+++ b/src/i18n/locales/ja/editor.json
@@ -83,20 +83,25 @@
       "description": "本文テキスト",
       "aliases": "段落,paragraph,p,text"
     },
-    "heading1": {
-      "title": "見出し1",
-      "description": "大見出し",
-      "aliases": "見出し1,h1,大見出し,heading"
-    },
     "heading2": {
       "title": "見出し2",
-      "description": "中見出し",
-      "aliases": "見出し2,h2,中見出し,heading"
+      "description": "大見出し",
+      "aliases": "見出し2,h2,大見出し,heading"
     },
     "heading3": {
       "title": "見出し3",
+      "description": "中見出し",
+      "aliases": "見出し3,h3,中見出し,heading"
+    },
+    "heading4": {
+      "title": "見出し4",
       "description": "小見出し",
-      "aliases": "見出し3,h3,小見出し,heading"
+      "aliases": "見出し4,h4,小見出し,heading"
+    },
+    "heading5": {
+      "title": "見出し5",
+      "description": "最下層の見出し",
+      "aliases": "見出し5,h5,最小見出し,heading"
     },
     "bulletList": {
       "title": "箇条書き",


### PR DESCRIPTION
## 概要

ページタイトル input が h1 を担うため、本文エディタの schema は `levels: [2, 3, 4, 5]` に制限されています。スラッシュメニューの見出しエントリを実際のスキーマレベルに合わせるため、`heading1` を削除し、`heading2`～`heading5` に統一しました。各エントリの ID、アイコン、ラベルが実際に挿入されるレベルと 1:1 で対応するようになります。

## 変更点

- **slashCommandItems.ts**: `heading1` を削除し、`heading2`～`heading5` に統一（ID とアイコンを実レベルに合わせる）
- **i18n/locales/en/editor.json**: 見出しエントリを `heading2`～`heading5` に更新、説明文を調整
- **i18n/locales/ja/editor.json**: 見出しエントリを `heading2`～`heading5` に更新、説明文を調整
- **slashSuggestionIcons.tsx**: `Heading1` アイコンを削除、`Heading4` と `Heading5` を追加
- **slashCommandItems.test.ts**: 
  - 既存テストで `heading1` → `heading2` に修正
  - 新しいテストスイート「slashCommandItems heading entries」を追加し、`heading2`～`heading5` の存在確認と各レベルが正しく設定されることを検証

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm test` または `vitest` を実行し、すべてのテストがパスすることを確認
2. スラッシュメニューを開き、`heading2`～`heading5` が表示され、`heading1` が表示されないことを確認
3. 各見出しエントリを選択し、正しいレベルの見出しが挿入されることを確認

## チェックリスト

- [x] テストがすべてパスする（新規テストスイートで heading レベルの 1:1 対応を検証）
- [x] Lint エラーがない
- [x] 必要に応じてドキュメント（i18n）を更新した
- [x] コミットメッセージが Conventional Commits に従っている

https://claude.ai/code/session_01QVCdQXhDFTkM8mzQKKsHkc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
