### PR TITLE
feat: add api_errors table and service for Sentry error aggregation

### DIFF
--- a/server/api/drizzle/0019_add_api_errors.sql
+++ b/server/api/drizzle/0019_add_api_errors.sql
@@ -24,8 +24,10 @@ CREATE TABLE IF NOT EXISTS "api_errors" (
     "occurrences" integer DEFAULT 1 NOT NULL,
     "first_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
     "last_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
-    "severity" text DEFAULT 'unknown' NOT NULL,
-    "status" text DEFAULT 'open' NOT NULL,
+    "severity" text DEFAULT 'unknown' NOT NULL
+        CHECK ("severity" IN ('high', 'medium', 'low', 'unknown')),
+    "status" text DEFAULT 'open' NOT NULL
+        CHECK ("status" IN ('open', 'investigating', 'resolved', 'ignored')),
     "ai_summary" text,
     "ai_suspected_files" jsonb,
     "ai_root_cause" text,

--- a/server/api/drizzle/0019_add_api_errors.sql
+++ b/server/api/drizzle/0019_add_api_errors.sql
@@ -1,0 +1,46 @@
+-- Add `api_errors` table — aggregated summary of API errors detected by Sentry.
+-- Sentry が検知した API エラーの集約サマリ用テーブルを追加する。
+--
+-- 生のスタックトレース・パラメータは Sentry 側に保持し、本テーブルでは
+-- `sentry_issue_id` をユニークキーとした「issue 単位の状態」のみ持つ。
+-- Webhook ハンドラは `INSERT ... ON CONFLICT (sentry_issue_id) DO UPDATE` で
+-- `occurrences` を加算し `last_seen_at` を前進させる（`first_seen_at` は保持）。
+--
+-- Raw stack traces / payloads stay in Sentry; this table only stores the
+-- per-issue aggregation (occurrence count, severity, status, AI analysis,
+-- GitHub issue mapping) keyed on `sentry_issue_id`. The webhook upserts via
+-- `ON CONFLICT (sentry_issue_id) DO UPDATE` to bump `occurrences` and advance
+-- `last_seen_at` while preserving `first_seen_at`.
+--
+-- See parent epic otomatty/zedi#616, sub-issue #802.
+
+CREATE TABLE IF NOT EXISTS "api_errors" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    "sentry_issue_id" text NOT NULL,
+    "fingerprint" text,
+    "title" text NOT NULL,
+    "route" text,
+    "status_code" integer,
+    "occurrences" integer DEFAULT 1 NOT NULL,
+    "first_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "last_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "severity" text DEFAULT 'unknown' NOT NULL,
+    "status" text DEFAULT 'open' NOT NULL,
+    "ai_summary" text,
+    "ai_suspected_files" jsonb,
+    "ai_root_cause" text,
+    "ai_suggested_fix" text,
+    "github_issue_number" integer,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT "api_errors_sentry_issue_id_unique" UNIQUE ("sentry_issue_id")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_api_errors_status_last_seen"
+    ON "api_errors" ("status", "last_seen_at" DESC);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_api_errors_severity_status"
+    ON "api_errors" ("severity", "status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_api_errors_last_seen"
+    ON "api_errors" ("last_seen_at" DESC);

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1777420800000,
       "tag": "0018_add_onboarding_and_page_kind",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1777507200000,
+      "tag": "0019_add_api_errors",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/src/schema/apiErrors.ts
+++ b/server/api/src/schema/apiErrors.ts
@@ -75,9 +75,13 @@ export const apiErrors = pgTable(
     /** 最終観測時刻（upsert で前進する） / Last-seen timestamp; advances on upsert */
     lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).defaultNow().notNull(),
     /** AI 解析後の重大度（既定 `unknown`） / Severity after AI analysis */
-    severity: text("severity").$type<ApiErrorSeverity>().notNull().default("unknown"),
+    severity: text("severity", { enum: ["high", "medium", "low", "unknown"] })
+      .notNull()
+      .default("unknown"),
     /** 管理画面で人が更新するワークフロー状態 / Admin-updated workflow status */
-    status: text("status").$type<ApiErrorStatus>().notNull().default("open"),
+    status: text("status", { enum: ["open", "investigating", "resolved", "ignored"] })
+      .notNull()
+      .default("open"),
     /** AI が生成した要約 / AI-generated summary */
     aiSummary: text("ai_summary"),
     /** AI が推定した関連ファイル一覧 / AI-suspected related files */

--- a/server/api/src/schema/apiErrors.ts
+++ b/server/api/src/schema/apiErrors.ts
@@ -1,0 +1,111 @@
+/**
+ * `api_errors` テーブル — Sentry が検知した API エラーの集約サマリ。
+ * 生のスタックトレース・パラメータは Sentry 側に保持し、本テーブルでは
+ * 重複排除済みの「issue 単位の状態」を保持する。Epic #616 / Sub-issue #802 に準拠。
+ *
+ * `api_errors` table — aggregated summary of API errors detected by Sentry.
+ * Raw stack traces and request payloads stay in Sentry; this table only stores
+ * the deduplicated "per-issue state" (occurrence count, severity, status,
+ * AI analysis output, GitHub issue mapping). See Epic #616 / sub-issue #802.
+ *
+ * @see https://github.com/otomatty/zedi/issues/616
+ * @see https://github.com/otomatty/zedi/issues/802
+ */
+import { pgTable, uuid, text, integer, timestamp, jsonb, index } from "drizzle-orm/pg-core";
+
+/**
+ * AI が判定する重大度。Issue 自動起票は `high` / `medium` のみが対象になる
+ * （`low` は集約のみ、`unknown` は AI 解析未完了の暫定値）。
+ *
+ * AI-assigned severity. Issue auto-creation only triggers for `high` / `medium`.
+ * `low` is aggregated but never escalated; `unknown` is the default before AI
+ * analysis finishes.
+ */
+export type ApiErrorSeverity = "high" | "medium" | "low" | "unknown";
+
+/**
+ * 管理者が更新するエラーのワークフロー状態。
+ * Workflow status updated by an admin via the management UI.
+ *
+ * - `open`: 新規検出・未対応 / Newly detected, untriaged
+ * - `investigating`: 調査中 / Currently being investigated
+ * - `resolved`: 解決済み（再発時は `open` に戻す） / Fixed; reopened on regression
+ * - `ignored`: 既知だが対応不要と判断 / Known and intentionally ignored
+ */
+export type ApiErrorStatus = "open" | "investigating" | "resolved" | "ignored";
+
+/**
+ * AI が推定した「関連しそうなファイル」のエントリ。
+ * Suspected file entry produced by the AI analysis step.
+ */
+export interface ApiErrorSuspectedFile {
+  /** リポジトリ相対パス / Repository-relative path */
+  path: string;
+  /** 関連と推定する根拠（任意） / Optional rationale */
+  reason?: string;
+  /** 行番号（任意） / Optional line number */
+  line?: number;
+}
+
+/**
+ * `api_errors` テーブル定義。`sentry_issue_id` をユニークキーにして upsert する。
+ *
+ * Drizzle definition for the `api_errors` table. `sentry_issue_id` is the
+ * idempotency key used by `apiErrorService.upsertFromSentrySummary` so the
+ * same Sentry issue cannot create duplicate rows when alerts fire repeatedly.
+ */
+export const apiErrors = pgTable(
+  "api_errors",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    /** Sentry の issue ID（`group.id`）。upsert キー / Sentry issue id; upsert key */
+    sentryIssueId: text("sentry_issue_id").notNull().unique(),
+    /** Sentry の fingerprint または自前計算したグルーピングキー / Grouping fingerprint */
+    fingerprint: text("fingerprint"),
+    /** エラー要約タイトル / Short error title */
+    title: text("title").notNull(),
+    /** 発生したルート（例: `POST /api/ingest`） / Route where the error fired */
+    route: text("route"),
+    /** HTTP ステータスコード / HTTP status code */
+    statusCode: integer("status_code"),
+    /** 集約済み発生回数（alert ごとに加算）/ Total occurrences across alerts */
+    occurrences: integer("occurrences").notNull().default(1),
+    /** 初回観測時刻（upsert で更新しない）/ First-seen timestamp; preserved on upsert */
+    firstSeenAt: timestamp("first_seen_at", { withTimezone: true }).defaultNow().notNull(),
+    /** 最終観測時刻（upsert で前進する） / Last-seen timestamp; advances on upsert */
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).defaultNow().notNull(),
+    /** AI 解析後の重大度（既定 `unknown`） / Severity after AI analysis */
+    severity: text("severity").$type<ApiErrorSeverity>().notNull().default("unknown"),
+    /** 管理画面で人が更新するワークフロー状態 / Admin-updated workflow status */
+    status: text("status").$type<ApiErrorStatus>().notNull().default("open"),
+    /** AI が生成した要約 / AI-generated summary */
+    aiSummary: text("ai_summary"),
+    /** AI が推定した関連ファイル一覧 / AI-suspected related files */
+    aiSuspectedFiles: jsonb("ai_suspected_files").$type<ApiErrorSuspectedFile[]>(),
+    /** AI が推定した原因仮説 / AI-suspected root cause */
+    aiRootCause: text("ai_root_cause"),
+    /** AI が推奨する修正方針 / AI-suggested fix direction */
+    aiSuggestedFix: text("ai_suggested_fix"),
+    /** 自動起票した GitHub Issue 番号（low / 起票前は null） / Linked GitHub issue number */
+    githubIssueNumber: integer("github_issue_number"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    // Admin UI の主クエリは「未対応を新着順で見る」なのでこれを先頭インデックスに置く。
+    // The admin UI's primary query lists open issues newest-first, so this
+    // composite index covers the hot path.
+    index("idx_api_errors_status_last_seen").on(table.status, table.lastSeenAt.desc()),
+    // severity フィルタ + status の絞り込み（severity:high & status:open 等）。
+    // For severity-filtered admin queries (e.g. severity=high & status=open).
+    index("idx_api_errors_severity_status").on(table.severity, table.status),
+    // last_seen_at だけでの新着順表示用 / For straight newest-first listings.
+    index("idx_api_errors_last_seen").on(table.lastSeenAt.desc()),
+  ],
+);
+
+/** SELECT 行型 / Row type for `api_errors` SELECT results. */
+export type ApiError = typeof apiErrors.$inferSelect;
+
+/** INSERT 値型 / Insert payload type for `api_errors`. */
+export type NewApiError = typeof apiErrors.$inferInsert;

--- a/server/api/src/schema/index.ts
+++ b/server/api/src/schema/index.ts
@@ -74,6 +74,14 @@ export {
   type NewThumbnailObject,
 } from "./thumbnails.js";
 export { adminAuditLogs, type AdminAuditLog, type NewAdminAuditLog } from "./auditLogs.js";
+export {
+  apiErrors,
+  type ApiError,
+  type NewApiError,
+  type ApiErrorSeverity,
+  type ApiErrorStatus,
+  type ApiErrorSuspectedFile,
+} from "./apiErrors.js";
 export { sources, type Source, type NewSource } from "./sources.js";
 export { pageSources, type PageSource, type NewPageSource } from "./pageSources.js";
 export {

--- a/server/api/src/services/apiErrorService.test.ts
+++ b/server/api/src/services/apiErrorService.test.ts
@@ -396,6 +396,26 @@ describe("listApiErrors", () => {
     expect(result.total).toBe(0);
   });
 
+  it("does not throw on fractional / NaN limit/offset (Postgres would reject non-integers)", async () => {
+    // Postgres は LIMIT/OFFSET に小数を許容しないため、サービス側で整数化する。
+    // Postgres rejects fractional LIMIT/OFFSET, so the service must coerce to
+    // an integer before issuing the query.
+    const db = createMockDb([[], [{ count: 0 }]]);
+
+    await expect(listApiErrors(db as never, { limit: 25.7, offset: 10.4 })).resolves.toEqual({
+      rows: [],
+      total: 0,
+    });
+
+    const db2 = createMockDb([[], [{ count: 0 }]]);
+    await expect(
+      listApiErrors(db2 as never, {
+        limit: Number.NaN,
+        offset: Number.POSITIVE_INFINITY,
+      }),
+    ).resolves.toEqual({ rows: [], total: 0 });
+  });
+
   it("accepts status and severity filters without error", async () => {
     const db = createMockDb([[], [{ count: 0 }]]);
 

--- a/server/api/src/services/apiErrorService.test.ts
+++ b/server/api/src/services/apiErrorService.test.ts
@@ -246,6 +246,49 @@ describe("upsertFromSentrySummary", () => {
     ).rejects.toThrow(/title is required/i);
   });
 
+  it("rejects non-integer / non-finite statusCode at the boundary", async () => {
+    const db = createMockDb([[makeRow()]]);
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        sentryIssueId: "sentry-issue-1",
+        title: "boom",
+        statusCode: 200.5,
+      }),
+    ).rejects.toThrow(/statusCode must be a finite integer/i);
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        sentryIssueId: "sentry-issue-1",
+        title: "boom",
+        statusCode: Number.NaN,
+      }),
+    ).rejects.toThrow(/statusCode must be a finite integer/i);
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        sentryIssueId: "sentry-issue-1",
+        title: "boom",
+        statusCode: Number.POSITIVE_INFINITY,
+      }),
+    ).rejects.toThrow(/statusCode must be a finite integer/i);
+  });
+
+  it("rejects Invalid Date for firstSeenAt / lastSeenAt", async () => {
+    const db = createMockDb([[makeRow()]]);
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        sentryIssueId: "sentry-issue-1",
+        title: "boom",
+        firstSeenAt: new Date("not-a-real-date"),
+      }),
+    ).rejects.toThrow(/firstSeenAt must be a valid Date/i);
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        sentryIssueId: "sentry-issue-1",
+        title: "boom",
+        lastSeenAt: new Date("not-a-real-date"),
+      }),
+    ).rejects.toThrow(/lastSeenAt must be a valid Date/i);
+  });
+
   it("on recurrence of a resolved row, the upsert reopens to status='open'", async () => {
     // 再発検出: 過去に resolved にされた issue が再来したら open に戻し、
     // admin の既定ビュー（未解決一覧）から見落とされないようにする。
@@ -272,6 +315,33 @@ describe("upsertFromSentrySummary", () => {
     });
 
     expect(result.status).toBe("open");
+    expect(result.firstSeenAt.toISOString()).toBe("2026-04-01T00:00:00.000Z");
+  });
+
+  it("on recurrence of an ignored row, the upsert keeps status='ignored'", async () => {
+    // 再発検出の対称側: admin が「無視」と明示判断した issue は再来しても
+    // 触らない。`set.status` の CASE は resolved のみを open に戻すため、
+    // ignored は元の値を維持する（CASE の ELSE 分岐）。
+    //
+    // Symmetric to the resolved auto-reopen: an admin's explicit `ignored`
+    // decision must not be overridden by a webhook recurrence. The CASE
+    // expression's ELSE branch preserves the existing status verbatim.
+    const stayIgnored = makeRow({
+      occurrences: 7,
+      status: "ignored",
+      firstSeenAt: new Date("2026-04-01T00:00:00Z"),
+      lastSeenAt: new Date("2026-05-04T00:00:00Z"),
+    });
+    const db = createMockDb([[stayIgnored]]);
+
+    const result = await upsertFromSentrySummary(db as never, {
+      sentryIssueId: "sentry-issue-1",
+      title: "recurrence",
+      occurrencesDelta: 1,
+      lastSeenAt: new Date("2026-05-04T00:00:00Z"),
+    });
+
+    expect(result.status).toBe("ignored");
     expect(result.firstSeenAt.toISOString()).toBe("2026-04-01T00:00:00.000Z");
   });
 

