### PR TITLE
feat: add note switcher dropdown to header (issue #827)

### DIFF
--- a/src/components/layout/Header/NoteSwitcher.test.tsx
+++ b/src/components/layout/Header/NoteSwitcher.test.tsx
@@ -12,11 +12,33 @@
  * 新規ノート作成への導線を置き、新規作成は `Notes` ページの既存ダイアログに
  * 委譲する。
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import type { NoteSummary } from "@/types/note";
+
+/**
+ * Mock return shapes mirroring the real `useNoteQueries` / `useAuth` hooks so
+ * the test harness keeps strict typing across calls and avoids hiding interface
+ * drift behind untyped `vi.fn()`.
+ *
+ * `useNoteQueries` / `useAuth` の戻り値型をテスト側で明示し、`vi.fn()` を
+ * 経由してインターフェースが食い違っても気付けるようにする。
+ */
+type UseNotesResult = {
+  data: NoteSummary[] | undefined;
+  isLoading: boolean;
+};
+type UseMyNoteResult = {
+  data: { id: string; is_default: boolean } | undefined;
+  isLoading: boolean;
+};
+type UseAuthResult = {
+  isSignedIn: boolean;
+  isLoaded: boolean;
+  userId: string | null;
+};
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -46,9 +68,9 @@ vi.mock("@zedi/ui", async () => {
   };
 });
 
