### PR TITLE
feat(api): repository_dispatch + AI analysis callback (#805)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -10,3 +10,15 @@
 # The TEST_TOKEN at invite.test.ts:38 is a hard-coded mock string used only for
 # invitation API unit tests — it is not a real API key or secret.
 b1e5dab7fa191b9f317b066099ca3fbb6450c5a7:server/api/src/__tests__/routes/invite.test.ts:generic-api-key:38
+
+# server/api/src/lib/githubAppAuth.test.ts:23 のコミット d10d11f に含まれる
+# RSA 秘密鍵は、PR #814 (issue #805) のテスト用に生成された使い捨ての鍵で、
+# 後続のコミット f6825d7 で `jose` モックに置き換えて削除済み。実際の署名には
+# 一度も使われていないが、Git 履歴には残るため fingerprint を追加して
+# 誤検知扱いにする。
+# The RSA private key in commit d10d11f at githubAppAuth.test.ts:23 was a
+# disposable test key generated solely for PR #814 (issue #805). The follow-up
+# commit f6825d7 replaced the JWT path with a `jose` mock and removed the key
+# from HEAD; it was never used to sign anything outside this test file. Git
+# history retains the blob, so we suppress the historical match here.
+d10d11f5fa92743bb5a8214ca5c088d7cb4b01dd:server/api/src/lib/githubAppAuth.test.ts:private-key:23

--- a/server/api/.env.example
+++ b/server/api/.env.example
@@ -4,3 +4,26 @@ SENTRY_DSN_API=
 # Sentry Internal Integration の Client Secret。`/api/webhooks/sentry` に
 # 届く `Sentry-Hook-Signature` ヘッダの HMAC-SHA256 署名検証に使う。
 SENTRY_WEBHOOK_SECRET=
+
+# GitHub App credentials for Epic #616 Phase 2 (AI error analysis).
+# - GITHUB_APP_ID: numeric App id from Settings → Developer settings → GitHub Apps.
+# - GITHUB_APP_PRIVATE_KEY: PKCS#8 PEM-formatted private key. Multi-line PEM is
+#   accepted; in `.env` files you can encode newlines as the literal `\n`.
+# - GITHUB_APP_INSTALLATION_ID: numeric installation id for the repository the
+#   App is installed on.
+# - GITHUB_DISPATCH_REPOSITORY: `owner/repo` to receive `repository_dispatch`
+#   events (typically the repository the App is installed on). When unset, the
+#   Sentry webhook skips the dispatch silently — useful while the GitHub
+#   Actions workflow is not deployed yet.
+#
+# Epic #616 Phase 2 用の GitHub App 認証情報（AI エラー解析）。
+# - GITHUB_APP_ID: GitHub App の数値 ID。
+# - GITHUB_APP_PRIVATE_KEY: PKCS#8 PEM 形式の private key（`\n` リテラル可）。
+# - GITHUB_APP_INSTALLATION_ID: インストール先リポジトリの installation ID。
+# - GITHUB_DISPATCH_REPOSITORY: `repository_dispatch` 先（`owner/repo`）。
+#   未設定時は Sentry webhook 側で dispatch をスキップする（Phase 2 の Actions
+#   が未デプロイでも API がデグレしないため）。
+GITHUB_APP_ID=
+GITHUB_APP_PRIVATE_KEY=
+GITHUB_APP_INSTALLATION_ID=
+GITHUB_DISPATCH_REPOSITORY=

--- a/server/api/src/__tests__/routes/webhooks/githubAiCallback.test.ts
+++ b/server/api/src/__tests__/routes/webhooks/githubAiCallback.test.ts
@@ -111,6 +111,41 @@ describe("PUT /api/webhooks/github/ai-result/:id", () => {
     expect(chains).toHaveLength(0);
   });
 
+  it("returns 503 when verifyInstallationToken throws (transient GitHub outage)", async () => {
+    // GitHub 側の 5xx / ネットワーク障害は 403 ではなく 503 にマップされ、
+    // workflow 側でリトライ可能であることを示す。
+    // GitHub-side outages must surface as 503 (retryable) rather than 403,
+    // so a transient outage doesn't permanently drop a valid AI result.
+    vi.resetModules();
+    await vi.doMock("../../../lib/githubAppAuth.js", async () => {
+      const actual = await vi.importActual<typeof import("../../../lib/githubAppAuth.js")>(
+        "../../../lib/githubAppAuth.js",
+      );
+      return {
+        ...actual,
+        verifyInstallationToken: async () => {
+          throw new actual.GitHubInstallationVerificationError("upstream 503");
+        },
+      };
+    });
+    const { default: routes } = await import("../../../routes/webhooks/githubAiCallback.js");
+    const { db } = createMockDb([]);
+    const app = new Hono<AppEnv>();
+    app.onError(errorHandler);
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/webhooks/github/ai-result", routes);
+
+    const res = await app.request(`/api/webhooks/github/ai-result/${VALID_UUID}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer ghs_xx" },
+      body: JSON.stringify({ severity: "high" }),
+    });
+    expect(res.status).toBe(503);
+  });
+
   it("returns 403 when verifyInstallationToken rejects the token", async () => {
     // verifyInstallationToken は外部 (GitHub) を叩くので必ずモックする。
     // Always stub verifyInstallationToken because it would otherwise hit

--- a/server/api/src/__tests__/routes/webhooks/githubAiCallback.test.ts
+++ b/server/api/src/__tests__/routes/webhooks/githubAiCallback.test.ts
@@ -248,9 +248,9 @@ describe("PUT /api/webhooks/github/ai-result/:id", () => {
     });
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { error: { id: string; severity: string } };
-    expect(body.error.id).toBe(VALID_UUID);
-    expect(body.error.severity).toBe("high");
+    const body = (await res.json()) as { data: { id: string; severity: string } };
+    expect(body.data.id).toBe(VALID_UUID);
+    expect(body.data.severity).toBe("high");
     expect(chains.filter((c) => c.startMethod === "update")).toHaveLength(1);
   });
 

--- a/server/api/src/__tests__/routes/webhooks/githubAiCallback.test.ts
+++ b/server/api/src/__tests__/routes/webhooks/githubAiCallback.test.ts
@@ -1,0 +1,285 @@
+/**
+ * `PUT /api/webhooks/github/ai-result/:id` — AI 解析結果コールバックのテスト
+ * (Epic #616 Phase 2 / sub-issue #805)。
+ *
+ * Tests for the GitHub Actions AI analysis callback. Covers:
+ * - 401: missing / malformed bearer token
+ * - 403: bearer token rejected by GitHub-side validation
+ * - 400: malformed body / invalid severity / malformed suspected files
+ * - 404: unknown id / non-UUID id
+ * - 200: successful update with AI analysis fields
+ */
+import { Hono } from "hono";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Context, Next } from "hono";
+import type { AppEnv } from "../../../types/index.js";
+
+vi.mock("../../../middleware/auth.js", () => ({
+  authRequired: async (_c: Context<AppEnv>, next: Next) => {
+    await next();
+  },
+  authOptional: async (_c: Context<AppEnv>, next: Next) => {
+    await next();
+  },
+}));
+
+import githubAiCallbackRoutes from "../../../routes/webhooks/githubAiCallback.js";
+import { errorHandler } from "../../../middleware/errorHandler.js";
+import { createMockDb } from "../notes/setup.js";
+
+const VALID_UUID = "00000000-0000-0000-0000-000000000001";
+
+/**
+ * テスト用アプリ。`dbResults` はハンドラ内のクエリ結果を順番に返す。
+ * Build a test app whose mock DB returns `dbResults` in order.
+ */
+function createApp(dbResults: unknown[]) {
+  const { db, chains } = createMockDb(dbResults);
+  const app = new Hono<AppEnv>();
+  app.onError(errorHandler);
+  app.use("*", async (c, next) => {
+    c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+    await next();
+  });
+  app.route("/api/webhooks/github/ai-result", githubAiCallbackRoutes);
+  return { app, chains };
+}
+
+/**
+ * `verifyInstallationToken` を一定の戻り値で差し替える。
+ * Stub `verifyInstallationToken` to a fixed boolean for the duration of one
+ * test. We bypass the GitHub round-trip so callback tests don't hit the
+ * network.
+ */
+function stubVerifyInstallationToken(result: boolean | (() => Promise<boolean>)) {
+  return vi.doMock("../../../lib/githubAppAuth.js", async () => {
+    const actual = await vi.importActual<typeof import("../../../lib/githubAppAuth.js")>(
+      "../../../lib/githubAppAuth.js",
+    );
+    return {
+      ...actual,
+      verifyInstallationToken: typeof result === "function" ? result : async () => result,
+    };
+  });
+}
+
+describe("PUT /api/webhooks/github/ai-result/:id", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    process.env.GITHUB_APP_ID = "123";
+    process.env.GITHUB_APP_INSTALLATION_ID = "456";
+    process.env.GITHUB_APP_PRIVATE_KEY = "stub";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    delete process.env.GITHUB_APP_ID;
+    delete process.env.GITHUB_APP_INSTALLATION_ID;
+    delete process.env.GITHUB_APP_PRIVATE_KEY;
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const { app } = createApp([]);
+    const res = await app.request(`/api/webhooks/github/ai-result/${VALID_UUID}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ severity: "high" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when Authorization header is not a Bearer token", async () => {
+    const { app } = createApp([]);
+    const res = await app.request(`/api/webhooks/github/ai-result/${VALID_UUID}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: "Token abc" },
+      body: JSON.stringify({ severity: "high" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when :id is not a valid UUID (no DB query issued)", async () => {
+    const { app, chains } = createApp([]);
+    const res = await app.request("/api/webhooks/github/ai-result/not-a-uuid", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer ghs_fake" },
+      body: JSON.stringify({ severity: "high" }),
+    });
+    expect(res.status).toBe(404);
+    expect(chains).toHaveLength(0);
+  });
+
+  it("returns 403 when verifyInstallationToken rejects the token", async () => {
+    // verifyInstallationToken は外部 (GitHub) を叩くので必ずモックする。
+    // Always stub verifyInstallationToken because it would otherwise hit
+    // GitHub. Here we simulate "GitHub said no, this token isn't ours".
+    vi.resetModules();
+    await stubVerifyInstallationToken(false);
+    const { default: routes } = await import("../../../routes/webhooks/githubAiCallback.js");
+    const { db } = createMockDb([]);
+    const app = new Hono<AppEnv>();
+    app.onError(errorHandler);
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/webhooks/github/ai-result", routes);
+
+    const res = await app.request(`/api/webhooks/github/ai-result/${VALID_UUID}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer ghs_bad" },
+      body: JSON.stringify({ severity: "high" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    vi.resetModules();
+    await stubVerifyInstallationToken(true);
+    const { default: routes } = await import("../../../routes/webhooks/githubAiCallback.js");
+    const { db } = createMockDb([]);
+    const app = new Hono<AppEnv>();
+    app.onError(errorHandler);
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/webhooks/github/ai-result", routes);
+
+    const res = await app.request(`/api/webhooks/github/ai-result/${VALID_UUID}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer ghs_ok" },
+      body: "{not-json",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body is JSON null", async () => {
+    vi.resetModules();
+    await stubVerifyInstallationToken(true);
+    const { default: routes } = await import("../../../routes/webhooks/githubAiCallback.js");
+    const { db } = createMockDb([]);
+    const app = new Hono<AppEnv>();
+    app.onError(errorHandler);
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/webhooks/github/ai-result", routes);
+
+    const res = await app.request(`/api/webhooks/github/ai-result/${VALID_UUID}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer ghs_ok" },
+      body: "null",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 and updates the row when payload is valid", async () => {
+    vi.resetModules();
+    await stubVerifyInstallationToken(true);
+    const { default: routes } = await import("../../../routes/webhooks/githubAiCallback.js");
+    const updated = {
+      id: VALID_UUID,
+      sentryIssueId: "abc",
+      severity: "high",
+      aiSummary: "ヌルポインタ参照",
+      aiSuspectedFiles: [{ path: "src/a.ts", line: 12 }],
+      aiRootCause: "X が undefined",
+      aiSuggestedFix: "guard 追加",
+    };
+    // updateAiAnalysis issues a single update chain that resolves to [row].
+    const { db, chains } = createMockDb([[updated]]);
+    const app = new Hono<AppEnv>();
+    app.onError(errorHandler);
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/webhooks/github/ai-result", routes);
+
+    const res = await app.request(`/api/webhooks/github/ai-result/${VALID_UUID}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer ghs_ok" },
+      body: JSON.stringify({
+        severity: "high",
+        ai_summary: "ヌルポインタ参照",
+        ai_suspected_files: [{ path: "src/a.ts", line: 12 }],
+        ai_root_cause: "X が undefined",
+        ai_suggested_fix: "guard 追加",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { error: { id: string; severity: string } };
+    expect(body.error.id).toBe(VALID_UUID);
+    expect(body.error.severity).toBe("high");
+    expect(chains.filter((c) => c.startMethod === "update")).toHaveLength(1);
+  });
+
+  it("returns 400 when severity is not a recognized value", async () => {
+    vi.resetModules();
+    await stubVerifyInstallationToken(true);
+    const { default: routes } = await import("../../../routes/webhooks/githubAiCallback.js");
+    const { db } = createMockDb([]);
+    const app = new Hono<AppEnv>();
+    app.onError(errorHandler);
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/webhooks/github/ai-result", routes);
+
+    const res = await app.request(`/api/webhooks/github/ai-result/${VALID_UUID}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer ghs_ok" },
+      body: JSON.stringify({ severity: "garbage" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when ai_suspected_files is not an array of objects with .path", async () => {
+    vi.resetModules();
+    await stubVerifyInstallationToken(true);
+    const { default: routes } = await import("../../../routes/webhooks/githubAiCallback.js");
+    const { db } = createMockDb([]);
+    const app = new Hono<AppEnv>();
+    app.onError(errorHandler);
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/webhooks/github/ai-result", routes);
+
+    const res = await app.request(`/api/webhooks/github/ai-result/${VALID_UUID}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer ghs_ok" },
+      body: JSON.stringify({ ai_suspected_files: [{ noPath: true }] }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the row does not exist", async () => {
+    vi.resetModules();
+    await stubVerifyInstallationToken(true);
+    const { default: routes } = await import("../../../routes/webhooks/githubAiCallback.js");
+    // updateAiAnalysis returns null when the UPDATE returns no rows.
+    const { db } = createMockDb([[]]);
+    const app = new Hono<AppEnv>();
+    app.onError(errorHandler);
+    app.use("*", async (c, next) => {
+      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+      await next();
+    });
+    app.route("/api/webhooks/github/ai-result", routes);
+
+    const res = await app.request(`/api/webhooks/github/ai-result/${VALID_UUID}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer ghs_ok" },
+      body: JSON.stringify({ severity: "high" }),
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/api/src/__tests__/routes/webhooks/sentry.test.ts
+++ b/server/api/src/__tests__/routes/webhooks/sentry.test.ts
@@ -179,15 +179,25 @@ describe("extractSentrySummary", () => {
 
 describe("POST /api/webhooks/sentry", () => {
   const ORIGINAL_ENV = process.env.SENTRY_WEBHOOK_SECRET;
+  const ORIGINAL_DISPATCH_REPO = process.env.GITHUB_DISPATCH_REPOSITORY;
 
   beforeEach(() => {
     process.env.SENTRY_WEBHOOK_SECRET = TEST_SECRET;
+    // Issue #805 のテストでは repository_dispatch が外部に飛ばないようにする。
+    // Keep `GITHUB_DISPATCH_REPOSITORY` unset so the dispatch helper short-
+    // circuits — we don't want fire-and-forget tasks reaching out to GitHub.
+    delete process.env.GITHUB_DISPATCH_REPOSITORY;
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.spyOn(console, "log").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     process.env.SENTRY_WEBHOOK_SECRET = ORIGINAL_ENV;
+    if (ORIGINAL_DISPATCH_REPO === undefined) {
+      delete process.env.GITHUB_DISPATCH_REPOSITORY;
+    } else {
+      process.env.GITHUB_DISPATCH_REPOSITORY = ORIGINAL_DISPATCH_REPO;
+    }
     vi.restoreAllMocks();
   });
 
@@ -197,8 +207,9 @@ describe("POST /api/webhooks/sentry", () => {
       sentryIssueId: "abc-123",
       occurrences: 1,
     };
-    // upsertFromSentrySummary issues a single insert chain that resolves to [row].
-    const { app, chains } = createApp([[upsertedRow]]);
+    // First chain: getApiErrorBySentryIssueId returns no existing row (isNew=true).
+    // Second chain: upsertFromSentrySummary returns the inserted row.
+    const { app, chains } = createApp([[], [upsertedRow]]);
     const body = JSON.stringify({
       action: "created",
       data: {
@@ -228,6 +239,78 @@ describe("POST /api/webhooks/sentry", () => {
     // The handler issued exactly one insert chain.
     const insertChains = chains.filter((c) => c.startMethod === "insert");
     expect(insertChains).toHaveLength(1);
+  });
+
+  it("logs and skips repository_dispatch when GITHUB_DISPATCH_REPOSITORY is unset (isNew=true)", async () => {
+    // 受け入れ条件: Actions 側未デプロイでも API がデグレしない。
+    // Issue #805 acceptance criterion: the API must not degrade when the
+    // Actions-side workflow is not deployed yet. We assert that on a fresh
+    // issue, with no dispatch repository configured, the handler still
+    // returns 200 and logs a deliberate skip.
+    delete process.env.GITHUB_DISPATCH_REPOSITORY;
+
+    const upsertedRow = {
+      id: "00000000-0000-0000-0000-0000000000bb",
+      sentryIssueId: "fresh-1",
+      title: "fresh issue",
+      route: null,
+      occurrences: 1,
+    };
+    const { app } = createApp([[], [upsertedRow]]);
+    const body = JSON.stringify({
+      data: { issue: { id: "fresh-1", title: "fresh issue" } },
+    });
+
+    const res = await app.request("/api/webhooks/sentry", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "sentry-hook-signature": sign(body),
+      },
+      body,
+    });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 0));
+    // We log "isNew=true" on the success line and a separate skip line for
+    // the dispatch — both go through `console.log`. Ensure no error path
+    // fired (the helper doesn't throw when the dispatch repo is unset).
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire repository_dispatch on a recurrence (isNew=false)", async () => {
+    process.env.GITHUB_DISPATCH_REPOSITORY = "owner/repo";
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const existingRow = {
+      id: "00000000-0000-0000-0000-0000000000cc",
+      sentryIssueId: "recur-1",
+      title: "recurrence",
+      route: null,
+      occurrences: 5,
+    };
+    const upserted = { ...existingRow, occurrences: 6 };
+    // First SELECT returns the existing row → isNew=false → no dispatch.
+    const { app } = createApp([[existingRow], [upserted]]);
+    const body = JSON.stringify({
+      data: { issue: { id: "recur-1", title: "recurrence" } },
+    });
+
+    const res = await app.request("/api/webhooks/sentry", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "sentry-hook-signature": sign(body),
+      },
+      body,
+    });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 0));
+    // No GitHub fetch should have happened: the dispatch path was skipped.
+    expect(fetchMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
   });
 
   it("returns 403 when signature is missing", async () => {

--- a/server/api/src/app.ts
+++ b/server/api/src/app.ts
@@ -35,6 +35,7 @@ import thumbCommitRoutes from "./routes/thumbnail/commit.js";
 import thumbServeRoutes from "./routes/thumbnail/serve.js";
 import webhookPolarRoutes from "./routes/webhooks/polar.js";
 import webhookSentryRoutes from "./routes/webhooks/sentry.js";
+import webhookGithubAiCallbackRoutes from "./routes/webhooks/githubAiCallback.js";
 import checkoutRoutes from "./routes/checkout.js";
 import subscriptionManageRoutes from "./routes/subscriptionManage.js";
 import lintRoutes from "./routes/lint.js";
@@ -102,6 +103,16 @@ export function createApp(): Hono<AppEnv> {
   // Sentry Internal Integration webhook (HMAC-SHA256 via Client Secret)
   // Sentry Internal Integration の webhook（Client Secret による HMAC 署名検証）
   app.route("/api/webhooks/sentry", webhookSentryRoutes);
+
+  // GitHub Actions AI 解析結果コールバック (Epic #616 Phase 2 / issue #805)
+  // GitHub App の installation token を Authorization ヘッダで受け取り、
+  // GitHub API 越しに検証してから `api_errors` 行に AI 解析結果を書き戻す。
+  //
+  // GitHub Actions AI analysis callback (Epic #616 Phase 2 / issue #805).
+  // Authentication: GitHub App installation tokens validated via the GitHub
+  // API. Mounted outside the admin gate because the workflow has no user
+  // session.
+  app.route("/api/webhooks/github/ai-result", webhookGithubAiCallbackRoutes);
 
   // Checkout & Customer Portal
   app.route("/api", checkoutRoutes);

--- a/server/api/src/lib/githubAppAuth.test.ts
+++ b/server/api/src/lib/githubAppAuth.test.ts
@@ -56,6 +56,7 @@ vi.mock("jose", () => {
 
 import {
   __resetInstallationTokenCacheForTests,
+  GitHubInstallationVerificationError,
   getInstallationToken,
   readDispatchRepository,
   triggerRepositoryDispatch,
@@ -236,16 +237,53 @@ describe("verifyInstallationToken", () => {
     expect(await verifyInstallationToken("ghs_other_install")).toBe(false);
   });
 
-  it("returns false when GitHub returns non-2xx", async () => {
+  it("returns false on a definitive 401 (auth failure)", async () => {
     const fetchMock = vi.fn(async () => new Response("unauthorized", { status: 401 }));
     vi.stubGlobal("fetch", fetchMock);
     expect(await verifyInstallationToken("ghs_bad")).toBe(false);
   });
 
-  it("returns false when response body is malformed", async () => {
+  it("returns false on 403 / 404 (auth failure)", async () => {
+    for (const status of [403, 404]) {
+      const fetchMock = vi.fn(async () => new Response("nope", { status }));
+      vi.stubGlobal("fetch", fetchMock);
+      expect(await verifyInstallationToken("ghs_bad")).toBe(false);
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("throws GitHubInstallationVerificationError on 5xx (transient outage)", async () => {
+    // 5xx は GitHub 側の障害なので 403 (false) ではなく throw して、
+    // 呼び出し側で 503 リトライ可能としてマップさせる。
+    // 5xx is GitHub-side trouble: callback layer maps a thrown error to 503
+    // (retryable) rather than dropping a valid AI result as a permanent 403.
+    const fetchMock = vi.fn(async () => new Response("upstream broke", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(verifyInstallationToken("ghs_unknown")).rejects.toBeInstanceOf(
+      GitHubInstallationVerificationError,
+    );
+  });
+
+  it("throws GitHubInstallationVerificationError on network error", async () => {
+    // ネットワーク障害も transient 扱い。
+    // Network errors are transient too.
+    const fetchMock = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(verifyInstallationToken("ghs_unknown")).rejects.toBeInstanceOf(
+      GitHubInstallationVerificationError,
+    );
+  });
+
+  it("throws GitHubInstallationVerificationError when 200 body is malformed JSON", async () => {
+    // 200 で壊れた body を返すのは GitHub 側の異常 → transient 扱い。
+    // A 200 with malformed JSON is a GitHub anomaly; don't paper over it as auth failure.
     const fetchMock = vi.fn(async () => new Response("not-json", { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
-    expect(await verifyInstallationToken("ghs_garbled")).toBe(false);
+    await expect(verifyInstallationToken("ghs_garbled")).rejects.toBeInstanceOf(
+      GitHubInstallationVerificationError,
+    );
   });
 
   it("returns false when the response omits the id field", async () => {

--- a/server/api/src/lib/githubAppAuth.test.ts
+++ b/server/api/src/lib/githubAppAuth.test.ts
@@ -4,50 +4,63 @@
  * - `readDispatchRepository`: env 解析（owner/repo, 未設定, 不正値）
  * - `getInstallationToken`: モック fetch 越しのキャッシュ挙動
  * - `triggerRepositoryDispatch`: 設定欠落時のエラーと正常時のリクエスト形状
+ * - `verifyInstallationToken`: GET /installation 経由の id 比較
  *
  * Unit tests for `githubAppAuth`. Network calls are mocked by stubbing the
  * global `fetch`, and the in-module token cache is reset between tests via
  * the exported `__resetInstallationTokenCacheForTests` helper so each test
- * starts from a deterministic state.
+ * starts from a deterministic state. The JWT-signing path (`createAppJWT`)
+ * is mocked at the `jose` boundary so the test suite does not need to ship
+ * a real RSA private key (which would trip secret-scanners like gitleaks).
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// `jose` の RS256 署名は実鍵を要求するが、テストでは JWT の中身も署名検証も
+// しないので、`importPKCS8` / `SignJWT` ともに固定の文字列を返すモックに置き換える。
+// これによりテスト用の PEM をリポジトリに置く必要がなくなり、gitleaks 等の
+// 秘密情報スキャナでの誤検知も避けられる。
+//
+// Mock `jose` at the boundary so JWT minting becomes deterministic without a
+// real private key. The tests don't actually verify the signature; they only
+// care that the install-token fetch happens with `Bearer <something>`. Avoiding
+// a real PEM also keeps gitleaks/secret-scanners quiet on this test file.
+vi.mock("jose", () => {
+  // `new SignJWT()` を `new` で呼ぶので、コンストラクタ可能なクラスを返す。
+  // vi.fn().mockImplementation(...) は constructor として動かないため、
+  // 素のクラスにフルチェーンの no-op メソッドを生やす。
+  // `SignJWT` is invoked with `new`, so we expose a real constructible class.
+  // `vi.fn().mockImplementation(...)` is not constructible in vitest, so we
+  // hand-roll the chainable no-op surface that `createAppJWT` walks through.
+  class MockSignJWT {
+    setProtectedHeader(): this {
+      return this;
+    }
+    setIssuedAt(): this {
+      return this;
+    }
+    setIssuer(): this {
+      return this;
+    }
+    setExpirationTime(): this {
+      return this;
+    }
+    async sign(): Promise<string> {
+      return "mock.app.jwt";
+    }
+  }
+  return {
+    importPKCS8: async () => "mock-key" as unknown,
+    SignJWT: MockSignJWT,
+  };
+});
+
 import {
   __resetInstallationTokenCacheForTests,
   getInstallationToken,
   readDispatchRepository,
   triggerRepositoryDispatch,
+  verifyInstallationToken,
 } from "./githubAppAuth.js";
-
-// テスト用 PEM。RSA 2048 bit, PKCS#8。テスト中だけ使う使い捨て鍵。
-// Disposable RSA-2048 PKCS#8 PEM used only during tests; do not reuse outside.
-const TEST_PRIVATE_KEY_PEM = `-----BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7VJTUt9Us8cKj
-MzEfYyjiWA4R4/M2bS1GB4t7NXp98C3SC6dVMvDuictGeurT8jNbvJZHtCSuYEvu
-NMoSfm76oqFvAp8Gy0iz5sxjZmSnXyCdPEovGhLa0VzMaQ8s+CLOyS56YyCFGeJZ
-qgtzJ6GR3eqoYSW9b9UMvkBpZODSctWSNGj3P7jRFDO5VoTwCQAWbFnOjDfH5Ulg
-p2PKSQnSJP3AJLQNFNe7br1XbrhV//eO+t51mIpGSDCUv3E0DDFcWDTH9cXDTTlR
-ZVEiR2BwpZOOkE/Z0/BVnhZYL71oZV34bKfWjQIt6V/isSMahdsAASACp4ZTGtwi
-VuNd9tybAgMBAAECggEAVc0HhJ/KJHfhjkEMKE5sROhntQWuXp42rEcwKZ3os3VR
-1BjzjXQdKp+UROBYOQGcGmCD78vMLbn78Yh+RCv8UAJZzAlVf8eEfQoTxxojTLmZ
-i2I7GpghKIjDyQAyOAWmZN8Qp8Hz/fVPMcG8h2PTPhFxQgjJB7hFfcJsXtv6zIag
-v+KeoESNKf9xmH5o5WLyNaRBJ1DK9Cmt5nYyy+8ftXnQq8HppOPK9pYr3W9XTHjF
-DtAZyAkKddF80z3YA6NWyEWh/gZ9GDtDCxWoVI1JqDQK1Y3i9lNGvExTrEefbJQF
-yCyDRbHPwkydL7Gd4gPjbXhccYKHZUpyqd87fc0poQKBgQDzh+oyrA4F84pq5zMm
-4jSUZbZbjp4hZAkVbB6AZAnK8O1mTcDrcjZIQ1adnaCPgaBjsnBdVMdq+zAdEN/J
-2RFpPN4n4HpvXSTxe/hEIxQv0v0XhvhmM8XNumC+4Vbkfsy6Pg8+L65GFy+k88iV
-DpcvGvUySMl9+9R26YNrAwsUGwKBgQDFL/ZvT2XTQkcoGY9P36Yta4S3W3i/VW5e
-38IBHNm7zb+sDGw1DsWGSKM4DtxP3R0+cElrEzSx0ICZQJ9tjROvKRC2Chx0HaJj
-SDOhhsC4MBoqTGz7WKU5HxgY5p0iOcvjFjnIrG3lCt5ZBaVSeKpPtJzZb5hzOpLs
-n9cs/rWlIQKBgF4dC/6cFqLPgxvSwNQ4EMjPSBtoHchhkIs2DOxx9DK/cFFcxjyy
-T+wpXnk3SwvuO5BgaUbgxIzIvjNiR8+LYpRtcM37LcGE//MJ4qfIz3fBXewEoP3x
-MEkXSTmNqCcLgC4S7gHfzAVf/oREEa6fewd2u7qdGYOSpRy7p8yEsVxJAoGADUcS
-wMrtrA8zumlPv+EgQbbg2lI7TCmVH1fWLAFb1cSTWeAmLfXCmsM1ZYlW4aS4z+lU
-LbmZPeAlhJMuFcQ/r0POqRAUgUaJv+nlNVWmokbywCsBoEY/5cXhPo2eJ6FYY9FJ
-SVxKb3tzq4IHpf4F8WJwO8z4i9Lq0UZ3dTLi8EECgYEA0wAEh4+AVGbg4kGVU9YJ
-cyaXdoxe8yflsi05F8R5OLUjgbXfKOZRDgxWJyqNFwGsVOQ8b5AszqM9+jRkEWj/
-UqWjVzsAiv5uRnDrBJSIIz8ymdQ9y5NfZf/9dnjV7Fs2xFLLqo7w6Kn2KbWA5J5b
-PhBSjz2eOhevAQrpvqdYvUw=
------END PRIVATE KEY-----`;
 
 describe("readDispatchRepository", () => {
   const ORIGINAL = process.env.GITHUB_DISPATCH_REPOSITORY;
@@ -82,7 +95,9 @@ describe("getInstallationToken / triggerRepositoryDispatch", () => {
     __resetInstallationTokenCacheForTests();
     process.env.GITHUB_APP_ID = "12345";
     process.env.GITHUB_APP_INSTALLATION_ID = "67890";
-    process.env.GITHUB_APP_PRIVATE_KEY = TEST_PRIVATE_KEY_PEM;
+    // 実鍵は不要 — `jose` をモック済みなので任意の文字列で OK。
+    // No real key needed; `jose` is mocked above so any non-empty string passes.
+    process.env.GITHUB_APP_PRIVATE_KEY = "mocked-not-a-real-key";
   });
 
   afterEach(() => {
@@ -111,6 +126,7 @@ describe("getInstallationToken / triggerRepositoryDispatch", () => {
     const t2 = await getInstallationToken();
     expect(t1).toBe("ghs_install_token_abc");
     expect(t2).toBe(t1);
+    // キャッシュ済み: 2 回呼んでもネットワーク往復は 1 回だけ。
     // Cached: only one network call, despite two callers.
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
@@ -139,6 +155,7 @@ describe("getInstallationToken / triggerRepositoryDispatch", () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
       calls.push({ url, init });
+      // 1 回目: installation token 取得。2 回目: dispatch 本体。
       // First call: installation token. Second call: dispatch.
       if (url.includes("/access_tokens")) {
         return new Response(
@@ -167,5 +184,79 @@ describe("getInstallationToken / triggerRepositoryDispatch", () => {
     const sentBody = JSON.parse(String(calls[1]?.init?.body));
     expect(sentBody.event_type).toBe("analyze-error");
     expect(sentBody.client_payload).toEqual({ api_error_id: "abc" });
+  });
+});
+
+describe("verifyInstallationToken", () => {
+  beforeEach(() => {
+    process.env.GITHUB_APP_ID = "12345";
+    process.env.GITHUB_APP_INSTALLATION_ID = "67890";
+    process.env.GITHUB_APP_PRIVATE_KEY = "mocked-not-a-real-key";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.GITHUB_APP_ID;
+    delete process.env.GITHUB_APP_INSTALLATION_ID;
+    delete process.env.GITHUB_APP_PRIVATE_KEY;
+  });
+
+  it("returns false for an empty token without hitting GitHub", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await verifyInstallationToken("")).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns true when GET /installation returns the matching installation id", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      expect(url).toBe("https://api.github.com/installation");
+      return new Response(JSON.stringify({ id: 67890 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await verifyInstallationToken("ghs_ok")).toBe(true);
+  });
+
+  it("returns false when GET /installation returns a different installation id", async () => {
+    // セキュリティ重要: 別のインストールから盗まれた token をはじく。
+    // Security-critical: a token minted for a *different* installation of the
+    // same App must not authenticate against ours.
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ id: 99999 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await verifyInstallationToken("ghs_other_install")).toBe(false);
+  });
+
+  it("returns false when GitHub returns non-2xx", async () => {
+    const fetchMock = vi.fn(async () => new Response("unauthorized", { status: 401 }));
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await verifyInstallationToken("ghs_bad")).toBe(false);
+  });
+
+  it("returns false when response body is malformed", async () => {
+    const fetchMock = vi.fn(async () => new Response("not-json", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await verifyInstallationToken("ghs_garbled")).toBe(false);
+  });
+
+  it("returns false when the response omits the id field", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ account: { login: "x" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await verifyInstallationToken("ghs_no_id")).toBe(false);
   });
 });

--- a/server/api/src/lib/githubAppAuth.test.ts
+++ b/server/api/src/lib/githubAppAuth.test.ts
@@ -1,0 +1,171 @@
+/**
+ * `githubAppAuth` の単体テスト (Epic #616 Phase 2 / sub-issue #805)。
+ *
+ * - `readDispatchRepository`: env 解析（owner/repo, 未設定, 不正値）
+ * - `getInstallationToken`: モック fetch 越しのキャッシュ挙動
+ * - `triggerRepositoryDispatch`: 設定欠落時のエラーと正常時のリクエスト形状
+ *
+ * Unit tests for `githubAppAuth`. Network calls are mocked by stubbing the
+ * global `fetch`, and the in-module token cache is reset between tests via
+ * the exported `__resetInstallationTokenCacheForTests` helper so each test
+ * starts from a deterministic state.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  __resetInstallationTokenCacheForTests,
+  getInstallationToken,
+  readDispatchRepository,
+  triggerRepositoryDispatch,
+} from "./githubAppAuth.js";
+
+// テスト用 PEM。RSA 2048 bit, PKCS#8。テスト中だけ使う使い捨て鍵。
+// Disposable RSA-2048 PKCS#8 PEM used only during tests; do not reuse outside.
+const TEST_PRIVATE_KEY_PEM = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7VJTUt9Us8cKj
+MzEfYyjiWA4R4/M2bS1GB4t7NXp98C3SC6dVMvDuictGeurT8jNbvJZHtCSuYEvu
+NMoSfm76oqFvAp8Gy0iz5sxjZmSnXyCdPEovGhLa0VzMaQ8s+CLOyS56YyCFGeJZ
+qgtzJ6GR3eqoYSW9b9UMvkBpZODSctWSNGj3P7jRFDO5VoTwCQAWbFnOjDfH5Ulg
+p2PKSQnSJP3AJLQNFNe7br1XbrhV//eO+t51mIpGSDCUv3E0DDFcWDTH9cXDTTlR
+ZVEiR2BwpZOOkE/Z0/BVnhZYL71oZV34bKfWjQIt6V/isSMahdsAASACp4ZTGtwi
+VuNd9tybAgMBAAECggEAVc0HhJ/KJHfhjkEMKE5sROhntQWuXp42rEcwKZ3os3VR
+1BjzjXQdKp+UROBYOQGcGmCD78vMLbn78Yh+RCv8UAJZzAlVf8eEfQoTxxojTLmZ
+i2I7GpghKIjDyQAyOAWmZN8Qp8Hz/fVPMcG8h2PTPhFxQgjJB7hFfcJsXtv6zIag
+v+KeoESNKf9xmH5o5WLyNaRBJ1DK9Cmt5nYyy+8ftXnQq8HppOPK9pYr3W9XTHjF
+DtAZyAkKddF80z3YA6NWyEWh/gZ9GDtDCxWoVI1JqDQK1Y3i9lNGvExTrEefbJQF
+yCyDRbHPwkydL7Gd4gPjbXhccYKHZUpyqd87fc0poQKBgQDzh+oyrA4F84pq5zMm
+4jSUZbZbjp4hZAkVbB6AZAnK8O1mTcDrcjZIQ1adnaCPgaBjsnBdVMdq+zAdEN/J
+2RFpPN4n4HpvXSTxe/hEIxQv0v0XhvhmM8XNumC+4Vbkfsy6Pg8+L65GFy+k88iV
+DpcvGvUySMl9+9R26YNrAwsUGwKBgQDFL/ZvT2XTQkcoGY9P36Yta4S3W3i/VW5e
+38IBHNm7zb+sDGw1DsWGSKM4DtxP3R0+cElrEzSx0ICZQJ9tjROvKRC2Chx0HaJj
+SDOhhsC4MBoqTGz7WKU5HxgY5p0iOcvjFjnIrG3lCt5ZBaVSeKpPtJzZb5hzOpLs
+n9cs/rWlIQKBgF4dC/6cFqLPgxvSwNQ4EMjPSBtoHchhkIs2DOxx9DK/cFFcxjyy
+T+wpXnk3SwvuO5BgaUbgxIzIvjNiR8+LYpRtcM37LcGE//MJ4qfIz3fBXewEoP3x
+MEkXSTmNqCcLgC4S7gHfzAVf/oREEa6fewd2u7qdGYOSpRy7p8yEsVxJAoGADUcS
+wMrtrA8zumlPv+EgQbbg2lI7TCmVH1fWLAFb1cSTWeAmLfXCmsM1ZYlW4aS4z+lU
+LbmZPeAlhJMuFcQ/r0POqRAUgUaJv+nlNVWmokbywCsBoEY/5cXhPo2eJ6FYY9FJ
+SVxKb3tzq4IHpf4F8WJwO8z4i9Lq0UZ3dTLi8EECgYEA0wAEh4+AVGbg4kGVU9YJ
+cyaXdoxe8yflsi05F8R5OLUjgbXfKOZRDgxWJyqNFwGsVOQ8b5AszqM9+jRkEWj/
+UqWjVzsAiv5uRnDrBJSIIz8ymdQ9y5NfZf/9dnjV7Fs2xFLLqo7w6Kn2KbWA5J5b
+PhBSjz2eOhevAQrpvqdYvUw=
+-----END PRIVATE KEY-----`;
+
+describe("readDispatchRepository", () => {
+  const ORIGINAL = process.env.GITHUB_DISPATCH_REPOSITORY;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.GITHUB_DISPATCH_REPOSITORY;
+    else process.env.GITHUB_DISPATCH_REPOSITORY = ORIGINAL;
+  });
+
+  it("returns null when env is unset", () => {
+    delete process.env.GITHUB_DISPATCH_REPOSITORY;
+    expect(readDispatchRepository()).toBeNull();
+  });
+
+  it("returns null when env is empty / blank", () => {
+    process.env.GITHUB_DISPATCH_REPOSITORY = "   ";
+    expect(readDispatchRepository()).toBeNull();
+  });
+
+  it("returns null when the value is not in owner/repo form", () => {
+    process.env.GITHUB_DISPATCH_REPOSITORY = "owner-only";
+    expect(readDispatchRepository()).toBeNull();
+  });
+
+  it("parses owner/repo into structured form", () => {
+    process.env.GITHUB_DISPATCH_REPOSITORY = "otomatty/zedi";
+    expect(readDispatchRepository()).toEqual({ owner: "otomatty", repo: "zedi" });
+  });
+});
+
+describe("getInstallationToken / triggerRepositoryDispatch", () => {
+  beforeEach(() => {
+    __resetInstallationTokenCacheForTests();
+    process.env.GITHUB_APP_ID = "12345";
+    process.env.GITHUB_APP_INSTALLATION_ID = "67890";
+    process.env.GITHUB_APP_PRIVATE_KEY = TEST_PRIVATE_KEY_PEM;
+  });
+
+  afterEach(() => {
+    __resetInstallationTokenCacheForTests();
+    vi.unstubAllGlobals();
+    delete process.env.GITHUB_APP_ID;
+    delete process.env.GITHUB_APP_INSTALLATION_ID;
+    delete process.env.GITHUB_APP_PRIVATE_KEY;
+    delete process.env.GITHUB_DISPATCH_REPOSITORY;
+  });
+
+  it("fetches an installation token and caches it across calls", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            token: "ghs_install_token_abc",
+            expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const t1 = await getInstallationToken();
+    const t2 = await getInstallationToken();
+    expect(t1).toBe("ghs_install_token_abc");
+    expect(t2).toBe(t1);
+    // Cached: only one network call, despite two callers.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when GitHub returns non-2xx", async () => {
+    const fetchMock = vi.fn(async () => new Response("nope", { status: 401 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(getInstallationToken()).rejects.toThrow(/401/);
+  });
+
+  it("throws when GitHub response body is missing token / expires_at", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({}), { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(getInstallationToken()).rejects.toThrow(/missing token/i);
+  });
+
+  it("triggerRepositoryDispatch throws when GITHUB_DISPATCH_REPOSITORY is unset and no override given", async () => {
+    delete process.env.GITHUB_DISPATCH_REPOSITORY;
+    await expect(triggerRepositoryDispatch({ eventType: "x", clientPayload: {} })).rejects.toThrow(
+      /GITHUB_DISPATCH_REPOSITORY is not configured/,
+    );
+  });
+
+  it("triggerRepositoryDispatch posts to /repos/:owner/:repo/dispatches with the bearer token", async () => {
+    const calls: { url: string; init?: RequestInit }[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      calls.push({ url, init });
+      // First call: installation token. Second call: dispatch.
+      if (url.includes("/access_tokens")) {
+        return new Response(
+          JSON.stringify({
+            token: "ghs_X",
+            expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await triggerRepositoryDispatch({
+      eventType: "analyze-error",
+      clientPayload: { api_error_id: "abc" },
+      owner: "otomatty",
+      repo: "zedi",
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1]?.url).toBe("https://api.github.com/repos/otomatty/zedi/dispatches");
+    const auth = (calls[1]?.init?.headers as Record<string, string>)?.Authorization;
+    expect(auth).toBe("Bearer ghs_X");
+    const sentBody = JSON.parse(String(calls[1]?.init?.body));
+    expect(sentBody.event_type).toBe("analyze-error");
+    expect(sentBody.client_payload).toEqual({ api_error_id: "abc" });
+  });
+});

--- a/server/api/src/lib/githubAppAuth.ts
+++ b/server/api/src/lib/githubAppAuth.ts
@@ -224,17 +224,21 @@ export async function triggerRepositoryDispatch(input: {
 /**
  * 受信した installation token を GitHub 側で検証する。
  *
- * GitHub の installation token は不透明文字列（`ghs_...`）なので、ローカル検証は
- * できない。`GET /installation/repositories` を当該 token で呼び、200 が返り、
- * かつ `installation.id` が当アプリの `GITHUB_APP_INSTALLATION_ID` と一致する場合
- * のみ有効と判定する。タイムアウトは 5 秒に短く設定し、コールバック側を遅延させない。
+ * GitHub の installation token は不透明文字列（`ghs_...`）なのでローカル検証は
+ * できない。`GET /installation` を当該 token で呼ぶと、その installation 自身の
+ * メタデータ（`id` を含む）が返るので、`id` を `GITHUB_APP_INSTALLATION_ID`
+ * と比較して一致した場合のみ有効と判定する。これにより別のインストールから
+ * 盗まれた token をなりすましに使われることを防ぐ。タイムアウトは 5 秒に短く
+ * 設定し、コールバック側を遅延させない。
  *
  * Validate an inbound installation access token. GitHub installation tokens are
- * opaque (`ghs_...`), so we round-trip to GitHub: hit
- * `GET /installation/repositories` with the token, accept 200, and require the
- * returned `installation.id` to match our `GITHUB_APP_INSTALLATION_ID` so a
- * stolen token from a different installation cannot impersonate ours. Times
- * out at 5 s to keep the callback path responsive.
+ * opaque (`ghs_...`), so we round-trip to GitHub: hit `GET /installation`,
+ * which returns the installation's own metadata (including `id`), and require
+ * the returned id to equal our configured `GITHUB_APP_INSTALLATION_ID`. This
+ * blocks tokens minted for any *other* installation of the same App from
+ * impersonating ours. Times out at 5 s to keep the callback path responsive.
+ *
+ * @see https://docs.github.com/en/rest/apps/installations#get-an-installation-for-the-authenticated-app
  */
 export async function verifyInstallationToken(token: string): Promise<boolean> {
   if (!token) return false;
@@ -242,7 +246,7 @@ export async function verifyInstallationToken(token: string): Promise<boolean> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 5_000);
   try {
-    const res = await fetch(`${GITHUB_API_BASE}/installation/repositories?per_page=1`, {
+    const res = await fetch(`${GITHUB_API_BASE}/installation`, {
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: GITHUB_ACCEPT,
@@ -252,23 +256,16 @@ export async function verifyInstallationToken(token: string): Promise<boolean> {
       signal: controller.signal,
     });
     if (!res.ok) return false;
-    const json = (await res.json().catch(() => null)) as {
-      total_count?: unknown;
-      repositories?: unknown;
-    } | null;
+    const json = (await res.json().catch(() => null)) as { id?: unknown } | null;
     if (!json) return false;
-    // GitHub returns the installation id only via the `installation` field on
-    // some endpoints. `/installation/repositories` does not echo it, so we
-    // additionally call `/installation` via the token to confirm the binding.
-    // Simpler: reconcile by header `x-github-installation-id` when provided,
-    // otherwise rely on the App-id-bound listing matching our installation.
-    const headerId = res.headers.get("x-github-installation-id");
-    if (headerId !== null) {
-      return headerId === installationId;
-    }
-    // Fallback: the listing succeeded under our App private key's installation,
-    // so accept the token. (We've already verified our App config matches.)
-    return true;
+    // `id` は数値で返るので文字列比較できるよう正規化する。env 側は文字列なので、
+    // 両側を文字列に揃えて比較しないと `123 === "123"` が常に false になり、
+    // 検証が常に失敗側へフェイルクローズしてしまう。
+    // GitHub returns `id` as a number; normalize to string for comparison
+    // against the env-string `installationId`. Without this, `123 === "123"`
+    // would always be false and verification would silently fail closed.
+    const idStr = typeof json.id === "number" || typeof json.id === "string" ? String(json.id) : "";
+    return idStr.length > 0 && idStr === installationId;
   } catch {
     return false;
   } finally {

--- a/server/api/src/lib/githubAppAuth.ts
+++ b/server/api/src/lib/githubAppAuth.ts
@@ -1,0 +1,277 @@
+/**
+ * GitHub App 認証ヘルパー（Epic #616 Phase 2 / Sub-issue #805）。
+ *
+ * - GitHub App の private key で App JWT (RS256) を発行し、
+ *   `POST /app/installations/{id}/access_tokens` で installation access token を取得する。
+ * - 取得した token は短命（既定 1 時間）なのでメモリにキャッシュし、
+ *   有効期限 60 秒前に切れる前に再取得する。
+ * - `triggerRepositoryDispatch` は `repository_dispatch` を fire-and-forget で発火する。
+ * - `verifyInstallationToken` は届いた installation token を GitHub API 越しに検証し、
+ *   それが当アプリのインストール (`GITHUB_APP_INSTALLATION_ID`) のものかを確認する。
+ *
+ * GitHub App authentication helpers (Epic #616 Phase 2 / sub-issue #805).
+ *
+ * - Mints an App JWT (RS256) from the configured private key, then exchanges
+ *   it for an installation access token via
+ *   `POST /app/installations/{id}/access_tokens`.
+ * - Caches the resulting installation token in memory and refreshes 60 s
+ *   before expiry to avoid stampede on every dispatch.
+ * - `triggerRepositoryDispatch` fires a `repository_dispatch` event without
+ *   awaiting the response on the user-visible path (errors are logged).
+ * - `verifyInstallationToken` validates inbound installation tokens by calling
+ *   GitHub and confirms the token's `installation.id` matches our configured
+ *   `GITHUB_APP_INSTALLATION_ID`.
+ *
+ * @see https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app
+ * @see https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
+ * @see https://github.com/otomatty/zedi/issues/616
+ * @see https://github.com/otomatty/zedi/issues/805
+ */
+import { SignJWT, importPKCS8 } from "jose";
+
+const GITHUB_API_BASE = "https://api.github.com";
+const GITHUB_API_VERSION = "2022-11-28";
+const GITHUB_ACCEPT = "application/vnd.github+json";
+const USER_AGENT = "zedi-api-github-app";
+
+/**
+ * App JWT の有効期間（秒）。GitHub の上限は 10 分なので余裕を見て 9 分に設定する。
+ * Lifetime of an App JWT in seconds. GitHub caps at 10 minutes; we use 9 to
+ * tolerate small clock skew between this server and GitHub.
+ */
+const APP_JWT_TTL_SEC = 9 * 60;
+
+/**
+ * Installation token の早期更新マージン（ms）。期限直前のリクエストで 401 を
+ * 食らわないよう、この秒数だけ手前で再取得する。
+ *
+ * Refresh window (ms) before an installation token's actual `expires_at`. We
+ * rotate this much earlier to avoid racing GitHub's expiry boundary on a
+ * dispatch call that lands right at the cliff.
+ */
+const REFRESH_MARGIN_MS = 60_000;
+
+interface CachedInstallationToken {
+  token: string;
+  /** ms epoch — token expiry as reported by GitHub. */
+  expiresAt: number;
+}
+
+let cachedInstallationToken: CachedInstallationToken | null = null;
+
+/**
+ * 環境変数から GitHub App の設定を読み出す。各値が欠けていれば throw する。
+ * Read GitHub App configuration from environment. Throws when any value is
+ * missing — callers must catch and log so a misconfiguration surfaces early
+ * rather than as a silent fire-and-forget failure.
+ */
+function readAppConfig(): {
+  appId: string;
+  privateKey: string;
+  installationId: string;
+} {
+  const appId = process.env.GITHUB_APP_ID?.trim();
+  const installationId = process.env.GITHUB_APP_INSTALLATION_ID?.trim();
+  const rawKey = process.env.GITHUB_APP_PRIVATE_KEY;
+
+  if (!appId) throw new Error("GITHUB_APP_ID is not configured");
+  if (!installationId) throw new Error("GITHUB_APP_INSTALLATION_ID is not configured");
+  if (!rawKey) throw new Error("GITHUB_APP_PRIVATE_KEY is not configured");
+
+  // .env では改行を `\n` (リテラル) で表現することが多いので両方を受け付ける。
+  // .env files commonly encode the PEM newlines as the literal two-character
+  // sequence `\n`; normalize to real newlines so importPKCS8 can parse it.
+  const privateKey = rawKey.includes("\\n") ? rawKey.replace(/\\n/g, "\n") : rawKey;
+
+  return { appId, privateKey, installationId };
+}
+
+/**
+ * App JWT (RS256) を発行する。`iss` はアプリ ID、`exp` は 9 分後。
+ * `iat` は 60 秒前にして GitHub 側との時計ズレを許容する。
+ *
+ * Mint an App JWT signed with the configured private key (RS256). `iss` is the
+ * GitHub App ID, `exp` is 9 minutes ahead, and `iat` is offset 60 s in the
+ * past to absorb mild clock drift between this host and GitHub's API.
+ */
+export async function createAppJWT(): Promise<string> {
+  const { appId, privateKey } = readAppConfig();
+  const key = await importPKCS8(privateKey, "RS256");
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({})
+    .setProtectedHeader({ alg: "RS256" })
+    .setIssuedAt(now - 60)
+    .setIssuer(appId)
+    .setExpirationTime(now + APP_JWT_TTL_SEC)
+    .sign(key);
+}
+
+/**
+ * Installation access token を取得する。キャッシュ済みで有効期限まで余裕があれば
+ * それを返し、そうでなければ App JWT を発行して GitHub から取り直す。
+ *
+ * Fetch a fresh installation access token. Returns the cached value when it is
+ * still valid for at least `REFRESH_MARGIN_MS`; otherwise mints a new App JWT
+ * and exchanges it via `POST /app/installations/{id}/access_tokens`.
+ *
+ * @throws when the GitHub API responds non-2xx or returns an unparseable body.
+ */
+export async function getInstallationToken(): Promise<string> {
+  if (
+    cachedInstallationToken &&
+    cachedInstallationToken.expiresAt - Date.now() > REFRESH_MARGIN_MS
+  ) {
+    return cachedInstallationToken.token;
+  }
+  const { installationId } = readAppConfig();
+  const jwt = await createAppJWT();
+  const res = await fetch(
+    `${GITHUB_API_BASE}/app/installations/${encodeURIComponent(installationId)}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: GITHUB_ACCEPT,
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        "User-Agent": USER_AGENT,
+      },
+    },
+  );
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub installation token request failed: ${res.status} ${body}`);
+  }
+  const json = (await res.json()) as { token?: unknown; expires_at?: unknown };
+  const token = typeof json.token === "string" ? json.token : null;
+  const expiresAtIso = typeof json.expires_at === "string" ? json.expires_at : null;
+  if (!token || !expiresAtIso) {
+    throw new Error("GitHub installation token response missing token/expires_at");
+  }
+  const expiresAt = Date.parse(expiresAtIso);
+  if (!Number.isFinite(expiresAt)) {
+    throw new Error(`GitHub installation token returned unparseable expires_at: ${expiresAtIso}`);
+  }
+  cachedInstallationToken = { token, expiresAt };
+  return token;
+}
+
+/**
+ * テスト用: キャッシュ済み installation token をクリアする。
+ * Test helper: drop the cached installation token so the next call re-fetches.
+ */
+export function __resetInstallationTokenCacheForTests(): void {
+  cachedInstallationToken = null;
+}
+
+/**
+ * dispatch 先のリポジトリを `owner/repo` 形式で読み取る。未設定なら null。
+ *
+ * Read the dispatch target repository in `owner/repo` form. Returns `null` when
+ * `GITHUB_DISPATCH_REPOSITORY` is not configured, signaling the caller to skip
+ * the dispatch (Phase 2 keeps the wiring optional so the API stays functional
+ * before the GitHub Actions workflow exists).
+ */
+export function readDispatchRepository(): { owner: string; repo: string } | null {
+  const raw = process.env.GITHUB_DISPATCH_REPOSITORY?.trim();
+  if (!raw) return null;
+  const [owner, repo] = raw.split("/", 2);
+  if (!owner || !repo) return null;
+  return { owner, repo };
+}
+
+/**
+ * `repository_dispatch` を発火する。失敗時は throw する（呼び出し側はログのみで握りつぶす）。
+ *
+ * Fire a `repository_dispatch` event. Throws on non-2xx so the caller can log;
+ * the webhook entrypoint is expected to detach this with `.catch(() => log)`
+ * so user-visible Sentry webhook responses never block on this call.
+ */
+export async function triggerRepositoryDispatch(input: {
+  eventType: string;
+  clientPayload: Record<string, unknown>;
+  owner?: string;
+  repo?: string;
+}): Promise<void> {
+  const target =
+    input.owner && input.repo ? { owner: input.owner, repo: input.repo } : readDispatchRepository();
+  if (!target) {
+    throw new Error("GITHUB_DISPATCH_REPOSITORY is not configured");
+  }
+  const token = await getInstallationToken();
+  const res = await fetch(
+    `${GITHUB_API_BASE}/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/dispatches`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: GITHUB_ACCEPT,
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        "User-Agent": USER_AGENT,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        event_type: input.eventType,
+        client_payload: input.clientPayload,
+      }),
+    },
+  );
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub repository_dispatch failed: ${res.status} ${body}`);
+  }
+}
+
+/**
+ * 受信した installation token を GitHub 側で検証する。
+ *
+ * GitHub の installation token は不透明文字列（`ghs_...`）なので、ローカル検証は
+ * できない。`GET /installation/repositories` を当該 token で呼び、200 が返り、
+ * かつ `installation.id` が当アプリの `GITHUB_APP_INSTALLATION_ID` と一致する場合
+ * のみ有効と判定する。タイムアウトは 5 秒に短く設定し、コールバック側を遅延させない。
+ *
+ * Validate an inbound installation access token. GitHub installation tokens are
+ * opaque (`ghs_...`), so we round-trip to GitHub: hit
+ * `GET /installation/repositories` with the token, accept 200, and require the
+ * returned `installation.id` to match our `GITHUB_APP_INSTALLATION_ID` so a
+ * stolen token from a different installation cannot impersonate ours. Times
+ * out at 5 s to keep the callback path responsive.
+ */
+export async function verifyInstallationToken(token: string): Promise<boolean> {
+  if (!token) return false;
+  const { installationId } = readAppConfig();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5_000);
+  try {
+    const res = await fetch(`${GITHUB_API_BASE}/installation/repositories?per_page=1`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: GITHUB_ACCEPT,
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        "User-Agent": USER_AGENT,
+      },
+      signal: controller.signal,
+    });
+    if (!res.ok) return false;
+    const json = (await res.json().catch(() => null)) as {
+      total_count?: unknown;
+      repositories?: unknown;
+    } | null;
+    if (!json) return false;
+    // GitHub returns the installation id only via the `installation` field on
+    // some endpoints. `/installation/repositories` does not echo it, so we
+    // additionally call `/installation` via the token to confirm the binding.
+    // Simpler: reconcile by header `x-github-installation-id` when provided,
+    // otherwise rely on the App-id-bound listing matching our installation.
+    const headerId = res.headers.get("x-github-installation-id");
+    if (headerId !== null) {
+      return headerId === installationId;
+    }
+    // Fallback: the listing succeeded under our App private key's installation,
+    // so accept the token. (We've already verified our App config matches.)
+    return true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/server/api/src/lib/githubAppAuth.ts
+++ b/server/api/src/lib/githubAppAuth.ts
@@ -51,6 +51,42 @@ const APP_JWT_TTL_SEC = 9 * 60;
  */
 const REFRESH_MARGIN_MS = 60_000;
 
+/**
+ * GitHub API 呼び出しのタイムアウト（ms）。GitHub の通常レイテンシは 100ms〜
+ * 数百 ms 程度なので、ハング検知としては 10 秒で十分。これを超えると
+ * AbortError として外側に伝搬し、呼び出し側の .catch / 503 パスが走る。
+ *
+ * Timeout (ms) for outbound GitHub API calls. Normal latency is well under
+ * 1 s; 10 s catches genuine hangs without false-tripping on cold edges. Hits
+ * surface as `AbortError` so the caller's `.catch` / 503 path triggers
+ * instead of leaking a pending promise on bursty webhook traffic.
+ */
+const GITHUB_FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * `fetch` を AbortController ベースのタイムアウトでラップする。
+ * GitHub API がスタックしたときに、未解決のままの Promise が積もって
+ * webhook ハンドラの fire-and-forget パスを詰まらせるのを防ぐ。
+ *
+ * Wrap `fetch` with an `AbortController`-based timeout so a stalled GitHub API
+ * call cannot leave a forever-pending promise behind. Without this, bursts of
+ * Sentry webhooks that all detach `triggerRepositoryDispatch().catch(log)`
+ * would slowly accumulate hung promises whenever GitHub stalls.
+ */
+async function fetchGitHubWithTimeout(
+  input: string,
+  init: RequestInit,
+  timeoutMs: number = GITHUB_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 interface CachedInstallationToken {
   token: string;
   /** ms epoch — token expiry as reported by GitHub. */
@@ -125,7 +161,7 @@ export async function getInstallationToken(): Promise<string> {
   }
   const { installationId } = readAppConfig();
   const jwt = await createAppJWT();
-  const res = await fetch(
+  const res = await fetchGitHubWithTimeout(
     `${GITHUB_API_BASE}/app/installations/${encodeURIComponent(installationId)}/access_tokens`,
     {
       method: "POST",
@@ -198,7 +234,7 @@ export async function triggerRepositoryDispatch(input: {
     throw new Error("GITHUB_DISPATCH_REPOSITORY is not configured");
   }
   const token = await getInstallationToken();
-  const res = await fetch(
+  const res = await fetchGitHubWithTimeout(
     `${GITHUB_API_BASE}/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/dispatches`,
     {
       method: "POST",
@@ -222,53 +258,112 @@ export async function triggerRepositoryDispatch(input: {
 }
 
 /**
+ * `verifyInstallationToken` が GitHub 側の障害（5xx / ネットワーク / タイムアウト）
+ * で検証できなかったときに投げるエラー。呼び出し側は本物の認証失敗 (`false`) と
+ * 区別して 503 / リトライ可能なレスポンスにマップする。
+ *
+ * Thrown by `verifyInstallationToken` when the failure is on GitHub's side
+ * (5xx / network / timeout) rather than a definitive "this token is invalid".
+ * Lets the caller distinguish transient outages (retryable, → 503) from real
+ * auth failures (`false`, → 403) so an outage does not silently drop valid AI
+ * results as permanent auth errors.
+ */
+export class GitHubInstallationVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GitHubInstallationVerificationError";
+  }
+}
+
+/**
  * 受信した installation token を GitHub 側で検証する。
  *
  * GitHub の installation token は不透明文字列（`ghs_...`）なのでローカル検証は
  * できない。`GET /installation` を当該 token で呼ぶと、その installation 自身の
  * メタデータ（`id` を含む）が返るので、`id` を `GITHUB_APP_INSTALLATION_ID`
  * と比較して一致した場合のみ有効と判定する。これにより別のインストールから
- * 盗まれた token をなりすましに使われることを防ぐ。タイムアウトは 5 秒に短く
- * 設定し、コールバック側を遅延させない。
+ * 盗まれた token をなりすましに使われることを防ぐ。
+ *
+ * 戻り値の意味づけ:
+ * - `true`: 認証成功（id 一致）。
+ * - `false`: 本物の認証失敗（401/403/404 / id 不一致 / レスポンス body の
+ *   `id` が欠落・型違い）。呼び出し側は HTTP 403 にマップする。
+ * - throw `GitHubInstallationVerificationError`: GitHub 側の障害
+ *   （5xx / ネットワーク / タイムアウト / JSON パース失敗）。呼び出し側は
+ *   HTTP 503 にマップしてリトライ可能であることを示す。
  *
  * Validate an inbound installation access token. GitHub installation tokens are
  * opaque (`ghs_...`), so we round-trip to GitHub: hit `GET /installation`,
  * which returns the installation's own metadata (including `id`), and require
  * the returned id to equal our configured `GITHUB_APP_INSTALLATION_ID`. This
  * blocks tokens minted for any *other* installation of the same App from
- * impersonating ours. Times out at 5 s to keep the callback path responsive.
+ * impersonating ours.
+ *
+ * Result semantics:
+ * - `true` → token authenticates as our installation.
+ * - `false` → genuine auth failure (401/403/404, id mismatch, missing id).
+ *   Callers map this to HTTP 403.
+ * - throws `GitHubInstallationVerificationError` → GitHub-side trouble (5xx,
+ *   network error, timeout, malformed JSON). Callers map this to HTTP 503 so
+ *   the workflow can retry instead of dropping a valid AI result.
  *
  * @see https://docs.github.com/en/rest/apps/installations#get-an-installation-for-the-authenticated-app
  */
 export async function verifyInstallationToken(token: string): Promise<boolean> {
   if (!token) return false;
   const { installationId } = readAppConfig();
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 5_000);
+  let res: Response;
   try {
-    const res = await fetch(`${GITHUB_API_BASE}/installation`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: GITHUB_ACCEPT,
-        "X-GitHub-Api-Version": GITHUB_API_VERSION,
-        "User-Agent": USER_AGENT,
+    res = await fetchGitHubWithTimeout(
+      `${GITHUB_API_BASE}/installation`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: GITHUB_ACCEPT,
+          "X-GitHub-Api-Version": GITHUB_API_VERSION,
+          "User-Agent": USER_AGENT,
+        },
       },
-      signal: controller.signal,
-    });
-    if (!res.ok) return false;
-    const json = (await res.json().catch(() => null)) as { id?: unknown } | null;
-    if (!json) return false;
-    // `id` は数値で返るので文字列比較できるよう正規化する。env 側は文字列なので、
-    // 両側を文字列に揃えて比較しないと `123 === "123"` が常に false になり、
-    // 検証が常に失敗側へフェイルクローズしてしまう。
-    // GitHub returns `id` as a number; normalize to string for comparison
-    // against the env-string `installationId`. Without this, `123 === "123"`
-    // would always be false and verification would silently fail closed.
-    const idStr = typeof json.id === "number" || typeof json.id === "string" ? String(json.id) : "";
-    return idStr.length > 0 && idStr === installationId;
-  } catch {
-    return false;
-  } finally {
-    clearTimeout(timer);
+      5_000,
+    );
+  } catch (err) {
+    // ネットワーク障害 / AbortError は GitHub 側の不調として扱い、
+    // throw して呼び出し側に 503 マップさせる（403 でドロップしない）。
+    // Network failures and AbortError are treated as upstream outages so the
+    // route can retry-by-503 instead of permanently rejecting a valid token.
+    const message = err instanceof Error ? err.message : String(err);
+    throw new GitHubInstallationVerificationError(
+      `GitHub installation verification network error: ${message}`,
+    );
   }
+  // 401/403/404 は本物の認証失敗（token 不正・存在しない・権限なし）。
+  // 401/403/404 are definitive auth failures: token rejected by GitHub.
+  if (res.status === 401 || res.status === 403 || res.status === 404) return false;
+  // 5xx などその他の非 2xx は GitHub 側の障害として throw する。
+  // Other non-2xx responses (mainly 5xx) are upstream issues; surface as
+  // retryable so callers can map to 503.
+  if (!res.ok) {
+    throw new GitHubInstallationVerificationError(
+      `GitHub installation verification returned ${res.status}`,
+    );
+  }
+  let json: { id?: unknown } | null;
+  try {
+    json = (await res.json()) as { id?: unknown } | null;
+  } catch {
+    // 200 を返したのに JSON が壊れているのは GitHub 側の異常なので transient 扱い。
+    // A 200 with malformed JSON is a GitHub-side anomaly, not an auth issue.
+    throw new GitHubInstallationVerificationError(
+      "GitHub installation verification returned malformed JSON",
+    );
+  }
+  if (!json) return false;
+  // `id` は数値で返るので文字列比較できるよう正規化する。env 側は文字列なので、
+  // 両側を文字列に揃えて比較しないと `123 === "123"` が常に false になり、
+  // 検証が常に失敗側へフェイルクローズしてしまう。
+  // GitHub returns `id` as a number; normalize to string for comparison
+  // against the env-string `installationId`. Without this, `123 === "123"`
+  // would always be false and verification would silently fail closed.
+  const idStr = typeof json.id === "number" || typeof json.id === "string" ? String(json.id) : "";
+  return idStr.length > 0 && idStr === installationId;
 }

--- a/server/api/src/routes/webhooks/githubAiCallback.ts
+++ b/server/api/src/routes/webhooks/githubAiCallback.ts
@@ -99,6 +99,8 @@ function normalizeBody(body: unknown): Omit<UpdateAiAnalysisInput, "id"> | null 
  *
  * - 401: missing / malformed bearer token
  * - 403: token did not validate against our GitHub App installation
+ * - 503: transient GitHub-side failure (5xx / timeout / network) — caller
+ *   should retry; we never silently turn outages into 403s.
  * - 400: invalid JSON, invalid severity, or malformed `ai_suspected_files`
  * - 404: no row matches `:id` (or `:id` is not a UUID)
  * - 200: returned the post-update row

--- a/server/api/src/routes/webhooks/githubAiCallback.ts
+++ b/server/api/src/routes/webhooks/githubAiCallback.ts
@@ -157,7 +157,16 @@ app.put("/:id", async (c) => {
     console.log(
       `[github-ai-callback] updated api_error=${updated.id} severity=${updated.severity}`,
     );
-    return c.json({ error: updated });
+    // 外部 (GitHub Actions) 向けの webhook なので、`error` キーを成功時に流用する
+    // 内部 admin API の慣習ではなく、`data` キーで返して "error 有無で失敗判定"
+    // できる素直な形にする（admin/src/api/admin.ts と異なり消費者がまだ存在しない）。
+    //
+    // External GitHub-Actions-facing webhook: don't reuse the admin route's
+    // `{ error: row }` success shape — it's confusing for outside consumers
+    // (presence-of-`error` no longer means failure). Use `data` so the
+    // response shape is unambiguous. No backward-compat concern: the AI
+    // workflow that calls this endpoint hasn't been written yet.
+    return c.json({ data: updated });
   } catch (err) {
     if (err instanceof ApiErrorAiAnalysisValidationError) {
       return c.json({ error: err.message }, 400);

--- a/server/api/src/routes/webhooks/githubAiCallback.ts
+++ b/server/api/src/routes/webhooks/githubAiCallback.ts
@@ -1,0 +1,167 @@
+/**
+ * `PUT /api/webhooks/github/ai-result/:id` — GitHub Actions の AI 解析ワークフロー
+ * から結果を受け取るコールバック (Epic #616 Phase 2 / sub-issue #805)。
+ *
+ * 認証は GitHub App の installation access token のみ受け付ける
+ * (`Authorization: Bearer ghs_...`)。受信した token は GitHub API に問い合わせて
+ * 当アプリのインストール ID と一致するかを検証してから DB に書き戻す。
+ *
+ * Callback endpoint hit by the GitHub Actions AI analysis workflow when it has
+ * results for a given `api_errors` row (Epic #616 Phase 2 / issue #805).
+ * Authentication is GitHub App installation tokens only — the bearer token is
+ * round-tripped to GitHub for validation, and we additionally require the
+ * resulting installation id to match `GITHUB_APP_INSTALLATION_ID` so a token
+ * minted by an unrelated installation cannot impersonate ours.
+ *
+ * @see ../../lib/githubAppAuth.ts
+ * @see ../../services/apiErrorService.ts
+ * @see https://github.com/otomatty/zedi/issues/616
+ * @see https://github.com/otomatty/zedi/issues/805
+ */
+import { Hono } from "hono";
+import {
+  ApiErrorAiAnalysisValidationError,
+  updateAiAnalysis,
+  type UpdateAiAnalysisInput,
+} from "../../services/apiErrorService.js";
+import { verifyInstallationToken } from "../../lib/githubAppAuth.js";
+import type { AppEnv } from "../../types/index.js";
+
+const app = new Hono<AppEnv>();
+
+/**
+ * 受け付ける UUID 形式（v1〜v5）。`api_errors.id` は `uuid` 型なので
+ * 不正な形式が来た時点で 404 を返し、Postgres まで投げない。
+ *
+ * RFC 4122 UUID matcher (any version). `api_errors.id` is a Postgres `uuid`
+ * column, so reject malformed values early to keep the route resilient.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * `Authorization: Bearer ...` ヘッダから token を抜き出す。
+ * Extract the bearer token from an `Authorization` header value, or null when
+ * the header is missing or malformed.
+ */
+function extractBearerToken(header: string | undefined): string | null {
+  if (!header) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  if (!match) return null;
+  const token = match[1]?.trim();
+  return token && token.length > 0 ? token : null;
+}
+
+/**
+ * リクエスト body を `UpdateAiAnalysisInput` に正規化する。受け付けるフィールド:
+ * `ai_summary`, `ai_suspected_files`, `ai_root_cause`, `ai_suggested_fix`,
+ * `severity`。snake_case / camelCase の両方を許容する（GitHub Actions 側の
+ * 実装次第で揺れるため）。
+ *
+ * Normalize the JSON body into a `UpdateAiAnalysisInput`. Accepts both
+ * `snake_case` (canonical for GitHub Actions YAML) and `camelCase` (matches the
+ * service-layer field names) so the workflow author isn't forced into one
+ * style. Unknown keys are ignored.
+ */
+function normalizeBody(body: unknown): Omit<UpdateAiAnalysisInput, "id"> | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  const b = body as Record<string, unknown>;
+  const out: Omit<UpdateAiAnalysisInput, "id"> = {};
+  const aiSummary = b.ai_summary ?? b.aiSummary;
+  if (aiSummary !== undefined) {
+    out.aiSummary = aiSummary === null ? null : String(aiSummary);
+  }
+  const aiRootCause = b.ai_root_cause ?? b.aiRootCause;
+  if (aiRootCause !== undefined) {
+    out.aiRootCause = aiRootCause === null ? null : String(aiRootCause);
+  }
+  const aiSuggestedFix = b.ai_suggested_fix ?? b.aiSuggestedFix;
+  if (aiSuggestedFix !== undefined) {
+    out.aiSuggestedFix = aiSuggestedFix === null ? null : String(aiSuggestedFix);
+  }
+  const aiSuspectedFiles = b.ai_suspected_files ?? b.aiSuspectedFiles;
+  if (aiSuspectedFiles !== undefined) {
+    // 構造の検証は service 層 (`updateAiAnalysis`) で行う。ここでは `undefined`
+    // との区別だけ通す。
+    // Defer per-entry shape validation to the service layer; here we only need
+    // to distinguish "field present" from "field omitted".
+    out.aiSuspectedFiles = aiSuspectedFiles as UpdateAiAnalysisInput["aiSuspectedFiles"];
+  }
+  const severity = b.severity;
+  if (severity !== undefined) {
+    out.severity = severity as UpdateAiAnalysisInput["severity"];
+  }
+  return out;
+}
+
+/**
+ * PUT /:id — AI 解析結果の書き戻し。
+ * PUT /:id — write back AI analysis output for a specific `api_errors` row.
+ *
+ * - 401: missing / malformed bearer token
+ * - 403: token did not validate against our GitHub App installation
+ * - 400: invalid JSON, invalid severity, or malformed `ai_suspected_files`
+ * - 404: no row matches `:id` (or `:id` is not a UUID)
+ * - 200: returned the post-update row
+ */
+app.put("/:id", async (c) => {
+  const id = c.req.param("id");
+  if (!UUID_RE.test(id)) {
+    return c.json({ error: "Not found" }, 404);
+  }
+
+  const token = extractBearerToken(c.req.header("authorization"));
+  if (!token) {
+    return c.json({ error: "Missing or malformed Authorization header" }, 401);
+  }
+
+  // GitHub Actions から渡された installation token を GitHub 側で検証する。
+  // 検証には外部 API 呼び出しが必要なので、未認証アクセスがある場合に攻撃者が
+  // 大量にこの分岐を叩き続けて GitHub の rate limit を消費しないよう、
+  // 直前で UUID / Authorization ヘッダ形式を済ませている。
+  //
+  // Round-trip the bearer token through GitHub's API to confirm it belongs to
+  // our App installation. We deliberately gate the upstream call behind the
+  // UUID + bearer-format checks above so a flood of malformed requests can't
+  // burn through our GitHub rate limit before being rejected.
+  let valid: boolean;
+  try {
+    valid = await verifyInstallationToken(token);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error(`[github-ai-callback] verifyInstallationToken failed: ${message}`);
+    return c.json({ error: "Token verification failed" }, 503);
+  }
+  if (!valid) {
+    return c.json({ error: "Invalid installation token" }, 403);
+  }
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid JSON body" }, 400);
+  }
+  const normalized = normalizeBody(body);
+  if (!normalized) {
+    return c.json({ error: "body must be a JSON object" }, 400);
+  }
+
+  const db = c.get("db");
+  try {
+    const updated = await updateAiAnalysis(db, { id, ...normalized });
+    if (!updated) {
+      return c.json({ error: "Not found" }, 404);
+    }
+    console.log(
+      `[github-ai-callback] updated api_error=${updated.id} severity=${updated.severity}`,
+    );
+    return c.json({ error: updated });
+  } catch (err) {
+    if (err instanceof ApiErrorAiAnalysisValidationError) {
+      return c.json({ error: err.message }, 400);
+    }
+    throw err;
+  }
+});
+
+export default app;

--- a/server/api/src/routes/webhooks/sentry.ts
+++ b/server/api/src/routes/webhooks/sentry.ts
@@ -25,8 +25,10 @@ import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import {
   ApiErrorValidationError,
+  getApiErrorBySentryIssueId,
   upsertFromSentrySummary,
 } from "../../services/apiErrorService.js";
+import { readDispatchRepository, triggerRepositoryDispatch } from "../../lib/githubAppAuth.js";
 import type { AppEnv } from "../../types/index.js";
 
 const app = new Hono<AppEnv>();
@@ -304,6 +306,48 @@ export function extractSentrySummary(payload: unknown): SentrySummaryExtraction 
 }
 
 /**
+ * 新規 `sentry_issue_id` を初めて観測したときに `repository_dispatch`
+ * (`event_type: analyze-error`) を発火する。Webhook レスポンスを遅らせない
+ * よう必ず非 await で呼び出し、失敗時はログのみ残す。
+ *
+ * Trigger the `analyze-error` `repository_dispatch` event when a brand-new
+ * Sentry issue lands. This MUST be called without `await` so the Sentry
+ * webhook response is not delayed by GitHub round-trips. Configuration is
+ * optional: if `GITHUB_DISPATCH_REPOSITORY` is unset we skip the dispatch
+ * silently — issue #805 explicitly allows the AI workflow to be wired up
+ * later without breaking this endpoint.
+ */
+async function dispatchAnalyzeError(
+  apiErrorId: string,
+  sentryIssueId: string,
+  title: string,
+  route: string | null,
+): Promise<void> {
+  const target = readDispatchRepository();
+  if (!target) {
+    // 未設定: Phase 2 の Actions が未デプロイの段階では正常系。
+    // Unconfigured: a deliberate Phase 2 staging state where the Actions side
+    // is not deployed yet. Skip without raising.
+    console.log("[sentry-webhook] GITHUB_DISPATCH_REPOSITORY unset; skipping repository_dispatch");
+    return;
+  }
+  await triggerRepositoryDispatch({
+    eventType: "analyze-error",
+    clientPayload: {
+      api_error_id: apiErrorId,
+      sentry_issue_id: sentryIssueId,
+      title,
+      route,
+    },
+    owner: target.owner,
+    repo: target.repo,
+  });
+  console.log(
+    `[sentry-webhook] repository_dispatch fired for issue=${sentryIssueId} target=${target.owner}/${target.repo}`,
+  );
+}
+
+/**
  * POST /api/webhooks/sentry — Sentry Internal Integration 受信エンドポイント。
  * POST /api/webhooks/sentry — Sentry Internal Integration receiver.
  */
@@ -344,6 +388,17 @@ app.post("/", async (c) => {
 
   const db = c.get("db");
   try {
+    // 既存行の有無を upsert 前に判定する。`isNew === true` のときだけ
+    // GitHub Actions の AI 解析ワークフローを起動し、再来時には起動しない。
+    // 競合時は二重起動になり得るが、Phase 2 のワークフロー側で冪等に扱う前提。
+    //
+    // Detect first-sight before the upsert so we only kick off the AI analysis
+    // workflow on net-new issues. Concurrent webhooks for the same id may both
+    // observe `null` and both dispatch — Phase 2's workflow must dedupe on its
+    // side; the trade-off keeps this path race-free of an additional lock.
+    const existing = await getApiErrorBySentryIssueId(db, summary.sentryIssueId);
+    const isNew = existing === null;
+
     const row = await upsertFromSentrySummary(db, {
       sentryIssueId: summary.sentryIssueId,
       title: summary.title,
@@ -353,8 +408,28 @@ app.post("/", async (c) => {
       occurrencesDelta: 1,
     });
     console.log(
-      `[sentry-webhook] resource=${resource} upserted issue=${row.sentryIssueId} occurrences=${row.occurrences}`,
+      `[sentry-webhook] resource=${resource} upserted issue=${row.sentryIssueId} occurrences=${row.occurrences} isNew=${isNew}`,
     );
+
+    if (isNew) {
+      // fire-and-forget: dispatch のレスポンスを await せずに 200 を返す。
+      // dispatch 失敗は Sentry 側へリトライさせず、ログだけ残して握りつぶす
+      // （Actions が未デプロイでも API がデグレしない、issue #805 受け入れ条件）。
+      //
+      // Fire-and-forget so the Sentry webhook's HTTP response doesn't block on
+      // GitHub. Failures are logged, not thrown — issue #805 explicitly
+      // requires the API to keep working even when the Actions workflow is not
+      // deployed yet.
+      void dispatchAnalyzeError(row.id, row.sentryIssueId, row.title, row.route ?? null).catch(
+        (err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(
+            `[sentry-webhook] repository_dispatch failed for issue=${row.sentryIssueId}: ${message}`,
+          );
+        },
+      );
+    }
+
     return c.json({ received: true, id: row.id });
   } catch (err) {
     // 入力検証エラー (sentryIssueId / title / statusCode 等) は 400 で返す。

--- a/server/api/src/services/apiErrorService.test.ts
+++ b/server/api/src/services/apiErrorService.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect } from "vitest";
 import {
   ALLOWED_API_ERROR_STATUS_TRANSITIONS,
+  ApiErrorAiAnalysisValidationError,
   ApiErrorStatusConflictError,
   assertValidApiErrorStatusTransition,
   isValidApiErrorStatusTransition,
@@ -23,6 +24,7 @@ import {
   listApiErrors,
   getApiErrorById,
   getApiErrorBySentryIssueId,
+  updateAiAnalysis,
   updateApiErrorStatus,
   API_ERROR_LIST_DEFAULT_LIMIT,
   API_ERROR_LIST_MAX_LIMIT,
@@ -560,5 +562,80 @@ describe("updateApiErrorStatus", () => {
         nextStatus: "investigating",
       }),
     ).rejects.toBeInstanceOf(ApiErrorStatusConflictError);
+  });
+});
+
+// ── updateAiAnalysis ───────────────────────────────────────────────────────
+
+describe("updateAiAnalysis", () => {
+  it("updates AI fields and severity when payload is valid", async () => {
+    const after = makeRow({
+      severity: "high",
+      aiSummary: "ヌルポインタ参照",
+      aiSuspectedFiles: [{ path: "src/a.ts", line: 12 }],
+      aiRootCause: "X が undefined",
+      aiSuggestedFix: "guard 追加",
+    });
+    const db = createMockDb([[after]]);
+    const result = await updateAiAnalysis(db as never, {
+      id: after.id,
+      severity: "high",
+      aiSummary: "ヌルポインタ参照",
+      aiSuspectedFiles: [{ path: "src/a.ts", line: 12 }],
+      aiRootCause: "X が undefined",
+      aiSuggestedFix: "guard 追加",
+    });
+    expect(result?.severity).toBe("high");
+    expect(result?.aiSummary).toBe("ヌルポインタ参照");
+  });
+
+  it("returns null when the row does not exist (UPDATE returns no rows)", async () => {
+    const db = createMockDb([[]]);
+    const result = await updateAiAnalysis(db as never, {
+      id: "00000000-0000-0000-0000-000000000099",
+      severity: "high",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("rejects an unknown severity value at the boundary", async () => {
+    const db = createMockDb([[makeRow()]]);
+    await expect(
+      updateAiAnalysis(db as never, {
+        id: "00000000-0000-0000-0000-000000000001",
+        // biome-ignore lint/suspicious/noExplicitAny: simulating an external bad payload
+        severity: "garbage" as never,
+      }),
+    ).rejects.toBeInstanceOf(ApiErrorAiAnalysisValidationError);
+  });
+
+  it("rejects ai_suspected_files entries without a non-empty path", async () => {
+    const db = createMockDb([[makeRow()]]);
+    await expect(
+      updateAiAnalysis(db as never, {
+        id: "00000000-0000-0000-0000-000000000001",
+        aiSuspectedFiles: [{ path: "" } as never],
+      }),
+    ).rejects.toBeInstanceOf(ApiErrorAiAnalysisValidationError);
+  });
+
+  it("rejects ai_suspected_files entries with non-integer line numbers", async () => {
+    const db = createMockDb([[makeRow()]]);
+    await expect(
+      updateAiAnalysis(db as never, {
+        id: "00000000-0000-0000-0000-000000000001",
+        aiSuspectedFiles: [{ path: "src/a.ts", line: 1.5 } as never],
+      }),
+    ).rejects.toBeInstanceOf(ApiErrorAiAnalysisValidationError);
+  });
+
+  it("with no fields, falls back to a SELECT to probe row existence", async () => {
+    // 全フィールド undefined のときは UPDATE を発行しない（不要な書き込みを避ける）。
+    // When all fields are undefined the service must not issue a noop UPDATE;
+    // it only probes existence so callers can map "row gone" to 404 cleanly.
+    const row = makeRow();
+    const db = createMockDb([[row]]);
+    const result = await updateAiAnalysis(db as never, { id: row.id });
+    expect(result?.id).toBe(row.id);
   });
 });

--- a/server/api/src/services/apiErrorService.ts
+++ b/server/api/src/services/apiErrorService.ts
@@ -464,6 +464,138 @@ export async function updateApiErrorStatus(
   return updated;
 }
 
+/**
+ * `updateAiAnalysis` の入力。AI 解析結果コールバック (Epic #616 Phase 2) で
+ * GitHub Actions から渡される。受け取り側 (`updateAiAnalysis`) は与えられた
+ * フィールドのみ更新し、`undefined` のものは既存値を保持する。
+ *
+ * Input shape used by `updateAiAnalysis` — the callback path that GitHub
+ * Actions hits with the AI analysis results. Fields left `undefined` keep
+ * their existing value so the workflow can post partial updates (e.g. just
+ * the severity) without clobbering earlier data.
+ */
+export interface UpdateAiAnalysisInput {
+  id: string;
+  aiSummary?: string | null;
+  aiSuspectedFiles?: ApiErrorSuspectedFile[] | null;
+  aiRootCause?: string | null;
+  aiSuggestedFix?: string | null;
+  severity?: ApiErrorSeverity;
+}
+
+/**
+ * `updateAiAnalysis` の境界バリデーションで投げるエラー。
+ * Thrown by `updateAiAnalysis` when the callback payload fails boundary
+ * validation (unknown severity, malformed suspected-files entries, etc.).
+ *
+ * 呼び出し側は HTTP 400 にマップすることを想定する。
+ * Callers map this to HTTP 400.
+ */
+export class ApiErrorAiAnalysisValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ApiErrorAiAnalysisValidationError";
+  }
+}
+
+const VALID_SEVERITIES_FOR_AI: readonly ApiErrorSeverity[] = ["high", "medium", "low", "unknown"];
+
+/**
+ * `aiSuspectedFiles` を境界で検証する。配列であり、各要素が
+ * `{ path: string }` を最低限満たすことを要求する。
+ *
+ * Validate `aiSuspectedFiles` at the boundary. Each entry must be an object
+ * with a non-empty `path`; `reason` and `line` are optional but must be the
+ * right shape when present, so we don't persist garbage into the JSONB column.
+ */
+function validateSuspectedFiles(value: unknown): ApiErrorSuspectedFile[] | null {
+  if (value === null) return null;
+  if (!Array.isArray(value)) {
+    throw new ApiErrorAiAnalysisValidationError("aiSuspectedFiles must be an array");
+  }
+  const out: ApiErrorSuspectedFile[] = [];
+  for (const [i, entry] of value.entries()) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new ApiErrorAiAnalysisValidationError(`aiSuspectedFiles[${i}] must be an object`);
+    }
+    const e = entry as Record<string, unknown>;
+    if (typeof e.path !== "string" || e.path.length === 0) {
+      throw new ApiErrorAiAnalysisValidationError(
+        `aiSuspectedFiles[${i}].path must be a non-empty string`,
+      );
+    }
+    if (e.reason !== undefined && typeof e.reason !== "string") {
+      throw new ApiErrorAiAnalysisValidationError(`aiSuspectedFiles[${i}].reason must be a string`);
+    }
+    if (
+      e.line !== undefined &&
+      (typeof e.line !== "number" || !Number.isFinite(e.line) || !Number.isInteger(e.line))
+    ) {
+      throw new ApiErrorAiAnalysisValidationError(
+        `aiSuspectedFiles[${i}].line must be a finite integer`,
+      );
+    }
+    const normalized: ApiErrorSuspectedFile = { path: e.path };
+    if (typeof e.reason === "string") normalized.reason = e.reason;
+    if (typeof e.line === "number") normalized.line = e.line;
+    out.push(normalized);
+  }
+  return out;
+}
+
+/**
+ * AI 解析結果を `api_errors` 行に書き戻す（Epic #616 Phase 2）。
+ *
+ * - 行が存在しなければ `null` を返す。
+ * - `severity` が不正値ならば `ApiErrorAiAnalysisValidationError` を投げる。
+ * - `undefined` のフィールドは UPDATE に含めず、既存値を保持する。
+ *
+ * Persist AI analysis results onto an `api_errors` row (Epic #616 Phase 2).
+ * Returns `null` when the row does not exist; throws
+ * `ApiErrorAiAnalysisValidationError` for invalid severity / suspected-files
+ * shape. `undefined` fields are omitted from the UPDATE so partial workflow
+ * posts (e.g. severity only) don't clobber pre-existing AI fields.
+ */
+export async function updateAiAnalysis(
+  db: Database,
+  input: UpdateAiAnalysisInput,
+): Promise<ApiError | null> {
+  if (input.severity !== undefined && !VALID_SEVERITIES_FOR_AI.includes(input.severity)) {
+    throw new ApiErrorAiAnalysisValidationError(
+      `severity must be one of ${VALID_SEVERITIES_FOR_AI.join(", ")}`,
+    );
+  }
+
+  const updates: Partial<
+    Pick<
+      NewApiError,
+      "aiSummary" | "aiSuspectedFiles" | "aiRootCause" | "aiSuggestedFix" | "severity"
+    >
+  > = {};
+  if (input.aiSummary !== undefined) updates.aiSummary = input.aiSummary;
+  if (input.aiSuspectedFiles !== undefined) {
+    updates.aiSuspectedFiles = validateSuspectedFiles(input.aiSuspectedFiles);
+  }
+  if (input.aiRootCause !== undefined) updates.aiRootCause = input.aiRootCause;
+  if (input.aiSuggestedFix !== undefined) updates.aiSuggestedFix = input.aiSuggestedFix;
+  if (input.severity !== undefined) updates.severity = input.severity;
+
+  // 何も更新しないコールバックは行存在のみ返す（不要な UPDATE を発行しない）。
+  // No-op callback: just probe existence so the route can return 404 cleanly
+  // without burning a NOOP UPDATE on the row.
+  if (Object.keys(updates).length === 0) {
+    return getApiErrorById(db, input.id);
+  }
+
+  const [updated] = await db
+    .update(apiErrors)
+    .set({ ...updates, updatedAt: sql`NOW()` })
+    .where(eq(apiErrors.id, input.id))
+    .returning();
+
+  return updated ?? null;
+}
+
 // 公開はしないがコンパイル時に未使用警告が出ないよう、import を参照しておく。
 // Touch types so tsc/eslint don't strip them in `--isolatedModules` builds.
 export type { ApiErrorSuspectedFile };


### PR DESCRIPTION
Wire up Epic #616 Phase 2: when the Sentry webhook upserts a brand-new
sentry_issue_id, fire-and-forget a GitHub `repository_dispatch`
(`event_type: analyze-error`) so a downstream Actions workflow can run
AI analysis on the error. Add a callback endpoint
`PUT /api/webhooks/github/ai-result/:id` for the workflow to write back
ai_summary, ai_suspected_files, ai_root_cause, ai_suggested_fix, and
severity, authenticated via the GitHub App installation token.

- New `lib/githubAppAuth.ts`: App JWT (RS256) → installation token with
  in-memory caching, repository_dispatch trigger, installation-token
  verification.
- New `routes/webhooks/githubAiCallback.ts`: PUT endpoint mounted
  outside the admin gate; validates Bearer installation tokens via the
  GitHub API and rejects non-matching installation IDs.
- `services/apiErrorService.ts`: `updateAiAnalysis` helper with
  boundary validation for severity / suspected-files shape.
- `routes/webhooks/sentry.ts`: pre-upsert SELECT to detect first-sight,
  then fire dispatch only on isNew=true. Failures are logged, never
  thrown — issue #805 acceptance criterion: API stays functional even
  when the Actions workflow is not deployed yet.
- Adds `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`,
  `GITHUB_APP_INSTALLATION_ID`, `GITHUB_DISPATCH_REPOSITORY` env vars.
- 25 new Vitest cases covering token cache, dispatch flow, callback
  auth/validation, and isNew/recurrence branching.

Closes #805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub Actions AI webhook to submit analysis results (severity, summaries, suspected files) and update error records
  * Sentry webhook now detects new vs recurring issues and conditionally triggers repository dispatches
  * Server-side GitHub App auth and repository-dispatch support for outbound dispatches

* **Tests**
  * Expanded tests covering webhooks, auth/verification, payload validation, and dispatch behavior

* **Chores**
  * Example config updated with GitHub App and dispatch settings; gitleaksignore entry added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->