### PR TITLE
fix(mobile): widen bottom-nav item padding and add bottom margin

### DIFF
--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -79,7 +79,7 @@ describe("AppLayout", () => {
     expect(screen.getByTestId("bottom-nav")).toBeInTheDocument();
   });
 
-  it("sets mobile layout CSS variables (--app-header-height: 4rem, --app-bottom-nav-height: 3.5rem)", () => {
+  it("sets mobile layout CSS variables (--app-header-height: 4rem, --app-bottom-nav-height: 4.5rem)", () => {
     vi.mocked(useIsMobile).mockReturnValue(true);
     const { container } = render(
       <AppLayout>
@@ -89,7 +89,7 @@ describe("AppLayout", () => {
     const wrapper = container.firstElementChild as HTMLElement | null;
     const style = wrapper?.getAttribute("style") ?? "";
     expect(style).toMatch(/--app-header-height:\s*4rem/);
-    expect(style).toMatch(/--app-bottom-nav-height:\s*3\.5rem/);
+    expect(style).toMatch(/--app-bottom-nav-height:\s*4\.5rem/);
   });
 
   /**

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -27,7 +27,7 @@ export function AppLayout({ children }: AppLayoutProps) {
         style={
           {
             "--app-header-height": isMobile ? "4rem" : "4.5rem",
-            "--app-bottom-nav-height": isMobile ? "3.5rem" : "0px",
+            "--app-bottom-nav-height": isMobile ? "4.5rem" : "0px",
             "--ai-chat-width": "22rem",
           } as React.CSSProperties
         }

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -51,7 +51,7 @@ export function AppLayout({ children }: AppLayoutProps) {
               isMobile
                 ? {
                     paddingBottom:
-                      "calc(var(--app-bottom-nav-height, 3.5rem) + env(safe-area-inset-bottom))",
+                      "calc(var(--app-bottom-nav-height, 4.5rem) + env(safe-area-inset-bottom))",
                   }
                 : undefined
             }

--- a/src/components/layout/BottomNav/BottomNavTab.tsx
+++ b/src/components/layout/BottomNav/BottomNavTab.tsx
@@ -24,7 +24,7 @@ export const BottomNavTab: React.FC<BottomNavTabProps> = ({ to, icon: Icon, labe
         to={to}
         aria-current={active ? "page" : undefined}
         className={cn(
-          "flex h-full w-full flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors",
+          "flex h-full w-full flex-col items-center justify-center gap-1 py-2 text-[10px] font-medium transition-colors",
           active ? "text-primary" : "text-muted-foreground hover:text-foreground",
         )}
       >

--- a/src/components/layout/BottomNav/index.tsx
+++ b/src/components/layout/BottomNav/index.tsx
@@ -37,9 +37,9 @@ export const BottomNav: React.FC = () => {
         "border-border bg-background/95 supports-[backdrop-filter]:bg-background/80 fixed right-0 bottom-0 left-0 z-40 border-t backdrop-blur",
         "pb-[env(safe-area-inset-bottom)]",
       )}
-      style={{ height: "calc(var(--app-bottom-nav-height, 3.5rem) + env(safe-area-inset-bottom))" }}
+      style={{ height: "calc(var(--app-bottom-nav-height, 4.5rem) + env(safe-area-inset-bottom))" }}
     >
-      <ul className="mx-auto flex h-[var(--app-bottom-nav-height,3.5rem)] max-w-md items-stretch">
+      <ul className="mx-auto flex h-[var(--app-bottom-nav-height,4.5rem)] max-w-md items-stretch">
         {PRIMARY_NAV_ITEMS.map((item) => (
           <BottomNavTab
             key={item.path}

--- a/src/components/layout/BottomNav/index.tsx
+++ b/src/components/layout/BottomNav/index.tsx
@@ -94,7 +94,7 @@ const MeTab: React.FC<MeTabProps> = ({ open, onOpenChange }) => {
       aria-expanded={open}
       onClick={() => onOpenChange(true)}
       className={cn(
-        "text-muted-foreground hover:text-foreground flex h-full w-full flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors",
+        "text-muted-foreground hover:text-foreground flex h-full w-full flex-col items-center justify-center gap-1 py-2 text-[10px] font-medium transition-colors",
       )}
     >
       <span className="relative">


### PR DESCRIPTION
Increase --app-bottom-nav-height from 3.5rem to 4.5rem on mobile and add
py-2 to each BottomNavTab and the MeTab. The taller bar gives each tap
target more vertical breathing room, and because <main>'s padding-bottom
is already derived from --app-bottom-nav-height, scrolled content now
clears the translucent BottomNav by an extra 16px.

モバイルでボトムナビ各項目の上下余白を広げ、メイン領域の下端マージンも
連動して大きくして、最終行がボトムナビに隠れにくくした。

https://claude.ai/code/session_01Rqq8FUGwBUcZEipPDPcFJh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/zedi/pull/799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Increased mobile bottom navigation height and added vertical padding to navigation items for improved spacing and usability.

* **Tests**
  * Updated layout tests to validate the adjusted bottom navigation spacing and padding on mobile while keeping desktop layout expectations unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->