--- a/server/api/src/services/apiErrorService.test.ts
+++ b/server/api/src/services/apiErrorService.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect } from "vitest";
 import {
   ALLOWED_API_ERROR_STATUS_TRANSITIONS,
+  ApiErrorStatusConflictError,
   assertValidApiErrorStatusTransition,
   isValidApiErrorStatusTransition,
   upsertFromSentrySummary,
@@ -214,6 +215,88 @@ describe("upsertFromSentrySummary", () => {
       }),
     ).rejects.toThrow(/sentryIssueId is required/i);
   });
+
+  it("rejects null/undefined sentry_issue_id without throwing TypeError", async () => {
+    // Webhook 由来の不正なペイロード（null や欠落）でも構造化されたメッセージで弾く。
+    // Malformed webhook payloads (null / missing) are rejected with a clear
+    // validation message rather than a runtime TypeError on `.trim()`.
+    const db = createMockDb([[makeRow()]]);
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        // biome-ignore lint/suspicious/noExplicitAny: simulating a malformed external payload
+        sentryIssueId: null as unknown as string,
+        title: "noop",
+      }),
+    ).rejects.toThrow(/sentryIssueId is required/i);
+  });
+
+  it("rejects empty / null title at the boundary", async () => {
+    const db = createMockDb([[makeRow()]]);
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        sentryIssueId: "sentry-issue-1",
+        title: "   ",
+      }),
+    ).rejects.toThrow(/title is required/i);
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        sentryIssueId: "sentry-issue-1",
+        title: null as unknown as string,
+      }),
+    ).rejects.toThrow(/title is required/i);
+  });
+
+  it("on recurrence of a resolved row, the upsert reopens to status='open'", async () => {
+    // 再発検出: 過去に resolved にされた issue が再来したら open に戻し、
+    // admin の既定ビュー（未解決一覧）から見落とされないようにする。
+    // この振る舞いは upsert SQL の `set.status` で `CASE` 式により実装。
+    // 単体テストではモックが返す「再オープン後」の行で振る舞いを検証する。
+    //
+    // Regression detection: a previously-resolved issue must reopen on
+    // recurrence so it doesn't fall outside the admin's default open view.
+    // The behavior lives in the upsert's `set.status` CASE expression; this
+    // unit test asserts the contract via the mock-returned post-upsert row.
+    const reopened = makeRow({
+      occurrences: 5,
+      status: "open",
+      firstSeenAt: new Date("2026-04-01T00:00:00Z"),
+      lastSeenAt: new Date("2026-05-04T00:00:00Z"),
+    });
+    const db = createMockDb([[reopened]]);
+
+    const result = await upsertFromSentrySummary(db as never, {
+      sentryIssueId: "sentry-issue-1",
+      title: "regression",
+      occurrencesDelta: 1,
+      lastSeenAt: new Date("2026-05-04T00:00:00Z"),
+    });
+
+    expect(result.status).toBe("open");
+    expect(result.firstSeenAt.toISOString()).toBe("2026-04-01T00:00:00.000Z");
+  });
+
+  it("treats non-finite occurrencesDelta (NaN, Infinity) as 1", async () => {
+    // NaN / Infinity がそのまま SQL に渡るとクエリが失敗するので、安全側に倒して 1 にする。
+    // NaN / Infinity would fail the underlying query; coerce to the safe default of 1.
+    const upserted = makeRow({ occurrences: 1 });
+    const db = createMockDb([[upserted], [upserted]]);
+
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        sentryIssueId: "sentry-issue-1",
+        title: "boom",
+        occurrencesDelta: Number.NaN,
+      }),
+    ).resolves.toEqual(upserted);
+
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        sentryIssueId: "sentry-issue-1",
+        title: "boom",
+        occurrencesDelta: Number.POSITIVE_INFINITY,
+      }),
+    ).resolves.toEqual(upserted);
+  });
 });
 
 // ── listApiErrors / get* ───────────────────────────────────────────────────
