### PR TITLE
feat: role-based share modal tabs and read-only modes (#675)

### DIFF
--- a/src/pages/NoteMembers/NoteInviteLinksSection.tsx
+++ b/src/pages/NoteMembers/NoteInviteLinksSection.tsx
@@ -129,6 +129,18 @@ export interface NoteInviteLinksSectionProps {
    * `NoteEditPermission` domain type (#676 coderabbit).
    */
   editPermission?: NoteEditPermission;
+  /**
+   * read-only モードで描画するか。editor 向けに既存のリンクだけ閲覧（コピー）
+   * させたいときに `true` を渡す。
+   * - 発行フォーム（Label / Role / Expiry / MaxUses / Create）は非表示
+   * - 既存リンクのコピーボタンは引き続き表示（共有用途）
+   * - 取り消しボタンは非表示（破壊的操作なので owner 限定）
+   *
+   * Render in read-only mode. Hides the create form and revoke buttons but
+   * keeps the per-row copy button so editors can still distribute existing
+   * links. Owner-only destructive ops stay hidden.
+   */
+  readOnly?: boolean;
 }
 
 /**
@@ -139,6 +151,7 @@ export const NoteInviteLinksSection: React.FC<NoteInviteLinksSectionProps> = ({
   noteId,
   now,
   editPermission,
+  readOnly = false,
 }) => {
   const { t } = useTranslation();
   const { toast } = useToast();
@@ -338,68 +351,77 @@ export const NoteInviteLinksSection: React.FC<NoteInviteLinksSectionProps> = ({
       <h2 className="mb-1 text-sm font-semibold">{t("notes.inviteLinksTitle")}</h2>
       <p className="text-muted-foreground mb-4 text-xs">{t("notes.inviteLinksPhase5Hint")}</p>
 
-      <div className="grid gap-3 md:grid-cols-[1fr_140px_160px_160px_auto]">
-        <Input
-          value={label}
-          onChange={(e) => setLabel(e.target.value)}
-          placeholder={t("notes.inviteLinksLabelPlaceholder")}
-          aria-label={t("notes.inviteLinksLabelAria")}
-        />
-        <Select value={role} onValueChange={handleRoleChange}>
-          <SelectTrigger aria-label={t("notes.inviteLinksRoleAria")}>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="viewer">{t("notes.inviteLinksRoleViewer")}</SelectItem>
-            <SelectItem value="editor" disabled={!canCreateEditorLink}>
-              {t("notes.inviteLinksRoleEditor")}
-            </SelectItem>
-          </SelectContent>
-        </Select>
-        <Select value={expiryPreset} onValueChange={(v) => setExpiryPreset(v as ExpiryPreset)}>
-          <SelectTrigger aria-label={t("notes.inviteLinksExpiryAria")}>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="d1">{t("notes.inviteLinksExpiry1d")}</SelectItem>
-            <SelectItem value="d7">{t("notes.inviteLinksExpiry7d")}</SelectItem>
-            <SelectItem value="d30">{t("notes.inviteLinksExpiry30d")}</SelectItem>
-            <SelectItem value="d90">{t("notes.inviteLinksExpiry90d")}</SelectItem>
-          </SelectContent>
-        </Select>
-        <Select value={maxUsesPreset} onValueChange={(v) => setMaxUsesPreset(v as MaxUsesPreset)}>
-          <SelectTrigger aria-label={t("notes.inviteLinksMaxUsesAria")}>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="1">{t("notes.inviteLinksMaxUsesN", { count: 1 })}</SelectItem>
-            <SelectItem value="10">{t("notes.inviteLinksMaxUsesN", { count: 10 })}</SelectItem>
-            <SelectItem value="50">{t("notes.inviteLinksMaxUsesN", { count: 50 })}</SelectItem>
-            <SelectItem value="100">{t("notes.inviteLinksMaxUsesN", { count: 100 })}</SelectItem>
-            <SelectItem value="unlimited">{t("notes.inviteLinksMaxUsesUnlimited")}</SelectItem>
-          </SelectContent>
-        </Select>
-        <Button
-          onClick={handleCreate}
-          disabled={createMutation.isPending || needsEditorAck}
-          className="gap-1"
-        >
-          {createMutation.isPending ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Plus className="h-4 w-4" />
-          )}
-          {t("notes.inviteLinksCreateCta")}
-        </Button>
-      </div>
+      {!readOnly ? (
+        <>
+          <div className="grid gap-3 md:grid-cols-[1fr_140px_160px_160px_auto]">
+            <Input
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder={t("notes.inviteLinksLabelPlaceholder")}
+              aria-label={t("notes.inviteLinksLabelAria")}
+            />
+            <Select value={role} onValueChange={handleRoleChange}>
+              <SelectTrigger aria-label={t("notes.inviteLinksRoleAria")}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="viewer">{t("notes.inviteLinksRoleViewer")}</SelectItem>
+                <SelectItem value="editor" disabled={!canCreateEditorLink}>
+                  {t("notes.inviteLinksRoleEditor")}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={expiryPreset} onValueChange={(v) => setExpiryPreset(v as ExpiryPreset)}>
+              <SelectTrigger aria-label={t("notes.inviteLinksExpiryAria")}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="d1">{t("notes.inviteLinksExpiry1d")}</SelectItem>
+                <SelectItem value="d7">{t("notes.inviteLinksExpiry7d")}</SelectItem>
+                <SelectItem value="d30">{t("notes.inviteLinksExpiry30d")}</SelectItem>
+                <SelectItem value="d90">{t("notes.inviteLinksExpiry90d")}</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select
+              value={maxUsesPreset}
+              onValueChange={(v) => setMaxUsesPreset(v as MaxUsesPreset)}
+            >
+              <SelectTrigger aria-label={t("notes.inviteLinksMaxUsesAria")}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="1">{t("notes.inviteLinksMaxUsesN", { count: 1 })}</SelectItem>
+                <SelectItem value="10">{t("notes.inviteLinksMaxUsesN", { count: 10 })}</SelectItem>
+                <SelectItem value="50">{t("notes.inviteLinksMaxUsesN", { count: 50 })}</SelectItem>
+                <SelectItem value="100">
+                  {t("notes.inviteLinksMaxUsesN", { count: 100 })}
+                </SelectItem>
+                <SelectItem value="unlimited">{t("notes.inviteLinksMaxUsesUnlimited")}</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              onClick={handleCreate}
+              disabled={createMutation.isPending || needsEditorAck}
+              className="gap-1"
+            >
+              {createMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plus className="h-4 w-4" />
+              )}
+              {t("notes.inviteLinksCreateCta")}
+            </Button>
+          </div>
 
-      {role === "editor" && !canCreateEditorLink ? (
-        <p className="mt-2 text-xs text-red-600 dark:text-red-400">
-          {t("notes.inviteLinksEditorUnavailableOwnerOnly")}
-        </p>
+          {role === "editor" && !canCreateEditorLink ? (
+            <p className="mt-2 text-xs text-red-600 dark:text-red-400">
+              {t("notes.inviteLinksEditorUnavailableOwnerOnly")}
+            </p>
+          ) : null}
+        </>
       ) : null}
 
-      <div className="mt-4 space-y-3">
+      <div className={readOnly ? "space-y-3" : "mt-4 space-y-3"}>
         {isLoading ? (
           <p className="text-muted-foreground text-sm">{t("common.loading")}</p>
         ) : links.length === 0 ? (
@@ -413,12 +435,16 @@ export const NoteInviteLinksSection: React.FC<NoteInviteLinksSectionProps> = ({
               onCopy={() => handleCopy(link.token)}
               onRevoke={() => handleRevoke(link.id)}
               revoking={revokeMutation.isPending}
+              readOnly={readOnly}
             />
           ))
         )}
       </div>
 
-      <AlertDialog open={editorConfirmOpen} onOpenChange={handleEditorDialogOpenChange}>
+      <AlertDialog
+        open={!readOnly && editorConfirmOpen}
+        onOpenChange={handleEditorDialogOpenChange}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle className="flex items-center gap-2">
@@ -452,6 +478,11 @@ interface InviteLinkRowViewProps {
   onCopy: () => void;
   onRevoke: () => void;
   revoking: boolean;
+  /**
+   * read-only モードでは取り消しボタンを出さない（コピーは引き続き可）。
+   * In read-only mode the revoke button is hidden; copy stays available.
+   */
+  readOnly?: boolean;
 }
 
 const InviteLinkRowView: React.FC<InviteLinkRowViewProps> = ({
@@ -460,6 +491,7 @@ const InviteLinkRowView: React.FC<InviteLinkRowViewProps> = ({
   onCopy,
   onRevoke,
   revoking,
+  readOnly = false,
 }) => {
   const { t } = useTranslation();
   const expiresMs = new Date(link.expires_at).getTime();
@@ -539,16 +571,18 @@ const InviteLinkRowView: React.FC<InviteLinkRowViewProps> = ({
         >
           <Copy className="h-4 w-4" />
         </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label={t("notes.inviteLinksRevokeAria")}
-          title={t("notes.inviteLinksRevoke")}
-          onClick={onRevoke}
-          disabled={revoking}
-        >
-          <XCircle className="h-4 w-4" />
-        </Button>
+        {!readOnly ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={t("notes.inviteLinksRevokeAria")}
+            title={t("notes.inviteLinksRevoke")}
+            onClick={onRevoke}
+            disabled={revoking}
+          >
+            <XCircle className="h-4 w-4" />
+          </Button>
+        ) : null}
       </div>
     </div>
   );

--- a/src/pages/NoteMembers/NoteMembers.test.tsx
+++ b/src/pages/NoteMembers/NoteMembers.test.tsx
@@ -44,7 +44,18 @@ vi.mock("@/components/layout/Container", () => ({
   ),
 }));
 vi.mock("./NoteMembersManageSection", () => ({
-  NoteMembersManageSection: () => <div data-testid="members-manage-section">ManageSection</div>,
+  NoteMembersManageSection: ({ readOnly }: { readOnly?: boolean }) => (
+    <div data-testid="members-manage-section" data-readonly={readOnly ? "true" : "false"}>
+      ManageSection
+    </div>
+  ),
+}));
+vi.mock("./NoteInviteLinksSection", () => ({
+  NoteInviteLinksSection: ({ readOnly }: { readOnly?: boolean }) => (
+    <div data-testid="invite-links-section" data-readonly={readOnly ? "true" : "false"}>
+      InviteLinksSection
+    </div>
+  ),
 }));
 
 function renderNoteMembers(noteId: string) {
@@ -106,10 +117,10 @@ describe("NoteMembers", () => {
     );
   });
 
-  it("shows no permission to manage members when canManageMembers is false", () => {
+  it("shows no permission to manage members when role=viewer (no manage + no editor read-only)", () => {
     vi.mocked(useNote).mockReturnValue({
       note: { id: "n1", title: "My Note" },
-      access: { canView: true, canManageMembers: false },
+      access: { role: "viewer", canView: true, canManageMembers: false },
       source: "local",
       isLoading: false,
     } as never);
@@ -118,14 +129,31 @@ describe("NoteMembers", () => {
     expect(screen.queryByTestId("members-manage-section")).not.toBeInTheDocument();
   });
 
-  it("shows manage section when canManageMembers is true", () => {
+  it("shows manage section when canManageMembers is true (owner editable)", () => {
     vi.mocked(useNote).mockReturnValue({
       note: { id: "n1", title: "My Note" },
-      access: { canView: true, canManageMembers: true },
+      access: { role: "owner", canView: true, canManageMembers: true },
       source: "local",
       isLoading: false,
     } as never);
     renderNoteMembers("note-1");
-    expect(screen.getByTestId("members-manage-section")).toBeInTheDocument();
+    const section = screen.getByTestId("members-manage-section");
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveAttribute("data-readonly", "false");
+  });
+
+  it("editor (canView, no manage) sees the members section in read-only mode (#675)", () => {
+    vi.mocked(useNote).mockReturnValue({
+      note: { id: "n1", title: "My Note" },
+      access: { role: "editor", canView: true, canManageMembers: false },
+      source: "local",
+      isLoading: false,
+    } as never);
+    renderNoteMembers("note-1");
+    const section = screen.getByTestId("members-manage-section");
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveAttribute("data-readonly", "true");
+    // Permission denial message must NOT appear for editors
+    expect(screen.queryByText("notes.noPermissionToManageMembers")).not.toBeInTheDocument();
   });
 });

--- a/src/pages/NoteMembers/NoteMembersManageSection.test.tsx
+++ b/src/pages/NoteMembers/NoteMembersManageSection.test.tsx
@@ -45,7 +45,10 @@ function makeInvitation(overrides: Partial<NoteMemberInvitation> = {}): NoteMemb
   };
 }
 
-function renderSection(members: React.ComponentProps<typeof NoteMembersManageSection>["members"]) {
+function renderSection(
+  members: React.ComponentProps<typeof NoteMembersManageSection>["members"],
+  extra: Partial<React.ComponentProps<typeof NoteMembersManageSection>> = {},
+) {
   return render(
     <NoteMembersManageSection
       members={members}
@@ -63,6 +66,7 @@ function renderSection(members: React.ComponentProps<typeof NoteMembersManageSec
       onRemoveMember={async () => {}}
       onResendInvitation={async () => {}}
       now={() => NOW_MS}
+      {...extra}
     />,
   );
 }
@@ -142,5 +146,49 @@ describe("NoteMembersManageSection — badge derivation", () => {
     ]);
 
     expect(screen.getByText("notes.statusPending")).toBeInTheDocument();
+  });
+
+  // ------------------------------------------------------------------
+  // readOnly mode (#675) — editor / viewer browses the list without editing
+  // ------------------------------------------------------------------
+
+  it("readOnly=true は招待フォーム・操作ボタンを隠し、ステータスバッジは残す", () => {
+    renderSection(
+      [
+        {
+          memberEmail: "guest@example.com",
+          role: "viewer",
+          status: "pending",
+          invitation: makeInvitation(),
+        },
+        {
+          memberEmail: "alice@example.com",
+          role: "editor",
+          status: "accepted",
+          invitation: null,
+        },
+      ],
+      { readOnly: true },
+    );
+
+    // 招待フォームの見出しは出さない（read-only 用の "members" 見出しに置き換わる）
+    expect(screen.queryByRole("heading", { name: "notes.inviteMember" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "notes.members" })).toBeInTheDocument();
+
+    // Add ボタン・再送ボタン・取り消し / 削除ボタンは全て非表示
+    expect(screen.queryByRole("button", { name: "notes.add" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /notes\.a11yResendInvitation/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /notes\.a11yCancelInvitation/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /notes\.a11yRemoveMember/ }),
+    ).not.toBeInTheDocument();
+
+    // ステータスバッジは引き続き表示されている
+    expect(screen.getByText("notes.statusAccepted")).toBeInTheDocument();
+    expect(screen.getByText(/^notes\.statusPendingWithMeta\(/)).toBeInTheDocument();
   });
 });

--- a/src/pages/NoteMembers/NoteMembersManageSection.tsx
+++ b/src/pages/NoteMembers/NoteMembersManageSection.tsx
@@ -254,7 +254,7 @@ export function NoteMembersManageSection({
                           ? t("notes.a11yCancelInvitation", { email: member.memberEmail })
                           : t("notes.a11yRemoveMember", { email: member.memberEmail })
                       }
-                      title={isActionable ? t("notes.cancelInvitation") : undefined}
+                      title={isActionable ? t("notes.cancelInvitation") : t("notes.removeMember")}
                       onClick={() => onRemoveMember(member.memberEmail)}
                     >
                       {isActionable ? (

--- a/src/pages/NoteMembers/NoteMembersManageSection.tsx
+++ b/src/pages/NoteMembers/NoteMembersManageSection.tsx
@@ -113,6 +113,18 @@ export interface NoteMembersManageSectionProps {
    * Injection point for tests; defaults to `Date.now()`.
    */
   now?: () => number;
+  /**
+   * read-only モードで描画するか。editor / viewer 向けにメンバー一覧だけ
+   * 閲覧させたいときに `true` を渡す。
+   * - 招待フォーム（Email / Role / Add）は非表示
+   * - 各メンバー行の Role セレクトは disabled
+   * - 再送信 / 取り消し ボタンは非表示
+   * - ステータスバッジ（pending / expired / accepted）は引き続き表示する
+   *
+   * Render in read-only mode (editor / viewer browsing the list). Hides the
+   * invite form and per-row action buttons; status badges remain.
+   */
+  readOnly?: boolean;
 }
 
 /**
@@ -132,36 +144,43 @@ export function NoteMembersManageSection({
   onRemoveMember,
   onResendInvitation,
   now,
+  readOnly = false,
 }: NoteMembersManageSectionProps) {
   const { t } = useTranslation();
   const nowMs = (now ?? Date.now)();
   return (
     <section className="border-border/60 mt-6 rounded-lg border p-4">
-      <h2 className="mb-4 text-sm font-semibold">{t("notes.inviteMember")}</h2>
-      <div className="grid gap-3 md:grid-cols-[1fr_200px_auto]">
-        <Input
-          value={memberEmail}
-          onChange={(event) => setMemberEmail(event.target.value)}
-          placeholder={t("notes.emailPlaceholder")}
-        />
-        <Select
-          value={memberRole}
-          onValueChange={(value) => setMemberRole(value as NoteMemberRole)}
-        >
-          <SelectTrigger>
-            <SelectValue placeholder={t("notes.role")} />
-          </SelectTrigger>
-          <SelectContent>
-            {roleOptions.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Button onClick={onAddMember}>{t("notes.add")}</Button>
-      </div>
-      <div className="mt-4 space-y-3">
+      {readOnly ? (
+        <h2 className="mb-4 text-sm font-semibold">{t("notes.members")}</h2>
+      ) : (
+        <>
+          <h2 className="mb-4 text-sm font-semibold">{t("notes.inviteMember")}</h2>
+          <div className="grid gap-3 md:grid-cols-[1fr_200px_auto]">
+            <Input
+              value={memberEmail}
+              onChange={(event) => setMemberEmail(event.target.value)}
+              placeholder={t("notes.emailPlaceholder")}
+            />
+            <Select
+              value={memberRole}
+              onValueChange={(value) => setMemberRole(value as NoteMemberRole)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder={t("notes.role")} />
+              </SelectTrigger>
+              <SelectContent>
+                {roleOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button onClick={onAddMember}>{t("notes.add")}</Button>
+          </div>
+        </>
+      )}
+      <div className={readOnly ? "space-y-3" : "mt-4 space-y-3"}>
         {isMembersLoading ? (
           <p className="text-muted-foreground text-sm">{t("common.loading")}</p>
         ) : members.length === 0 ? (
@@ -202,6 +221,7 @@ export function NoteMembersManageSection({
                     onValueChange={(value) =>
                       onUpdateRole(member.memberEmail, value as NoteMemberRole)
                     }
+                    disabled={readOnly}
                   >
                     <SelectTrigger className="w-32">
                       <SelectValue />
@@ -214,7 +234,7 @@ export function NoteMembersManageSection({
                       ))}
                     </SelectContent>
                   </Select>
-                  {isPending && (
+                  {!readOnly && isPending && (
                     <Button
                       variant="ghost"
                       size="icon"
@@ -225,23 +245,25 @@ export function NoteMembersManageSection({
                       <RefreshCw className="h-4 w-4" />
                     </Button>
                   )}
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={
-                      isActionable
-                        ? t("notes.a11yCancelInvitation", { email: member.memberEmail })
-                        : t("notes.a11yRemoveMember", { email: member.memberEmail })
-                    }
-                    title={isActionable ? t("notes.cancelInvitation") : undefined}
-                    onClick={() => onRemoveMember(member.memberEmail)}
-                  >
-                    {isActionable ? (
-                      <XCircle className="h-4 w-4" />
-                    ) : (
-                      <Trash2 className="h-4 w-4" />
-                    )}
-                  </Button>
+                  {!readOnly && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label={
+                        isActionable
+                          ? t("notes.a11yCancelInvitation", { email: member.memberEmail })
+                          : t("notes.a11yRemoveMember", { email: member.memberEmail })
+                      }
+                      title={isActionable ? t("notes.cancelInvitation") : undefined}
+                      onClick={() => onRemoveMember(member.memberEmail)}
+                    >
+                      {isActionable ? (
+                        <XCircle className="h-4 w-4" />
+                      ) : (
+                        <Trash2 className="h-4 w-4" />
+                      )}
+                    </Button>
+                  )}
                 </div>
               </div>
             );

--- a/src/pages/NoteMembers/index.tsx
+++ b/src/pages/NoteMembers/index.tsx
@@ -10,7 +10,16 @@ import { NoteInviteLinksSection } from "./NoteInviteLinksSection";
 import { useNoteMembersController } from "./useNoteMembersController";
 
 /**
+ * ノートメンバー管理ページ。
+ * Note members management page.
  *
+ * - owner: 編集可（招待 / Role 変更 / 取り消し / リンク発行・取り消し）
+ * - editor: read-only（メンバー一覧 + 既存リンク一覧の閲覧 + リンクのコピーは可）
+ * - viewer / 非ログイン: 閲覧不可
+ *
+ * Owners can manage everything; editors browse the same UI in read-only mode
+ * for transparency over who has access. Viewers (and unsigned users) hit the
+ * "no access" branch.
  */
 const NoteMembers: React.FC = () => {
   const { t } = useTranslation();
@@ -23,9 +32,24 @@ const NoteMembers: React.FC = () => {
     isLoading: isNoteLoading,
   } = useNote(noteId ?? "", { allowRemote: true });
 
-  const canManageMembers = Boolean(access?.canManageMembers && source === "local");
+  const isLocal = source === "local";
+  const canManageMembers = Boolean(access?.canManageMembers && isLocal);
+  // editor は read-only でメンバー一覧と発行済みリンクを閲覧できる。viewer は
+  // プライバシー配慮で個別ページからは見せない（共有モーダルの公開設定タブ
+  // 経由でアクセス手段は説明される）。
+  // Editors can browse the page in read-only mode; viewers don't see this
+  // page at all (privacy — they only get the visibility tab in the modal).
+  const canViewAsEditor = Boolean(access?.role === "editor" && access.canView && isLocal);
+  const canShowPage = canManageMembers || canViewAsEditor;
+  const readOnly = !canManageMembers;
 
-  const controller = useNoteMembersController(noteId ?? "", canManageMembers);
+  // editor は members API を read-only で読みたい。`canManageMembers` ベースの
+  // ガードだと `enabled=false` になり一覧が空になるため、ページが表示できる
+  // ロール（owner / editor）であれば fetch を有効化する。
+  // The `enabled` flag for `useNoteMembers` was previously gated on
+  // `canManageMembers`, which would block editors. Open it up to anyone who
+  // can see the page so the read-only list actually populates.
+  const controller = useNoteMembersController(noteId ?? "", canShowPage);
 
   if (isNoteLoading) {
     return (
@@ -57,7 +81,7 @@ const NoteMembers: React.FC = () => {
           </Button>
         </div>
 
-        {!canManageMembers ? (
+        {!canShowPage ? (
           <p className="text-muted-foreground mt-6 text-sm">
             {t("notes.noPermissionToManageMembers")}
           </p>
@@ -80,10 +104,15 @@ const NoteMembers: React.FC = () => {
                 onUpdateRole={controller.handleUpdateMemberRole}
                 onRemoveMember={controller.handleRemoveMember}
                 onResendInvitation={controller.handleResendInvitation}
+                readOnly={readOnly}
               />
             </TabsContent>
             <TabsContent value="share-links">
-              <NoteInviteLinksSection noteId={noteId ?? ""} editPermission={note.editPermission} />
+              <NoteInviteLinksSection
+                noteId={noteId ?? ""}
+                editPermission={note.editPermission}
+                readOnly={readOnly}
+              />
             </TabsContent>
           </Tabs>
         )}

--- a/src/pages/NoteView/NoteViewHeaderActions.test.tsx
+++ b/src/pages/NoteView/NoteViewHeaderActions.test.tsx
@@ -103,6 +103,7 @@ describe("NoteViewHeaderActions — role-based visibility (#675)", () => {
     renderActions({ canManageMembers: true, userRole: "owner" });
     expect(screen.getByRole("button", { name: "notes.openActions" })).toBeInTheDocument();
     // 共有ボタン単体は出さない（ドロップダウン経由でアクセス）
+    // No standalone share button — owner accesses Share via the dropdown.
     expect(screen.queryByRole("button", { name: "notes.shareAria" })).not.toBeInTheDocument();
   });
 

--- a/src/pages/NoteView/NoteViewHeaderActions.test.tsx
+++ b/src/pages/NoteView/NoteViewHeaderActions.test.tsx
@@ -11,7 +11,7 @@
  */
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NoteViewHeaderActions } from "./NoteViewHeaderActions";
@@ -106,6 +106,16 @@ describe("NoteViewHeaderActions — role-based visibility (#675)", () => {
   it("viewer は単独の共有ボタンを表示する（公開設定を read-only で見せるため）", () => {
     renderActions({ canManageMembers: false, userRole: "viewer" });
     expect(screen.getByRole("button", { name: "notes.shareAria" })).toBeInTheDocument();
+  });
+
+  it("editor の共有ボタン押下で userRole がモーダルへ伝播する", () => {
+    // クリック経路で `userRole` が NoteShareModal に渡り続けていることを担保。
+    // ロールマトリックス全体を支える接続点なので、回帰検知用に明示的に確認する。
+    // Click-path regression guard: ensures the editor's role keeps flowing into
+    // NoteShareModal so the read-only matrix is not silently bypassed.
+    renderActions({ canManageMembers: false, userRole: "editor" });
+    fireEvent.click(screen.getByRole("button", { name: "notes.shareAria" }));
+    expect(screen.getByTestId("note-share-modal")).toHaveAttribute("data-user-role", "editor");
   });
 
   it("サインイン済み guest は共有ボタンを表示しない", () => {

--- a/src/pages/NoteView/NoteViewHeaderActions.test.tsx
+++ b/src/pages/NoteView/NoteViewHeaderActions.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * NoteViewHeaderActions のロール別表示テスト (#675)。
+ * Tests for the role-based visibility of the share entry point in the note
+ * view header (#675 follow-up to the share modal V1).
+ *
+ * 観点 / Coverage:
+ *   - Owner: ドロップダウン（共有 + 設定）が表示される
+ *   - Editor / Viewer (signed-in, canView): 共有ボタンのみが表示される
+ *   - Guest (canView だが未ログイン): 「ログインすると投稿できます」ヒント
+ *   - canView=false: 何もレンダリングしない
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NoteViewHeaderActions } from "./NoteViewHeaderActions";
+import type { Note } from "@/types/note";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts
+        ? `${key}(${Object.entries(opts)
+            .map(([k, v]) => `${k}=${String(v)}`)
+            .join(",")})`
+        : key,
+    i18n: { language: "ja" },
+  }),
+}));
+
+vi.mock("@zedi/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@zedi/ui")>();
+  return {
+    ...actual,
+    useToast: () => ({ toast: vi.fn() }),
+  };
+});
+
+vi.mock("@/hooks/useNoteQueries", () => ({
+  useNoteMembers: vi.fn(() => ({ data: [], isLoading: false })),
+}));
+
+// 共有モーダルは別テストでカバー済み。ここは「呼ばれたか」だけ気にする。
+// The share modal has its own test suite — stub it here to keep this file
+// focused on the entry-point UI.
+vi.mock("./ShareModal/NoteShareModal", () => ({
+  NoteShareModal: ({ open, userRole }: { open: boolean; userRole?: string }) =>
+    open ? (
+      <div data-testid="note-share-modal" data-user-role={userRole ?? "owner"}>
+        ShareModal
+      </div>
+    ) : null,
+}));
+
+const baseNote: Note = {
+  id: "note-1",
+  ownerUserId: "user-1",
+  title: "Test note",
+  visibility: "private",
+  editPermission: "owner_only",
+  isOfficial: false,
+  viewCount: 0,
+  createdAt: 0,
+  updatedAt: 0,
+  isDeleted: false,
+};
+
+function renderActions(props: Partial<React.ComponentProps<typeof NoteViewHeaderActions>> = {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const merged = {
+    note: baseNote,
+    canManageMembers: true,
+    isSignedIn: true,
+    canView: true,
+    userRole: "owner" as const,
+    ...props,
+  };
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <NoteViewHeaderActions {...merged} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("NoteViewHeaderActions — role-based visibility (#675)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("owner は MoreHorizontal ドロップダウンを表示（共有 + 設定リンクへの導線）", () => {
+    renderActions({ canManageMembers: true, userRole: "owner" });
+    expect(screen.getByRole("button", { name: "notes.openActions" })).toBeInTheDocument();
+    // 共有ボタン単体は出さない（ドロップダウン経由でアクセス）
+    expect(screen.queryByRole("button", { name: "notes.shareAria" })).not.toBeInTheDocument();
+  });
+
+  it("editor は単独の共有ボタンを表示しドロップダウンは出さない", () => {
+    renderActions({ canManageMembers: false, userRole: "editor" });
+    expect(screen.getByRole("button", { name: "notes.shareAria" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "notes.openActions" })).not.toBeInTheDocument();
+  });
+
+  it("viewer は単独の共有ボタンを表示する（公開設定を read-only で見せるため）", () => {
+    renderActions({ canManageMembers: false, userRole: "viewer" });
+    expect(screen.getByRole("button", { name: "notes.shareAria" })).toBeInTheDocument();
+  });
+
+  it("未ログイン (canView=true, isSignedIn=false) はログインヒントを表示する", () => {
+    renderActions({
+      canManageMembers: false,
+      isSignedIn: false,
+      canView: true,
+      userRole: "guest",
+    });
+    expect(screen.getByText("notes.loginToPost")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "notes.shareAria" })).not.toBeInTheDocument();
+  });
+
+  it("canView=false の場合は何もレンダリングしない", () => {
+    const { container } = renderActions({
+      canManageMembers: false,
+      canView: false,
+      userRole: "none",
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/pages/NoteView/NoteViewHeaderActions.test.tsx
+++ b/src/pages/NoteView/NoteViewHeaderActions.test.tsx
@@ -6,7 +6,7 @@
  * 観点 / Coverage:
  *   - Owner: ドロップダウン（共有 + 設定）が表示される
  *   - Editor / Viewer (signed-in, canView): 共有ボタンのみが表示される
- *   - Guest (canView だが未ログイン): 「ログインすると投稿できます」ヒント
+ *   - Guest: 未ログインならヒント、サインイン済み public/unlisted guest は共有導線なし
  *   - canView=false: 何もレンダリングしない
  */
 import React from "react";
@@ -106,6 +106,17 @@ describe("NoteViewHeaderActions — role-based visibility (#675)", () => {
   it("viewer は単独の共有ボタンを表示する（公開設定を read-only で見せるため）", () => {
     renderActions({ canManageMembers: false, userRole: "viewer" });
     expect(screen.getByRole("button", { name: "notes.shareAria" })).toBeInTheDocument();
+  });
+
+  it("サインイン済み guest は共有ボタンを表示しない", () => {
+    const { container } = renderActions({
+      canManageMembers: false,
+      isSignedIn: true,
+      canView: true,
+      userRole: "guest",
+    });
+    expect(screen.queryByRole("button", { name: "notes.shareAria" })).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it("未ログイン (canView=true, isSignedIn=false) はログインヒントを表示する", () => {

--- a/src/pages/NoteView/NoteViewHeaderActions.test.tsx
+++ b/src/pages/NoteView/NoteViewHeaderActions.test.tsx
@@ -15,7 +15,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NoteViewHeaderActions } from "./NoteViewHeaderActions";
-import type { Note } from "@/types/note";
+import type { Note, NoteAccessRole } from "@/types/note";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -42,12 +42,17 @@ vi.mock("@/hooks/useNoteQueries", () => ({
 }));
 
 // 共有モーダルは別テストでカバー済み。ここは「呼ばれたか」だけ気にする。
+// `userRole` のフォールバックはコンポーネント本体の最小権限既定値 (`"none"`) と
+// 揃え、呼び出し側で渡し漏れがあった場合に回帰として顕在化させる (#794 review)。
+//
 // The share modal has its own test suite — stub it here to keep this file
-// focused on the entry-point UI.
+// focused on the entry-point UI. The fallback for `userRole` mirrors the
+// component's least-privilege default (`"none"`) so a missing-prop regression
+// surfaces in tests instead of being silently promoted to owner UI.
 vi.mock("./ShareModal/NoteShareModal", () => ({
-  NoteShareModal: ({ open, userRole }: { open: boolean; userRole?: string }) =>
+  NoteShareModal: ({ open, userRole }: { open: boolean; userRole?: NoteAccessRole }) =>
     open ? (
-      <div data-testid="note-share-modal" data-user-role={userRole ?? "owner"}>
+      <div data-testid="note-share-modal" data-user-role={userRole ?? "none"}>
         ShareModal
       </div>
     ) : null,

--- a/src/pages/NoteView/NoteViewHeaderActions.test.tsx
+++ b/src/pages/NoteView/NoteViewHeaderActions.test.tsx
@@ -73,12 +73,16 @@ const baseNote: Note = {
 
 function renderActions(props: Partial<React.ComponentProps<typeof NoteViewHeaderActions>> = {}) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  // 既定値は最小権限の `"none"`。各テストはエレベートしたロールを明示的に渡す。
+  // Default to least-privilege `"none"`; tests opt into elevated roles
+  // explicitly so a missing override surfaces as an obvious test failure
+  // instead of silently rendering owner UI.
   const merged = {
     note: baseNote,
     canManageMembers: true,
     isSignedIn: true,
     canView: true,
-    userRole: "owner" as const,
+    userRole: "none" as const,
     ...props,
   };
   return render(

--- a/src/pages/NoteView/NoteViewHeaderActions.tsx
+++ b/src/pages/NoteView/NoteViewHeaderActions.tsx
@@ -13,7 +13,7 @@ import {
 } from "@zedi/ui";
 import { useTranslation } from "react-i18next";
 import { useNoteMembers } from "@/hooks/useNoteQueries";
-import type { Note } from "@/types/note";
+import type { Note, NoteAccessRole } from "@/types/note";
 import { NoteShareModal } from "./ShareModal/NoteShareModal";
 
 /**
@@ -25,33 +25,74 @@ export interface NoteViewHeaderActionsProps {
   canManageMembers: boolean;
   isSignedIn: boolean;
   canView: boolean;
+  /**
+   * 共有モーダルのタブ可視性 / read-only 制御に使う現在ユーザーのロール。
+   * Current user's role on this note. Used to gate which share-modal tabs are
+   * visible and which are rendered as read-only for editor / viewer.
+   */
+  userRole: NoteAccessRole;
 }
 
 /**
- * Renders the note detail page top actions as a single dropdown button.
- * Exposes Share (opens modal) and Settings (navigates) entries so the header
- * stays compact; add-page is handled by the FAB and is not included here.
+ * Renders the note detail page top actions.
  *
- * /notes/[id] 上部アクションを 1 つのドロップダウンにまとめる。
- * 共有（モーダル起動）と設定（遷移）を提供し、ページ追加は FAB 側に委譲する。
+ * - Owner: ドロップダウン（共有 + 設定）+ 招待済みメンバー数バッジ。
+ * - Editor / Viewer (signed-in, canView): 共有ボタンのみを表示する。共有モーダルは
+ *   `userRole` に応じて owner 向け編集 UI / editor 向け read-only / viewer 向け
+ *   公開設定のみ、と出し分ける。
+ * - Guest (canView だが未ログイン): 「ログインすると投稿できます」ヒント。
+ *
+ * /notes/[id] 上部アクション。オーナーは共有 + 設定のドロップダウンを、
+ * editor / viewer はサインインしていれば共有ボタンを表示する。共有モーダル
+ * 側で `userRole` を解釈し閲覧可能タブ・read-only モードを切り替える。
  */
 export function NoteViewHeaderActions({
   note,
   canManageMembers,
   isSignedIn,
   canView,
+  userRole,
 }: NoteViewHeaderActionsProps) {
   const { t } = useTranslation();
   const [isShareOpen, setIsShareOpen] = useState(false);
 
+  // 招待済みメンバー数バッジは owner のみ取得・表示する。editor もメンバー一覧を
+  // 閲覧できるが、ヘッダー上のバッジ価値は管理者向けのため owner 限定のままにする。
+  // Only owners fetch + display the accepted-member count badge. Editors can
+  // still browse the list inside the modal, but the header badge stays
+  // owner-only since it is an at-a-glance signal for the manager.
   const { data: members = [] } = useNoteMembers(note.id, canManageMembers);
   const acceptedCount = members.filter((m) => m.status === "accepted").length;
 
+  if (!canView) return null;
+
+  if (!isSignedIn) {
+    return <span className="text-muted-foreground text-sm">{t("notes.loginToPost")}</span>;
+  }
+
+  // editor / viewer は共有ボタン単体を出す（設定ページは owner 限定）。
+  // Editors / viewers see a single share button — the settings page link stays
+  // owner-only.
   if (!canManageMembers) {
-    if (!isSignedIn && canView) {
-      return <span className="text-muted-foreground text-sm">{t("notes.loginToPost")}</span>;
-    }
-    return null;
+    return (
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setIsShareOpen(true)}
+          aria-label={t("notes.shareAria")}
+        >
+          <Share2 className="mr-2 h-4 w-4" aria-hidden />
+          {t("notes.share")}
+        </Button>
+        <NoteShareModal
+          open={isShareOpen}
+          onOpenChange={setIsShareOpen}
+          note={note}
+          userRole={userRole}
+        />
+      </div>
+    );
   }
 
   return (
@@ -100,7 +141,12 @@ export function NoteViewHeaderActions({
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <NoteShareModal open={isShareOpen} onOpenChange={setIsShareOpen} note={note} />
+      <NoteShareModal
+        open={isShareOpen}
+        onOpenChange={setIsShareOpen}
+        note={note}
+        userRole={userRole}
+      />
     </div>
   );
 }

--- a/src/pages/NoteView/NoteViewHeaderActions.tsx
+++ b/src/pages/NoteView/NoteViewHeaderActions.tsx
@@ -40,7 +40,7 @@ export interface NoteViewHeaderActionsProps {
  * - Editor / Viewer (signed-in, canView): 共有ボタンのみを表示する。共有モーダルは
  *   `userRole` に応じて owner 向け編集 UI / editor 向け read-only / viewer 向け
  *   公開設定のみ、と出し分ける。
- * - Guest (canView だが未ログイン): 「ログインすると投稿できます」ヒント。
+ * - Guest: 共有導線は表示しない。未ログイン guest のみログインヒントを表示する。
  *
  * /notes/[id] 上部アクション。オーナーは共有 + 設定のドロップダウンを、
  * editor / viewer はサインインしていれば共有ボタンを表示する。共有モーダル
@@ -70,10 +70,13 @@ export function NoteViewHeaderActions({
     return <span className="text-muted-foreground text-sm">{t("notes.loginToPost")}</span>;
   }
 
+  const canOpenShareModal = userRole === "editor" || userRole === "viewer";
+
   // editor / viewer は共有ボタン単体を出す（設定ページは owner 限定）。
   // Editors / viewers see a single share button — the settings page link stays
-  // owner-only.
-  if (!canManageMembers) {
+  // owner-only. Signed-in guests can view public/unlisted notes but do not get
+  // the share entry point.
+  if (!canManageMembers && canOpenShareModal) {
     return (
       <div className="flex items-center gap-2">
         <Button
@@ -93,6 +96,10 @@ export function NoteViewHeaderActions({
         />
       </div>
     );
+  }
+
+  if (!canManageMembers) {
+    return null;
   }
 
   return (

--- a/src/pages/NoteView/ShareModal/NoteShareModal.test.tsx
+++ b/src/pages/NoteView/ShareModal/NoteShareModal.test.tsx
@@ -129,6 +129,54 @@ describe("NoteShareModal", () => {
     expect(screen.queryByLabelText("notes.shareLink")).not.toBeInTheDocument();
   });
 
+  // ------------------------------------------------------------------
+  // Role-based tab visibility (#675)
+  // ロール別タブ表示マトリックス (#675)
+  // ------------------------------------------------------------------
+
+  it("editor sees all tabs but the visibility tab shows the read-only notice", async () => {
+    const user = userEvent.setup();
+    renderModal({ userRole: "editor" });
+    expect(screen.getByRole("tab", { name: "notes.shareTabMembers" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "notes.shareTabLinks" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "notes.shareTabDomains" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "notes.shareTabVisibility" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "notes.shareTabVisibility" }));
+    expect(screen.getByText("notes.shareReadOnlyNotice")).toBeInTheDocument();
+    // owner-only Save button must be absent for editors
+    expect(
+      screen.queryByRole("button", { name: "notes.shareSaveChanges" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("viewer only sees the visibility tab and gets the read-only notice", () => {
+    renderModal({ userRole: "viewer" });
+    expect(screen.queryByRole("tab", { name: "notes.shareTabMembers" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "notes.shareTabLinks" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "notes.shareTabDomains" })).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "notes.shareTabVisibility" })).toBeInTheDocument();
+    expect(screen.getByText("notes.shareReadOnlyNotice")).toBeInTheDocument();
+  });
+
+  it("owner sees all tabs and the visibility tab Save button (no read-only notice)", () => {
+    renderModal({ userRole: "owner" });
+    expect(screen.getByRole("tab", { name: "notes.shareTabMembers" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "notes.shareTabLinks" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "notes.shareTabDomains" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "notes.shareTabVisibility" })).toBeInTheDocument();
+    expect(screen.queryByText("notes.shareReadOnlyNotice")).not.toBeInTheDocument();
+  });
+
+  it("editor's members tab hides the invite form and full-page link", () => {
+    renderModal({ userRole: "editor" });
+    // Invite form heading is replaced by a plain "members" heading in read-only mode
+    expect(screen.queryByRole("heading", { name: "notes.inviteMember" })).not.toBeInTheDocument();
+    // The full-members-page link (rendered in the footer of the tab) is hidden for editors
+    expect(
+      screen.queryByRole("link", { name: /notes\.shareOpenMembersPage/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("falls back to the members tab when showDomainsTab flips to false on the active tab", async () => {
     const user = userEvent.setup();
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/src/pages/NoteView/ShareModal/NoteShareModal.test.tsx
+++ b/src/pages/NoteView/ShareModal/NoteShareModal.test.tsx
@@ -71,12 +71,22 @@ const baseNote: Note = {
   isDeleted: false,
 };
 
+/**
+ * Default to `userRole="owner"` for tab-structure tests. The component itself
+ * defaults to `"none"` (least-privilege) so an accidental omission cannot
+ * surface owner-only edit controls; tests opt into the privileged flow
+ * explicitly via the helper unless they override `userRole`.
+ *
+ * タブ構造のテストは owner UI を前提にしているため helper 側で `"owner"` を
+ * 注入する。コンポーネント本体の既定値は `"none"` (最小権限) で、呼び出し側で
+ * ロールを明示しなかった場合にもオーナー UI が露出しないようにしている。
+ */
 function renderModal(props: Partial<React.ComponentProps<typeof NoteShareModal>> = {}) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={client}>
       <MemoryRouter>
-        <NoteShareModal open onOpenChange={() => {}} note={baseNote} {...props} />
+        <NoteShareModal open onOpenChange={() => {}} note={baseNote} userRole="owner" {...props} />
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -191,7 +201,13 @@ describe("NoteShareModal", () => {
     const { rerender } = render(
       <QueryClientProvider client={client}>
         <MemoryRouter>
-          <NoteShareModal open onOpenChange={() => {}} note={baseNote} showDomainsTab />
+          <NoteShareModal
+            open
+            onOpenChange={() => {}}
+            note={baseNote}
+            userRole="owner"
+            showDomainsTab
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -204,7 +220,13 @@ describe("NoteShareModal", () => {
     rerender(
       <QueryClientProvider client={client}>
         <MemoryRouter>
-          <NoteShareModal open onOpenChange={() => {}} note={baseNote} showDomainsTab={false} />
+          <NoteShareModal
+            open
+            onOpenChange={() => {}}
+            note={baseNote}
+            userRole="owner"
+            showDomainsTab={false}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -214,5 +236,33 @@ describe("NoteShareModal", () => {
       "data-state",
       "active",
     );
+  });
+
+  // ------------------------------------------------------------------
+  // Default `userRole` is least-privilege (#794 review)
+  // ------------------------------------------------------------------
+
+  it("omitting userRole falls back to least-privilege rendering (visibility tab read-only)", () => {
+    // 呼び出し側がうっかり userRole を渡し忘れた場合でも、メンバー / リンク /
+    // ドメインタブは表示されず、公開設定タブも read-only で描画される。
+    // If a caller accidentally omits `userRole`, the modal must NOT promote to
+    // owner-level UI. Members / links / domains tabs stay hidden and the
+    // visibility tab renders read-only with the notice.
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <NoteShareModal open onOpenChange={() => {}} note={baseNote} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    expect(screen.queryByRole("tab", { name: "notes.shareTabMembers" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "notes.shareTabLinks" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "notes.shareTabDomains" })).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "notes.shareTabVisibility" })).toBeInTheDocument();
+    expect(screen.getByText("notes.shareReadOnlyNotice")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "notes.shareSaveChanges" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/pages/NoteView/ShareModal/NoteShareModal.test.tsx
+++ b/src/pages/NoteView/ShareModal/NoteShareModal.test.tsx
@@ -153,7 +153,8 @@ describe("NoteShareModal", () => {
     expect(screen.getByRole("tab", { name: "notes.shareTabVisibility" })).toBeInTheDocument();
     await user.click(screen.getByRole("tab", { name: "notes.shareTabVisibility" }));
     expect(screen.getByText("notes.shareReadOnlyNotice")).toBeInTheDocument();
-    // owner-only Save button must be absent for editors
+    // editor では owner 専用の Save ボタンが描画されないこと。
+    // owner-only Save button must be absent for editors.
     expect(
       screen.queryByRole("button", { name: "notes.shareSaveChanges" }),
     ).not.toBeInTheDocument();
@@ -187,9 +188,11 @@ describe("NoteShareModal", () => {
 
   it("editor's members tab hides the invite form and full-page link", () => {
     renderModal({ userRole: "editor" });
-    // Invite form heading is replaced by a plain "members" heading in read-only mode
+    // read-only モードでは招待フォームの見出しが「メンバー」見出しに差し替わる。
+    // Invite form heading is replaced by a plain "members" heading in read-only mode.
     expect(screen.queryByRole("heading", { name: "notes.inviteMember" })).not.toBeInTheDocument();
-    // The full-members-page link (rendered in the footer of the tab) is hidden for editors
+    // フルメンバーページへのリンク（タブ末尾）も editor には表示しない。
+    // The full-members-page link (rendered in the footer of the tab) is hidden for editors.
     expect(
       screen.queryByRole("link", { name: /notes\.shareOpenMembersPage/ }),
     ).not.toBeInTheDocument();

--- a/src/pages/NoteView/ShareModal/NoteShareModal.test.tsx
+++ b/src/pages/NoteView/ShareModal/NoteShareModal.test.tsx
@@ -10,7 +10,7 @@
  */
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -158,13 +158,21 @@ describe("NoteShareModal", () => {
     expect(screen.getByText("notes.shareReadOnlyNotice")).toBeInTheDocument();
   });
 
-  it("owner sees all tabs and the visibility tab Save button (no read-only notice)", () => {
+  it("owner sees all tabs and the visibility tab Save button (no read-only notice)", async () => {
+    const user = userEvent.setup();
     renderModal({ userRole: "owner" });
     expect(screen.getByRole("tab", { name: "notes.shareTabMembers" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "notes.shareTabLinks" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "notes.shareTabDomains" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "notes.shareTabVisibility" })).toBeInTheDocument();
-    expect(screen.queryByText("notes.shareReadOnlyNotice")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "notes.shareTabVisibility" }));
+    const visibilityPanel = screen.getByRole("tabpanel");
+    expect(
+      within(visibilityPanel).queryByText("notes.shareReadOnlyNotice"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(visibilityPanel).getByRole("button", { name: "notes.shareSaveChanges" }),
+    ).toBeInTheDocument();
   });
 
   it("editor's members tab hides the invite form and full-page link", () => {

--- a/src/pages/NoteView/ShareModal/NoteShareModal.tsx
+++ b/src/pages/NoteView/ShareModal/NoteShareModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Dialog,
@@ -88,6 +88,8 @@ function getTabPermissions(role: NoteAccessRole): {
   };
 }
 
+type ShareModalTab = "members" | "links" | "domains" | "visibility";
+
 /**
  * ノート共有モーダル。メンバー招待・共有リンク・ドメイン招待・公開設定を 1 つのダイアログに集約する。
  * `userRole` でタブ表示と read-only モードを出し分ける（owner=編集可、editor=全タブ
@@ -110,38 +112,38 @@ export function NoteShareModal({
 
   const showDomains = perms.showDomains && showDomainsTab;
 
-  const initialTab = perms.showMembers
-    ? "members"
-    : perms.showLinks
-      ? "links"
-      : showDomains
-        ? "domains"
-        : "visibility";
+  const getFirstVisibleTab = useCallback((): ShareModalTab => {
+    if (perms.showMembers) return "members";
+    if (perms.showLinks) return "links";
+    if (showDomains) return "domains";
+    return "visibility";
+  }, [perms.showMembers, perms.showLinks, showDomains]);
 
-  const [activeTab, setActiveTab] = useState(initialTab);
+  const [activeTab, setActiveTab] = useState<ShareModalTab>(getFirstVisibleTab);
 
   // タブがロール / showDomainsTab 変化で消えると Tabs が空パネルを保持してしまう。
   // 利用可能な先頭タブにフォールバックする。
   // If the active tab disappears (role change or `showDomainsTab` flip), fall
   // back to the first remaining tab so the panel never goes blank.
   useEffect(() => {
-    const visible = new Set<string>();
-    if (perms.showMembers) visible.add("members");
-    if (perms.showLinks) visible.add("links");
-    if (showDomains) visible.add("domains");
-    if (perms.showVisibility) visible.add("visibility");
-    if (!visible.has(activeTab)) {
-      const fallback = perms.showMembers
-        ? "members"
-        : perms.showLinks
-          ? "links"
-          : showDomains
-            ? "domains"
-            : "visibility";
+    const isVisible =
+      (activeTab === "members" && perms.showMembers) ||
+      (activeTab === "links" && perms.showLinks) ||
+      (activeTab === "domains" && showDomains) ||
+      (activeTab === "visibility" && perms.showVisibility);
+
+    if (!isVisible) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- guard for vanished tab
-      setActiveTab(fallback);
+      setActiveTab(getFirstVisibleTab());
     }
-  }, [perms, showDomains, activeTab]);
+  }, [
+    activeTab,
+    getFirstVisibleTab,
+    perms.showLinks,
+    perms.showMembers,
+    perms.showVisibility,
+    showDomains,
+  ]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/pages/NoteView/ShareModal/NoteShareModal.tsx
+++ b/src/pages/NoteView/ShareModal/NoteShareModal.tsx
@@ -43,7 +43,12 @@ export interface NoteShareModalProps {
    * - guest / none: そもそも ShareButton 側で出さない想定だが、フォールバックで
    *   viewer と同等の最小表示にする
    *
+   * 既定値は最小権限の `"none"`。呼び出し側でロールを明示的に渡し損ねた場合に
+   * オーナー UI を露出させないためのフェイルセーフ (#794 review)。
+   *
    * Current user's role on the note. Drives tab visibility + read-only state.
+   * Defaults to least-privilege `"none"` so a caller that forgets to pass a
+   * role can never accidentally surface owner-only edit controls (#794 review).
    */
   userRole?: NoteAccessRole;
 }
@@ -105,7 +110,7 @@ export function NoteShareModal({
   onOpenChange,
   note,
   showDomainsTab = true,
-  userRole = "owner",
+  userRole = "none",
 }: NoteShareModalProps) {
   const { t } = useTranslation();
   const perms = useMemo(() => getTabPermissions(userRole), [userRole]);

--- a/src/pages/NoteView/ShareModal/NoteShareModal.tsx
+++ b/src/pages/NoteView/ShareModal/NoteShareModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Dialog,
@@ -11,7 +11,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "@zedi/ui";
-import type { Note } from "@/types/note";
+import type { Note, NoteAccessRole } from "@/types/note";
 import { NoteInviteLinksSection } from "@/pages/NoteMembers/NoteInviteLinksSection";
 import { ShareModalDomainTab } from "./ShareModalDomainTab";
 import { ShareModalMembersTab } from "./ShareModalMembersTab";
@@ -34,38 +34,114 @@ export interface NoteShareModalProps {
    * specific flows (e.g. tests, edge-case UIs).
    */
   showDomainsTab?: boolean;
+  /**
+   * 現在ユーザーのノート上のロール。タブの表示可否・read-only モードを切り替える。
+   * - owner: 全タブ + 編集可
+   * - editor: 全タブ表示 + 全タブ read-only（誰がアクセス可能か透明性のため）
+   * - viewer: 公開設定タブのみ表示（read-only）。メンバー / リンク / ドメインは
+   *   プライバシー配慮のため非表示
+   * - guest / none: そもそも ShareButton 側で出さない想定だが、フォールバックで
+   *   viewer と同等の最小表示にする
+   *
+   * Current user's role on the note. Drives tab visibility + read-only state.
+   */
+  userRole?: NoteAccessRole;
+}
+
+/**
+ * `userRole` から各タブの可視性・編集可否を導出する。
+ * Derive per-tab visibility + edit-state from the current user's role.
+ */
+function getTabPermissions(role: NoteAccessRole): {
+  canEdit: boolean;
+  showMembers: boolean;
+  showLinks: boolean;
+  showDomains: boolean;
+  showVisibility: boolean;
+} {
+  if (role === "owner") {
+    return {
+      canEdit: true,
+      showMembers: true,
+      showLinks: true,
+      showDomains: true,
+      showVisibility: true,
+    };
+  }
+  if (role === "editor") {
+    return {
+      canEdit: false,
+      showMembers: true,
+      showLinks: true,
+      showDomains: true,
+      showVisibility: true,
+    };
+  }
+  // viewer / guest / none — 公開設定 read-only のみ
+  // viewer / guest / none — visibility tab only, read-only
+  return {
+    canEdit: false,
+    showMembers: false,
+    showLinks: false,
+    showDomains: false,
+    showVisibility: true,
+  };
 }
 
 /**
  * ノート共有モーダル。メンバー招待・共有リンク・ドメイン招待・公開設定を 1 つのダイアログに集約する。
+ * `userRole` でタブ表示と read-only モードを出し分ける（owner=編集可、editor=全タブ
+ * read-only、viewer=公開設定のみ read-only）。
+ *
  * Consolidated share modal for a note: members, share links, domain access,
- * and visibility.
- *
- * このモーダルはオーナー向け UI のみサポートする。エディタ向けの読み取り専用
- * 表示は別 Issue のフォローアップで追加する。
- *
- * Only supports the owner UI for now; editor-facing read-only tabs will arrive
- * in a follow-up issue.
+ * and visibility. `userRole` gates which tabs are visible and toggles read-only
+ * mode for non-owners (owner edits everything; editor sees everything as
+ * read-only for transparency; viewer only sees the visibility tab).
  */
 export function NoteShareModal({
   open,
   onOpenChange,
   note,
   showDomainsTab = true,
+  userRole = "owner",
 }: NoteShareModalProps) {
   const { t } = useTranslation();
-  const [activeTab, setActiveTab] = useState("members");
+  const perms = useMemo(() => getTabPermissions(userRole), [userRole]);
 
-  // ドメインタブを表示中に `showDomainsTab` が false に切り替わると、Tabs が
-  // 存在しない値を保持してパネルが空になる。先頭の members タブへフォールバック。
-  // If `showDomainsTab` flips to false while the domains tab is active, the
-  // Tabs control would hold a non-existent value; fall back to the first tab.
+  const showDomains = perms.showDomains && showDomainsTab;
+
+  const initialTab = perms.showMembers
+    ? "members"
+    : perms.showLinks
+      ? "links"
+      : showDomains
+        ? "domains"
+        : "visibility";
+
+  const [activeTab, setActiveTab] = useState(initialTab);
+
+  // タブがロール / showDomainsTab 変化で消えると Tabs が空パネルを保持してしまう。
+  // 利用可能な先頭タブにフォールバックする。
+  // If the active tab disappears (role change or `showDomainsTab` flip), fall
+  // back to the first remaining tab so the panel never goes blank.
   useEffect(() => {
-    if (!showDomainsTab && activeTab === "domains") {
+    const visible = new Set<string>();
+    if (perms.showMembers) visible.add("members");
+    if (perms.showLinks) visible.add("links");
+    if (showDomains) visible.add("domains");
+    if (perms.showVisibility) visible.add("visibility");
+    if (!visible.has(activeTab)) {
+      const fallback = perms.showMembers
+        ? "members"
+        : perms.showLinks
+          ? "links"
+          : showDomains
+            ? "domains"
+            : "visibility";
       // eslint-disable-next-line react-hooks/set-state-in-effect -- guard for vanished tab
-      setActiveTab("members");
+      setActiveTab(fallback);
     }
-  }, [showDomainsTab, activeTab]);
+  }, [perms, showDomains, activeTab]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -76,35 +152,52 @@ export function NoteShareModal({
         </DialogHeader>
         <Tabs value={activeTab} onValueChange={setActiveTab} className="mt-2">
           <TabsList>
-            <TabsTrigger value="members">{t("notes.shareTabMembers")}</TabsTrigger>
-            <TabsTrigger value="links">{t("notes.shareTabLinks")}</TabsTrigger>
-            {showDomainsTab ? (
+            {perms.showMembers ? (
+              <TabsTrigger value="members">{t("notes.shareTabMembers")}</TabsTrigger>
+            ) : null}
+            {perms.showLinks ? (
+              <TabsTrigger value="links">{t("notes.shareTabLinks")}</TabsTrigger>
+            ) : null}
+            {showDomains ? (
               <TabsTrigger value="domains">{t("notes.shareTabDomains")}</TabsTrigger>
             ) : null}
-            <TabsTrigger value="visibility">{t("notes.shareTabVisibility")}</TabsTrigger>
+            {perms.showVisibility ? (
+              <TabsTrigger value="visibility">{t("notes.shareTabVisibility")}</TabsTrigger>
+            ) : null}
           </TabsList>
 
-          <TabsContent value="members">
-            <ShareModalMembersTab
-              noteId={note.id}
-              enabled={open}
-              onNavigate={() => onOpenChange(false)}
-            />
-          </TabsContent>
-
-          <TabsContent value="links">
-            <NoteInviteLinksSection noteId={note.id} editPermission={note.editPermission} />
-          </TabsContent>
-
-          {showDomainsTab ? (
-            <TabsContent value="domains">
-              <ShareModalDomainTab noteId={note.id} enabled={open} />
+          {perms.showMembers ? (
+            <TabsContent value="members">
+              <ShareModalMembersTab
+                noteId={note.id}
+                enabled={open}
+                onNavigate={() => onOpenChange(false)}
+                readOnly={!perms.canEdit}
+              />
             </TabsContent>
           ) : null}
 
-          <TabsContent value="visibility">
-            <ShareModalVisibilityTab note={note} canEdit />
-          </TabsContent>
+          {perms.showLinks ? (
+            <TabsContent value="links">
+              <NoteInviteLinksSection
+                noteId={note.id}
+                editPermission={note.editPermission}
+                readOnly={!perms.canEdit}
+              />
+            </TabsContent>
+          ) : null}
+
+          {showDomains ? (
+            <TabsContent value="domains">
+              <ShareModalDomainTab noteId={note.id} enabled={open} readOnly={!perms.canEdit} />
+            </TabsContent>
+          ) : null}
+
+          {perms.showVisibility ? (
+            <TabsContent value="visibility">
+              <ShareModalVisibilityTab note={note} canEdit={perms.canEdit} />
+            </TabsContent>
+          ) : null}
         </Tabs>
       </DialogContent>
     </Dialog>

--- a/src/pages/NoteView/ShareModal/ShareModalDomainTab.tsx
+++ b/src/pages/NoteView/ShareModal/ShareModalDomainTab.tsx
@@ -62,6 +62,14 @@ export interface ShareModalDomainTabProps {
    * so we don't fetch while the modal is hidden.
    */
   enabled: boolean;
+  /**
+   * read-only モードで描画するか。editor 向けに既存ルールだけ閲覧させたいときに
+   * `true` を渡す。発行フォーム・削除ボタン・editor 確認モーダルを抑止する。
+   *
+   * Render in read-only mode (editor browsing the rules). Hides the add form,
+   * remove buttons, and editor-role confirmation dialog.
+   */
+  readOnly?: boolean;
 }
 
 /**
@@ -151,10 +159,12 @@ function DomainAccessRuleItem({
   rule,
   onRemove,
   removePending,
+  readOnly = false,
 }: {
   rule: DomainAccessRow;
   onRemove: (rule: DomainAccessRow) => void;
   removePending: boolean;
+  readOnly?: boolean;
 }) {
   const { t } = useTranslation();
   const roleLabel =
@@ -175,16 +185,18 @@ function DomainAccessRuleItem({
           {t("notes.domainTabRuleSummary", { domain: rule.domain, role: roleLabel })}
         </p>
       </div>
-      <Button
-        variant="ghost"
-        size="icon"
-        aria-label={t("notes.domainTabRemoveAria", { domain: rule.domain })}
-        title={t("notes.domainTabRemove")}
-        onClick={() => onRemove(rule)}
-        disabled={removePending}
-      >
-        <Trash2 className="h-4 w-4" />
-      </Button>
+      {!readOnly ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={t("notes.domainTabRemoveAria", { domain: rule.domain })}
+          title={t("notes.domainTabRemove")}
+          onClick={() => onRemove(rule)}
+          disabled={removePending}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      ) : null}
     </div>
   );
 }
@@ -193,7 +205,11 @@ function DomainAccessRuleItem({
  * 共有モーダルのドメインタブ。ドメインルールの追加・一覧・削除を扱う。
  * Domain tab — handles add / list / remove for domain-access rules.
  */
-export function ShareModalDomainTab({ noteId, enabled }: ShareModalDomainTabProps) {
+export function ShareModalDomainTab({
+  noteId,
+  enabled,
+  readOnly = false,
+}: ShareModalDomainTabProps) {
   const { t } = useTranslation();
   const { toast } = useToast();
 
@@ -278,16 +294,18 @@ export function ShareModalDomainTab({ noteId, enabled }: ShareModalDomainTabProp
         <p className="text-muted-foreground text-xs">{t("notes.domainTabDescription")}</p>
       </header>
 
-      <DomainAccessAddForm
-        domainInput={domainInput}
-        setDomainInput={setDomainInput}
-        roleInput={roleInput}
-        setRoleInput={setRoleInput}
-        onAdd={handleAddClick}
-        isPending={createMutation.isPending}
-        isValid={validation.ok}
-        inputError={inputError}
-      />
+      {!readOnly ? (
+        <DomainAccessAddForm
+          domainInput={domainInput}
+          setDomainInput={setDomainInput}
+          roleInput={roleInput}
+          setRoleInput={setRoleInput}
+          onAdd={handleAddClick}
+          isPending={createMutation.isPending}
+          isValid={validation.ok}
+          inputError={inputError}
+        />
+      ) : null}
 
       <section className="space-y-2">
         {isLoading ? (
@@ -305,13 +323,14 @@ export function ShareModalDomainTab({ noteId, enabled }: ShareModalDomainTabProp
               rule={rule}
               onRemove={(target) => void handleRemove(target)}
               removePending={deleteMutation.isPending}
+              readOnly={readOnly}
             />
           ))
         )}
       </section>
 
       <AlertDialog
-        open={pendingEditorConfirm !== null}
+        open={!readOnly && pendingEditorConfirm !== null}
         onOpenChange={(open) => {
           if (!open) setPendingEditorConfirm(null);
         }}

--- a/src/pages/NoteView/ShareModal/ShareModalMembersTab.tsx
+++ b/src/pages/NoteView/ShareModal/ShareModalMembersTab.tsx
@@ -13,14 +13,30 @@ export interface ShareModalMembersTabProps {
   noteId: string;
   enabled: boolean;
   onNavigate?: () => void;
+  /**
+   * read-only 表示にするか。editor 用にメンバー一覧だけ閲覧させたいときに `true` を渡す。
+   * Render the section read-only (used for editors who can browse the member
+   * list but cannot mutate it).
+   */
+  readOnly?: boolean;
 }
 
 /**
  * 共有モーダルのメンバータブ。既存のメンバー管理セクションを埋め込みで再利用する。
+ * read-only モードのとき、フルメンバーページへのリンクは出さず（その先も
+ * editor 用 read-only ページに遷移できるが UI を簡素化するため）、招待 UI / 操作
+ * ボタンは下層で隠す。
+ *
  * Members tab inside the share modal. Reuses `NoteMembersManageSection` and
- * offers a link to the full members management page for bulk operations.
+ * offers a link to the full members page for owners. In read-only mode we skip
+ * that footer link to keep the UI focused on browsing the list.
  */
-export function ShareModalMembersTab({ noteId, enabled, onNavigate }: ShareModalMembersTabProps) {
+export function ShareModalMembersTab({
+  noteId,
+  enabled,
+  onNavigate,
+  readOnly = false,
+}: ShareModalMembersTabProps) {
   const { t } = useTranslation();
   const controller = useNoteMembersController(noteId, enabled);
 
@@ -38,15 +54,18 @@ export function ShareModalMembersTab({ noteId, enabled, onNavigate }: ShareModal
         onUpdateRole={controller.handleUpdateMemberRole}
         onRemoveMember={controller.handleRemoveMember}
         onResendInvitation={controller.handleResendInvitation}
+        readOnly={readOnly}
       />
-      <div className="mt-3 flex justify-end">
-        <Button asChild variant="link" size="sm" onClick={onNavigate}>
-          <Link to={`/notes/${noteId}/members`}>
-            <ExternalLink className="mr-1 h-3 w-3" />
-            {t("notes.shareOpenMembersPage")}
-          </Link>
-        </Button>
-      </div>
+      {!readOnly ? (
+        <div className="mt-3 flex justify-end">
+          <Button asChild variant="link" size="sm" onClick={onNavigate}>
+            <Link to={`/notes/${noteId}/members`}>
+              <ExternalLink className="mr-1 h-3 w-3" />
+              {t("notes.shareOpenMembersPage")}
+            </Link>
+          </Button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/pages/NoteView/ShareModal/ShareModalVisibilityTab.tsx
+++ b/src/pages/NoteView/ShareModal/ShareModalVisibilityTab.tsx
@@ -225,7 +225,11 @@ function VisibilityTabView({
             {isSaving ? t("common.saving") : t("notes.shareSaveChanges")}
           </Button>
         </div>
-      ) : null}
+      ) : (
+        <p className="text-muted-foreground text-xs" role="note">
+          {t("notes.shareReadOnlyNotice")}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/pages/NoteView/index.tsx
+++ b/src/pages/NoteView/index.tsx
@@ -114,6 +114,7 @@ const NoteView: React.FC = () => {
               canManageMembers={canManageMembers}
               isSignedIn={isSignedIn}
               canView={Boolean(access?.canView)}
+              userRole={access?.role ?? "none"}
             />
           </div>
           <NoteViewMainContent


### PR DESCRIPTION
## 概要

共有モーダルと関連コンポーネントにロールベースのアクセス制御を実装しました。owner は全機能を編集可能、editor は全タブを read-only で閲覧可能、viewer は公開設定タブのみ表示という3段階の権限に応じた UI を提供します。

## 変更点

- **NoteShareModal**: `userRole` prop を追加し、ロールに応じてタブの表示可否と read-only 状態を制御
  - `getTabPermissions()` ヘルパー関数で各ロールの権限マトリックスを定義
  - owner: 全タブ編集可、editor: 全タブ read-only、viewer: 公開設定タブのみ read-only
  - アクティブタブが消える場合は利用可能な先頭タブにフォールバック

- **NoteInviteLinksSection**: `readOnly` prop を追加
  - read-only モード時は発行フォーム（Label/Role/Expiry/MaxUses/Create）を非表示
  - 既存リンクのコピーボタンは引き続き表示（共有用途）
  - 取り消しボタンは非表示（破壊的操作のため owner 限定）

- **NoteMembersManageSection**: `readOnly` prop を追加
  - read-only モード時は招待フォーム（Email/Role/Add）を非表示
  - 各メンバー行の Role セレクトは disabled
  - 再送信・取り消し・削除ボタンは非表示
  - ステータスバッジ（pending/expired/accepted）は引き続き表示

- **ShareModalDomainTab**: `readOnly` prop を追加
  - read-only モード時はドメイン追加フォームと削除ボタンを非表示
  - editor 確認モーダルも抑止

- **ShareModalMembersTab**: `readOnly` prop を追加
  - read-only モード時はフルメンバーページへのリンクを非表示

- **ShareModalVisibilityTab**: `canEdit` prop に応じた read-only 表示
  - 編集不可時は「読み取り専用」通知を表示
  - Save ボタンを非表示

- **NoteViewHeaderActions**: ロール別の UI 出し分け
  - owner: ドロップダウン（共有 + 設定）+ メンバー数バッジ
  - editor/viewer (signed-in): 共有ボタン単体
  - guest (unsigned): ログインヒント
  - `userRole` を NoteShareModal に渡して権限制御

- **NoteMembers ページ**: editor 向け read-only 表示対応
  - editor は `readOnly=true` でメンバー一覧と発行済みリンクを閲覧可能
  - viewer はプライバシー配慮で個別ページからは非表示（共有モーダルの公開設定タブ経由のみ）

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. **owner ロール**: 共有モーダルで全タブ（Members/Links/Domains/Visibility）が表示され、各タブで編集可能なことを確認
2. **editor ロール**: 
   - ヘッダーに共有ボタン単体が表示される

https://claude.ai/code/session_01CbJXeSEbL9m6Cg3GeRob9y
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editors and viewers can open the members/share UI in read-only mode; the share button now appears for editors and viewers in the note header.

* **Improvements**
  * Members, invite-links and domain UIs render read-only variants that hide destructive controls, suppress editor confirmation dialogs, and show read-only notices where applicable; page permission logic now distinguishes manage vs. view-as-editor.

* **Tests**
  * Added role-based tests for header actions, share modal tabs, members, invite-links, and read-only vs. editable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->