-const useNotesMock = vi.fn();
-const useMyNoteMock = vi.fn();
-const useAuthMock = vi.fn();
+const useNotesMock: Mock<() => UseNotesResult> = vi.fn();
+const useMyNoteMock: Mock<(options?: { enabled?: boolean }) => UseMyNoteResult> = vi.fn();
+const useAuthMock: Mock<() => UseAuthResult> = vi.fn();
 
 vi.mock("@/hooks/useNoteQueries", () => ({
   useNotes: () => useNotesMock(),
@@ -164,6 +186,7 @@ describe("NoteSwitcher", () => {
 
     const items = await screen.findAllByRole("menuitem");
     // Filter to note rows (footer items have distinct names).
+    // ノート行のみに絞り込む（フッター項目は名前が異なる）。
     const noteRowNames = items
       .map((el) => el.textContent ?? "")
       .filter((text) => /My default|Alpha note|Beta note|Gamma note/.test(text));
@@ -171,6 +194,7 @@ describe("NoteSwitcher", () => {
     expect(noteRowNames[0]).toMatch(/My default/);
     expect(noteRowNames[0]).toMatch(/既定/);
     // Beta (updatedAt=300) > Gamma (200) > Alpha (100).
+    // updatedAt が大きい順に Beta(300) > Gamma(200) > Alpha(100)。
     expect(noteRowNames[1]).toMatch(/Beta note/);
     expect(noteRowNames[2]).toMatch(/Gamma note/);
     expect(noteRowNames[3]).toMatch(/Alpha note/);
@@ -229,7 +253,13 @@ describe("NoteSwitcher", () => {
     await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
 
     const betaItem = await screen.findByRole("menuitem", { name: /Beta note/ });
+    // Exercise actual click-to-navigate so the test catches breakage in the
+    // `Link` wiring beyond just the static href.
+    // 静的な href だけでなく、`Link` のクリック遷移そのものが壊れた場合も
+    // 検知できるよう、実際にクリックして遷移を確認する。
     expect(betaItem).toHaveAttribute("href", "/notes/note-beta");
+    await user.click(betaItem);
+    expect(screen.getByTestId("location")).toHaveTextContent("/notes/note-beta");
   });
 
   it("renders an 'all notes' footer that links to /notes", async () => {
@@ -274,6 +304,7 @@ describe("NoteSwitcher", () => {
 
     expect(await screen.findByText("まだノートがありません")).toBeInTheDocument();
     // The footer shortcuts must remain available even when the list is empty.
+    // 一覧が空でもフッターのショートカットは表示され続ける必要がある。
     expect(screen.getByRole("menuitem", { name: "新規ノートを作成" })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: "すべてのノートを見る" })).toBeInTheDocument();
   });
@@ -303,6 +334,7 @@ describe("NoteSwitcher", () => {
     );
     expect(rows.length).toBe(50);
     // 80 -> sorted by updatedAt DESC, expect Note 79 first.
+    // 80 件を updatedAt 降順で並べた場合、先頭は Note 79 になる。
     expect(rows[0].textContent?.trim()).toBe("Note 79");
   });
 

--- a/src/components/layout/Header/NoteSwitcher.test.tsx
+++ b/src/components/layout/Header/NoteSwitcher.test.tsx
@@ -1,0 +1,325 @@
+/**
+ * Tests for {@link NoteSwitcher}, the header dropdown that lets users hop
+ * between their notes without leaving the editor surface (issue #827). The
+ * default note is pinned to the top with a badge; the rest of the rows are
+ * sorted by `updatedAt` descending. The footer links to `/notes` ("see all")
+ * and offers a quick "new note" entry that delegates to the existing
+ * create-note dialog on the notes index page.
+ *
+ * ヘッダーにノート切替用のドロップダウン {@link NoteSwitcher} を追加するテスト
+ * （issue #827）。デフォルトノートはバッジ付きで先頭に固定し、それ以外は
+ * `updatedAt` 降順で並べる。フッターには `/notes`（一覧）への "see all" と
+ * 新規ノート作成への導線を置き、新規作成は `Notes` ページの既存ダイアログに
+ * 委譲する。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import type { NoteSummary } from "@/types/note";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => {
+      const table: Record<string, string> = {
+        "nav.menu": "メニュー",
+        "notes.switcher.trigger": "ノートを切り替え",
+        "notes.switcher.heading": "ノート",
+        "notes.switcher.defaultBadge": "既定",
+        "notes.switcher.empty": "まだノートがありません",
+        "notes.switcher.loading": "読み込み中…",
+        "notes.switcher.allNotes": "すべてのノートを見る",
+        "notes.switcher.newNote": "新規ノートを作成",
+        "notes.untitledNote": "無題のノート",
+      };
+      return table[key] ?? fallback ?? key;
+    },
+    i18n: { language: "ja" },
+  }),
+}));
+
+vi.mock("@zedi/ui", async () => {
+  const actual = await vi.importActual<typeof import("@zedi/ui")>("@zedi/ui");
+  return {
+    ...actual,
+    useIsMobile: vi.fn(() => false),
+  };
+});
+
+const useNotesMock = vi.fn();
+const useMyNoteMock = vi.fn();
+const useAuthMock = vi.fn();
+
+vi.mock("@/hooks/useNoteQueries", () => ({
+  useNotes: () => useNotesMock(),
+  useMyNote: (options?: { enabled?: boolean }) => useMyNoteMock(options),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+import { NoteSwitcher } from "./NoteSwitcher";
+
+function makeNote(overrides: Partial<NoteSummary> & { id: string }): NoteSummary {
+  return {
+    id: overrides.id,
+    ownerUserId: overrides.ownerUserId ?? "user-1",
+    title: overrides.title ?? "",
+    visibility: overrides.visibility ?? "private",
+    editPermission: overrides.editPermission ?? "owner_only",
+    isOfficial: overrides.isOfficial ?? false,
+    viewCount: overrides.viewCount ?? 0,
+    createdAt: overrides.createdAt ?? 0,
+    updatedAt: overrides.updatedAt ?? 0,
+    isDeleted: overrides.isDeleted ?? false,
+    role: overrides.role ?? "owner",
+    pageCount: overrides.pageCount ?? 0,
+    memberCount: overrides.memberCount ?? 0,
+  };
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname + location.search}</div>;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <>
+              <NoteSwitcher />
+              <LocationProbe />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const noteAlpha = makeNote({
+  id: "note-alpha",
+  title: "Alpha note",
+  updatedAt: 100,
+});
+const noteBeta = makeNote({
+  id: "note-beta",
+  title: "Beta note",
+  updatedAt: 300,
+});
+const noteGamma = makeNote({
+  id: "note-gamma",
+  title: "Gamma note",
+  updatedAt: 200,
+});
+const defaultNote = makeNote({
+  id: "note-default",
+  title: "My default",
+  updatedAt: 50,
+});
+
+describe("NoteSwitcher", () => {
+  beforeEach(() => {
+    useAuthMock.mockReturnValue({ isSignedIn: true, isLoaded: true, userId: "user-1" });
+    useNotesMock.mockReturnValue({
+      data: [noteAlpha, noteBeta, noteGamma, defaultNote],
+      isLoading: false,
+    });
+    useMyNoteMock.mockReturnValue({
+      data: { id: defaultNote.id, is_default: true },
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when the user is signed out", () => {
+    useAuthMock.mockReturnValue({ isSignedIn: false, isLoaded: true, userId: null });
+    renderAt("/notes/note-alpha");
+    expect(screen.queryByRole("button", { name: "ノートを切り替え" })).not.toBeInTheDocument();
+  });
+
+  it("renders the trigger with the switcher aria-label when signed in", () => {
+    renderAt("/notes/note-alpha");
+    expect(screen.getByRole("button", { name: "ノートを切り替え" })).toBeInTheDocument();
+  });
+
+  it("does not render note items until the trigger is clicked", () => {
+    renderAt("/notes/note-alpha");
+    expect(screen.queryByRole("menuitem", { name: /Alpha note/ })).not.toBeInTheDocument();
+  });
+
+  it("pins the default note first and sorts the rest by updatedAt DESC", async () => {
+    const user = userEvent.setup();
+    renderAt("/notes/note-alpha");
+
+    await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
+
+    const items = await screen.findAllByRole("menuitem");
+    // Filter to note rows (footer items have distinct names).
+    const noteRowNames = items
+      .map((el) => el.textContent ?? "")
+      .filter((text) => /My default|Alpha note|Beta note|Gamma note/.test(text));
+
+    expect(noteRowNames[0]).toMatch(/My default/);
+    expect(noteRowNames[0]).toMatch(/既定/);
+    // Beta (updatedAt=300) > Gamma (200) > Alpha (100).
+    expect(noteRowNames[1]).toMatch(/Beta note/);
+    expect(noteRowNames[2]).toMatch(/Gamma note/);
+    expect(noteRowNames[3]).toMatch(/Alpha note/);
+  });
+
+  it("marks the active note with aria-current=true", async () => {
+    const user = userEvent.setup();
+    renderAt("/notes/note-beta");
+    await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
+
+    const betaItem = await screen.findByRole("menuitem", { name: /Beta note/ });
+    expect(betaItem).toHaveAttribute("aria-current", "true");
+
+    const alphaItem = await screen.findByRole("menuitem", { name: /Alpha note/ });
+    expect(alphaItem).not.toHaveAttribute("aria-current", "true");
+  });
+
+  it("does not mark anything active on /notes (the index)", async () => {
+    const user = userEvent.setup();
+    renderAt("/notes");
+    await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
+
+    const noteItems = (await screen.findAllByRole("menuitem")).filter((el) =>
+      /Alpha note|Beta note|Gamma note|My default/.test(el.textContent ?? ""),
+    );
+    for (const item of noteItems) {
+      expect(item).not.toHaveAttribute("aria-current", "true");
+    }
+  });
+
+  it("treats sub-paths like /notes/:noteId/:pageId as still on that note", async () => {
+    const user = userEvent.setup();
+    renderAt("/notes/note-gamma/some-page");
+    await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
+
+    const gammaItem = await screen.findByRole("menuitem", { name: /Gamma note/ });
+    expect(gammaItem).toHaveAttribute("aria-current", "true");
+  });
+
+  it("ignores the literal /notes/me landing path for active highlighting", async () => {
+    const user = userEvent.setup();
+    renderAt("/notes/me");
+    await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
+
+    const noteItems = (await screen.findAllByRole("menuitem")).filter((el) =>
+      /Alpha note|Beta note|Gamma note|My default/.test(el.textContent ?? ""),
+    );
+    for (const item of noteItems) {
+      expect(item).not.toHaveAttribute("aria-current", "true");
+    }
+  });
+
+  it("navigates to /notes/:noteId when a row is selected", async () => {
+    const user = userEvent.setup();
+    renderAt("/notes/note-alpha");
+    await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
+
+    const betaItem = await screen.findByRole("menuitem", { name: /Beta note/ });
+    expect(betaItem).toHaveAttribute("href", "/notes/note-beta");
+  });
+
+  it("renders an 'all notes' footer that links to /notes", async () => {
+    const user = userEvent.setup();
+    renderAt("/notes/note-alpha");
+    await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
+
+    const allLink = await screen.findByRole("menuitem", {
+      name: "すべてのノートを見る",
+    });
+    expect(allLink).toHaveAttribute("href", "/notes");
+  });
+
+  it("renders a 'new note' footer that links to /notes?new=1", async () => {
+    const user = userEvent.setup();
+    renderAt("/notes/note-alpha");
+    await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
+
+    const newLink = await screen.findByRole("menuitem", { name: "新規ノートを作成" });
+    expect(newLink).toHaveAttribute("href", "/notes?new=1");
+  });
+
+  it("falls back to a placeholder when a note has an empty title", async () => {
+    useNotesMock.mockReturnValue({
+      data: [makeNote({ id: "note-untitled", title: "", updatedAt: 999 })],
+      isLoading: false,
+    });
+    useMyNoteMock.mockReturnValue({ data: undefined, isLoading: false });
+    const user = userEvent.setup();
+    renderAt("/notes");
+    await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
+
+    expect(await screen.findByRole("menuitem", { name: /無題のノート/ })).toBeInTheDocument();
+  });
+
+  it("shows an empty hint when the user has no notes", async () => {
+    useNotesMock.mockReturnValue({ data: [], isLoading: false });
+    useMyNoteMock.mockReturnValue({ data: undefined, isLoading: false });
+    const user = userEvent.setup();
+    renderAt("/notes");
+    await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
+
+    expect(await screen.findByText("まだノートがありません")).toBeInTheDocument();
+    // The footer shortcuts must remain available even when the list is empty.
+    expect(screen.getByRole("menuitem", { name: "新規ノートを作成" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "すべてのノートを見る" })).toBeInTheDocument();
+  });
+
+  it("shows a loading hint while the notes list is fetching", async () => {
+    useNotesMock.mockReturnValue({ data: undefined, isLoading: true });
+    useMyNoteMock.mockReturnValue({ data: undefined, isLoading: true });
+    const user = userEvent.setup();
+    renderAt("/notes");
+    await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
+
+    expect(await screen.findByText("読み込み中…")).toBeInTheDocument();
+  });
+
+  it("caps the listed notes at 50 entries", async () => {
+    const many: NoteSummary[] = Array.from({ length: 80 }, (_, i) =>
+      makeNote({ id: `note-${i}`, title: `Note ${i}`, updatedAt: i }),
+    );
+    useNotesMock.mockReturnValue({ data: many, isLoading: false });
+    useMyNoteMock.mockReturnValue({ data: undefined, isLoading: false });
+    const user = userEvent.setup();
+    renderAt("/notes");
+    await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
+
+    const rows = (await screen.findAllByRole("menuitem")).filter((el) =>
+      /^Note \d+$/.test((el.textContent ?? "").trim()),
+    );
+    expect(rows.length).toBe(50);
+    // 80 -> sorted by updatedAt DESC, expect Note 79 first.
+    expect(rows[0].textContent?.trim()).toBe("Note 79");
+  });
+
+  it("does not list soft-deleted notes", async () => {
+    useNotesMock.mockReturnValue({
+      data: [
+        makeNote({ id: "note-live", title: "Live note", updatedAt: 200 }),
+        makeNote({ id: "note-dead", title: "Dead note", updatedAt: 300, isDeleted: true }),
+      ],
+      isLoading: false,
+    });
+    useMyNoteMock.mockReturnValue({ data: undefined, isLoading: false });
+    const user = userEvent.setup();
+    renderAt("/notes");
+    await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
+
+    expect(screen.queryByRole("menuitem", { name: /Dead note/ })).not.toBeInTheDocument();
+    expect(await screen.findByRole("menuitem", { name: /Live note/ })).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/Header/NoteSwitcher.tsx
+++ b/src/components/layout/Header/NoteSwitcher.tsx
@@ -1,0 +1,227 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { Link, matchPath, useLocation } from "react-router-dom";
+import { Check, ChevronsUpDown, NotebookText, Plus, ListTree } from "lucide-react";
+import {
+  Badge,
+  Button,
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  ScrollArea,
+} from "@zedi/ui";
+import { useTranslation } from "react-i18next";
+import { useAuth } from "@/hooks/useAuth";
+import { useMyNote, useNotes } from "@/hooks/useNoteQueries";
+import type { NoteSummary } from "@/types/note";
+
+/**
+ * Hard cap on the number of rows the dropdown renders inline. Beyond this we
+ * funnel users to `/notes` via the "see all" footer link rather than letting
+ * the menu balloon. Tuned per issue #827; revisit if a tenant-scale UX hits
+ * the cap regularly.
+ *
+ * ドロップダウンに直接並べる行数の上限。これを超える場合はフッターの
+ * 「すべてのノートを見る」リンクから `/notes` に誘導し、メニューが肥大化
+ * しないようにする（issue #827）。テナントによって日常的に超える運用が
+ * 出てきたら見直す。
+ */
+const MAX_ROWS = 50;
+
+/**
+ * Resolve the active note id from the current URL. Only `/notes/:noteId`
+ * (and its sub-paths) resolve to a noteId — sibling routes such as
+ * `/notes`, `/notes/me`, `/notes/discover`, and `/notes/official-guide`
+ * stay unmarked because they are not editable note views.
+ *
+ * URL から現在開いているノートの id を解決する。`/notes/:noteId` 系のみが
+ * 有効で、`/notes` や `/notes/me`、`/notes/discover`、`/notes/official-guide`
+ * といった兄弟ルートはノートビューではないためアクティブ判定の対象外とする。
+ */
+function resolveActiveNoteId(pathname: string): string | null {
+  const reservedSegments = new Set(["me", "discover", "official-guide"]);
+  const match = matchPath({ path: "/notes/:noteId", end: false }, pathname);
+  const id = match?.params.noteId;
+  if (!id) return null;
+  if (reservedSegments.has(id)) return null;
+  return id;
+}
+
+const SwitcherTrigger = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<typeof Button>
+>((props, ref) => {
+  const { t } = useTranslation();
+  return (
+    <Button
+      ref={ref}
+      type="button"
+      variant="ghost"
+      size="sm"
+      aria-label={t("notes.switcher.trigger")}
+      className="text-foreground hover:bg-muted h-9 gap-2 px-2"
+      {...props}
+    >
+      <NotebookText aria-hidden="true" className="h-4 w-4" />
+      <span className="hidden text-sm font-medium md:inline">{t("notes.switcher.trigger")}</span>
+      <ChevronsUpDown aria-hidden="true" className="text-muted-foreground h-3.5 w-3.5" />
+    </Button>
+  );
+});
+SwitcherTrigger.displayName = "SwitcherTrigger";
+
+interface NoteRowProps {
+  note: NoteSummary;
+  isDefault: boolean;
+  isActive: boolean;
+  onSelect: () => void;
+}
+
+/**
+ * One note row inside the switcher dropdown. The default note keeps a
+ * `既定 / Default` badge; the currently open note carries `aria-current=true`
+ * and a leading check icon. The link target is `/notes/:noteId`, matching
+ * the route shape consumed by `NoteView`.
+ *
+ * スイッチャー内の 1 ノート行。デフォルトノートには `既定 / Default` バッジを
+ * 付け、現在開いているノートには `aria-current=true` とチェックアイコンを
+ * 付与する。リンク先は `NoteView` が解釈する `/notes/:noteId`。
+ */
+const NoteRow: React.FC<NoteRowProps> = ({ note, isDefault, isActive, onSelect }) => {
+  const { t } = useTranslation();
+  const title = note.title.trim().length > 0 ? note.title : t("notes.untitledNote");
+  return (
+    <DropdownMenuItem
+      asChild
+      onSelect={onSelect}
+      className={cn(
+        "cursor-pointer gap-2 py-1.5 pr-2 pl-2",
+        isActive && "bg-accent/60 data-[highlighted]:bg-accent",
+      )}
+    >
+      <Link
+        to={`/notes/${note.id}`}
+        aria-current={isActive ? "true" : undefined}
+        className="flex w-full items-center gap-2"
+      >
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+          {isActive ? (
+            <Check aria-hidden="true" className="h-4 w-4" />
+          ) : (
+            <NotebookText aria-hidden="true" className="text-muted-foreground h-4 w-4" />
+          )}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-sm">{title}</span>
+        {isDefault && (
+          <Badge variant="secondary" className="shrink-0 text-[10px] uppercase">
+            {t("notes.switcher.defaultBadge")}
+          </Badge>
+        )}
+      </Link>
+    </DropdownMenuItem>
+  );
+};
+
+/**
+ * Header-mounted note switcher. Lists the current user's notes, pins the
+ * default note to the top with a badge, and offers shortcuts to the notes
+ * index (`/notes`) and the create-note flow. Mirrors the issue #827 spec:
+ * a dropdown rather than a sidebar, accessible from any AppLayout-wrapped
+ * page (desktop and mobile).
+ *
+ * ヘッダー内のノート切替 UI。サインイン中ユーザーのノートを並べ、デフォルト
+ * ノートはバッジ付きで先頭に固定する。フッターには `/notes` 一覧と
+ * 新規作成フローへのショートカットを置く。issue #827 のドロップダウン案を
+ * 踏襲し、AppLayout 配下のあらゆるページ（モバイル含む）から開けるようにする。
+ */
+export const NoteSwitcher: React.FC = () => {
+  const { t } = useTranslation();
+  const { isSignedIn } = useAuth();
+  const isAuthed = isSignedIn === true;
+  const [open, setOpen] = useState(false);
+  const close = useCallback(() => setOpen(false), []);
+
+  const notesQuery = useNotes();
+  const myNoteQuery = useMyNote({ enabled: isAuthed });
+  const myNoteId = myNoteQuery.data?.id ?? null;
+
+  const location = useLocation();
+  const activeNoteId = useMemo(() => resolveActiveNoteId(location.pathname), [location.pathname]);
+
+  const sortedNotes = useMemo<NoteSummary[]>(() => {
+    const list = notesQuery.data ?? [];
+    const live = list.filter((note) => !note.isDeleted);
+    const def = myNoteId ? (live.find((note) => note.id === myNoteId) ?? null) : null;
+    const others = live
+      .filter((note) => note.id !== def?.id)
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+    const ordered = def ? [def, ...others] : others;
+    return ordered.slice(0, MAX_ROWS);
+  }, [notesQuery.data, myNoteId]);
+
+  if (!isAuthed) return null;
+
+  const isLoading = notesQuery.isLoading;
+  const isEmpty = !isLoading && sortedNotes.length === 0;
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <SwitcherTrigger />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" sideOffset={8} className="w-72 p-0">
+        <DropdownMenuLabel className="text-muted-foreground px-3 py-2 text-xs font-medium tracking-wide uppercase">
+          {t("notes.switcher.heading")}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator className="my-0" />
+
+        {isLoading && (
+          <p role="status" aria-live="polite" className="text-muted-foreground px-3 py-3 text-sm">
+            {t("notes.switcher.loading")}
+          </p>
+        )}
+
+        {isEmpty && (
+          <p className="text-muted-foreground px-3 py-3 text-sm">{t("notes.switcher.empty")}</p>
+        )}
+
+        {!isLoading && sortedNotes.length > 0 && (
+          <ScrollArea className="max-h-72">
+            <div className="p-1">
+              {sortedNotes.map((note) => (
+                <NoteRow
+                  key={note.id}
+                  note={note}
+                  isDefault={note.id === myNoteId}
+                  isActive={note.id === activeNoteId}
+                  onSelect={close}
+                />
+              ))}
+            </div>
+          </ScrollArea>
+        )}
+
+        <DropdownMenuSeparator className="my-0" />
+        <div className="p-1">
+          <DropdownMenuItem asChild onSelect={close} className="cursor-pointer gap-2">
+            <Link to="/notes?new=1" className="flex w-full items-center gap-2">
+              <Plus aria-hidden="true" className="h-4 w-4" />
+              <span className="text-sm">{t("notes.switcher.newNote")}</span>
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild onSelect={close} className="cursor-pointer gap-2">
+            <Link to="/notes" className="flex w-full items-center gap-2">
+              <ListTree aria-hidden="true" className="h-4 w-4" />
+              <span className="text-sm">{t("notes.switcher.allNotes")}</span>
+            </Link>
+          </DropdownMenuItem>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default NoteSwitcher;

--- a/src/components/layout/Header/index.test.tsx
+++ b/src/components/layout/Header/index.test.tsx
@@ -73,6 +73,9 @@ vi.mock("./HeaderSearchBar", () => ({
 vi.mock("./NavigationMenu", () => ({
   NavigationMenu: () => <div data-testid="navigation-menu">NavigationMenu</div>,
 }));
+vi.mock("./NoteSwitcher", () => ({
+  NoteSwitcher: () => <div data-testid="note-switcher">NoteSwitcher</div>,
+}));
 vi.mock("./UnifiedMenu", () => ({ UnifiedMenu: () => <div data-testid="unified-menu">Menu</div> }));
 
 describe("Header", () => {

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -4,6 +4,7 @@ import { cn, useIsMobile } from "@zedi/ui";
 import { HeaderLogo } from "./HeaderLogo";
 import { HeaderSearchBar } from "./HeaderSearchBar";
 import { NavigationMenu } from "./NavigationMenu";
+import { NoteSwitcher } from "./NoteSwitcher";
 import { UnifiedMenu } from "./UnifiedMenu";
 import { MobileHeader } from "../MobileHeader";
 import { useAuth } from "@/hooks/useAuth";
@@ -46,12 +47,19 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
       )}
     >
       <Container className="flex h-[4.5rem] items-center justify-between gap-3 md:gap-4">
-        {/* Left: Logo.
-            左: ロゴ。 */}
+        {/* Left: Logo + NoteSwitcher.
+            The switcher sits next to the logo so users on any AppLayout
+            page can hop between their notes without leaving the editor
+            surface. Hidden for guests; the inner component handles that.
+            See issue #827.
+            左: ロゴと NoteSwitcher。AppLayout 配下のどのページからでも
+            ノートを切り替えられるよう、ロゴの隣に配置する。未ログイン時は
+            内部で非表示になる。issue #827。 */}
         <div className="flex min-w-0 shrink-0 items-center gap-2 md:gap-3">
           <div className="hidden items-center gap-3 md:flex">
             <HeaderLogo />
           </div>
+          <NoteSwitcher />
         </div>
 
         {/* Center: Search bar with optional left/right action slots wrapping it.

--- a/src/components/layout/MobileHeader.test.tsx
+++ b/src/components/layout/MobileHeader.test.tsx
@@ -49,6 +49,14 @@ vi.mock("./Header/UnifiedMenu", () => ({
   UnifiedMenu: () => unifiedMenuMock(),
 }));
 
+// NoteSwitcher pulls in heavy dependencies (auth + react-query). The mobile
+// header test only cares that the bar layout stays compact, so stub it out.
+// NoteSwitcher は auth / react-query 経由で重い依存を引き込むため、
+// レイアウト検証だけの本テストではスタブ化する。
+vi.mock("./Header/NoteSwitcher", () => ({
+  NoteSwitcher: () => <div data-testid="note-switcher" />,
+}));
+
 function renderHeader() {
   return render(
     <MemoryRouter>

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { cn } from "@zedi/ui";
 import { HeaderSearchBar } from "./Header/HeaderSearchBar";
+import { NoteSwitcher } from "./Header/NoteSwitcher";
 import Container from "@/components/layout/Container";
 import { useGlobalSearchContextOptional } from "@/contexts/GlobalSearchContext";
 import { useHeaderActions } from "@/contexts/HeaderActionsContext";
@@ -42,6 +43,14 @@ export const MobileHeader: React.FC<MobileHeaderProps> = ({ className }) => {
           className="flex shrink-0 items-center gap-1 empty:hidden"
           data-testid="header-left-slot"
         />
+        {/* Mobile NoteSwitcher: rendered as a compact icon trigger so the
+            mobile bar still fits the search input in one row. The component
+            collapses to a label-less icon button at this breakpoint and
+            self-hides for signed-out users. Issue #827.
+            モバイルの NoteSwitcher は、検索入力と 1 行に収まるよう
+            コンパクトなアイコントリガーとして描画する。サインアウト中は
+            内部で非表示になる。issue #827。 */}
+        <NoteSwitcher />
         {hasSearchContext && (
           <div className="min-w-0 flex-1">
             <HeaderSearchBar />

--- a/src/i18n/locales/en/notes.json
+++ b/src/i18n/locales/en/notes.json
@@ -1,5 +1,14 @@
 {
   "title": "Notes",
+  "switcher": {
+    "trigger": "Switch note",
+    "heading": "Your notes",
+    "defaultBadge": "Default",
+    "empty": "You don't have any notes yet.",
+    "loading": "Loading notes…",
+    "allNotes": "See all notes",
+    "newNote": "Create new note"
+  },
   "newNote": "New note",
   "newNoteDialogTitle": "New note",
   "noteTitle": "Title",

--- a/src/i18n/locales/ja/notes.json
+++ b/src/i18n/locales/ja/notes.json
@@ -1,5 +1,14 @@
 {
   "title": "ノート",
+  "switcher": {
+    "trigger": "ノートを切り替え",
+    "heading": "あなたのノート",
+    "defaultBadge": "既定",
+    "empty": "まだノートがありません",
+    "loading": "ノートを読み込み中…",
+    "allNotes": "すべてのノートを見る",
+    "newNote": "新規ノートを作成"
+  },
   "newNote": "新規ノート",
   "newNoteDialogTitle": "新しいノート",
   "noteTitle": "タイトル",

--- a/src/pages/Notes.test.tsx
+++ b/src/pages/Notes.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Regression tests for the `?new=1` deep-link handling on the `Notes` page
+ * (issue #827, gemini / codex review on PR #834). The header NoteSwitcher
+ * sends users to `/notes?new=1` to open the create-note dialog. The hook
+ * must fire `onOpen` both on first mount AND when the URL transitions
+ * `/notes` → `/notes?new=1` while `Notes` is already mounted, then strip
+ * the param so a refresh does not reopen the dialog.
+ *
+ * `Notes` ページの `?new=1` ディープリンク処理の退行テスト
+ * （issue #827・PR #834 の gemini / codex レビュー指摘）。
+ * ヘッダーの NoteSwitcher は `/notes?new=1` に遷移して新規作成ダイアログを
+ * 開かせる。フックは「初回マウント時」と「`Notes` がマウントされたまま
+ * `/notes` → `/notes?new=1` に遷移した場合」の両方で `onOpen` を発火し、
+ * リロード時に再オープンしないようクエリを除去しなければならない。
+ */
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { MemoryRouter, useNavigate, useLocation } from "react-router-dom";
+import { useNewNoteDeepLink } from "./Notes";
+
+function wrapper(initialEntries: string[]) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>;
+  };
+}
+
+describe("useNewNoteDeepLink", () => {
+  it("fires onOpen and strips ?new=1 when the page first mounts with the param", () => {
+    const onOpen = vi.fn();
+    let observedSearch = "";
+    const { result } = renderHook(
+      () => {
+        observedSearch = useLocation().search;
+        useNewNoteDeepLink(onOpen);
+        return useNavigate();
+      },
+      { wrapper: wrapper(["/notes?new=1&keep=yes"]) },
+    );
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    // The `new` param is gone but unrelated params (`keep`) remain intact.
+    // `new` だけ除去され、無関係なクエリ（`keep`）は残る。
+    expect(observedSearch).toBe("?keep=yes");
+    // Hook should not call onOpen again on subsequent renders without a
+    // fresh `?new=1`.
+    // 以降のレンダーで `?new=1` が無い限り onOpen は再発火しない。
+    void result.current;
+  });
+
+  it("fires onOpen when ?new=1 appears after mount (route stays on /notes)", () => {
+    const onOpen = vi.fn();
+    let navigateRef: ReturnType<typeof useNavigate> | null = null;
+    let observedSearch = "";
+
+    renderHook(
+      () => {
+        navigateRef = useNavigate();
+        observedSearch = useLocation().search;
+        useNewNoteDeepLink(onOpen);
+      },
+      { wrapper: wrapper(["/notes"]) },
+    );
+
+    // Initial mount on `/notes` (no `new` param) should not fire.
+    // 初期マウントは `?new=1` 無しなので発火しない。
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(observedSearch).toBe("");
+
+    // Simulate the header NoteSwitcher pushing `/notes?new=1` while the
+    // page is still mounted.
+    // ヘッダーの NoteSwitcher が `/notes?new=1` を push したのを再現する。
+    act(() => {
+      navigateRef?.("/notes?new=1");
+    });
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    // Hook strips the param after firing.
+    // 発火後にクエリが除去されている。
+    expect(observedSearch).toBe("");
+  });
+
+  it("does nothing when ?new is missing", () => {
+    const onOpen = vi.fn();
+    renderHook(() => useNewNoteDeepLink(onOpen), { wrapper: wrapper(["/notes"]) });
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when ?new has a non-1 value", () => {
+    const onOpen = vi.fn();
+    renderHook(() => useNewNoteDeepLink(onOpen), {
+      wrapper: wrapper(["/notes?new=0"]),
+    });
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useRef, useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useLocation, useNavigate, Link } from "react-router-dom";
 import { Plus } from "lucide-react";
 import { NotesLayout } from "@/components/note/NotesLayout";
 import { useNotes, useCreateNote } from "@/hooks/useNoteQueries";
@@ -31,6 +31,36 @@ import { Label } from "@zedi/ui";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@zedi/ui";
 import { useToast } from "@zedi/ui";
 import { useTranslation } from "react-i18next";
+
+/**
+ * Decide whether the create-note dialog should auto-open from a `?new=1`
+ * deep-link, and strip the param on first render so a refresh does not
+ * reopen the dialog. Used by the header NoteSwitcher (issue #827).
+ *
+ * `?new=1` ディープリンクから新規作成ダイアログを自動的に開くかどうかを
+ * 判定し、リロード時に再度開かないよう初回レンダーで除去する。
+ * ヘッダーの NoteSwitcher（issue #827）から呼び出される。
+ */
+function useNewNoteDeepLink(): boolean {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const wantsCreate = useMemo(
+    () => new URLSearchParams(location.search).get("new") === "1",
+    [location.search],
+  );
+
+  useEffect(() => {
+    if (!wantsCreate) return;
+    const next = new URLSearchParams(location.search);
+    next.delete("new");
+    navigate(
+      { pathname: location.pathname, search: next.toString(), hash: location.hash },
+      { replace: true },
+    );
+  }, [wantsCreate, location.pathname, location.search, location.hash, navigate]);
+
+  return wantsCreate;
+}
 
 interface CreateNoteDialogContentProps {
   title: string;
@@ -124,7 +154,9 @@ const Notes: React.FC = () => {
   /** After closing the public-collab confirm, reopen the create dialog if user cancelled. / 確認をキャンセルしたら作成ダイアログを再度開く */
   const reopenCreateAfterPublicConfirmRef = useRef(false);
 
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const wantsCreate = useNewNoteDeepLink();
+
+  const [isDialogOpen, setIsDialogOpen] = useState<boolean>(() => wantsCreate);
   const [isPublicAnyLoggedInCreateConfirmOpen, setIsPublicAnyLoggedInCreateConfirmOpen] =
     useState(false);
   const [title, setTitle] = useState("");

--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -33,33 +33,42 @@ import { useToast } from "@zedi/ui";
 import { useTranslation } from "react-i18next";
 
 /**
- * Decide whether the create-note dialog should auto-open from a `?new=1`
- * deep-link, and strip the param on first render so a refresh does not
- * reopen the dialog. Used by the header NoteSwitcher (issue #827).
+ * Watch for the `?new=1` deep-link from the header NoteSwitcher (issue #827).
+ * When the param is present, fire `onOpen` (typically opens the create dialog)
+ * and strip the param so a refresh does not reopen the dialog. Reacts to URL
+ * transitions while `Notes` is already mounted, since the same component
+ * persists across `/notes` ↔ `/notes?new=1` route updates.
  *
- * `?new=1` ディープリンクから新規作成ダイアログを自動的に開くかどうかを
- * 判定し、リロード時に再度開かないよう初回レンダーで除去する。
- * ヘッダーの NoteSwitcher（issue #827）から呼び出される。
+ * `?new=1` ディープリンク（ヘッダーの NoteSwitcher、issue #827）を監視する。
+ * クエリが現れたら `onOpen` を呼び出し（通常は作成ダイアログを開く）、
+ * リロード時に再オープンしないようクエリを除去する。`Notes` がマウントされた
+ * まま `/notes` ↔ `/notes?new=1` を遷移するケースにも対応する。
  */
-function useNewNoteDeepLink(): boolean {
+export function useNewNoteDeepLink(onOpen: () => void): void {
   const location = useLocation();
   const navigate = useNavigate();
-  const wantsCreate = useMemo(
-    () => new URLSearchParams(location.search).get("new") === "1",
-    [location.search],
-  );
+  // Latest-callback ref so the URL-watch effect can fire `onOpen` without
+  // listing it in its dependency array — callers typically pass an inline
+  // `() => setIsDialogOpen(true)`, which would otherwise re-trigger the
+  // effect on every render of `Notes`.
+  // 最新の onOpen を ref で保持し、URL 監視 effect の依存配列に含めない。
+  // 呼び出し側がインライン関数（`() => setIsDialogOpen(true)` など）を
+  // 渡す場合、毎レンダーで effect が再走するのを避けるため。
+  const onOpenRef = useRef(onOpen);
+  useEffect(() => {
+    onOpenRef.current = onOpen;
+  });
 
   useEffect(() => {
-    if (!wantsCreate) return;
-    const next = new URLSearchParams(location.search);
-    next.delete("new");
+    const params = new URLSearchParams(location.search);
+    if (params.get("new") !== "1") return;
+    onOpenRef.current();
+    params.delete("new");
     navigate(
-      { pathname: location.pathname, search: next.toString(), hash: location.hash },
+      { pathname: location.pathname, search: params.toString(), hash: location.hash },
       { replace: true },
     );
-  }, [wantsCreate, location.pathname, location.search, location.hash, navigate]);
-
-  return wantsCreate;
+  }, [location.pathname, location.search, location.hash, navigate]);
 }
 
 interface CreateNoteDialogContentProps {
@@ -154,9 +163,8 @@ const Notes: React.FC = () => {
   /** After closing the public-collab confirm, reopen the create dialog if user cancelled. / 確認をキャンセルしたら作成ダイアログを再度開く */
   const reopenCreateAfterPublicConfirmRef = useRef(false);
 
-  const wantsCreate = useNewNoteDeepLink();
-
-  const [isDialogOpen, setIsDialogOpen] = useState<boolean>(() => wantsCreate);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  useNewNoteDeepLink(() => setIsDialogOpen(true));
   const [isPublicAnyLoggedInCreateConfirmOpen, setIsPublicAnyLoggedInCreateConfirmOpen] =
     useState(false);
   const [title, setTitle] = useState("");


### PR DESCRIPTION
## 概要

ヘッダーにノート切替用のドロップダウンメニュー `NoteSwitcher` を追加しました。ユーザーはエディタ画面を離れることなく、ノート間を素早く切り替えられるようになります。デフォルトノートはバッジ付きで先頭に固定され、その他のノートは更新日時の降順でソートされます。

## 変更点

- **新規コンポーネント**: `src/components/layout/Header/NoteSwitcher.tsx`
  - ドロップダウン形式のノート切替 UI
  - デフォルトノートを先頭に固定、他のノートを `updatedAt` 降順でソート
  - 最大 50 件のノートを表示（超過時は `/notes` へ誘導）
  - 削除済みノートをフィルタリング
  - フッターに「すべてのノートを見る」と「新規ノート作成」のショートカット
  - サインアウト時は非表示

- **新規テスト**: `src/components/layout/Header/NoteSwitcher.test.tsx`
  - 325 行の包括的なテストスイート
  - ソート順序、アクティブ状態、ナビゲーション、エッジケースをカバー

- **ヘッダーレイアウト更新**: `src/components/layout/Header/index.tsx`
  - `NoteSwitcher` をロゴの隣に配置
  - デスクトップ・モバイル両対応

- **モバイルヘッダー更新**: `src/components/layout/MobileHeader.tsx`
  - モバイル環境でも `NoteSwitcher` を表示

- **Notes ページ機能拡張**: `src/pages/Notes.tsx`
  - `?new=1` ディープリンク対応
  - ヘッダーの「新規ノート作成」から自動的に作成ダイアログを開く

- **国際化対応**: `src/i18n/locales/en/notes.json` と `src/i18n/locales/ja/notes.json`
  - 英語・日本語の翻訳文字列を追加

- **テスト更新**: `src/components/layout/MobileHeader.test.tsx` と `src/components/layout/Header/index.test.tsx`
  - `NoteSwitcher` のモック化

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `npm test` でテストスイートを実行 → 全テストがパス
2. ヘッダーに「ノートを切り替え」ボタンが表示されることを確認
3. ボタンをクリックしてドロップダウンが開き、ノート一覧が表示されることを確認
4. デフォルトノートが先頭に「既定」バッジ付きで表示されることを確認
5. ノート行をクリックして `/notes/:noteId` に遷移することを確認
6. 「新規ノートを作成」をクリックして `/notes?new=1` に遷移し、作成ダイアログが開くことを確認
7. 「すべてのノートを見る」をクリックして `/notes` に遷移することを確認

## チェックリスト

- [x] テストがすべてパ

https://claude.ai/code/session_01QdsfMsd3PEzYWySzAPpcP5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a note switcher dropdown in the header (desktop and mobile) for quick access to your notes
  * Default note is pinned to the top; other notes sorted by most recently updated
  * Support for deep-link URL parameter to open the create note dialog
  * Includes "See All Notes" and "Create New Note" shortcuts within the switcher

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/834)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->