### PR TITLE
feat: implement auto-file GitHub Issue on high/medium severity (Epic #616 Phase 3)

### DIFF
--- a/.github/actions/claude-analyze/README.md
+++ b/.github/actions/claude-analyze/README.md
@@ -2,25 +2,32 @@
 
 Sentry が検知した API エラーを Claude (Anthropic) で解析し、構造化 JSON を Zedi
 API のコールバックに `PUT` する composite action。Epic [#616](https://github.com/otomatty/zedi/issues/616)
-Phase 2 / Issue [#806](https://github.com/otomatty/zedi/issues/806) の実装。
+Phase 2 ([#806](https://github.com/otomatty/zedi/issues/806)) と Phase 3
+（severity 判定による自動 Issue 起票・[#808](https://github.com/otomatty/zedi/issues/808)）
+を併せて実装する。
 
-Composite action that asks Claude to analyze a Sentry-reported API error and
-PUTs the validated structured result back to the Zedi API callback. Implements
-Epic [#616](https://github.com/otomatty/zedi/issues/616) Phase 2 / issue
-[#806](https://github.com/otomatty/zedi/issues/806).
+Composite action that asks Claude to analyze a Sentry-reported API error,
+PUTs the validated structured result back to the Zedi API callback, and
+auto-files (or comments on) a GitHub Issue when AI severity is `high` or
+`medium`. Implements Epic [#616](https://github.com/otomatty/zedi/issues/616)
+Phase 2 ([#806](https://github.com/otomatty/zedi/issues/806)) and Phase 3
+([#808](https://github.com/otomatty/zedi/issues/808)).
 
 ---
 
 ## ファイル構成 / Files
 
-| ファイル / file             | 役割 / role                                                      |
-| --------------------------- | ---------------------------------------------------------------- |
-| `action.yml`                | composite action 定義 / composite action definition              |
-| `analyze.mjs`               | Claude を呼んで JSON を生成するスクリプト / Claude orchestrator  |
-| `schema.mjs`                | Zod 出力スキーマ / output schema (mirrors API)                   |
-| `prompt.md`                 | Claude へのプロンプトテンプレ / prompt template                  |
-| `__tests__/schema.test.mjs` | 出力スキーマ fixture テスト / fixture tests for the schema       |
-| `__tests__/fixtures/*.json` | 有効・無効ペイロードのサンプル / valid + invalid sample payloads |
+| ファイル / file                | 役割 / role                                                      |
+| ------------------------------ | ---------------------------------------------------------------- |
+| `action.yml`                   | composite action 定義 / composite action definition              |
+| `analyze.mjs`                  | Claude を呼んで JSON を生成するスクリプト / Claude orchestrator  |
+| `schema.mjs`                   | Zod 出力スキーマ / output schema (mirrors API)                   |
+| `prompt.md`                    | Claude へのプロンプトテンプレ / prompt template                  |
+| `autoIssue.mjs`                | Issue 起票・コメント追記の純粋関数と HTTP 層 / Issue helpers     |
+| `autoIssueRunner.mjs`          | `autoIssue.mjs` を action から呼ぶエントリ / runner entry        |
+| `__tests__/schema.test.mjs`    | 出力スキーマ fixture テスト / fixture tests for the schema       |
+| `__tests__/autoIssue.test.mjs` | Issue 起票ロジックの単体テスト / unit tests for the Issue helper |
+| `__tests__/fixtures/*.json`    | 有効・無効ペイロードのサンプル / valid + invalid sample payloads |
 
 呼び出し元 / called from: `.github/workflows/analyze-error.yml`.
 
@@ -105,14 +112,21 @@ Node 24 の組み込みテストランナーで動く（vitest 不要）。
 Runs on Node 24's built-in test runner — no vitest needed.
 
 ```bash
-node --test .github/actions/claude-analyze/__tests__/schema.test.mjs
+node --test .github/actions/claude-analyze/__tests__/schema.test.mjs \
+            .github/actions/claude-analyze/__tests__/autoIssue.test.mjs
 ```
 
 新しいシナリオを追加するときは `__tests__/fixtures/` に JSON を置いて、`schema.test.mjs`
-にケースを 1 つ足す。
+にケースを 1 つ足す。Issue 起票ロジックを変更したときは `autoIssue.test.mjs` の
+純粋関数テスト（`shouldFileIssue`, `buildIssueTitle`, `buildIssueBody`,
+`buildSentryIssueLabel`, `parseRepository`）と `runAutoIssue` の経路分岐に
+ケースを追加する。
 
-To add a new scenario, drop a fixture JSON in `__tests__/fixtures/` and add one
-test case in `schema.test.mjs`.
+To add a schema scenario, drop a fixture JSON in `__tests__/fixtures/` and add
+one case in `schema.test.mjs`. When changing the auto-issue logic, extend the
+pure-function tests (`shouldFileIssue`, `buildIssueTitle`, `buildIssueBody`,
+`buildSentryIssueLabel`, `parseRepository`) and `runAutoIssue`'s branch
+coverage in `autoIssue.test.mjs`.
 
 ---
 
@@ -180,14 +194,97 @@ and the GitHub App secrets to be configured.
 
 ---
 
+## 自動 Issue 起票 / Auto-file GitHub Issue (Phase 3)
+
+Epic [#616](https://github.com/otomatty/zedi/issues/616) Phase 3 / Issue
+[#808](https://github.com/otomatty/zedi/issues/808) で実装した自動起票ステップ。
+`analyze` ステップの直後に走り、`severity` に応じて以下のように分岐する。
+
+The auto-issue step (Phase 3) runs immediately after `analyze` and branches
+on `severity` as follows.
+
+| severity          | 挙動 / behavior                                                                                                                                                                           |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `high` / `medium` | `sentry-issue:<sentry_issue_id>` ラベルでオープン Issue を検索 → あればコメント追記 / なければ新規 Issue を作成 / Search by label, then comment on the existing Issue or create a new one |
+| `low` / `unknown` | 何もしない（DB / Sentry のみに残す）/ No-op (the record stays in the DB and Sentry only)                                                                                                  |
+
+### 重複防止 / Dedup guarantee
+
+- 同一 `sentry_issue_id` で **オープン Issue は 1 件** に保つ。連続 100 回エラーが
+  発生しても Issue は増えず、コメントが 100 件付く。Epic #616 の受け入れ条件
+  「同じエラーが連続 100 回発生しても Issue は 1 件 (もしくはコメント追記)」を満たす。
+- Maintains exactly one open Issue per `sentry_issue_id`. 100 recurrences of
+  the same error produce 1 Issue and 100 recurrence comments — meeting the
+  Epic #616 acceptance criterion "100 hits → 1 Issue".
+
+### 付与するラベル / Labels applied
+
+| label               | 用途 / purpose                                                              |
+| ------------------- | --------------------------------------------------------------------------- |
+| `monitoring`        | 監視関連 Issue の集約 / monitoring triage view                              |
+| `auto-reported`     | 自動起票であることのフラグ / "auto-filed by workflow" flag                  |
+| `sentry-issue:<id>` | 1:1 dedup key — 検索クエリのキーになる / dedup key used by the search query |
+
+未存在のラベルは Issue 起票時に `POST /repos/{o}/{r}/labels` で自動作成する。
+`auto-reported` も同様に未存在なら作成される（事前に `gh label create` する必要は
+ない）。
+
+Missing labels are created on the fly via `POST /repos/{o}/{r}/labels` —
+including `auto-reported`, so no manual `gh label create` step is needed
+before the first run.
+
+### PII 防衛 / PII guards
+
+- Issue 本文には Sentry URL を埋め込まない（org / project slug の漏洩防止）。
+  `sentry_issue_id` と `sentry-issue:<id>` ラベルがあれば Sentry 上のデータと
+  相関できる。
+- AI 由来のテキスト（`ai_summary` 等）は Sentry の data scrubbing 後の入力で
+  生成されているため、二段防御済み。
+- Sentry の data scrubbing 設定（Epic #616 §「Sentry 設定方針」）が一次防御で、
+  この Issue 本文の構成が二次防御。
+
+The Issue body never embeds a Sentry URL (would leak the org / project slug);
+cross-reference via the `sentry-issue:<id>` label instead. AI-derived text
+inherits the Sentry data-scrubbing applied upstream.
+
+### 必要な権限 / Required permissions
+
+- ワークフローの `permissions` に `issues: write` を明示。
+- 実際の書き込みは GitHub App installation token (`actions/create-github-app-token@v2`)
+  経由で行う。App の権限は `Issues: Read & Write` が必須。
+
+The workflow declares `issues: write` for visibility; the actual writes use
+the GitHub App installation token, which must hold `Issues: Read & Write`.
+
+### `workflow_dispatch` でのドライラン / Dry-running on workflow_dispatch
+
+`workflow_dispatch` 入力には `skip_issue` が追加されていて、デフォルトは `true`。
+`dry_run` / `skip_callback` と同じ感覚で、誤って Issue を起票しないように守る。
+
+The `workflow_dispatch` form exposes a `skip_issue` toggle (default `true`)
+mirroring `dry_run` / `skip_callback`. Set it to `false` only when you
+explicitly want to exercise the live Issue-write path.
+
+### ローカルで `runAutoIssue` を試す / Local exercise of `runAutoIssue`
+
+`fetchImpl` を差し替えて GitHub API を叩かずにロジックを確認できる。
+`autoIssue.test.mjs` の `makeFetchStub` ヘルパが参考実装。
+
+Inject a `fetch` stub to exercise `runAutoIssue` without hitting the real
+GitHub API. The `makeFetchStub` helper in `autoIssue.test.mjs` is the
+reference recipe.
+
+---
+
 ## リトライ・失敗時の挙動 / Retry & failure semantics
 
-| 失敗箇所 / failure point          | 挙動 / behavior                                                                    |
-| --------------------------------- | ---------------------------------------------------------------------------------- |
-| Anthropic API (5xx / network)     | `analyze.mjs` 側で 2 試行まで（5 秒間隔）/ 2 attempts inside the script            |
-| 出力 JSON 検証失敗                | `parseAndValidate` が throw → ジョブ失敗、API には書き戻さない / job fails, no PUT |
-| API callback 5xx / network        | composite action の curl ループで 2 試行まで（5 秒間隔）/ 2 attempts in shell      |
-| API callback 4xx (auth / payload) | 即時失敗（リトライしない）/ immediate failure (no retry)                           |
+| 失敗箇所 / failure point          | 挙動 / behavior                                                                                                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Anthropic API (5xx / network)     | `analyze.mjs` 側で 2 試行まで（5 秒間隔）/ 2 attempts inside the script                                                                           |
+| 出力 JSON 検証失敗                | `parseAndValidate` が throw → ジョブ失敗、API には書き戻さない / job fails, no PUT                                                                |
+| API callback 5xx / network        | composite action の curl ループで 2 試行まで（5 秒間隔）/ 2 attempts in shell                                                                     |
+| API callback 4xx (auth / payload) | 即時失敗（リトライしない）/ immediate failure (no retry)                                                                                          |
+| Issue 起票・コメント API 失敗     | `autoIssue.mjs` が throw → ステップ失敗。analyze 結果は既に PUT 済みなので DB は最新 / step fails after the analysis was PUT, so DB stays current |
 
 いずれの失敗もユーザーリクエストには影響しない（Epic #616 の不変条件）。Sentry
 webhook 側は `triggerRepositoryDispatch().catch(log)` で発火しているので、本ワーク

--- a/.github/actions/claude-analyze/__tests__/autoIssue.test.mjs
+++ b/.github/actions/claude-analyze/__tests__/autoIssue.test.mjs
@@ -1,0 +1,441 @@
+/**
+ * Unit tests for the auto-issue helpers (Epic #616 Phase 3 / Issue #808).
+ *
+ * 実行方法 / How to run:
+ *   `node --test .github/actions/claude-analyze/__tests__/autoIssue.test.mjs`
+ *
+ * 純粋関数（severity ゲート / ラベル生成 / 検索クエリ生成 / Issue 本文ビルダー）と、
+ * `fetch` を差し替えた `runAutoIssue` の経路分岐をカバーする。実 GitHub API は
+ * 叩かない（fetch スタブを注入する）。
+ *
+ * Covers the pure helpers (severity gate, label string, search query, body
+ * builders) plus the `runAutoIssue` orchestrator with an injected `fetch` stub.
+ * No real GitHub API calls — the HTTP boundary is mocked end-to-end.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  STATIC_LABELS,
+  buildIssueBody,
+  buildIssueTitle,
+  buildRecurrenceCommentBody,
+  buildSentryIssueLabel,
+  parseRepository,
+  runAutoIssue,
+  shouldFileIssue,
+} from "../autoIssue.mjs";
+
+test("STATIC_LABELS includes monitoring and auto-reported in deterministic order", () => {
+  assert.deepEqual(STATIC_LABELS, ["monitoring", "auto-reported"]);
+});
+
+test("shouldFileIssue is true for high and medium only", () => {
+  assert.equal(shouldFileIssue("high"), true);
+  assert.equal(shouldFileIssue("medium"), true);
+  assert.equal(shouldFileIssue("low"), false);
+  assert.equal(shouldFileIssue("unknown"), false);
+  assert.equal(shouldFileIssue(""), false);
+  assert.equal(shouldFileIssue(undefined), false);
+});
+
+test("buildSentryIssueLabel prefixes with sentry-issue:", () => {
+  assert.equal(buildSentryIssueLabel("abc-123"), "sentry-issue:abc-123");
+});
+
+test("buildSentryIssueLabel rejects empty / non-string ids", () => {
+  assert.throws(() => buildSentryIssueLabel(""), /non-empty string/);
+  assert.throws(() => buildSentryIssueLabel(undefined), /non-empty string/);
+  assert.throws(() => buildSentryIssueLabel(42), /non-empty string/);
+});
+
+test("parseRepository splits owner/repo and rejects malformed values", () => {
+  assert.deepEqual(parseRepository("otomatty/zedi"), { owner: "otomatty", repo: "zedi" });
+  assert.throws(() => parseRepository(""), /owner\/repo/);
+  assert.throws(() => parseRepository("only-one"), /owner\/repo/);
+  assert.throws(() => parseRepository("a/b/c"), /owner\/repo/);
+});
+
+test("buildIssueTitle prefixes severity, includes sentry id, and trims long titles", () => {
+  const title = buildIssueTitle({
+    severity: "high",
+    title: "TypeError: Cannot read property 'note_id' of null",
+    sentryIssueId: "fixture-1",
+  });
+  assert.match(title, /^\[high\]/);
+  assert.match(title, /TypeError/);
+  assert.match(title, /\(sentry:fixture-1\)$/);
+});
+
+test("buildIssueTitle truncates titles longer than the cap and falls back to placeholder", () => {
+  const long = "x".repeat(500);
+  const title = buildIssueTitle({ severity: "medium", title: long, sentryIssueId: "fixture-2" });
+  // 256 は GitHub の Issue タイトル上限。本実装は body 部分を 180 で打ち切るので
+  // prefix `[medium] ` (10) + 180 + suffix ` (sentry:fixture-2)` (19) = 209 で
+  // 256 未満に収まる。回帰検知のためには 256 上限を assert すれば十分。
+  // GitHub caps Issue titles at 256 chars; we slice the body at 180 so the
+  // total stays under 256 even with prefix/suffix overhead. Asserting the
+  // 256 ceiling is sufficient regression coverage.
+  assert.ok(title.length <= 256, `expected ≤256 chars, got ${title.length}`);
+  // 入力の `x` が 200 個以上残っていないこと（= 中で切られていること）を確認。
+  // Confirm truncation actually happened (not just under the GitHub limit).
+  const xCount = (title.match(/x/g) ?? []).length;
+  assert.ok(xCount < 500, `expected truncation, ${xCount} 'x' chars remained`);
+
+  const placeholder = buildIssueTitle({ severity: "high", title: "", sentryIssueId: "fixture-3" });
+  assert.match(placeholder, /\(no title\)/);
+});
+
+test("buildIssueBody includes AI fields and the sentry id but no Sentry URL", () => {
+  const body = buildIssueBody({
+    severity: "high",
+    summary: "Database migration failed mid-flight.",
+    rootCause: "Migration 0042 added NOT NULL without backfill.",
+    suggestedFix: "Backfill then re-apply.",
+    suspectedFiles: [
+      { path: "server/api/drizzle/0042_add_note_id.sql", reason: "Introduced NOT NULL." },
+      { path: "server/api/src/services/pageService.ts", line: 42 },
+    ],
+    route: "POST /api/pages",
+    sentryIssueId: "fixture-1",
+    apiErrorId: "00000000-0000-0000-0000-000000000001",
+    workflowRunUrl: "https://github.com/otomatty/zedi/actions/runs/123",
+  });
+  assert.match(body, /Severity\s*\|\s*`high`/);
+  assert.match(body, /sentry_issue_id.*fixture-1/);
+  assert.match(body, /api_error_id.*00000000-0000-0000-0000-000000000001/);
+  assert.match(body, /Database migration failed mid-flight\./);
+  assert.match(body, /Migration 0042 added NOT NULL without backfill\./);
+  assert.match(body, /server\/api\/drizzle\/0042_add_note_id\.sql/);
+  assert.match(body, /actions\/runs\/123/);
+  // PII 防衛: Sentry URL は本文に含めない（`sentry-issue:` ラベルと id のみで参照可能）。
+  // PII guard: do not embed a Sentry URL — the `sentry-issue:` label and id
+  // alone are enough to cross-reference, and including the URL would leak the
+  // org / project slug into a public-by-default Issue body.
+  assert.ok(!/sentry\.io/.test(body), "Sentry URL must not appear in the issue body");
+});
+
+test("buildIssueBody handles missing optional fields without showing 'null'", () => {
+  const body = buildIssueBody({
+    severity: "medium",
+    summary: "Transient blip.",
+    rootCause: null,
+    suggestedFix: null,
+    suspectedFiles: null,
+    route: "",
+    sentryIssueId: "fixture-2",
+    apiErrorId: "00000000-0000-0000-0000-000000000002",
+    workflowRunUrl: "https://github.com/otomatty/zedi/actions/runs/124",
+  });
+  assert.ok(!/null/.test(body), "raw 'null' should not appear in the body");
+  assert.match(body, /Transient blip\./);
+});
+
+test("buildRecurrenceCommentBody references the workflow run and severity", () => {
+  const body = buildRecurrenceCommentBody({
+    severity: "high",
+    summary: "Same migration crash hit again.",
+    apiErrorId: "00000000-0000-0000-0000-000000000003",
+    workflowRunUrl: "https://github.com/otomatty/zedi/actions/runs/200",
+  });
+  assert.match(body, /Recurrence detected/i);
+  assert.match(body, /high/);
+  assert.match(body, /Same migration crash hit again\./);
+  assert.match(body, /actions\/runs\/200/);
+  assert.match(body, /00000000-0000-0000-0000-000000000003/);
+  assert.ok(!/sentry\.io/.test(body), "Sentry URL must not appear in the recurrence comment");
+});
+
+/**
+ * fetch スタブ。`{ method, url, body }` を順に記録し、登録した応答を返す。
+ * Mock fetch that records every call and returns scripted responses by URL+method.
+ *
+ * @param {Array<{ match: (url: string, init: { method?: string }) => boolean, status: number, json?: unknown }>} responses
+ */
+function makeFetchStub(responses) {
+  const calls = [];
+  /**
+   * @param {string} url
+   * @param {{ method?: string, headers?: Record<string, string>, body?: string }} [init]
+   */
+  async function fetchImpl(url, init = {}) {
+    calls.push({ url, method: init.method ?? "GET", body: init.body });
+    const match = responses.find((r) => r.match(url, init));
+    if (!match) {
+      throw new Error(`Unexpected fetch call: ${init.method ?? "GET"} ${url}`);
+    }
+    return {
+      ok: match.status >= 200 && match.status < 300,
+      status: match.status,
+      async json() {
+        return match.json ?? {};
+      },
+      async text() {
+        return JSON.stringify(match.json ?? {});
+      },
+    };
+  }
+  return { fetchImpl, calls };
+}
+
+test("runAutoIssue skips entirely when severity is low", async () => {
+  const { fetchImpl, calls } = makeFetchStub([]);
+  const result = await runAutoIssue({
+    analysis: { severity: "low", ai_summary: "noop" },
+    sentryIssueId: "fixture-low",
+    apiErrorId: "id",
+    title: "noop",
+    route: "",
+    repository: "otomatty/zedi",
+    token: "tok",
+    workflowRunUrl: "https://example.invalid/run/1",
+    fetchImpl,
+  });
+  assert.deepEqual(result, { action: "skipped", reason: "severity-not-actionable" });
+  assert.equal(calls.length, 0, "no GitHub API calls should be made for low severity");
+});
+
+test("runAutoIssue skips when severity is unknown", async () => {
+  const { fetchImpl, calls } = makeFetchStub([]);
+  const result = await runAutoIssue({
+    analysis: { severity: "unknown", ai_summary: "no clue" },
+    sentryIssueId: "fixture-unknown",
+    apiErrorId: "id",
+    title: "?",
+    route: "",
+    repository: "otomatty/zedi",
+    token: "tok",
+    workflowRunUrl: "https://example.invalid/run/2",
+    fetchImpl,
+  });
+  assert.equal(result.action, "skipped");
+  assert.equal(calls.length, 0);
+});
+
+test("runAutoIssue creates a new issue when no existing match is found", async () => {
+  const responses = [
+    // ensure label: monitoring (exists)
+    {
+      match: (u, i) => i.method === "GET" && u.endsWith("/labels/monitoring"),
+      status: 200,
+      json: { name: "monitoring" },
+    },
+    // ensure label: auto-reported (missing → create)
+    { match: (u, i) => i.method === "GET" && u.endsWith("/labels/auto-reported"), status: 404 },
+    {
+      match: (u, i) => i.method === "POST" && u.endsWith("/labels"),
+      status: 201,
+      json: { name: "auto-reported" },
+    },
+    // ensure label: sentry-issue:fixture-create (missing → create)
+    { match: (u, i) => i.method === "GET" && /\/labels\/sentry-issue/.test(u), status: 404 },
+    // search → no existing issue
+    { match: (u, i) => i.method === "GET" && u.includes("/issues?"), status: 200, json: [] },
+    // create issue
+    {
+      match: (u, i) => i.method === "POST" && u.endsWith("/issues"),
+      status: 201,
+      json: { number: 999, html_url: "https://github.com/otomatty/zedi/issues/999" },
+    },
+  ];
+  const labelCreates = [];
+  // 2 つ目のラベル作成（sentry-issue:...) のレスポンスを上書き経路として追加。
+  // POST /labels の 2 回目（sentry-issue: ラベル作成）は同じ matcher で 2 件目に
+  // hit させたいので、レスポンス配列を順番消費する形に拡張する。
+  let labelPostCount = 0;
+  /** @type {ReturnType<typeof makeFetchStub>} */
+  const stub = makeFetchStub([
+    ...responses.filter(
+      (r) => !(r.match.toString().includes('endsWith("/labels")') && r.status === 201),
+    ),
+  ]);
+  // 上の filter で削った POST /labels を、複数回応答可能なエントリで挿入する。
+  // Inject a multi-call POST /labels handler so both `auto-reported` and the
+  // dynamic `sentry-issue:<id>` label creations succeed.
+  const originalFetch = stub.fetchImpl;
+  /**
+   * @param {string} url
+   * @param {{ method?: string, body?: string, headers?: Record<string, string> }} [init]
+   */
+  stub.fetchImpl = async (url, init = {}) => {
+    if (init.method === "POST" && url.endsWith("/labels")) {
+      labelPostCount += 1;
+      labelCreates.push(JSON.parse(init.body ?? "{}"));
+      return {
+        ok: true,
+        status: 201,
+        async json() {
+          return { name: labelCreates[labelCreates.length - 1].name };
+        },
+        async text() {
+          return "{}";
+        },
+      };
+    }
+    return originalFetch(url, init);
+  };
+
+  const result = await runAutoIssue({
+    analysis: {
+      severity: "high",
+      ai_summary: "DB migration crash.",
+      ai_root_cause: "NOT NULL without backfill.",
+      ai_suggested_fix: "Backfill first.",
+      ai_suspected_files: [{ path: "server/api/drizzle/0042.sql" }],
+    },
+    sentryIssueId: "fixture-create",
+    apiErrorId: "00000000-0000-0000-0000-000000000010",
+    title: "TypeError: Cannot read property 'note_id' of null",
+    route: "POST /api/pages",
+    repository: "otomatty/zedi",
+    token: "tok",
+    workflowRunUrl: "https://github.com/otomatty/zedi/actions/runs/300",
+    fetchImpl: stub.fetchImpl,
+  });
+
+  assert.equal(result.action, "created");
+  assert.equal(result.issueNumber, 999);
+  // auto-reported と sentry-issue:fixture-create の 2 ラベルを作成しているはず。
+  assert.equal(labelPostCount, 2, "both missing labels should be created");
+  assert.deepEqual(labelCreates.map((l) => l.name).sort(), [
+    "auto-reported",
+    "sentry-issue:fixture-create",
+  ]);
+  // 作成 POST /issues に高 severity のラベル群が乗っているか。
+  const createCall = stub.calls.find((c) => c.method === "POST" && c.url.endsWith("/issues"));
+  assert.ok(createCall, "issue create call should be present");
+  const createPayload = JSON.parse(createCall.body ?? "{}");
+  assert.deepEqual(createPayload.labels.sort(), [
+    "auto-reported",
+    "monitoring",
+    "sentry-issue:fixture-create",
+  ]);
+  assert.match(createPayload.title, /^\[high\] TypeError/);
+});
+
+test("runAutoIssue comments on the existing issue when one is already open", async () => {
+  let labelPostCount = 0;
+  const responses = [
+    {
+      match: (u, i) => i.method === "GET" && u.endsWith("/labels/monitoring"),
+      status: 200,
+      json: { name: "monitoring" },
+    },
+    {
+      match: (u, i) => i.method === "GET" && u.endsWith("/labels/auto-reported"),
+      status: 200,
+      json: { name: "auto-reported" },
+    },
+    {
+      match: (u, i) => i.method === "GET" && /\/labels\/sentry-issue/.test(u),
+      status: 200,
+      json: { name: "sentry-issue:fixture-recur" },
+    },
+    {
+      match: (u, i) => i.method === "GET" && u.includes("/issues?"),
+      status: 200,
+      json: [{ number: 555, html_url: "https://github.com/otomatty/zedi/issues/555" }],
+    },
+    {
+      match: (u, i) => i.method === "POST" && /\/issues\/555\/comments$/.test(u),
+      status: 201,
+      json: { id: 7777, html_url: "https://github.com/otomatty/zedi/issues/555#issuecomment-7777" },
+    },
+  ];
+  const { fetchImpl, calls } = makeFetchStub(
+    responses.concat([
+      // POST /labels が呼ばれてしまった場合は失敗にして、未作成パスを保証する。
+      // Trip the test if the orchestrator tries to create labels that already exist.
+      {
+        match: (u, i) => {
+          if (i.method === "POST" && u.endsWith("/labels")) {
+            labelPostCount += 1;
+            throw new Error("must not create existing label");
+          }
+          return false;
+        },
+        status: 0,
+      },
+    ]),
+  );
+
+  const result = await runAutoIssue({
+    analysis: {
+      severity: "medium",
+      ai_summary: "Same crash again.",
+    },
+    sentryIssueId: "fixture-recur",
+    apiErrorId: "00000000-0000-0000-0000-000000000020",
+    title: "TypeError: ...",
+    route: "POST /api/pages",
+    repository: "otomatty/zedi",
+    token: "tok",
+    workflowRunUrl: "https://github.com/otomatty/zedi/actions/runs/400",
+    fetchImpl,
+  });
+
+  assert.equal(result.action, "commented");
+  assert.equal(result.issueNumber, 555);
+  assert.equal(labelPostCount, 0, "no labels should be created when all already exist");
+  // 検索クエリは sentry-issue:<id> ラベル + state=open。
+  const searchCall = calls.find((c) => c.url.includes("/issues?"));
+  assert.ok(searchCall, "search call should be present");
+  assert.match(searchCall.url, /labels=sentry-issue%3Afixture-recur/);
+  assert.match(searchCall.url, /state=open/);
+  // コメント本文に「再発」が含まれている。
+  const commentCall = calls.find((c) => c.method === "POST" && /\/comments$/.test(c.url));
+  assert.ok(commentCall);
+  const commentBody = JSON.parse(commentCall.body ?? "{}").body;
+  assert.match(commentBody, /Recurrence detected/i);
+  assert.match(commentBody, /Same crash again\./);
+});
+
+test("runAutoIssue picks the lowest-numbered open issue when multiple match (defensive)", async () => {
+  const responses = [
+    {
+      match: (u, i) => i.method === "GET" && u.endsWith("/labels/monitoring"),
+      status: 200,
+      json: {},
+    },
+    {
+      match: (u, i) => i.method === "GET" && u.endsWith("/labels/auto-reported"),
+      status: 200,
+      json: {},
+    },
+    {
+      match: (u, i) => i.method === "GET" && /\/labels\/sentry-issue/.test(u),
+      status: 200,
+      json: {},
+    },
+    {
+      match: (u, i) => i.method === "GET" && u.includes("/issues?"),
+      status: 200,
+      // 故意に降順で返す。実装側は number 昇順で最古を選ぶこと。
+      json: [
+        { number: 900, html_url: "https://github.com/otomatty/zedi/issues/900" },
+        { number: 100, html_url: "https://github.com/otomatty/zedi/issues/100" },
+      ],
+    },
+    {
+      match: (u, i) => i.method === "POST" && /\/issues\/100\/comments$/.test(u),
+      status: 201,
+      json: { id: 1, html_url: "x" },
+    },
+  ];
+  const { fetchImpl } = makeFetchStub(responses);
+
+  const result = await runAutoIssue({
+    analysis: { severity: "high", ai_summary: "..." },
+    sentryIssueId: "fixture-multi",
+    apiErrorId: "id",
+    title: "t",
+    route: "",
+    repository: "otomatty/zedi",
+    token: "tok",
+    workflowRunUrl: "https://example.invalid/run/x",
+    fetchImpl,
+  });
+
+  assert.equal(result.action, "commented");
+  assert.equal(result.issueNumber, 100);
+});

--- a/.github/actions/claude-analyze/__tests__/autoIssue.test.mjs
+++ b/.github/actions/claude-analyze/__tests__/autoIssue.test.mjs
@@ -149,6 +149,29 @@ test("buildIssueBody escapes pipe characters in table cells so Markdown tables s
   assert.match(body, /GET \/api\/foo\\\|bar/);
 });
 
+test("buildIssueBody escapes backslashes before pipes (CodeQL: Incomplete string escaping)", () => {
+  // 入力 `\|` を `\\|` ではなく `\\\\\|` (= リテラル `\\` + escaped `|`) に
+  // しなければ、Markdown では「リテラル `\` + 生 `|`」と解釈され表が崩れる。
+  // バックスラッシュを先にエスケープすることでこの誤解釈を防ぐ。
+  // Input `\|` must become `\\\|` (literal backslash + escaped pipe), not
+  // `\\|` — otherwise Markdown reads `\\` as a literal backslash and the
+  // bare `|` breaks the table cell.
+  const body = buildIssueBody({
+    severity: "medium",
+    summary: "summary",
+    rootCause: null,
+    suggestedFix: null,
+    suspectedFiles: null,
+    route: "weird\\|route",
+    sentryIssueId: "fixture-bs",
+    apiErrorId: "id",
+    workflowRunUrl: "https://example.invalid/run/2",
+  });
+  // ファイル中のリテラル文字列としては `weird\\\\\\|route` (= `weird\\\|route`).
+  // Literal in JS source: `weird\\\\\\|route` — represents `weird\\\|route`.
+  assert.match(body, /weird\\\\\\|route/);
+});
+
 test("buildIssueBody handles missing optional fields without showing 'null'", () => {
   const body = buildIssueBody({
     severity: "medium",

--- a/.github/actions/claude-analyze/__tests__/autoIssue.test.mjs
+++ b/.github/actions/claude-analyze/__tests__/autoIssue.test.mjs
@@ -21,6 +21,7 @@ import {
   buildIssueTitle,
   buildRecurrenceCommentBody,
   buildSentryIssueLabel,
+  ensureLabel,
   parseRepository,
   runAutoIssue,
   shouldFileIssue,
@@ -81,6 +82,20 @@ test("buildIssueTitle truncates titles longer than the cap and falls back to pla
   // Confirm truncation actually happened (not just under the GitHub limit).
   const xCount = (title.match(/x/g) ?? []).length;
   assert.ok(xCount < 500, `expected truncation, ${xCount} 'x' chars remained`);
+  // 末尾に省略記号があり、切り捨てが視覚的に分かること。
+  // Truncated titles should end with `...` so readers see at a glance that
+  // the title was cut.
+  assert.match(title, /\.\.\. \(sentry:fixture-2\)$/);
+
+  // 上限ちょうど (TITLE_BODY_MAX) なら省略記号は付かない。
+  // A title exactly at the cap should NOT receive the ellipsis.
+  const exactCap = "y".repeat(180);
+  const exactTitle = buildIssueTitle({
+    severity: "high",
+    title: exactCap,
+    sentryIssueId: "fixture-cap",
+  });
+  assert.ok(!/\.\.\./.test(exactTitle), "no ellipsis when title length is exactly the cap");
 
   const placeholder = buildIssueTitle({ severity: "high", title: "", sentryIssueId: "fixture-3" });
   assert.match(placeholder, /\(no title\)/);
@@ -113,6 +128,25 @@ test("buildIssueBody includes AI fields and the sentry id but no Sentry URL", ()
   // alone are enough to cross-reference, and including the URL would leak the
   // org / project slug into a public-by-default Issue body.
   assert.ok(!/sentry\.io/.test(body), "Sentry URL must not appear in the issue body");
+});
+
+test("buildIssueBody escapes pipe characters in table cells so Markdown tables stay intact", () => {
+  // route に `|` が混入した場合 (例えば proxy 由来の奇妙なルート文字列など) でも
+  // 表組みが崩れないこと。エスケープ後は `\|` として表示される。
+  // A `|` in the route (or any inline-rendered field) must be escaped to
+  // `\|` so the Markdown table doesn't get split into extra columns.
+  const body = buildIssueBody({
+    severity: "medium",
+    summary: "summary",
+    rootCause: null,
+    suggestedFix: null,
+    suspectedFiles: null,
+    route: "GET /api/foo|bar",
+    sentryIssueId: "fixture-pipe",
+    apiErrorId: "id",
+    workflowRunUrl: "https://example.invalid/run/1",
+  });
+  assert.match(body, /GET \/api\/foo\\\|bar/);
 });
 
 test("buildIssueBody handles missing optional fields without showing 'null'", () => {
@@ -438,4 +472,63 @@ test("runAutoIssue picks the lowest-numbered open issue when multiple match (def
 
   assert.equal(result.action, "commented");
   assert.equal(result.issueNumber, 100);
+});
+
+test("ensureLabel tolerates 422 from POST /labels (race when another run created the label)", async () => {
+  // GET → 404 (未存在), POST → 422 (別 run が直前に作成) のシナリオ。
+  // throw せず "existing" を返すこと。
+  // GET → 404 (missing), POST → 422 (created by a concurrent run between our
+  // GET and POST). The function should not throw and should report
+  // "existing" so the caller treats it as success.
+  const responses = [
+    {
+      match: (u, i) => i.method === "GET" && u.endsWith("/labels/auto-reported"),
+      status: 404,
+    },
+    { match: (u, i) => i.method === "POST" && u.endsWith("/labels"), status: 422 },
+  ];
+  const { fetchImpl } = makeFetchStub(responses);
+  const outcome = await ensureLabel({
+    owner: "otomatty",
+    repo: "zedi",
+    label: "auto-reported",
+    token: "tok",
+    fetchImpl,
+    logger: { log: () => {} },
+  });
+  assert.equal(outcome, "existing");
+});
+
+test("ensureLabel returns 'existing' immediately when GET succeeds (no POST issued)", async () => {
+  let postCount = 0;
+  /**
+   * @param {string} url
+   * @param {{ method?: string }} init
+   */
+  async function fetchImpl(url, init = {}) {
+    if (init.method === "GET") {
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return { name: "monitoring" };
+        },
+        async text() {
+          return "{}";
+        },
+      };
+    }
+    postCount += 1;
+    throw new Error("POST should not be called");
+  }
+  const outcome = await ensureLabel({
+    owner: "otomatty",
+    repo: "zedi",
+    label: "monitoring",
+    token: "tok",
+    fetchImpl,
+    logger: { log: () => {} },
+  });
+  assert.equal(outcome, "existing");
+  assert.equal(postCount, 0);
 });

--- a/.github/actions/claude-analyze/action.yml
+++ b/.github/actions/claude-analyze/action.yml
@@ -48,6 +48,12 @@ inputs:
     description: When "true", validate locally but do not PUT to the API (pairs with dry_run for fixture validation).
     required: false
     default: "false"
+  skip_issue:
+    description: >
+      When "true", skip the auto-issue (create / comment) step. Pairs with
+      `dry_run` / `skip_callback` for fixture validation. Epic #616 Phase 3.
+    required: false
+    default: "false"
 
 outputs:
   severity:
@@ -56,6 +62,17 @@ outputs:
   output_path:
     description: Path to the validated analysis JSON written by the script.
     value: ${{ steps.analyze.outputs.output_path }}
+  issue_action:
+    description: >
+      Outcome of the auto-issue step: `skipped`, `created`, or `commented`.
+      Empty when `skip_issue=true`. Epic #616 Phase 3 / Issue #808.
+    value: ${{ steps.auto-issue.outputs.action }}
+  issue_number:
+    description: GitHub Issue number created or commented on (empty when skipped).
+    value: ${{ steps.auto-issue.outputs.issue_number }}
+  issue_html_url:
+    description: HTML URL of the created Issue or recurrence comment (empty when skipped).
+    value: ${{ steps.auto-issue.outputs.issue_html_url }}
 
 runs:
   using: composite
@@ -149,3 +166,27 @@ runs:
           attempt=$((attempt + 1))
           sleep 5
         done
+
+    - name: Auto-file or comment GitHub Issue
+      # Epic #616 Phase 3 / Issue #808: severity が high / medium のときだけ
+      # Issue を起票し、同一 sentry_issue_id に既存オープン Issue があれば
+      # コメント追記で再発を表現する（連続 100 回でも 1 件に集約）。`skip_issue`
+      # は `workflow_dispatch` のドライラン用フラグ。
+      #
+      # Files a GitHub Issue when AI severity is high / medium, or appends a
+      # recurrence comment when an open Issue with the matching
+      # `sentry-issue:<id>` label already exists. Honors `skip_issue` so
+      # workflow_dispatch dry runs cannot accidentally create Issues.
+      if: inputs.skip_issue != 'true'
+      id: auto-issue
+      shell: bash
+      env:
+        AUTO_ISSUE_OUTPUT_PATH: ${{ steps.analyze.outputs.output_path }}
+        AUTO_ISSUE_SENTRY_ISSUE_ID: ${{ inputs.sentry_issue_id }}
+        AUTO_ISSUE_API_ERROR_ID: ${{ inputs.api_error_id }}
+        AUTO_ISSUE_TITLE: ${{ inputs.title }}
+        AUTO_ISSUE_ROUTE: ${{ inputs.route }}
+        AUTO_ISSUE_REPOSITORY: ${{ github.repository }}
+        AUTO_ISSUE_TOKEN: ${{ inputs.installation_token }}
+        AUTO_ISSUE_WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: node "${{ github.action_path }}/autoIssueRunner.mjs"

--- a/.github/actions/claude-analyze/autoIssue.mjs
+++ b/.github/actions/claude-analyze/autoIssue.mjs
@@ -197,7 +197,14 @@ export function buildIssueTitle({ severity, title, sentryIssueId }) {
 function inlineOrNone(value) {
   if (value === null || value === undefined) return "(none)";
   if (typeof value !== "string") return "(none)";
-  const collapsed = value.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+  // バックスラッシュを先にエスケープしてから pipe をエスケープする。順序を
+  // 逆にすると入力 `\|` が `\\|` になり、Markdown 上は「リテラル `\` + 生 `|`」
+  // と解釈されて表が壊れる（CodeQL: Incomplete string escaping）。
+  // Escape backslashes first, then pipes. Reversing the order would turn an
+  // input of `\|` into `\\|`, which Markdown renders as a literal `\` plus a
+  // raw `|` — and the raw pipe would break the surrounding table cell.
+  const escaped = value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+  const collapsed = escaped.replace(/\s+/g, " ").trim();
   return collapsed.length === 0 ? "(none)" : collapsed;
 }
 

--- a/.github/actions/claude-analyze/autoIssue.mjs
+++ b/.github/actions/claude-analyze/autoIssue.mjs
@@ -163,18 +163,33 @@ export function parseRepository(repository) {
  */
 export function buildIssueTitle({ severity, title, sentryIssueId }) {
   const trimmed = (title ?? "").trim();
-  const body = trimmed.length === 0 ? "(no title)" : trimmed.slice(0, TITLE_BODY_MAX);
+  let body;
+  if (trimmed.length === 0) {
+    body = "(no title)";
+  } else if (trimmed.length <= TITLE_BODY_MAX) {
+    body = trimmed;
+  } else {
+    // 切り捨ての可視化のため末尾 3 文字を `...` に置き換える。文字数は
+    // `TITLE_BODY_MAX` 内に収める（合計サイズは GitHub の 256 文字上限を侵さない）。
+    // Replace the last 3 chars with `...` so readers see at a glance that the
+    // title was truncated. Keeps total length ≤ TITLE_BODY_MAX so the
+    // prefix/suffix stay safely under GitHub's 256-char Issue-title cap.
+    body = `${trimmed.slice(0, TITLE_BODY_MAX - 3)}...`;
+  }
   return `[${severity}] ${body} (sentry:${sentryIssueId})`;
 }
 
 /**
  * 抜粋 Markdown 用にユーザー由来の任意文字列をエスケープして 1 行表示する。
- * 空文字列・null / undefined は `(none)` を返す。改行は半角スペースに畳む
- * （表組みが崩れないようにするため）。
+ * 空文字列・null / undefined は `(none)` を返す。改行は半角スペースに畳み、
+ * 表組みのセル区切り `|` はバックスラッシュでエスケープする（route や AI 出力に
+ * `|` が混入したときに表が崩れないようにする）。
  *
- * Inline-safe formatter for free-form strings dropped into the issue body
- * tables. Returns `(none)` for empty / null / undefined input and collapses
- * newlines to spaces so Markdown tables do not break.
+ * Inline-safe formatter for free-form strings dropped into the Issue body
+ * tables. Returns `(none)` for empty / null / undefined input. Collapses
+ * newlines to a single space and escapes `|` as `\|` so a stray pipe in a
+ * route segment or AI-generated string cannot break the surrounding Markdown
+ * table.
  *
  * @param {unknown} value
  * @returns {string}
@@ -182,7 +197,7 @@ export function buildIssueTitle({ severity, title, sentryIssueId }) {
 function inlineOrNone(value) {
   if (value === null || value === undefined) return "(none)";
   if (typeof value !== "string") return "(none)";
-  const collapsed = value.replace(/\s+/g, " ").trim();
+  const collapsed = value.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
   return collapsed.length === 0 ? "(none)" : collapsed;
 }
 
@@ -395,13 +410,29 @@ export async function ensureLabel({ owner, repo, label, token, fetchImpl, logger
     return "existing";
   }
   const meta = LABEL_METADATA[label] ?? LABEL_METADATA.__sentryIssue;
-  await ghRequest({
+  // 422 は「同名ラベルが既に存在」を意味する（GitHub API の検証エラー）。
+  // GET と POST の間に別 workflow run が同じラベルを作った場合に発生し得る
+  // ので、ここでは throw せず "existing" として扱う。同一 sentry_issue_id への
+  // 並行起動は workflow の `concurrency` で 1 本に絞っているが、別 sentry_issue_id
+  // が共通の `auto-reported` を初回作成するレースは残るためこのガードを付ける。
+  //
+  // 422 means "label already exists" (GitHub API validation error). Can happen
+  // if another workflow run created the same label between our GET and POST.
+  // The workflow's `concurrency` group serializes per `sentry_issue_id`, but
+  // different ids racing to create the shared `auto-reported` label is still
+  // possible — tolerate 422 so the recurrent path doesn't fail spuriously.
+  const post = await ghRequest({
     url: `${GITHUB_API}/repos/${owner}/${repo}/labels`,
     method: "POST",
     token,
     body: { name: label, color: meta.color, description: meta.description },
     fetchImpl,
+    acceptStatuses: [422],
   });
+  if (post.status === 422) {
+    logger.log?.(`[auto-issue] label already existed (race tolerated): ${label}`);
+    return "existing";
+  }
   logger.log?.(`[auto-issue] created missing label: ${label}`);
   return "created";
 }

--- a/.github/actions/claude-analyze/autoIssue.mjs
+++ b/.github/actions/claude-analyze/autoIssue.mjs
@@ -1,0 +1,664 @@
+/**
+ * Auto-issue helpers and orchestrator for the analyze-error workflow.
+ * Epic #616 Phase 3 / Issue #808.
+ *
+ * `analyze.mjs` の出力 JSON を受け取り、AI が判定した `severity` が `high` /
+ * `medium` のときに限り、GitHub Issue を新規起票するか、既存の重複 Issue に
+ * コメントを追記する。`sentry-issue:<sentry_issue_id>` ラベルを「同一 Sentry
+ * issue に対するオープン Issue は 1 件」の判定キーとして使う。
+ *
+ * Reads the validated analysis JSON emitted by `analyze.mjs`. When AI-assigned
+ * `severity` is `high` or `medium`, files a fresh GitHub Issue or appends a
+ * recurrence comment if an open Issue already exists for the same Sentry issue
+ * id. The `sentry-issue:<id>` label is the dedup key — there must be at most
+ * one open Issue per Sentry id (Epic #616 acceptance criterion: "same error
+ * 100 times → 1 Issue").
+ *
+ * 設計上の分離 / Design split:
+ *   - 純粋関数（`shouldFileIssue`, `buildIssueTitle`, `buildIssueBody`,
+ *     `buildRecurrenceCommentBody`, `buildSentryIssueLabel`,
+ *     `parseRepository`）は副作用ゼロでユニットテスト可能。
+ *   - HTTP 層は `runAutoIssue` 経由のみ。`fetch` を引数で差し替え可能にして
+ *     テストでは GitHub API を叩かない。
+ *
+ *   - Pure helpers are side-effect-free and unit-tested in
+ *     `__tests__/autoIssue.test.mjs`.
+ *   - The HTTP layer goes through `runAutoIssue` only; tests inject a `fetch`
+ *     stub so no real GitHub API call is ever made by the test runner.
+ *
+ * @see ./schema.mjs
+ * @see ./analyze.mjs
+ * @see https://github.com/otomatty/zedi/issues/808
+ * @see https://github.com/otomatty/zedi/issues/616
+ */
+
+/**
+ * GitHub REST API ベース URL。GitHub Enterprise では差し替えが必要だが、
+ * 本リポジトリは github.com 固定なので定数で良い。
+ *
+ * GitHub REST API base URL. Hard-coded to github.com; if Zedi ever migrates
+ * to GHES this needs to read from the `GITHUB_API_URL` env exposed by Actions.
+ */
+const GITHUB_API = "https://api.github.com";
+
+/**
+ * Issue 起票の対象になる severity 値。`low` / `unknown` はスキップ
+ * （Epic #616：「low は集約のみ」）。
+ *
+ * Severity values that warrant filing an Issue. `low` and `unknown` are
+ * intentionally skipped per Epic #616 ("low はノイズ抑制のため起票しない").
+ */
+const ISSUE_SEVERITIES = new Set(["high", "medium"]);
+
+/**
+ * 新規 Issue に必ず付与する静的ラベル。`sentry-issue:<id>` は別途追加する。
+ * 順序は決定論的にしておくとスナップショット系テストが安定する。
+ *
+ * Static labels applied to every auto-filed Issue. The dynamic
+ * `sentry-issue:<id>` label is added separately. Ordering is deterministic so
+ * snapshot-style assertions stay stable.
+ */
+export const STATIC_LABELS = Object.freeze(["monitoring", "auto-reported"]);
+
+/**
+ * 自動付与するラベルのメタデータ。リポジトリに未登録の場合に
+ * `POST /repos/{o}/{r}/labels` で生成する際に使う。
+ *
+ * Metadata for labels we auto-create when missing. Used by `ensureLabel` when
+ * `GET /labels/{name}` returns 404. Colors are intentionally muted so they do
+ * not visually drown out human-curated labels.
+ */
+const LABEL_METADATA = {
+  monitoring: {
+    color: "5319e7",
+    description: "Production monitoring & on-call surface (Epic #616).",
+  },
+  "auto-reported": {
+    color: "ededed",
+    description: "Auto-filed by the analyze-error workflow (Epic #616 Phase 3).",
+  },
+  // sentry-issue:<id> 系は description にラベルの趣旨だけ書く。色は黄系。
+  // sentry-issue:<id> labels share a yellow-ish color and a single description.
+  __sentryIssue: {
+    color: "fbca04",
+    description: "1:1 dedup key for a Sentry issue id (sentry-issue:<id>).",
+  },
+};
+
+/**
+ * Issue タイトルに含めるエラー本文の最大長。GitHub の Issue タイトルは 256 文字
+ * までだが、severity prefix と sentry suffix を足した上で 256 を割らないよう、
+ * 本文部分は控えめに 180 で打ち切る。
+ *
+ * Cap on the embedded error-title portion of the Issue title. GitHub allows up
+ * to 256 chars; reserving headroom for the `[severity]` prefix and
+ * `(sentry:<id>)` suffix keeps the result safely under the limit even with
+ * long Sentry ids.
+ */
+const TITLE_BODY_MAX = 180;
+
+/**
+ * AI 判定 severity が Issue 起票対象（high / medium）か判定する純粋関数。
+ *
+ * Pure predicate: returns `true` when the AI-assigned severity warrants
+ * creating or commenting on a GitHub Issue.
+ *
+ * @param {unknown} severity - The `severity` field from the analysis JSON.
+ * @returns {boolean}
+ */
+export function shouldFileIssue(severity) {
+  return typeof severity === "string" && ISSUE_SEVERITIES.has(severity);
+}
+
+/**
+ * `sentry-issue:<id>` ラベル名を生成する。空文字 / 非文字列は早期に弾いて
+ * 呼び出し側のバグ（payload 欠落など）を可視化する。
+ *
+ * Build the `sentry-issue:<id>` label string. Throws on empty / non-string
+ * input so a missing payload field surfaces as a CI failure rather than as a
+ * silently-malformed label.
+ *
+ * @param {unknown} sentryIssueId
+ * @returns {string}
+ */
+export function buildSentryIssueLabel(sentryIssueId) {
+  if (typeof sentryIssueId !== "string" || sentryIssueId.length === 0) {
+    throw new Error("sentryIssueId must be a non-empty string");
+  }
+  return `sentry-issue:${sentryIssueId}`;
+}
+
+/**
+ * `owner/repo` 形式の文字列を分解する。`github.repository` env からの値を
+ * 想定。スラッシュが 1 つでないものは弾く。
+ *
+ * Parse an `owner/repo` slug (typically `process.env.GITHUB_REPOSITORY`).
+ * Throws unless the input has exactly one `/`.
+ *
+ * @param {unknown} repository
+ * @returns {{ owner: string, repo: string }}
+ */
+export function parseRepository(repository) {
+  if (typeof repository !== "string") {
+    throw new Error("repository must be a string in 'owner/repo' form");
+  }
+  const parts = repository.split("/");
+  if (parts.length !== 2 || parts[0].length === 0 || parts[1].length === 0) {
+    throw new Error(`repository must be in 'owner/repo' form, got: ${repository}`);
+  }
+  return { owner: parts[0], repo: parts[1] };
+}
+
+/**
+ * Issue タイトルを生成する。`[severity] <error title> (sentry:<id>)` 形式。
+ * 本文タイトルは `TITLE_BODY_MAX` で打ち切る（GitHub の 256 文字上限対策）。
+ *
+ * Build the GitHub Issue title in `[severity] <title> (sentry:<id>)` form.
+ * The error-title segment is truncated to `TITLE_BODY_MAX` to leave room for
+ * the prefix / suffix under GitHub's 256-character cap. Empty titles fall
+ * back to `(no title)` so the issue list stays readable.
+ *
+ * @param {{ severity: string, title: string, sentryIssueId: string }} input
+ * @returns {string}
+ */
+export function buildIssueTitle({ severity, title, sentryIssueId }) {
+  const trimmed = (title ?? "").trim();
+  const body = trimmed.length === 0 ? "(no title)" : trimmed.slice(0, TITLE_BODY_MAX);
+  return `[${severity}] ${body} (sentry:${sentryIssueId})`;
+}
+
+/**
+ * 抜粋 Markdown 用にユーザー由来の任意文字列をエスケープして 1 行表示する。
+ * 空文字列・null / undefined は `(none)` を返す。改行は半角スペースに畳む
+ * （表組みが崩れないようにするため）。
+ *
+ * Inline-safe formatter for free-form strings dropped into the issue body
+ * tables. Returns `(none)` for empty / null / undefined input and collapses
+ * newlines to spaces so Markdown tables do not break.
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
+function inlineOrNone(value) {
+  if (value === null || value === undefined) return "(none)";
+  if (typeof value !== "string") return "(none)";
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  return collapsed.length === 0 ? "(none)" : collapsed;
+}
+
+/**
+ * 複数行文字列をブロック表示用に整形する。空 / null は `(none)` を返す。
+ * Markdown のコードフェンスではなく blockquote にして、AI 出力の Markdown
+ * 構文（リスト等）が壊れないようにする。
+ *
+ * Block-style formatter for multi-line strings. Returns `(none)` for empty
+ * input. Uses blockquotes (`>`) rather than fenced code so the AI's Markdown
+ * (lists, links) renders inline.
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
+function blockOrNone(value) {
+  if (typeof value !== "string" || value.trim().length === 0) return "(none)";
+  return value
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => `> ${line}`)
+    .join("\n");
+}
+
+/**
+ * `ai_suspected_files` を bullet list に整形する。空 / null は `(none)` を返す。
+ *
+ * Render `ai_suspected_files` as a bullet list. Returns `(none)` for empty /
+ * null. Each entry is `path` (with optional `line` and `reason`).
+ *
+ * @param {ReadonlyArray<{ path: string, reason?: string, line?: number }> | null | undefined} files
+ * @returns {string}
+ */
+function renderSuspectedFiles(files) {
+  if (!Array.isArray(files) || files.length === 0) return "(none)";
+  return files
+    .map((f) => {
+      const lineSuffix = typeof f.line === "number" ? `:${f.line}` : "";
+      const reasonSuffix = f.reason ? ` — ${inlineOrNone(f.reason)}` : "";
+      return `- \`${f.path}${lineSuffix}\`${reasonSuffix}`;
+    })
+    .join("\n");
+}
+
+/**
+ * Issue 本文を組み立てる。PII を含めない方針:
+ *   - Sentry URL を埋め込まない（org/project slug 漏洩防止）。`sentry_issue_id`
+ *     と `sentry-issue:<id>` ラベルだけで相関可能。
+ *   - `route` は構造情報なので埋め込んでも PII にならないが、欠落時は `(none)`。
+ *   - AI 由来文字列（summary 等）は Sentry の data scrubbing 後の入力で生成
+ *     されているため二段防御済み。
+ *
+ * Build the GitHub Issue body. PII guards:
+ *   - No Sentry URL is embedded (would leak the org / project slug).
+ *     Cross-reference via the `sentry-issue:<id>` label and id instead.
+ *   - `route` is structural metadata (e.g. `POST /api/pages`), safe to embed;
+ *     missing values render as `(none)`.
+ *   - AI-derived strings come from prompts that already operate on
+ *     Sentry-scrubbed input, so they inherit the upstream PII filtering.
+ *
+ * @param {{
+ *   severity: string,
+ *   summary: string,
+ *   rootCause?: string | null,
+ *   suggestedFix?: string | null,
+ *   suspectedFiles?: ReadonlyArray<{ path: string, reason?: string, line?: number }> | null,
+ *   route?: string,
+ *   sentryIssueId: string,
+ *   apiErrorId: string,
+ *   workflowRunUrl: string,
+ * }} input
+ * @returns {string}
+ */
+export function buildIssueBody(input) {
+  const lines = [
+    "<!-- Auto-filed by analyze-error workflow (Epic #616 Phase 3 / Issue #808) -->",
+    "",
+    "| Field | Value |",
+    "| --- | --- |",
+    `| Severity | \`${input.severity}\` |`,
+    `| Route | ${inlineOrNone(input.route)} |`,
+    `| sentry_issue_id | \`${input.sentryIssueId}\` |`,
+    `| api_error_id | \`${input.apiErrorId}\` |`,
+    `| Workflow run | ${input.workflowRunUrl} |`,
+    "",
+    "## AI summary",
+    blockOrNone(input.summary),
+    "",
+    "## Suspected root cause",
+    blockOrNone(input.rootCause),
+    "",
+    "## Suggested fix",
+    blockOrNone(input.suggestedFix),
+    "",
+    "## Suspected files",
+    renderSuspectedFiles(input.suspectedFiles),
+    "",
+    "---",
+    "",
+    "_This issue was filed automatically. Reopen with the `monitoring` triage flow / 自動起票された Issue。`monitoring` トリアージで再オープンしてください。_",
+  ];
+  return lines.join("\n");
+}
+
+/**
+ * 再発時のコメント本文を組み立てる。サマリは AI が再判定した `ai_summary` を
+ * 1 行だけ載せ、詳細は workflow run のリンクを辿らせる方針（Issue 本文を
+ * 何度も肥大化させない）。
+ *
+ * Build the recurrence comment body. Keeps the comment short — only the new
+ * `ai_summary` plus a link to the workflow run — to avoid bloating the Issue
+ * thread when the same error recurs many times.
+ *
+ * @param {{
+ *   severity: string,
+ *   summary: string,
+ *   apiErrorId: string,
+ *   workflowRunUrl: string,
+ * }} input
+ * @returns {string}
+ */
+export function buildRecurrenceCommentBody(input) {
+  return [
+    `**Recurrence detected** (severity \`${input.severity}\`)`,
+    "",
+    blockOrNone(input.summary),
+    "",
+    `- api_error_id: \`${input.apiErrorId}\``,
+    `- Workflow run: ${input.workflowRunUrl}`,
+  ].join("\n");
+}
+
+/**
+ * GitHub REST API への共通リクエスト。Bearer に GitHub App installation token
+ * を載せる。失敗時は `Error` を throw する（呼び出し側で処理）。
+ *
+ * Thin REST helper. Bearer token is the GitHub App installation token. Throws
+ * on non-2xx (except for the 404-tolerated paths handled by `ensureLabel`).
+ *
+ * @param {{
+ *   url: string,
+ *   method?: string,
+ *   token: string,
+ *   body?: unknown,
+ *   fetchImpl: typeof fetch,
+ *   acceptStatuses?: ReadonlyArray<number>,
+ * }} args
+ * @returns {Promise<{ status: number, data: unknown }>}
+ */
+async function ghRequest({ url, method = "GET", token, body, fetchImpl, acceptStatuses = [] }) {
+  const init = {
+    method,
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/vnd.github+json",
+      "x-github-api-version": "2022-11-28",
+      "user-agent": "zedi-analyze-error/0.1",
+      ...(body !== undefined ? { "content-type": "application/json" } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  };
+  const res = await fetchImpl(url, init);
+  if (!res.ok && !acceptStatuses.includes(res.status)) {
+    let detail = "";
+    try {
+      detail = await res.text();
+    } catch {
+      detail = "(no body)";
+    }
+    throw new Error(`GitHub ${method} ${url} failed: ${res.status} ${detail}`);
+  }
+  let data = null;
+  try {
+    data = await res.json();
+  } catch {
+    data = null;
+  }
+  return { status: res.status, data };
+}
+
+/**
+ * ラベルが存在することを保証する。404 の場合は作成する。既存の場合は no-op。
+ * `sentry-issue:<id>` 系は `LABEL_METADATA.__sentryIssue` を使う。
+ *
+ * Ensure a label exists on the repo. If `GET /labels/{name}` returns 404,
+ * create it via `POST /labels`. No-op when the label already exists. The
+ * dynamic `sentry-issue:<id>` family uses the shared `__sentryIssue` metadata.
+ *
+ * @param {{
+ *   owner: string,
+ *   repo: string,
+ *   label: string,
+ *   token: string,
+ *   fetchImpl: typeof fetch,
+ *   logger?: Pick<Console, "log">,
+ * }} args
+ * @returns {Promise<"existing" | "created">}
+ */
+export async function ensureLabel({ owner, repo, label, token, fetchImpl, logger = console }) {
+  // GET /labels/{name} は 404 が「未存在」のシグナル。tolerate しないと throw に
+  // なるので acceptStatuses で許容。
+  const get = await ghRequest({
+    url: `${GITHUB_API}/repos/${owner}/${repo}/labels/${encodeURIComponent(label)}`,
+    method: "GET",
+    token,
+    fetchImpl,
+    acceptStatuses: [404],
+  });
+  if (get.status === 200) {
+    return "existing";
+  }
+  const meta = LABEL_METADATA[label] ?? LABEL_METADATA.__sentryIssue;
+  await ghRequest({
+    url: `${GITHUB_API}/repos/${owner}/${repo}/labels`,
+    method: "POST",
+    token,
+    body: { name: label, color: meta.color, description: meta.description },
+    fetchImpl,
+  });
+  logger.log?.(`[auto-issue] created missing label: ${label}`);
+  return "created";
+}
+
+/**
+ * `sentry-issue:<id>` ラベルが付いた **オープン** Issue を検索する。重複防止
+ * のため、最古 (number 昇順最小) を 1 件選ぶ（GitHub API の sort=created+asc
+ * を使うと安定）。
+ *
+ * Search for **open** Issues carrying a given `sentry-issue:<id>` label. To
+ * stay deterministic if multiple matches exist (race during initial rollout
+ * or manual edits), pick the issue with the smallest `number` — the original
+ * file. The `?sort=created&direction=asc` query is just a hint; we still
+ * defensively re-sort client-side.
+ *
+ * @param {{
+ *   owner: string,
+ *   repo: string,
+ *   label: string,
+ *   token: string,
+ *   fetchImpl: typeof fetch,
+ * }} args
+ * @returns {Promise<{ number: number, html_url: string } | null>}
+ */
+export async function findOpenIssueByLabel({ owner, repo, label, token, fetchImpl }) {
+  const params = new URLSearchParams({
+    state: "open",
+    labels: label,
+    per_page: "100",
+    sort: "created",
+    direction: "asc",
+  });
+  const { data } = await ghRequest({
+    url: `${GITHUB_API}/repos/${owner}/${repo}/issues?${params.toString()}`,
+    method: "GET",
+    token,
+    fetchImpl,
+  });
+  if (!Array.isArray(data) || data.length === 0) return null;
+  // GitHub の `/issues` 一覧には Pull Request も含まれる（`pull_request` プロパティで
+  // 識別）。PR は除外して純粋な Issue だけを残す。
+  // GitHub's `/issues` listing includes Pull Requests too (distinguishable by
+  // the `pull_request` property). Filter them out so we never comment on a PR.
+  const issues = data
+    .filter((entry) => entry && typeof entry === "object" && !("pull_request" in entry))
+    .map((entry) => ({
+      number: Number(entry.number),
+      html_url: typeof entry.html_url === "string" ? entry.html_url : "",
+    }))
+    .filter((e) => Number.isFinite(e.number));
+  if (issues.length === 0) return null;
+  issues.sort((a, b) => a.number - b.number);
+  return issues[0];
+}
+
+/**
+ * Issue を作成する。`labels` は事前に `ensureLabel` で存在確認済みである前提。
+ *
+ * Create a new Issue. Assumes all labels in `labels` already exist (call
+ * `ensureLabel` first). Returns the created issue number / html_url.
+ *
+ * @param {{
+ *   owner: string,
+ *   repo: string,
+ *   title: string,
+ *   body: string,
+ *   labels: ReadonlyArray<string>,
+ *   token: string,
+ *   fetchImpl: typeof fetch,
+ * }} args
+ * @returns {Promise<{ number: number, html_url: string }>}
+ */
+export async function createIssue({ owner, repo, title, body, labels, token, fetchImpl }) {
+  const { data } = await ghRequest({
+    url: `${GITHUB_API}/repos/${owner}/${repo}/issues`,
+    method: "POST",
+    token,
+    body: { title, body, labels: [...labels] },
+    fetchImpl,
+  });
+  return {
+    number: Number(data?.number),
+    html_url: typeof data?.html_url === "string" ? data.html_url : "",
+  };
+}
+
+/**
+ * 既存 Issue にコメントを追加する。
+ *
+ * Append a comment to an existing Issue.
+ *
+ * @param {{
+ *   owner: string,
+ *   repo: string,
+ *   issueNumber: number,
+ *   body: string,
+ *   token: string,
+ *   fetchImpl: typeof fetch,
+ * }} args
+ * @returns {Promise<{ id: number, html_url: string }>}
+ */
+export async function addIssueComment({ owner, repo, issueNumber, body, token, fetchImpl }) {
+  const { data } = await ghRequest({
+    url: `${GITHUB_API}/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+    method: "POST",
+    token,
+    body: { body },
+    fetchImpl,
+  });
+  return {
+    id: Number(data?.id),
+    html_url: typeof data?.html_url === "string" ? data.html_url : "",
+  };
+}
+
+/**
+ * @typedef {{
+ *   action: "skipped",
+ *   reason: "severity-not-actionable",
+ * } | {
+ *   action: "created",
+ *   issueNumber: number,
+ *   html_url: string,
+ * } | {
+ *   action: "commented",
+ *   issueNumber: number,
+ *   commentId: number,
+ *   html_url: string,
+ * }} AutoIssueResult
+ */
+
+/**
+ * オーケストレータ。`analyze.mjs` の出力 + dispatch payload を受け取り、
+ * severity ゲート → ラベル整備 → 既存検索 → 作成 or コメント の順で実行する。
+ *
+ * Top-level orchestrator. Given the validated analysis JSON and the dispatch
+ * payload, runs:
+ *   1. severity gate (skip `low` / `unknown`),
+ *   2. ensure required labels exist,
+ *   3. search for an open Issue with the `sentry-issue:<id>` label,
+ *   4. comment on the existing Issue, or create a new one if none.
+ *
+ * Throws on any HTTP failure so the workflow step turns red and the operator
+ * sees the error in CI logs.
+ *
+ * @param {{
+ *   analysis: { severity: string, ai_summary: string, ai_root_cause?: string | null, ai_suggested_fix?: string | null, ai_suspected_files?: ReadonlyArray<{ path: string, reason?: string, line?: number }> | null },
+ *   sentryIssueId: string,
+ *   apiErrorId: string,
+ *   title: string,
+ *   route: string,
+ *   repository: string,
+ *   token: string,
+ *   workflowRunUrl: string,
+ *   fetchImpl?: typeof fetch,
+ *   logger?: Pick<Console, "log">,
+ * }} args
+ * @returns {Promise<AutoIssueResult>}
+ */
+export async function runAutoIssue({
+  analysis,
+  sentryIssueId,
+  apiErrorId,
+  title,
+  route,
+  repository,
+  token,
+  workflowRunUrl,
+  fetchImpl = globalThis.fetch,
+  logger = console,
+}) {
+  if (!shouldFileIssue(analysis?.severity)) {
+    logger.log?.(
+      `[auto-issue] severity=${analysis?.severity} — skipping issue creation (Epic #616: low/unknown は集約のみ)`,
+    );
+    return { action: "skipped", reason: "severity-not-actionable" };
+  }
+  if (typeof token !== "string" || token.length === 0) {
+    throw new Error("token must be a non-empty GitHub installation token");
+  }
+  const { owner, repo } = parseRepository(repository);
+  const sentryLabel = buildSentryIssueLabel(sentryIssueId);
+  const allLabels = [...STATIC_LABELS, sentryLabel];
+
+  // 並列で 3 ラベル確認。GitHub の secondary rate limit を踏みやすいケースは
+  // 「1 リクエストあたり〜100ms 以下の連続発行」なので、3 並列なら問題ない。
+  // Run the three label checks in parallel — well below GitHub's secondary
+  // rate-limit threshold for short concurrent bursts.
+  await Promise.all(
+    allLabels.map((label) => ensureLabel({ owner, repo, label, token, fetchImpl, logger })),
+  );
+
+  const existing = await findOpenIssueByLabel({
+    owner,
+    repo,
+    label: sentryLabel,
+    token,
+    fetchImpl,
+  });
+
+  if (existing) {
+    const commentBody = buildRecurrenceCommentBody({
+      severity: analysis.severity,
+      summary: analysis.ai_summary,
+      apiErrorId,
+      workflowRunUrl,
+    });
+    const created = await addIssueComment({
+      owner,
+      repo,
+      issueNumber: existing.number,
+      body: commentBody,
+      token,
+      fetchImpl,
+    });
+    logger.log?.(
+      `[auto-issue] commented on existing issue #${existing.number} (sentry_issue_id=${sentryIssueId})`,
+    );
+    return {
+      action: "commented",
+      issueNumber: existing.number,
+      commentId: created.id,
+      html_url: created.html_url,
+    };
+  }
+
+  const issueTitle = buildIssueTitle({
+    severity: analysis.severity,
+    title,
+    sentryIssueId,
+  });
+  const issueBody = buildIssueBody({
+    severity: analysis.severity,
+    summary: analysis.ai_summary,
+    rootCause: analysis.ai_root_cause ?? null,
+    suggestedFix: analysis.ai_suggested_fix ?? null,
+    suspectedFiles: analysis.ai_suspected_files ?? null,
+    route,
+    sentryIssueId,
+    apiErrorId,
+    workflowRunUrl,
+  });
+  const created = await createIssue({
+    owner,
+    repo,
+    title: issueTitle,
+    body: issueBody,
+    labels: allLabels,
+    token,
+    fetchImpl,
+  });
+  logger.log?.(
+    `[auto-issue] created new issue #${created.number} for sentry_issue_id=${sentryIssueId} (severity=${analysis.severity})`,
+  );
+  return {
+    action: "created",
+    issueNumber: created.number,
+    html_url: created.html_url,
+  };
+}

--- a/.github/actions/claude-analyze/autoIssueRunner.mjs
+++ b/.github/actions/claude-analyze/autoIssueRunner.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * `autoIssue.mjs` を GitHub Actions のステップから呼び出すための薄いラッパ。
+ * Epic #616 Phase 3 / Issue #808。
+ *
+ * 期待する環境変数 / Required env (set by `action.yml`):
+ *   - `AUTO_ISSUE_OUTPUT_PATH`     : `analyze.mjs` が書き出した解析結果 JSON のパス
+ *   - `AUTO_ISSUE_SENTRY_ISSUE_ID` : Sentry の issue id
+ *   - `AUTO_ISSUE_API_ERROR_ID`    : `api_errors.id` (UUID)
+ *   - `AUTO_ISSUE_TITLE`           : Sentry 由来の短いエラータイトル
+ *   - `AUTO_ISSUE_ROUTE`           : ルート（空でも可）
+ *   - `AUTO_ISSUE_REPOSITORY`      : `${{ github.repository }}` 形式
+ *   - `AUTO_ISSUE_TOKEN`           : GitHub App installation token (issues: write)
+ *   - `AUTO_ISSUE_WORKFLOW_RUN_URL`: 当該 workflow run の URL
+ *
+ * Thin wrapper that loads the analysis JSON, then calls `runAutoIssue`. Exits
+ * non-zero on failure so the workflow step turns red. Intentionally minimal —
+ * all of the testable logic lives in `autoIssue.mjs`.
+ */
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+import { runAutoIssue } from "./autoIssue.mjs";
+
+/**
+ * Required env var を読み出す。欠落は `Error` で即時失敗させる。
+ *
+ * Read a required env var; throw if missing so misconfiguration surfaces at
+ * the start of the step rather than midway through HTTP calls.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function requireEnv(name) {
+  const value = process.env[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing required env var: ${name}`);
+  }
+  return value;
+}
+
+async function main() {
+  const outputPath = requireEnv("AUTO_ISSUE_OUTPUT_PATH");
+  const sentryIssueId = requireEnv("AUTO_ISSUE_SENTRY_ISSUE_ID");
+  const apiErrorId = requireEnv("AUTO_ISSUE_API_ERROR_ID");
+  const title = requireEnv("AUTO_ISSUE_TITLE");
+  const repository = requireEnv("AUTO_ISSUE_REPOSITORY");
+  const token = requireEnv("AUTO_ISSUE_TOKEN");
+  const workflowRunUrl = requireEnv("AUTO_ISSUE_WORKFLOW_RUN_URL");
+  // route は空文字を許容。
+  const route = process.env.AUTO_ISSUE_ROUTE ?? "";
+
+  const raw = await readFile(outputPath, "utf8");
+  /** @type {unknown} */
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to parse analysis JSON at ${outputPath}: ${msg}`);
+  }
+
+  // analyze.mjs が `parseAndValidate` 経由で出力しているので、ここでは型ナローイング
+  // のみ行う（再検証はしない — 二重バリデーションは責務分離を曖昧にするため）。
+  // The analyze step already runs `parseAndValidate`; we only narrow the type
+  // here. Re-validating would muddy the responsibility split (schema lives
+  // with the analyze script).
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Analysis JSON did not parse to an object");
+  }
+  const analysis = /** @type {{ severity: string, ai_summary: string }} */ (parsed);
+
+  const result = await runAutoIssue({
+    analysis,
+    sentryIssueId,
+    apiErrorId,
+    title,
+    route,
+    repository,
+    token,
+    workflowRunUrl,
+  });
+
+  // GITHUB_OUTPUT に結果を書き出して、後続ステップから参照できるようにする。
+  // Emit an `outcome` annotation + GITHUB_OUTPUT so reviewers can spot the
+  // outcome in the workflow run summary at a glance.
+  const summary = JSON.stringify(result);
+  console.log(`[auto-issue] result=${summary}`);
+  console.log(`::notice title=Auto-issue outcome::${summary}`);
+
+  const githubOutput = process.env.GITHUB_OUTPUT;
+  if (githubOutput) {
+    const { appendFile } = await import("node:fs/promises");
+    const lines = [`action=${result.action}`];
+    if (result.action !== "skipped") {
+      lines.push(`issue_number=${result.issueNumber}`);
+      lines.push(`issue_html_url=${result.html_url}`);
+    }
+    await appendFile(githubOutput, `${lines.join("\n")}\n`);
+  }
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.stack || err.message : String(err);
+  console.error(`[auto-issue] failed: ${msg}`);
+  process.exit(1);
+});

--- a/.github/workflows/analyze-error.yml
+++ b/.github/workflows/analyze-error.yml
@@ -50,13 +50,24 @@ on:
         required: false
         type: boolean
         default: true
+      skip_issue:
+        description: Skip GitHub Issue create / comment (Epic #616 Phase 3)
+        required: false
+        type: boolean
+        default: true
 
-# 最小権限。callback は GitHub App の installation token 経由で行うため、
-# `GITHUB_TOKEN` には何も書かせない。
-# Minimum permissions. The callback uses a GitHub App installation token, so
-# the default `GITHUB_TOKEN` needs nothing beyond `contents: read`.
+# API callback と Issue 起票はどちらも GitHub App の installation token 経由で行う
+# ため、デフォルト `GITHUB_TOKEN` には書き込みを与えない。`issues: write` を
+# 明示するのは Epic #616 Phase 3 (Issue #808) の要件: フォールバックで `gh`
+# CLI を使えるようにし、ジョブの権限境界を YAML 上で読み取れるようにする目的。
+#
+# Both the API callback and the auto-issue step use the GitHub App installation
+# token (minted just below). `issues: write` is declared explicitly per Issue
+# #808 so the workflow's intent is visible in YAML and `gh` CLI fallbacks are
+# usable; the App token is still the actual writer.
 permissions:
   contents: read
+  issues: write
 
 # 同一 sentry_issue_id への並行起動を防ぐ。再来時にも余計に Claude を呼ばないため。
 # Prevent concurrent runs for the same Sentry issue. Avoids spending Anthropic
@@ -81,16 +92,21 @@ jobs:
           fetch-depth: 1
 
       - name: Mint GitHub App installation token
-        # callback の Bearer に使う。`actions/create-github-app-token` は App ID +
-        # Private Key から短命 installation token を発行し、自動で revoke する。
-        # ワークフロー外には漏れない。`skip_callback=true` の場合はこのステップを
-        # スキップして、secrets 未設定環境（fork PR など）でもドライランが回るようにする。
+        # callback の Bearer + 自動 Issue 起票の bearer に使う。`actions/create-github-app-token`
+        # は App ID + Private Key から短命 installation token を発行し、自動で revoke する。
+        # ワークフロー外には漏れない。`skip_callback` と `skip_issue` の両方が true の
+        # ドライランではこのステップをスキップし、secrets 未設定環境（fork PR など）
+        # でもパイプラインが回るようにする。
         #
-        # Mint the bearer used for the API callback. `actions/create-github-app-token`
-        # exchanges App ID + Private Key for a short-lived installation token and
-        # auto-revokes it at job end. Skipped when `skip_callback=true` so the
-        # dry-run path works in environments without the App secrets configured.
-        if: github.event_name == 'repository_dispatch' || github.event.inputs.skip_callback != 'true'
+        # Mint the bearer used by both the API callback and the auto-issue
+        # step. Skipped only when both `skip_callback` and `skip_issue` are
+        # `true` (the workflow_dispatch dry-run default), so repositories
+        # without GitHub App secrets configured can still validate the
+        # pipeline end-to-end.
+        if: >-
+          github.event_name == 'repository_dispatch' ||
+          github.event.inputs.skip_callback != 'true' ||
+          github.event.inputs.skip_issue != 'true'
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
@@ -111,3 +127,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           dry_run: ${{ github.event.inputs.dry_run || 'false' }}
           skip_callback: ${{ github.event.inputs.skip_callback || 'false' }}
+          # `repository_dispatch` 経由（本番経路）では常に Issue 起票判定を回す。
+          # `workflow_dispatch` では入力 `skip_issue` を尊重し、デフォルトは true で
+          # ローカルのドライラン中に誤って Issue を作らないようにする。
+          # On `repository_dispatch` (production path) always run the auto-issue
+          # gate. On `workflow_dispatch` honor the `skip_issue` input (default
+          # true) so ad-hoc dry runs cannot accidentally file Issues.
+          skip_issue: ${{ github.event.inputs.skip_issue || 'false' }}


### PR DESCRIPTION
## 概要

Epic #616 Phase 3 の実装。AI が判定した `severity` が `high` または `medium` のときに、自動で GitHub Issue を新規起票するか、既存の重複 Issue にコメントを追記する機能を追加しました。`sentry-issue:<id>` ラベルを dedup キーとして使用し、同一 Sentry issue に対するオープン Issue は最大 1 件に保つ設計です。

Implements Epic #616 Phase 3 / Issue #808: auto-files a GitHub Issue when AI-assigned severity is `high` or `medium`, or appends a recurrence comment to an existing open Issue for the same Sentry issue id. Uses the `sentry-issue:<id>` label as the dedup key to maintain at most one open Issue per Sentry id.

## 変更点

- **`autoIssue.mjs`** (新規): Issue 起票・コメント追記の純粋関数と HTTP 層
  - `shouldFileIssue()`: severity ゲート（high/medium のみ起票対象）
  - `buildSentryIssueLabel()`: `sentry-issue:<id>` ラベル生成
  - `parseRepository()`: `owner/repo` 形式のパース
  - `buildIssueTitle()`: Issue タイトル生成（severity prefix + エラー本文 + sentry id suffix）
  - `buildIssueBody()`: Issue 本文生成（AI 判定結果を表形式で埋め込み）
  - `buildRecurrenceCommentBody()`: 再発時のコメント本文生成
  - `ensureLabel()`: ラベルの存在確認・自動作成
  - `findOpenIssueByLabel()`: `sentry-issue:<id>` ラベル付きのオープン Issue 検索
  - `createIssue()` / `addIssueComment()`: GitHub REST API ラッパー
  - `runAutoIssue()`: オーケストレータ（severity ゲート → ラベル整備 → 既存検索 → 作成 or コメント）

- **`autoIssueRunner.mjs`** (新規): GitHub Actions ステップから `autoIssue.mjs` を呼び出すエントリポイント
  - 環境変数から解析結果 JSON を読み込み
  - `runAutoIssue()` を実行
  - 結果を `GITHUB_OUTPUT` に書き出し

- **`__tests__/autoIssue.test.mjs`** (新規): 単体テスト
  - 純粋関数（severity ゲート、ラベル生成、タイトル/本文ビルダー）のテスト
  - `fetch` スタブを注入した `runAutoIssue` の経路分岐テスト（skip / create / comment）
  - 実 GitHub API は呼ばない設計

- **`.github/workflows/analyze-error.yml`**: 
  - `skip_issue` 入力パラメータを追加（デフォルト true）
  - `permissions.issues: write` を明示
  - `Auto-file or comment GitHub Issue` ステップを追加

- **`.github/actions/claude-analyze/action.yml`**:
  - `skip_issue` 入力を追加
  - `issue_action`, `issue_number`, `issue_html_url` 出力を追加
  - `auto-issue` ステップを追加

- **`.github/actions/claude-analyze/README.md`**:
  - Phase 3 の説明を追加
  - ファイル構成表を更新
  - テ

https://claude.ai/code/session_015fVApMc3zit4eL7ECcCnSu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated GitHub Issue creation for high/medium-severity API errors with one-issue-per-error deduplication, on-demand label creation, recurrence comments, and a CLI-run dry-run path; `skip_issue` input lets you disable auto-filing; action now emits `issue_action`, `issue_number`, and `issue_html_url`. Workflow permissions updated to allow issue writes when enabled.

* **Tests**
  * Expanded unit tests covering title/body/label/search/create/comment flows and race/failure cases.

* **Documentation**
  * Expanded docs and examples for auto-issue behavior, dry-run, permissions, retry semantics, and local testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->