@@ -337,5 +420,24 @@ describe("updateApiErrorStatus", () => {
     });
 
     expect(result?.status).toBe("open");
+  });
+
+  it("throws ApiErrorStatusConflictError when the row was changed concurrently", async () => {
+    // 読み取り時点 status='open' で遷移バリデーションをパスしたあと、
+    // UPDATE が行を返さない（= 他リクエストが status を変えていた）ケース。
+    // 並行更新を黙って上書きするのではなく 409 マップ可能なエラーにする。
+    //
+    // Read sees status='open' (transition validates), then the UPDATE returns
+    // zero rows because a competing write changed the row. We surface a
+    // typed error so the caller can map it to HTTP 409.
+    const before = makeRow({ status: "open" });
+    const db = createMockDb([[before], []]);
+
+    await expect(
+      updateApiErrorStatus(db as never, {
+        id: before.id,
+        nextStatus: "investigating",
+      }),
+    ).rejects.toBeInstanceOf(ApiErrorStatusConflictError);
   });
 });

--- a/server/api/src/services/apiErrorService.test.ts
+++ b/server/api/src/services/apiErrorService.test.ts
@@ -1,0 +1,341 @@
+/**
+ * `apiErrorService` の単体テスト。
+ *
+ * - 状態遷移のバリデーション（仕様: open ↔ investigating ↔ resolved/ignored、
+ *   ignored から resolved への直接遷移は禁止）。
+ * - Sentry サマリの upsert: 初回 insert と、同一 `sentry_issue_id` での
+ *   再来時に `occurrences` が増え `first_seen_at` が保持されることを、
+ *   モック DB が返す行を介して検証する。
+ * - 一覧取得・単件取得・状態更新の振る舞いをモック DB で確認する。
+ *
+ * Unit tests for `apiErrorService`. Status-transition logic is covered as a
+ * pure function; the upsert path uses a mock DB that returns the post-upsert
+ * row so we can assert the `occurrences` increment and `first_seen_at`
+ * preservation contract without spinning up Postgres.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  ALLOWED_API_ERROR_STATUS_TRANSITIONS,
+  assertValidApiErrorStatusTransition,
+  isValidApiErrorStatusTransition,
+  upsertFromSentrySummary,
+  listApiErrors,
+  getApiErrorById,
+  getApiErrorBySentryIssueId,
+  updateApiErrorStatus,
+  API_ERROR_LIST_DEFAULT_LIMIT,
+  API_ERROR_LIST_MAX_LIMIT,
+} from "./apiErrorService.js";
+import type { ApiError, ApiErrorStatus } from "../schema/apiErrors.js";
+
+// ── Mock DB helpers ─────────────────────────────────────────────────────────
+
+/**
+ * drizzle のチェイン (`select().from().where()...` や
+ * `insert().values().onConflictDoUpdate().returning()`) を素通しで一定の
+ * 結果に解決する Proxy。最終 `await` 時に `result` を返す。
+ *
+ * Proxy that lets any drizzle query-builder chain resolve to a fixed result.
+ * The terminal `await` returns the canned `result`, regardless of which
+ * builder method ends the chain.
+ */
+function makeChainProxy(result: unknown): unknown {
+  return new Proxy({} as Record<string, unknown>, {
+    get(_target, prop: string) {
+      if (prop === "then") {
+        return (resolve?: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+          Promise.resolve(result).then(resolve, reject);
+      }
+      if (prop === "catch") {
+        return (reject?: (e: unknown) => unknown) => Promise.resolve(result).catch(reject);
+      }
+      if (prop === "finally") {
+        return (fn?: () => void) => Promise.resolve(result).finally(fn);
+      }
+      return (..._args: unknown[]) => makeChainProxy(result);
+    },
+  });
+}
+
+function createMockDb(queryResults: unknown[]) {
+  let queryIndex = 0;
+  return new Proxy({} as Record<string, unknown>, {
+    get(_target, _prop: string) {
+      return (..._args: unknown[]) => {
+        const idx = queryIndex++;
+        return makeChainProxy(queryResults[idx] ?? []);
+      };
+    },
+  });
+}
+
+function makeRow(overrides: Partial<ApiError> = {}): ApiError {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    sentryIssueId: "sentry-issue-1",
+    fingerprint: null,
+    title: "TypeError: Cannot read properties of undefined",
+    route: "POST /api/ingest",
+    statusCode: 500,
+    occurrences: 1,
+    firstSeenAt: new Date("2026-05-01T00:00:00Z"),
+    lastSeenAt: new Date("2026-05-01T00:00:00Z"),
+    severity: "unknown",
+    status: "open",
+    aiSummary: null,
+    aiSuspectedFiles: null,
+    aiRootCause: null,
+    aiSuggestedFix: null,
+    githubIssueNumber: null,
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    updatedAt: new Date("2026-05-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+// ── Status transition rules ────────────────────────────────────────────────
+
+describe("ALLOWED_API_ERROR_STATUS_TRANSITIONS", () => {
+  it("exposes a complete map for every known status", () => {
+    const statuses: ApiErrorStatus[] = ["open", "investigating", "resolved", "ignored"];
+    for (const s of statuses) {
+      expect(ALLOWED_API_ERROR_STATUS_TRANSITIONS[s]).toBeDefined();
+    }
+  });
+});
+
+describe("isValidApiErrorStatusTransition", () => {
+  it("allows open -> investigating, resolved, ignored", () => {
+    expect(isValidApiErrorStatusTransition("open", "investigating")).toBe(true);
+    expect(isValidApiErrorStatusTransition("open", "resolved")).toBe(true);
+    expect(isValidApiErrorStatusTransition("open", "ignored")).toBe(true);
+  });
+
+  it("allows investigating -> resolved, ignored, open", () => {
+    expect(isValidApiErrorStatusTransition("investigating", "resolved")).toBe(true);
+    expect(isValidApiErrorStatusTransition("investigating", "ignored")).toBe(true);
+    expect(isValidApiErrorStatusTransition("investigating", "open")).toBe(true);
+  });
+
+  it("allows resolved -> open (regression) and resolved -> ignored", () => {
+    expect(isValidApiErrorStatusTransition("resolved", "open")).toBe(true);
+    expect(isValidApiErrorStatusTransition("resolved", "ignored")).toBe(true);
+  });
+
+  it("allows ignored -> open only", () => {
+    expect(isValidApiErrorStatusTransition("ignored", "open")).toBe(true);
+    expect(isValidApiErrorStatusTransition("ignored", "investigating")).toBe(false);
+    expect(isValidApiErrorStatusTransition("ignored", "resolved")).toBe(false);
+  });
+
+  it("rejects same-state transitions (caller is expected to short-circuit)", () => {
+    expect(isValidApiErrorStatusTransition("open", "open")).toBe(false);
+    expect(isValidApiErrorStatusTransition("resolved", "resolved")).toBe(false);
+  });
+
+  it("rejects skipping investigating: resolved -> investigating", () => {
+    expect(isValidApiErrorStatusTransition("resolved", "investigating")).toBe(false);
+  });
+});
+
+describe("assertValidApiErrorStatusTransition", () => {
+  it("throws with a structured message on invalid transition", () => {
+    expect(() => assertValidApiErrorStatusTransition("ignored", "resolved")).toThrow(
+      /invalid api_errors status transition: ignored -> resolved/i,
+    );
+  });
+
+  it("does not throw on a valid transition", () => {
+    expect(() => assertValidApiErrorStatusTransition("open", "investigating")).not.toThrow();
+  });
+});
+
+// ── upsertFromSentrySummary ────────────────────────────────────────────────
+
+describe("upsertFromSentrySummary", () => {
+  it("inserts a fresh row when the sentry_issue_id has not been seen", async () => {
+    const inserted = makeRow({ occurrences: 1 });
+    const db = createMockDb([[inserted]]);
+
+    const result = await upsertFromSentrySummary(db as never, {
+      sentryIssueId: "sentry-issue-1",
+      title: "TypeError: Cannot read properties of undefined",
+      route: "POST /api/ingest",
+      statusCode: 500,
+      lastSeenAt: new Date("2026-05-01T00:00:00Z"),
+    });
+
+    expect(result.occurrences).toBe(1);
+    expect(result.sentryIssueId).toBe("sentry-issue-1");
+    expect(result.firstSeenAt.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+  });
+
+  it("on conflict, returns the row with incremented occurrences and preserved first_seen_at", async () => {
+    // 2 回目の alert 受信を想定。upsert 後の行 (occurrences=2) が返る。
+    // Simulate a second alert for the same sentry_issue_id; the mock returns
+    // the post-upsert row to reflect the increment + preservation contract.
+    const upserted = makeRow({
+      occurrences: 2,
+      firstSeenAt: new Date("2026-05-01T00:00:00Z"),
+      lastSeenAt: new Date("2026-05-02T00:00:00Z"),
+    });
+    const db = createMockDb([[upserted]]);
+
+    const result = await upsertFromSentrySummary(db as never, {
+      sentryIssueId: "sentry-issue-1",
+      title: "TypeError: Cannot read properties of undefined",
+      route: "POST /api/ingest",
+      statusCode: 500,
+      occurrencesDelta: 1,
+      lastSeenAt: new Date("2026-05-02T00:00:00Z"),
+    });
+
+    expect(result.occurrences).toBe(2);
+    expect(result.firstSeenAt.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+    expect(result.lastSeenAt.toISOString()).toBe("2026-05-02T00:00:00.000Z");
+  });
+
+  it("throws when the upsert returns no rows (defensive guard)", async () => {
+    const db = createMockDb([[]]);
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        sentryIssueId: "sentry-issue-x",
+        title: "noop",
+      }),
+    ).rejects.toThrow(/upsert returned no rows/i);
+  });
+
+  it("rejects empty sentry_issue_id at the boundary", async () => {
+    const db = createMockDb([[makeRow()]]);
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        sentryIssueId: "  ",
+        title: "noop",
+      }),
+    ).rejects.toThrow(/sentryIssueId is required/i);
+  });
+});
+
+// ── listApiErrors / get* ───────────────────────────────────────────────────
+
+describe("listApiErrors", () => {
+  it("returns rows and total count", async () => {
+    const rows = [makeRow({ id: "00000000-0000-0000-0000-000000000001" })];
+    const db = createMockDb([rows, [{ count: 1 }]]);
+
+    const result = await listApiErrors(db as never, {});
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.total).toBe(1);
+  });
+
+  it("uses the documented default and max limits", () => {
+    expect(API_ERROR_LIST_DEFAULT_LIMIT).toBe(50);
+    expect(API_ERROR_LIST_MAX_LIMIT).toBe(200);
+  });
+
+  it("clamps oversized limits to the max without throwing", async () => {
+    const db = createMockDb([[], [{ count: 0 }]]);
+
+    const result = await listApiErrors(db as never, { limit: 10_000 });
+
+    expect(result.rows).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("accepts status and severity filters without error", async () => {
+    const db = createMockDb([[], [{ count: 0 }]]);
+
+    const result = await listApiErrors(db as never, {
+      status: "open",
+      severity: "high",
+      limit: 25,
+      offset: 50,
+    });
+
+    expect(result).toEqual({ rows: [], total: 0 });
+  });
+});
+
+describe("getApiErrorById", () => {
+  it("returns the row when present", async () => {
+    const row = makeRow({ id: "00000000-0000-0000-0000-000000000099" });
+    const db = createMockDb([[row]]);
+    const result = await getApiErrorById(db as never, row.id);
+    expect(result?.id).toBe(row.id);
+  });
+
+  it("returns null when not found", async () => {
+    const db = createMockDb([[]]);
+    const result = await getApiErrorById(db as never, "00000000-0000-0000-0000-000000000099");
+    expect(result).toBeNull();
+  });
+});
+
+describe("getApiErrorBySentryIssueId", () => {
+  it("returns the row when present", async () => {
+    const row = makeRow({ sentryIssueId: "sentry-issue-42" });
+    const db = createMockDb([[row]]);
+    const result = await getApiErrorBySentryIssueId(db as never, "sentry-issue-42");
+    expect(result?.sentryIssueId).toBe("sentry-issue-42");
+  });
+
+  it("returns null when not found", async () => {
+    const db = createMockDb([[]]);
+    const result = await getApiErrorBySentryIssueId(db as never, "missing");
+    expect(result).toBeNull();
+  });
+});
+
+// ── updateApiErrorStatus ───────────────────────────────────────────────────
+
+describe("updateApiErrorStatus", () => {
+  it("updates the status when the transition is valid", async () => {
+    const before = makeRow({ status: "open" });
+    const after = makeRow({ ...before, status: "investigating" });
+    // 1) SELECT current row, 2) UPDATE returning row
+    const db = createMockDb([[before], [after]]);
+
+    const result = await updateApiErrorStatus(db as never, {
+      id: before.id,
+      nextStatus: "investigating",
+    });
+
+    expect(result?.status).toBe("investigating");
+  });
+
+  it("rejects an invalid transition without issuing the UPDATE", async () => {
+    const before = makeRow({ status: "ignored" });
+    const db = createMockDb([[before]]);
+
+    await expect(
+      updateApiErrorStatus(db as never, {
+        id: before.id,
+        nextStatus: "resolved",
+      }),
+    ).rejects.toThrow(/invalid api_errors status transition/i);
+  });
+
+  it("returns null when the target row does not exist", async () => {
+    const db = createMockDb([[]]);
+
+    const result = await updateApiErrorStatus(db as never, {
+      id: "00000000-0000-0000-0000-000000000099",
+      nextStatus: "investigating",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("treats a same-state transition as an idempotent no-op (returns the existing row)", async () => {
+    const before = makeRow({ status: "open" });
+    const db = createMockDb([[before]]);
+
+    const result = await updateApiErrorStatus(db as never, {
+      id: before.id,
+      nextStatus: "open",
+    });
+
+    expect(result?.status).toBe("open");
+  });
+});

--- a/server/api/src/services/apiErrorService.test.ts
+++ b/server/api/src/services/apiErrorService.test.ts
@@ -271,6 +271,37 @@ describe("upsertFromSentrySummary", () => {
     ).rejects.toThrow(/statusCode must be a finite integer/i);
   });
 
+  it("rejects an inverted timeline (firstSeenAt > lastSeenAt)", async () => {
+    // 単調性の不変条件チェック: 逆転したタイムスタンプは DB に書かない。
+    // Monotonicity invariant: a webhook with firstSeenAt > lastSeenAt cannot
+    // persist its inverted timeline.
+    const db = createMockDb([[makeRow()]]);
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        sentryIssueId: "sentry-issue-1",
+        title: "boom",
+        firstSeenAt: new Date("2026-05-02T00:00:00Z"),
+        lastSeenAt: new Date("2026-05-01T00:00:00Z"),
+      }),
+    ).rejects.toThrow(/firstSeenAt must be less than or equal to lastSeenAt/i);
+  });
+
+  it("accepts firstSeenAt === lastSeenAt (boundary case)", async () => {
+    // 同時刻は許容する（初回観測と最終観測が同一イベントなら自然）。
+    // Equal timestamps are allowed (a fresh issue's first/last observation
+    // can coincide).
+    const t = new Date("2026-05-01T00:00:00Z");
+    const db = createMockDb([[makeRow({ firstSeenAt: t, lastSeenAt: t })]]);
+    await expect(
+      upsertFromSentrySummary(db as never, {
+        sentryIssueId: "sentry-issue-1",
+        title: "boom",
+        firstSeenAt: t,
+        lastSeenAt: t,
+      }),
+    ).resolves.toBeDefined();
+  });
+
   it("rejects Invalid Date for firstSeenAt / lastSeenAt", async () => {
     const db = createMockDb([[makeRow()]]);
     await expect(

--- a/server/api/src/services/apiErrorService.ts
+++ b/server/api/src/services/apiErrorService.ts
@@ -112,26 +112,6 @@ export interface UpsertFromSentrySummaryInput {
 }
 
 /**
- * `api_errors` を `sentry_issue_id` をキーに upsert する。
- *
- * - 初回 insert: 渡された値で行を作成。`occurrences` は `occurrencesDelta`
- *   （既定 1）。
- * - 競合時: `occurrences` を加算、`last_seen_at` は `GREATEST` で前進、
- *   `title` / `route` / `status_code` / `fingerprint` は新しい非 null 値で更新。
- *   **`first_seen_at` は意図的に保持する**（再来時に上書きしない）。
- *
- * Upsert keyed on `sentry_issue_id`. Inserts on first sight; on conflict,
- * increments `occurrences`, advances `last_seen_at` with `GREATEST`, refreshes
- * the descriptive columns from non-null EXCLUDED values, and **preserves
- * `first_seen_at`** by design.
- *
- * @throws when `sentryIssueId` または `title` が空、`statusCode` が
- *   有限の整数でない、`firstSeenAt` / `lastSeenAt` が不正な Date、もしくは
- *   upsert が行を返さなかった場合。Throws on empty `sentryIssueId` /
- *   `title`, non-integer `statusCode`, Invalid Date timestamps, or when
- *   the upsert produced no row.
- */
-/**
  * 外部 Webhook 由来の入力を境界で正規化・検証する内部ヘルパ。
  * 不正な値は構造化メッセージで throw する（呼び出し側で 400 にマップ）。
  *
@@ -171,6 +151,27 @@ function normalizeUpsertInput(input: UpsertFromSentrySummaryInput): {
   return { sentryIssueId, title, occurrencesDelta, now };
 }
 
+/**
+ * `api_errors` を `sentry_issue_id` をキーに upsert する。
+ *
+ * - 初回 insert: 渡された値で行を作成。`occurrences` は `occurrencesDelta`
+ *   （既定 1）。
+ * - 競合時: `occurrences` を加算、`last_seen_at` は `GREATEST` で前進、
+ *   `title` / `route` / `status_code` / `fingerprint` は新しい非 null 値で更新。
+ *   `status` は `resolved` のみ `open` に戻す（再発検出）。
+ *   **`first_seen_at` は意図的に保持する**（再来時に上書きしない）。
+ *
+ * Upsert keyed on `sentry_issue_id`. Inserts on first sight; on conflict,
+ * increments `occurrences`, advances `last_seen_at` with `GREATEST`, refreshes
+ * the descriptive columns from non-null EXCLUDED values, reopens
+ * `resolved` rows on recurrence, and **preserves `first_seen_at`** by design.
+ *
+ * @throws when `sentryIssueId` または `title` が空、`statusCode` が
+ *   有限の整数でない、`firstSeenAt` / `lastSeenAt` が不正な Date、もしくは
+ *   upsert が行を返さなかった場合。Throws on empty `sentryIssueId` /
+ *   `title`, non-integer `statusCode`, Invalid Date timestamps, or when
+ *   the upsert produced no row.
+ */
 export async function upsertFromSentrySummary(
   db: Database,
   input: UpsertFromSentrySummaryInput,
@@ -272,12 +273,22 @@ export async function listApiErrors(
   db: Database,
   filters: ListApiErrorsFilters,
 ): Promise<{ rows: ApiError[]; total: number }> {
+  // 小数や NaN をそのまま LIMIT/OFFSET に渡すと Postgres が拒否するため、
+  // clamp の前に整数化する（不正値は既定値にフォールバック）。
+  // Postgres rejects non-integer LIMIT/OFFSET, so coerce to an integer before
+  // clamping; non-finite inputs fall back to the documented defaults.
+  const rawLimit = Number(filters.limit ?? API_ERROR_LIST_DEFAULT_LIMIT);
+  const rawOffset = Number(filters.offset ?? 0);
   const limit = clamp(
-    Number(filters.limit ?? API_ERROR_LIST_DEFAULT_LIMIT),
+    Number.isFinite(rawLimit) ? Math.floor(rawLimit) : API_ERROR_LIST_DEFAULT_LIMIT,
     1,
     API_ERROR_LIST_MAX_LIMIT,
   );
-  const offset = clamp(Number(filters.offset ?? 0), 0, Number.MAX_SAFE_INTEGER);
+  const offset = clamp(
+    Number.isFinite(rawOffset) ? Math.floor(rawOffset) : 0,
+    0,
+    Number.MAX_SAFE_INTEGER,
+  );
 
   const conditions: SQL[] = [];
   if (filters.status) conditions.push(eq(apiErrors.status, filters.status));

--- a/server/api/src/services/apiErrorService.ts
+++ b/server/api/src/services/apiErrorService.ts
@@ -1,0 +1,322 @@
+/**
+ * `api_errors` テーブル用のサービスヘルパ。
+ *
+ * `apiErrorService` は Sentry Webhook ハンドラと管理者画面 (`/admin/errors`)
+ * の両方から呼ばれる。Webhook 経路では `upsertFromSentrySummary` が
+ * `sentry_issue_id` をユニークキーとして発生回数 (`occurrences`) を加算し、
+ * 初回観測時刻 (`first_seen_at`) を保持する。管理者画面経路では一覧・単件
+ * 取得とワークフロー状態 (`status`) の更新を提供する。
+ *
+ * Service helpers for the `api_errors` table. Used both by the Sentry webhook
+ * handler (idempotent upsert keyed on `sentry_issue_id`, occurrence-counter
+ * increment, first-seen preservation) and the admin error page (list / detail
+ * / status workflow updates).
+ *
+ * @see ../schema/apiErrors.ts
+ * @see https://github.com/otomatty/zedi/issues/616
+ * @see https://github.com/otomatty/zedi/issues/802
+ */
+import { and, desc, eq, sql, type SQL } from "drizzle-orm";
+import { apiErrors } from "../schema/apiErrors.js";
+import type {
+  ApiError,
+  ApiErrorSeverity,
+  ApiErrorStatus,
+  ApiErrorSuspectedFile,
+  NewApiError,
+} from "../schema/apiErrors.js";
+import type { Database } from "../types/index.js";
+
+/**
+ * 状態遷移の許可マップ。`from -> to` の集合で表現する。
+ *
+ * - 同一 status へのフラットな遷移はマップから除外しており、呼び出し側で
+ *   先回りに「同一なら no-op」と扱う想定。
+ * - `ignored` から再度ワークフローに戻すには一旦 `open` に戻す必要がある
+ *   （見落とし防止のため `investigating` への直接遷移を許可しない）。
+ *
+ * Allowed `from -> to` transitions for `api_errors.status`. Same-state moves
+ * are intentionally excluded; callers should short-circuit those as no-ops.
+ * Re-engaging an `ignored` issue must go via `open` so the ignore decision is
+ * explicitly revisited (no jumping straight to `investigating`).
+ */
+export const ALLOWED_API_ERROR_STATUS_TRANSITIONS: Readonly<
+  Record<ApiErrorStatus, readonly ApiErrorStatus[]>
+> = {
+  open: ["investigating", "resolved", "ignored"],
+  investigating: ["resolved", "ignored", "open"],
+  resolved: ["open", "ignored"],
+  ignored: ["open"],
+};
+
+/**
+ * 状態遷移が許可されているかを判定する。同一 status は `false` を返す
+ * （呼び出し側で no-op 判定する想定）。
+ *
+ * Returns whether `current -> next` is permitted by
+ * `ALLOWED_API_ERROR_STATUS_TRANSITIONS`. Same-state moves return `false`;
+ * callers are expected to detect and short-circuit them.
+ */
+export function isValidApiErrorStatusTransition(
+  current: ApiErrorStatus,
+  next: ApiErrorStatus,
+): boolean {
+  if (current === next) return false;
+  return ALLOWED_API_ERROR_STATUS_TRANSITIONS[current].includes(next);
+}
+
+/**
+ * 不正な状態遷移をエラーとして弾く。エラーメッセージにはどちらの遷移かを
+ * 含めて、API 経由での検証メッセージにそのまま使えるようにする。
+ *
+ * Throw on an invalid transition. The thrown message includes both endpoints
+ * so it can be surfaced to admins via the API as a validation error.
+ */
+export function assertValidApiErrorStatusTransition(
+  current: ApiErrorStatus,
+  next: ApiErrorStatus,
+): void {
+  if (!isValidApiErrorStatusTransition(current, next)) {
+    throw new Error(`Invalid api_errors status transition: ${current} -> ${next}`);
+  }
+}
+
+/**
+ * Sentry Webhook サマリから upsert する際の入力。
+ * Input shape used by `upsertFromSentrySummary` when handling Sentry alerts.
+ */
+export interface UpsertFromSentrySummaryInput {
+  /** Sentry issue ID（`group.id`）。空文字は拒否 / Sentry issue id; required */
+  sentryIssueId: string;
+  /** Sentry の fingerprint 等 / Sentry-provided fingerprint */
+  fingerprint?: string | null;
+  /** タイトル要約 / Short error title */
+  title: string;
+  /** 発生ルート / Originating route */
+  route?: string | null;
+  /** HTTP ステータス / HTTP status code */
+  statusCode?: number | null;
+  /**
+   * このアラートで観測された発生回数。複数イベントを 1 通の Webhook で
+   * 受け取る場合に 2 以上を渡す。デフォルト 1。
+   *
+   * Number of occurrences carried by this alert payload. Defaults to 1.
+   */
+  occurrencesDelta?: number;
+  /** 初回観測時刻（初回 insert のみ使用） / First-seen (insert-only) */
+  firstSeenAt?: Date;
+  /** 最終観測時刻（upsert で前進する） / Last-seen; advances on upsert */
+  lastSeenAt?: Date;
+  /** AI 解析未完了の暫定 severity / Tentative severity before AI analysis */
+  severity?: ApiErrorSeverity;
+}
+
+/**
+ * `api_errors` を `sentry_issue_id` をキーに upsert する。
+ *
+ * - 初回 insert: 渡された値で行を作成。`occurrences` は `occurrencesDelta`
+ *   （既定 1）。
+ * - 競合時: `occurrences` を加算、`last_seen_at` は `GREATEST` で前進、
+ *   `title` / `route` / `status_code` / `fingerprint` は新しい非 null 値で更新。
+ *   **`first_seen_at` は意図的に保持する**（再来時に上書きしない）。
+ *
+ * Upsert keyed on `sentry_issue_id`. Inserts on first sight; on conflict,
+ * increments `occurrences`, advances `last_seen_at` with `GREATEST`, refreshes
+ * the descriptive columns from non-null EXCLUDED values, and **preserves
+ * `first_seen_at`** by design.
+ *
+ * @throws when `sentryIssueId` is empty or the upsert returns no rows.
+ */
+export async function upsertFromSentrySummary(
+  db: Database,
+  input: UpsertFromSentrySummaryInput,
+): Promise<ApiError> {
+  const sentryIssueId = input.sentryIssueId.trim();
+  if (!sentryIssueId) {
+    throw new Error("sentryIssueId is required");
+  }
+  const occurrencesDelta = Math.max(1, Math.floor(input.occurrencesDelta ?? 1));
+  const now = input.lastSeenAt ?? new Date();
+
+  const values: NewApiError = {
+    sentryIssueId,
+    fingerprint: input.fingerprint ?? null,
+    title: input.title,
+    route: input.route ?? null,
+    statusCode: input.statusCode ?? null,
+    occurrences: occurrencesDelta,
+    firstSeenAt: input.firstSeenAt ?? now,
+    lastSeenAt: now,
+    severity: input.severity ?? "unknown",
+    status: "open",
+  };
+
+  const rows = await db
+    .insert(apiErrors)
+    .values(values)
+    .onConflictDoUpdate({
+      target: apiErrors.sentryIssueId,
+      set: {
+        // occurrences は EXCLUDED 値（= occurrencesDelta）で加算する。
+        // Increment by EXCLUDED.occurrences (== occurrencesDelta on this call).
+        occurrences: sql`${apiErrors.occurrences} + EXCLUDED.occurrences`,
+        // last_seen_at は新旧のうち遅い方を採用する。
+        // last_seen_at advances to whichever timestamp is later.
+        lastSeenAt: sql`GREATEST(${apiErrors.lastSeenAt}, EXCLUDED.last_seen_at)`,
+        // 表示用カラムは新しい値を採用、null の場合は既存を維持。
+        // Descriptive columns refresh from EXCLUDED, preserving on null.
+        title: sql`EXCLUDED.title`,
+        route: sql`COALESCE(EXCLUDED.route, ${apiErrors.route})`,
+        statusCode: sql`COALESCE(EXCLUDED.status_code, ${apiErrors.statusCode})`,
+        fingerprint: sql`COALESCE(EXCLUDED.fingerprint, ${apiErrors.fingerprint})`,
+        updatedAt: sql`NOW()`,
+        // first_seen_at / status / severity / ai_* / github_issue_number は意図的に
+        // 触らない。再来で初回時刻や人手で更新した状態を巻き戻さないため。
+        // first_seen_at, status, severity, ai_*, github_issue_number are
+        // intentionally untouched: a re-occurrence must not rewind first-seen
+        // or undo human / AI updates.
+      },
+    })
+    .returning();
+
+  const row = rows[0];
+  if (!row) {
+    throw new Error("upsertFromSentrySummary: upsert returned no rows");
+  }
+  return row;
+}
+
+/** 一覧取得のデフォルト件数 / Default page size for list queries. */
+export const API_ERROR_LIST_DEFAULT_LIMIT = 50;
+/** 一覧取得の最大件数 / Maximum page size for list queries. */
+export const API_ERROR_LIST_MAX_LIMIT = 200;
+
+/**
+ * 一覧取得時のフィルタ。
+ * Filters accepted by `listApiErrors`.
+ */
+export interface ListApiErrorsFilters {
+  status?: ApiErrorStatus;
+  severity?: ApiErrorSeverity;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * 数値を [lo, hi] にクリップする。
+ * Clamps a numeric value between `lo` and `hi`.
+ */
+function clamp(n: number, lo: number, hi: number): number {
+  if (!Number.isFinite(n)) return lo;
+  return Math.min(Math.max(n, lo), hi);
+}
+
+/**
+ * `api_errors` を最終観測時刻の降順で一覧する。
+ * `total` は同一フィルタ条件での件数（ページネーション用）。
+ *
+ * List `api_errors` rows ordered by `last_seen_at` descending. `total` is the
+ * count under the same filter clause for pagination.
+ */
+export async function listApiErrors(
+  db: Database,
+  filters: ListApiErrorsFilters,
+): Promise<{ rows: ApiError[]; total: number }> {
+  const limit = clamp(
+    Number(filters.limit ?? API_ERROR_LIST_DEFAULT_LIMIT),
+    1,
+    API_ERROR_LIST_MAX_LIMIT,
+  );
+  const offset = clamp(Number(filters.offset ?? 0), 0, Number.MAX_SAFE_INTEGER);
+
+  const conditions: SQL[] = [];
+  if (filters.status) conditions.push(eq(apiErrors.status, filters.status));
+  if (filters.severity) conditions.push(eq(apiErrors.severity, filters.severity));
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const rowsQuery = db
+    .select()
+    .from(apiErrors)
+    .orderBy(desc(apiErrors.lastSeenAt), desc(apiErrors.id))
+    .limit(limit)
+    .offset(offset);
+  const rows = await (whereClause ? rowsQuery.where(whereClause) : rowsQuery);
+
+  const countQuery = db.select({ count: sql<number>`cast(count(*) as integer)` }).from(apiErrors);
+  const [countRow] = await (whereClause ? countQuery.where(whereClause) : countQuery);
+
+  return { rows, total: countRow?.count ?? 0 };
+}
+
+/**
+ * ID で 1 件取得する。見つからなければ `null`。
+ * Fetch a single row by primary key; returns `null` when not found.
+ */
+export async function getApiErrorById(db: Database, id: string): Promise<ApiError | null> {
+  const [row] = await db.select().from(apiErrors).where(eq(apiErrors.id, id)).limit(1);
+  return row ?? null;
+}
+
+/**
+ * Sentry の issue ID で 1 件取得する。Webhook 経路で再来判定に使う。
+ * Fetch by Sentry issue id; used by the webhook handler to detect recurrences.
+ */
+export async function getApiErrorBySentryIssueId(
+  db: Database,
+  sentryIssueId: string,
+): Promise<ApiError | null> {
+  const [row] = await db
+    .select()
+    .from(apiErrors)
+    .where(eq(apiErrors.sentryIssueId, sentryIssueId))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * `updateApiErrorStatus` の入力。
+ * Input shape for `updateApiErrorStatus`.
+ */
+export interface UpdateApiErrorStatusInput {
+  id: string;
+  nextStatus: ApiErrorStatus;
+}
+
+/**
+ * ワークフロー状態を更新する。
+ *
+ * - 対象行が存在しなければ `null` を返す。
+ * - 同一 status への遷移は no-op として現在の行をそのまま返す。
+ * - 遷移が許可されていない場合は `Error` を投げる（呼び出し側で 400 へ変換）。
+ *
+ * Update the workflow status with transition validation.
+ *
+ * - Returns `null` when the target row does not exist.
+ * - Same-state transitions short-circuit to a no-op (returning the unchanged row).
+ * - Invalid transitions throw; the caller maps the error to HTTP 400.
+ */
+export async function updateApiErrorStatus(
+  db: Database,
+  input: UpdateApiErrorStatusInput,
+): Promise<ApiError | null> {
+  const current = await getApiErrorById(db, input.id);
+  if (!current) return null;
+  if (current.status === input.nextStatus) return current;
+
+  assertValidApiErrorStatusTransition(current.status, input.nextStatus);
+
+  const [updated] = await db
+    .update(apiErrors)
+    .set({
+      status: input.nextStatus,
+      updatedAt: sql`NOW()`,
+    })
+    .where(eq(apiErrors.id, input.id))
+    .returning();
+
+  return updated ?? null;
+}
+
+// 公開はしないがコンパイル時に未使用警告が出ないよう、import を参照しておく。
+// Touch types so tsc/eslint don't strip them in `--isolatedModules` builds.
+export type { ApiErrorSuspectedFile };

--- a/server/api/src/services/apiErrorService.ts
+++ b/server/api/src/services/apiErrorService.ts
@@ -125,23 +125,32 @@ export interface UpsertFromSentrySummaryInput {
  * the descriptive columns from non-null EXCLUDED values, and **preserves
  * `first_seen_at`** by design.
  *
- * @throws when `sentryIssueId` is empty or the upsert returns no rows.
+ * @throws when `sentryIssueId` または `title` が空、もしくは upsert が
+ *   行を返さなかった場合。Throws on empty `sentryIssueId` / `title`, or when
+ *   the upsert produced no row.
  */
 export async function upsertFromSentrySummary(
   db: Database,
   input: UpsertFromSentrySummaryInput,
 ): Promise<ApiError> {
-  const sentryIssueId = input.sentryIssueId.trim();
+  // Webhook 入力は外部由来。null / undefined / NaN を強めにバリデートする。
+  // Webhook payloads are external; defend hard against null/undefined/NaN.
+  const sentryIssueId = (input.sentryIssueId ?? "").trim();
   if (!sentryIssueId) {
     throw new Error("sentryIssueId is required");
   }
-  const occurrencesDelta = Math.max(1, Math.floor(input.occurrencesDelta ?? 1));
+  const title = (input.title ?? "").trim();
+  if (!title) {
+    throw new Error("title is required");
+  }
+  const rawDelta = input.occurrencesDelta ?? 1;
+  const occurrencesDelta = Number.isFinite(rawDelta) ? Math.max(1, Math.floor(rawDelta)) : 1;
   const now = input.lastSeenAt ?? new Date();
 
   const values: NewApiError = {
     sentryIssueId,
     fingerprint: input.fingerprint ?? null,
-    title: input.title,
+    title,
     route: input.route ?? null,
     statusCode: input.statusCode ?? null,
     occurrences: occurrencesDelta,
@@ -169,12 +178,21 @@ export async function upsertFromSentrySummary(
         route: sql`COALESCE(EXCLUDED.route, ${apiErrors.route})`,
         statusCode: sql`COALESCE(EXCLUDED.status_code, ${apiErrors.statusCode})`,
         fingerprint: sql`COALESCE(EXCLUDED.fingerprint, ${apiErrors.fingerprint})`,
+        // 再発検出: `resolved` は再来時に `open` へ戻す。`ignored` は
+        // admin が明示的に「無視」と判断したものなので尊重して触らない。
+        // それ以外（open / investigating）は維持。
+        //
+        // Regression detection: a recurrence reopens `resolved` rows so the
+        // admin's default open/triage view surfaces them again. `ignored` is
+        // an explicit admin decision and is left alone; `open` and
+        // `investigating` are preserved.
+        status: sql`CASE WHEN ${apiErrors.status} = 'resolved' THEN 'open'::text ELSE ${apiErrors.status} END`,
         updatedAt: sql`NOW()`,
-        // first_seen_at / status / severity / ai_* / github_issue_number は意図的に
+        // first_seen_at / severity / ai_* / github_issue_number は意図的に
         // 触らない。再来で初回時刻や人手で更新した状態を巻き戻さないため。
-        // first_seen_at, status, severity, ai_*, github_issue_number are
-        // intentionally untouched: a re-occurrence must not rewind first-seen
-        // or undo human / AI updates.
+        // first_seen_at, severity, ai_*, github_issue_number are intentionally
+        // untouched: a re-occurrence must not rewind first-seen or undo
+        // human / AI updates.
       },
     })
     .returning();
@@ -283,17 +301,42 @@ export interface UpdateApiErrorStatusInput {
 }
 
 /**
+ * `updateApiErrorStatus` が並行更新と衝突したときに投げるエラー。
+ * Thrown by `updateApiErrorStatus` when a concurrent write changed the row's
+ * status between the read and the conditional UPDATE.
+ *
+ * 呼び出し側（admin ルート）は HTTP 409 Conflict にマップすることを想定する。
+ * Callers (e.g. the admin route) are expected to map this to HTTP 409.
+ */
+export class ApiErrorStatusConflictError extends Error {
+  /**
+   * 衝突した行 ID を含むエラーを生成する。
+   * Build a conflict error tagged with the row id that lost the race.
+   */
+  constructor(id: string) {
+    super(`api_errors row changed concurrently while updating status: ${id}`);
+    this.name = "ApiErrorStatusConflictError";
+  }
+}
+
+/**
  * ワークフロー状態を更新する。
  *
  * - 対象行が存在しなければ `null` を返す。
  * - 同一 status への遷移は no-op として現在の行をそのまま返す。
  * - 遷移が許可されていない場合は `Error` を投げる（呼び出し側で 400 へ変換）。
+ * - 並行更新の検出: UPDATE 述語で「読み取り時点の status」を一致条件にし、
+ *   その間に他リクエストが status を変えていた場合は
+ *   `ApiErrorStatusConflictError` を投げる（409 にマップ）。
  *
  * Update the workflow status with transition validation.
  *
  * - Returns `null` when the target row does not exist.
  * - Same-state transitions short-circuit to a no-op (returning the unchanged row).
  * - Invalid transitions throw; the caller maps the error to HTTP 400.
+ * - Concurrency: the UPDATE WHERE clause includes the previously-read status,
+ *   so a competing write that flipped the row in between yields zero rows
+ *   and we throw `ApiErrorStatusConflictError` (caller maps to HTTP 409).
  */
 export async function updateApiErrorStatus(
   db: Database,
@@ -311,10 +354,16 @@ export async function updateApiErrorStatus(
       status: input.nextStatus,
       updatedAt: sql`NOW()`,
     })
-    .where(eq(apiErrors.id, input.id))
+    // status を読み取り時点の値に固定して、間に挟まった並行更新を検出する。
+    // Pin the WHERE on the read-time status so an interleaved write fails
+    // closed (zero rows) instead of silently overwriting.
+    .where(and(eq(apiErrors.id, input.id), eq(apiErrors.status, current.status)))
     .returning();
 
-  return updated ?? null;
+  if (!updated) {
+    throw new ApiErrorStatusConflictError(input.id);
+  }
+  return updated;
 }
 
 // 公開はしないがコンパイル時に未使用警告が出ないよう、import を参照しておく。

--- a/server/api/src/services/apiErrorService.ts
+++ b/server/api/src/services/apiErrorService.ts
@@ -125,16 +125,26 @@ export interface UpsertFromSentrySummaryInput {
  * the descriptive columns from non-null EXCLUDED values, and **preserves
  * `first_seen_at`** by design.
  *
- * @throws when `sentryIssueId` または `title` が空、もしくは upsert が
- *   行を返さなかった場合。Throws on empty `sentryIssueId` / `title`, or when
+ * @throws when `sentryIssueId` または `title` が空、`statusCode` が
+ *   有限の整数でない、`firstSeenAt` / `lastSeenAt` が不正な Date、もしくは
+ *   upsert が行を返さなかった場合。Throws on empty `sentryIssueId` /
+ *   `title`, non-integer `statusCode`, Invalid Date timestamps, or when
  *   the upsert produced no row.
  */
-export async function upsertFromSentrySummary(
-  db: Database,
-  input: UpsertFromSentrySummaryInput,
-): Promise<ApiError> {
-  // Webhook 入力は外部由来。null / undefined / NaN を強めにバリデートする。
-  // Webhook payloads are external; defend hard against null/undefined/NaN.
+/**
+ * 外部 Webhook 由来の入力を境界で正規化・検証する内部ヘルパ。
+ * 不正な値は構造化メッセージで throw する（呼び出し側で 400 にマップ）。
+ *
+ * Internal helper: normalize + validate a webhook payload at the boundary.
+ * Each violation throws with a structured message so the caller can map it
+ * to HTTP 400.
+ */
+function normalizeUpsertInput(input: UpsertFromSentrySummaryInput): {
+  sentryIssueId: string;
+  title: string;
+  occurrencesDelta: number;
+  now: Date;
+} {
   const sentryIssueId = (input.sentryIssueId ?? "").trim();
   if (!sentryIssueId) {
     throw new Error("sentryIssueId is required");
@@ -143,9 +153,31 @@ export async function upsertFromSentrySummary(
   if (!title) {
     throw new Error("title is required");
   }
+  if (
+    input.statusCode != null &&
+    (!Number.isFinite(input.statusCode) || !Number.isInteger(input.statusCode))
+  ) {
+    throw new Error("statusCode must be a finite integer");
+  }
+  if (input.firstSeenAt && !Number.isFinite(input.firstSeenAt.getTime())) {
+    throw new Error("firstSeenAt must be a valid Date");
+  }
+  if (input.lastSeenAt && !Number.isFinite(input.lastSeenAt.getTime())) {
+    throw new Error("lastSeenAt must be a valid Date");
+  }
   const rawDelta = input.occurrencesDelta ?? 1;
   const occurrencesDelta = Number.isFinite(rawDelta) ? Math.max(1, Math.floor(rawDelta)) : 1;
   const now = input.lastSeenAt ?? new Date();
+  return { sentryIssueId, title, occurrencesDelta, now };
+}
+
+export async function upsertFromSentrySummary(
+  db: Database,
+  input: UpsertFromSentrySummaryInput,
+): Promise<ApiError> {
+  // Webhook 入力は外部由来。null / undefined / NaN / Invalid Date を弾く。
+  // Webhook payloads are external; defend hard against null/NaN/Invalid Date.
+  const { sentryIssueId, title, occurrencesDelta, now } = normalizeUpsertInput(input);
 
   const values: NewApiError = {
     sentryIssueId,

--- a/server/api/src/services/apiErrorService.ts
+++ b/server/api/src/services/apiErrorService.ts
@@ -123,6 +123,7 @@ function normalizeUpsertInput(input: UpsertFromSentrySummaryInput): {
   sentryIssueId: string;
   title: string;
   occurrencesDelta: number;
+  firstSeenAt: Date;
   now: Date;
 } {
   const sentryIssueId = (input.sentryIssueId ?? "").trim();
@@ -148,7 +149,15 @@ function normalizeUpsertInput(input: UpsertFromSentrySummaryInput): {
   const rawDelta = input.occurrencesDelta ?? 1;
   const occurrencesDelta = Number.isFinite(rawDelta) ? Math.max(1, Math.floor(rawDelta)) : 1;
   const now = input.lastSeenAt ?? new Date();
-  return { sentryIssueId, title, occurrencesDelta, now };
+  const firstSeenAt = input.firstSeenAt ?? now;
+  // 単調性の不変条件: firstSeenAt <= lastSeenAt。malformed な webhook が
+  // 逆転したタイムラインを書き込むのを防ぐ。
+  // Monotonicity invariant: firstSeenAt <= lastSeenAt. Prevents a malformed
+  // webhook from persisting an inverted timeline into `api_errors`.
+  if (firstSeenAt.getTime() > now.getTime()) {
+    throw new Error("firstSeenAt must be less than or equal to lastSeenAt");
+  }
+  return { sentryIssueId, title, occurrencesDelta, firstSeenAt, now };
 }
 
 /**
@@ -167,10 +176,12 @@ function normalizeUpsertInput(input: UpsertFromSentrySummaryInput): {
  * `resolved` rows on recurrence, and **preserves `first_seen_at`** by design.
  *
  * @throws when `sentryIssueId` または `title` が空、`statusCode` が
- *   有限の整数でない、`firstSeenAt` / `lastSeenAt` が不正な Date、もしくは
- *   upsert が行を返さなかった場合。Throws on empty `sentryIssueId` /
- *   `title`, non-integer `statusCode`, Invalid Date timestamps, or when
- *   the upsert produced no row.
+ *   有限の整数でない、`firstSeenAt` / `lastSeenAt` が不正な Date、
+ *   `firstSeenAt` が `lastSeenAt` より後、もしくは upsert が行を返さなかった
+ *   場合。Throws on empty `sentryIssueId` / `title`, non-integer
+ *   `statusCode`, Invalid Date timestamps, an inverted timeline
+ *   (`firstSeenAt` later than `lastSeenAt`), or when the upsert produced
+ *   no row.
  */
 export async function upsertFromSentrySummary(
   db: Database,
@@ -178,7 +189,7 @@ export async function upsertFromSentrySummary(
 ): Promise<ApiError> {
   // Webhook 入力は外部由来。null / undefined / NaN / Invalid Date を弾く。
   // Webhook payloads are external; defend hard against null/NaN/Invalid Date.
-  const { sentryIssueId, title, occurrencesDelta, now } = normalizeUpsertInput(input);
+  const { sentryIssueId, title, occurrencesDelta, firstSeenAt, now } = normalizeUpsertInput(input);
 
   const values: NewApiError = {
     sentryIssueId,
@@ -187,7 +198,7 @@ export async function upsertFromSentrySummary(
     route: input.route ?? null,
     statusCode: input.statusCode ?? null,
     occurrences: occurrencesDelta,
-    firstSeenAt: input.firstSeenAt ?? now,
+    firstSeenAt,
     lastSeenAt: now,
     severity: input.severity ?? "unknown",
     status: "open",


### PR DESCRIPTION
## 概要

Sentry Webhook ハンドラと管理者画面向けの API エラー集約機能を実装します。`api_errors` テーブルを追加し、Sentry が検知したエラーを `sentry_issue_id` をキーに重複排除・集約します。発生回数の加算、初回観測時刻の保持、ワークフロー状態管理（open ↔ investigating ↔ resolved/ignored）を提供します。

## 変更点

- **`server/api/src/schema/apiErrors.ts`** (新規)
  - `api_errors` テーブルの Drizzle スキーマ定義
  - `ApiErrorStatus` (open/investigating/resolved/ignored) と `ApiErrorSeverity` (high/medium/low/unknown) の型定義
  - `ApiErrorSuspectedFile` インターフェース（AI 推定ファイル）
  - 3 つのインデックス定義（status + last_seen_at、severity + status、last_seen_at）

- **`server/api/src/services/apiErrorService.ts`** (新規)
  - `ALLOWED_API_ERROR_STATUS_TRANSITIONS`: 状態遷移ルール（ignored → resolved 直接遷移禁止）
  - `isValidApiErrorStatusTransition()` / `assertValidApiErrorStatusTransition()`: 遷移検証
  - `upsertFromSentrySummary()`: Sentry Webhook 用 upsert（occurrences 加算、first_seen_at 保持）
  - `listApiErrors()`: フィルタ・ページネーション対応の一覧取得
  - `getApiErrorById()` / `getApiErrorBySentryIssueId()`: 単件取得
  - `updateApiErrorStatus()`: ワークフロー状態更新（遷移検証付き）

- **`server/api/src/services/apiErrorService.test.ts`** (新規)
  - 状態遷移ルールの単体テスト（許可・禁止パターン）
  - upsert の初回 insert・再来時の occurrences 加算・first_seen_at 保持を検証
  - 一覧取得・単件取得・状態更新の振る舞いをモック DB で確認
  - 計 30+ のテストケース

- **`server/api/drizzle/0019_add_api_errors.sql`** (新規)
  - `api_errors` テーブル作成 SQL
  - `sentry_issue_id` ユニーク制約
  - 3 つのインデックス作成

- **`server/api/src/schema/index.ts`** (修正)
  - `apiErrors` テーブルと関連型をエクスポート

- **`server/api/drizzle/meta/_journal.json`** (修正)
  - マイグレーション履歴に `0019_add_api_errors` を追加

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

- 新規追加の `apiErrorService.test.ts` で状態遷移・upsert・一覧取得・単件取得・状態更新をカバー
- モック DB を使用して Postgres 起動なしに検証
- `npm run test` で全テストが通ることを確認

## チェックリスト

- [x] テストがすべてパスする（新規テスト 30+ ケース）
- [x

https://claude.ai/code/session_01Uu5RKkNr23MJGqsLjohR8e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System-wide API error tracking with occurrence counts, first/last seen timestamps, severity and workflow (open/investigating/resolved/ignored).
  * Ingestion/upsert behavior: increments occurrences, preserves first-seen, conditionally reopens resolved issues, preserves ignored state.
  * AI-assisted analysis (summaries, suspected files, root-cause hints, suggested fixes), optional GitHub linking, and list APIs with filters and clamped limits.

* **Tests**
  * Unit tests covering ingestion, validation, listing, status transitions, edge cases and concurrency.

* **Chores**
  * Database migration to add the new API errors table and supporting indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->