### PR TITLE
Add default note public exposure warning dialog

### DIFF
--- a/src/components/layout/Header/NoteSwitcher.test.tsx
+++ b/src/components/layout/Header/NoteSwitcher.test.tsx
@@ -91,6 +91,7 @@ function makeNote(overrides: Partial<NoteSummary> & { id: string }): NoteSummary
     visibility: overrides.visibility ?? "private",
     editPermission: overrides.editPermission ?? "owner_only",
     isOfficial: overrides.isOfficial ?? false,
+    isDefault: overrides.isDefault ?? false,
     viewCount: overrides.viewCount ?? 0,
     createdAt: overrides.createdAt ?? 0,
     updatedAt: overrides.updatedAt ?? 0,

--- a/src/hooks/useNoteQueries.ts
+++ b/src/hooks/useNoteQueries.ts
@@ -60,6 +60,7 @@ function apiNoteToNote(item: {
   visibility: string;
   edit_permission?: string;
   is_official?: boolean;
+  is_default?: boolean;
   view_count?: number;
   created_at: string;
   updated_at: string;
@@ -72,6 +73,7 @@ function apiNoteToNote(item: {
     visibility: item.visibility as Note["visibility"],
     editPermission: (item.edit_permission as Note["editPermission"]) ?? "owner_only",
     isOfficial: item.is_official ?? false,
+    isDefault: item.is_default ?? false,
     viewCount: item.view_count ?? 0,
     createdAt: parseTs(item.created_at),
     updatedAt: parseTs(item.updated_at),

--- a/src/i18n/locales/en/notes.json
+++ b/src/i18n/locales/en/notes.json
@@ -121,6 +121,8 @@
   "editPermissionHelpAnyLoggedIn": "Any signed-in user who can view this note (public or unlisted link) can edit pages.",
   "publicAnyLoggedInConfirmTitle": "Save with open collaboration for all signed-in users?",
   "publicAnyLoggedInConfirmDescription": "With this visibility and edit permission, every signed-in user who can open this note (public or unlisted link) can edit it. Continue?",
+  "defaultNotePublicWarningTitle": "Make your default note shareable?",
+  "defaultNotePublicWarningDescription": "This is your default note (\"My Note\"). Switching it to public or unlisted will expose every page you have stored here so far. Consider moving any private pages to another note before continuing.",
   "publicAnyLoggedInCreateConfirmTitle": "Create a note with open collaboration for all signed-in users?",
   "publicAnyLoggedInCreateConfirmDescription": "With this visibility and edit permission, every signed-in user who can open this note (public or unlisted link) can edit it. Continue?",
   "tabMyNotes": "My Notes",

--- a/src/i18n/locales/ja/notes.json
+++ b/src/i18n/locales/ja/notes.json
@@ -120,6 +120,8 @@
   "editPermissionHelpAnyLoggedIn": "このノートを閲覧できるログイン済みユーザー（公開・限定公開URL 経由を含む）なら誰でもページを編集できます。",
   "publicAnyLoggedInConfirmTitle": "ログイン済み全員が編集できる設定で保存しますか？",
   "publicAnyLoggedInConfirmDescription": "この公開範囲と編集権限では、このノートを開けるサインイン済みユーザー全員が編集できます（公開・限定公開URLのいずれも）。続行しますか？",
+  "defaultNotePublicWarningTitle": "マイノートを公開してもよろしいですか？",
+  "defaultNotePublicWarningDescription": "これはあなたのマイノートです。公開または限定公開（URL）に変更すると、これまでマイノートに保存していたページがすべて公開されます。続行する前に、公開したくないページを別のノートに移動することをおすすめします。",
   "publicAnyLoggedInCreateConfirmTitle": "ログイン済み全員が編集できるノートを作成しますか？",
   "publicAnyLoggedInCreateConfirmDescription": "この公開範囲と編集権限では、このノートを開けるサインイン済みユーザー全員が編集できます（公開・限定公開URLのいずれも）。続行しますか？",
   "tabMyNotes": "参加中のノート",

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -231,6 +231,12 @@ export interface NoteListItem {
   visibility: string;
   edit_permission?: string;
   is_official?: boolean;
+  /**
+   * Whether this is the caller's default note. Surfaced to the frontend so
+   * note settings can warn before flipping the default note to public/unlisted.
+   * 既定ノート（マイノート）かどうか。公開警告ダイアログ判定に利用する。
+   */
+  is_default?: boolean;
   view_count?: number;
   created_at: string;
   updated_at: string;
@@ -273,6 +279,12 @@ export interface GetNoteResponse {
   visibility: string;
   edit_permission?: string;
   is_official?: boolean;
+  /**
+   * Whether this is the caller's default note. The settings page reads this to
+   * gate the "公開化で個人メモが流出する可能性" warning dialog.
+   * 既定ノートかどうか。設定画面で公開化警告ダイアログを出す判定に使う。
+   */
+  is_default?: boolean;
   view_count?: number;
   created_at: string;
   updated_at: string;

--- a/src/lib/noteSharingRisk.test.ts
+++ b/src/lib/noteSharingRisk.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   isPublicAnyLoggedInCombo,
+  isShareableVisibility,
+  shouldConfirmDefaultNotePublicSave,
   shouldConfirmPublicAnyLoggedInSave,
 } from "@/lib/noteSharingRisk";
 
@@ -52,6 +54,41 @@ describe("noteSharingRisk", () => {
       expect(
         shouldConfirmPublicAnyLoggedInSave("unlisted", "any_logged_in", "public", "any_logged_in"),
       ).toBe(false);
+    });
+  });
+
+  describe("isShareableVisibility", () => {
+    it("returns true only for public / unlisted", () => {
+      expect(isShareableVisibility("public")).toBe(true);
+      expect(isShareableVisibility("unlisted")).toBe(true);
+      expect(isShareableVisibility("private")).toBe(false);
+      expect(isShareableVisibility("restricted")).toBe(false);
+    });
+  });
+
+  describe("shouldConfirmDefaultNotePublicSave", () => {
+    it("is false when the note is not the default note", () => {
+      expect(shouldConfirmDefaultNotePublicSave(false, "public", "private")).toBe(false);
+      expect(shouldConfirmDefaultNotePublicSave(false, "unlisted", "private")).toBe(false);
+    });
+
+    it("is false when the next visibility is private or restricted", () => {
+      expect(shouldConfirmDefaultNotePublicSave(true, "private", "private")).toBe(false);
+      expect(shouldConfirmDefaultNotePublicSave(true, "restricted", "private")).toBe(false);
+    });
+
+    it("is true when default note transitions from non-shareable to public/unlisted", () => {
+      expect(shouldConfirmDefaultNotePublicSave(true, "public", "private")).toBe(true);
+      expect(shouldConfirmDefaultNotePublicSave(true, "unlisted", "private")).toBe(true);
+      expect(shouldConfirmDefaultNotePublicSave(true, "public", "restricted")).toBe(true);
+      expect(shouldConfirmDefaultNotePublicSave(true, "unlisted", "restricted")).toBe(true);
+    });
+
+    it("is false when default note is already public or unlisted (re-save)", () => {
+      expect(shouldConfirmDefaultNotePublicSave(true, "public", "public")).toBe(false);
+      expect(shouldConfirmDefaultNotePublicSave(true, "unlisted", "unlisted")).toBe(false);
+      expect(shouldConfirmDefaultNotePublicSave(true, "public", "unlisted")).toBe(false);
+      expect(shouldConfirmDefaultNotePublicSave(true, "unlisted", "public")).toBe(false);
     });
   });
 });

--- a/src/lib/noteSharingRisk.ts
+++ b/src/lib/noteSharingRisk.ts
@@ -29,3 +29,36 @@ export function shouldConfirmPublicAnyLoggedInSave(
   if (!isPublicAnyLoggedInCombo(visibility, editPermission)) return false;
   return !isPublicAnyLoggedInCombo(previousVisibility, previousEditPermission);
 }
+
+/**
+ * Whether the visibility value would expose the note beyond the owner. `public`
+ * is fully indexable and `unlisted` is reachable by URL, so both leak personal
+ * pages stored in a default note.
+ *
+ * 公開範囲がノート所有者以外に見える状態か。`public` は検索対象、`unlisted` も
+ * URL を知る人なら閲覧可能なので、いずれも既定ノートの個人メモが流出しうる。
+ */
+export function isShareableVisibility(visibility: NoteVisibility): boolean {
+  return visibility === "public" || visibility === "unlisted";
+}
+
+/**
+ * Whether to surface the default-note public-exposure warning before saving:
+ * the note is the caller's default ("マイノート") and visibility is moving from
+ * a non-shareable value (e.g. `private` / `restricted`) to `public` or
+ * `unlisted`. We only warn on the **transition** so re-saving an already-public
+ * default note (e.g. just renaming) does not nag.
+ *
+ * 既定ノート（マイノート）の公開警告ダイアログを出すか:
+ * 公開範囲が「非共有 → public/unlisted」へ**初めて**切り替わるときに限定する。
+ * 既に公開済みの再保存（タイトル編集など）では出さない。
+ */
+export function shouldConfirmDefaultNotePublicSave(
+  isDefault: boolean,
+  visibility: NoteVisibility,
+  previousVisibility: NoteVisibility,
+): boolean {
+  if (!isDefault) return false;
+  if (!isShareableVisibility(visibility)) return false;
+  return !isShareableVisibility(previousVisibility);
+}

--- a/src/pages/NoteSettings/DefaultNotePublicWarningDialog.tsx
+++ b/src/pages/NoteSettings/DefaultNotePublicWarningDialog.tsx
@@ -1,0 +1,64 @@
+import type { JSX } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@zedi/ui";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Props for the default-note public/unlisted warning dialog.
+ * 既定ノート（マイノート）公開時の警告ダイアログ Props。
+ */
+export type DefaultNotePublicWarningDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isSaving: boolean;
+};
+
+/**
+ * Warning dialog shown before flipping a default note to `public` / `unlisted`.
+ * Switching exposes every page that the user previously saved into their
+ * personal default note, so we surface a heads-up before the save proceeds.
+ *
+ * 既定ノートを `public` / `unlisted` に変更する前に表示する警告ダイアログ。
+ * これまで個人用に保存したページが一括で公開されるリスクを通知する。
+ */
+export function DefaultNotePublicWarningDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  isSaving,
+}: DefaultNotePublicWarningDialogProps): JSX.Element {
+  const { t } = useTranslation();
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && isSaving) return;
+        onOpenChange(next);
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("notes.defaultNotePublicWarningTitle")}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("notes.defaultNotePublicWarningDescription")}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isSaving}>{t("common.cancel")}</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm} disabled={isSaving}>
+            {isSaving ? t("common.saving") : t("common.confirm")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/pages/NoteSettings/index.tsx
+++ b/src/pages/NoteSettings/index.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { NoteSettingsShareSection } from "./NoteSettingsShareSection";
 import { NoteSettingsVisibilitySection } from "./NoteSettingsVisibilitySection";
 import { NoteSettingsDeleteSection } from "./NoteSettingsDeleteSection";
+import { DefaultNotePublicWarningDialog } from "./DefaultNotePublicWarningDialog";
 import { PublicAnyLoggedInSaveAlertDialog } from "./PublicAnyLoggedInSaveAlertDialog";
 import { useNoteSettingsSaveWithPublicConfirm } from "./useNoteSettingsSaveWithPublicConfirm";
 
@@ -43,6 +44,9 @@ const NoteSettings: React.FC = () => {
     confirmOpen: isPublicAnyLoggedInSaveConfirmOpen,
     setConfirmOpen: setIsPublicAnyLoggedInSaveConfirmOpen,
     handleConfirmPublicAnyLoggedInSave,
+    defaultNoteWarningOpen: isDefaultNoteWarningOpen,
+    setDefaultNoteWarningOpen: setIsDefaultNoteWarningOpen,
+    handleConfirmDefaultNoteWarning,
     isSaving,
   } = useNoteSettingsSaveWithPublicConfirm({
     noteId,
@@ -158,6 +162,13 @@ const NoteSettings: React.FC = () => {
               onConfirmDelete={handleDeleteNote}
               isDeleting={deleteNoteMutation.isPending}
               noteTitle={note.title || t("notes.untitledNote")}
+            />
+
+            <DefaultNotePublicWarningDialog
+              open={isDefaultNoteWarningOpen}
+              onOpenChange={setIsDefaultNoteWarningOpen}
+              onConfirm={handleConfirmDefaultNoteWarning}
+              isSaving={isSaving}
             />
 
             <PublicAnyLoggedInSaveAlertDialog

--- a/src/pages/NoteSettings/useNoteSettingsSaveWithPublicConfirm.test.ts
+++ b/src/pages/NoteSettings/useNoteSettingsSaveWithPublicConfirm.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Save flow chains the default-note warning (issue #830) with the existing
+ * `public + any_logged_in` warning. Title-only edits (and saves that stay
+ * private) skip both dialogs.
+ *
+ * 保存フローは既定ノート公開警告（#830）と既存の `public + any_logged_in` 警告を
+ * 直列に表示する。タイトル変更だけ・private のままの保存はどちらも出さない。
+ */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Note } from "@/types/note";
+import { useNoteSettingsSaveWithPublicConfirm } from "./useNoteSettingsSaveWithPublicConfirm";
+
+const mutateAsyncMock = vi.fn();
+const toastMock = vi.fn();
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "ja" },
+  }),
+}));
+
+vi.mock("@zedi/ui", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/hooks/useNoteQueries", () => ({
+  useUpdateNote: () => ({ mutateAsync: mutateAsyncMock, isPending: false }),
+}));
+
+const baseDefaultNote: Note = {
+  id: "note-default",
+  ownerUserId: "user-1",
+  title: "user のノート",
+  visibility: "private",
+  editPermission: "owner_only",
+  isOfficial: false,
+  isDefault: true,
+  viewCount: 0,
+  createdAt: 0,
+  updatedAt: 0,
+  isDeleted: false,
+};
+
+const baseRegularNote: Note = {
+  ...baseDefaultNote,
+  id: "note-regular",
+  title: "Some shared note",
+  isDefault: false,
+};
+
+beforeEach(() => {
+  mutateAsyncMock.mockReset();
+  mutateAsyncMock.mockResolvedValue(undefined);
+  toastMock.mockReset();
+});
+
+describe("useNoteSettingsSaveWithPublicConfirm", () => {
+  it("saves immediately when nothing risky changes (private default note, title only)", async () => {
+    const { result } = renderHook(() =>
+      useNoteSettingsSaveWithPublicConfirm({
+        noteId: baseDefaultNote.id,
+        note: baseDefaultNote,
+        title: "Renamed",
+        visibility: "private",
+        editPermission: "owner_only",
+      }),
+    );
+
+    act(() => {
+      result.current.handleSaveNote();
+    });
+
+    expect(result.current.defaultNoteWarningOpen).toBe(false);
+    expect(result.current.confirmOpen).toBe(false);
+    await waitFor(() => expect(mutateAsyncMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("opens the default-note warning when flipping default note to public", () => {
+    const { result } = renderHook(() =>
+      useNoteSettingsSaveWithPublicConfirm({
+        noteId: baseDefaultNote.id,
+        note: baseDefaultNote,
+        title: baseDefaultNote.title,
+        visibility: "public",
+        editPermission: "owner_only",
+      }),
+    );
+
+    act(() => {
+      result.current.handleSaveNote();
+    });
+
+    expect(result.current.defaultNoteWarningOpen).toBe(true);
+    expect(result.current.confirmOpen).toBe(false);
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("opens the default-note warning when flipping default note to unlisted", () => {
+    const { result } = renderHook(() =>
+      useNoteSettingsSaveWithPublicConfirm({
+        noteId: baseDefaultNote.id,
+        note: baseDefaultNote,
+        title: baseDefaultNote.title,
+        visibility: "unlisted",
+        editPermission: "owner_only",
+      }),
+    );
+
+    act(() => {
+      result.current.handleSaveNote();
+    });
+
+    expect(result.current.defaultNoteWarningOpen).toBe(true);
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("does not open the default-note warning for non-default notes going public", () => {
+    const { result } = renderHook(() =>
+      useNoteSettingsSaveWithPublicConfirm({
+        noteId: baseRegularNote.id,
+        note: baseRegularNote,
+        title: baseRegularNote.title,
+        visibility: "public",
+        editPermission: "owner_only",
+      }),
+    );
+
+    act(() => {
+      result.current.handleSaveNote();
+    });
+
+    expect(result.current.defaultNoteWarningOpen).toBe(false);
+  });
+
+  it("cancelling the default-note warning leaves form state untouched and skips the save", () => {
+    const { result } = renderHook(() =>
+      useNoteSettingsSaveWithPublicConfirm({
+        noteId: baseDefaultNote.id,
+        note: baseDefaultNote,
+        title: baseDefaultNote.title,
+        visibility: "public",
+        editPermission: "owner_only",
+      }),
+    );
+
+    act(() => {
+      result.current.handleSaveNote();
+    });
+    expect(result.current.defaultNoteWarningOpen).toBe(true);
+
+    act(() => {
+      result.current.setDefaultNoteWarningOpen(false);
+    });
+
+    expect(result.current.defaultNoteWarningOpen).toBe(false);
+    expect(result.current.confirmOpen).toBe(false);
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("confirming the default-note warning saves directly when no any_logged_in dialog applies", async () => {
+    const { result } = renderHook(() =>
+      useNoteSettingsSaveWithPublicConfirm({
+        noteId: baseDefaultNote.id,
+        note: baseDefaultNote,
+        title: baseDefaultNote.title,
+        visibility: "public",
+        editPermission: "owner_only",
+      }),
+    );
+
+    act(() => {
+      result.current.handleSaveNote();
+    });
+    expect(result.current.defaultNoteWarningOpen).toBe(true);
+
+    act(() => {
+      result.current.handleConfirmDefaultNoteWarning();
+    });
+
+    expect(result.current.defaultNoteWarningOpen).toBe(false);
+    expect(result.current.confirmOpen).toBe(false);
+    await waitFor(() => expect(mutateAsyncMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("chains into the any_logged_in confirm dialog when both warnings apply", async () => {
+    const { result } = renderHook(() =>
+      useNoteSettingsSaveWithPublicConfirm({
+        noteId: baseDefaultNote.id,
+        note: baseDefaultNote,
+        title: baseDefaultNote.title,
+        visibility: "public",
+        editPermission: "any_logged_in",
+      }),
+    );
+
+    act(() => {
+      result.current.handleSaveNote();
+    });
+    expect(result.current.defaultNoteWarningOpen).toBe(true);
+    expect(result.current.confirmOpen).toBe(false);
+
+    act(() => {
+      result.current.handleConfirmDefaultNoteWarning();
+    });
+
+    expect(result.current.defaultNoteWarningOpen).toBe(false);
+    expect(result.current.confirmOpen).toBe(true);
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.handleConfirmPublicAnyLoggedInSave();
+    });
+
+    expect(result.current.confirmOpen).toBe(false);
+    await waitFor(() => expect(mutateAsyncMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("blocks saving with an empty title and surfaces the toast", () => {
+    const { result } = renderHook(() =>
+      useNoteSettingsSaveWithPublicConfirm({
+        noteId: baseDefaultNote.id,
+        note: baseDefaultNote,
+        title: "   ",
+        visibility: "private",
+        editPermission: "owner_only",
+      }),
+    );
+
+    act(() => {
+      result.current.handleSaveNote();
+    });
+
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "notes.titleRequired", variant: "destructive" }),
+    );
+    expect(result.current.defaultNoteWarningOpen).toBe(false);
+    expect(result.current.confirmOpen).toBe(false);
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/NoteSettings/useNoteSettingsSaveWithPublicConfirm.ts
+++ b/src/pages/NoteSettings/useNoteSettingsSaveWithPublicConfirm.ts
@@ -3,7 +3,10 @@ import { useTranslation } from "react-i18next";
 import { useToast } from "@zedi/ui";
 import { useUpdateNote } from "@/hooks/useNoteQueries";
 import type { Note, NoteEditPermission, NoteVisibility } from "@/types/note";
-import { shouldConfirmPublicAnyLoggedInSave } from "@/lib/noteSharingRisk";
+import {
+  shouldConfirmDefaultNotePublicSave,
+  shouldConfirmPublicAnyLoggedInSave,
+} from "@/lib/noteSharingRisk";
 
 type UseNoteSettingsSaveWithPublicConfirmArgs = {
   noteId: string | undefined;
@@ -14,8 +17,20 @@ type UseNoteSettingsSaveWithPublicConfirmArgs = {
 };
 
 /**
- * Save handler with optional confirm dialog when transitioning to public + any_logged_in.
- * 公開 + any_logged_in への初回変更時は確認ダイアログ経由で保存する。
+ * Save handler that may stage up to two warning dialogs in sequence:
+ *   1. The default-note exposure warning (issue #830) when a user flips their
+ *      `is_default` note from a non-shareable visibility to `public` / `unlisted`.
+ *   2. The existing `public` / `unlisted` + `any_logged_in` open-collaboration
+ *      warning when the resulting combo first becomes broadly editable.
+ *
+ * If both apply, the default-note dialog is shown first; confirming that one
+ * leads into the open-collaboration dialog before the actual save runs. This
+ * matches "案 A" (two-step dialogs) from the issue's implementation notes.
+ *
+ * 保存ハンドラ。状況に応じて最大 2 段の警告ダイアログを直列に表示する:
+ *   1. 既定ノートを `public` / `unlisted` に切り替える際の公開警告（#830）。
+ *   2. 既存の「公開/限定公開 + ログイン誰でも編集」警告。
+ * 両条件に該当するときは、まず既定ノート警告 → 確定後に協業警告 → 保存。
  */
 export function useNoteSettingsSaveWithPublicConfirm({
   noteId,
@@ -28,6 +43,7 @@ export function useNoteSettingsSaveWithPublicConfirm({
   const { toast } = useToast();
   const updateNoteMutation = useUpdateNote();
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [defaultNoteWarningOpen, setDefaultNoteWarningOpen] = useState(false);
 
   const performSaveNote = useCallback(async () => {
     if (!noteId) return;
@@ -43,6 +59,24 @@ export function useNoteSettingsSaveWithPublicConfirm({
     }
   }, [noteId, title, visibility, editPermission, updateNoteMutation, toast, t]);
 
+  const proceedAfterDefaultNoteWarning = useCallback(
+    (currentNote: Note) => {
+      if (
+        shouldConfirmPublicAnyLoggedInSave(
+          visibility,
+          editPermission,
+          currentNote.visibility,
+          currentNote.editPermission,
+        )
+      ) {
+        setConfirmOpen(true);
+        return;
+      }
+      void performSaveNote();
+    },
+    [visibility, editPermission, performSaveNote],
+  );
+
   const handleSaveNote = useCallback(() => {
     if (!noteId || !note) return;
     if (!title.trim()) {
@@ -52,19 +86,18 @@ export function useNoteSettingsSaveWithPublicConfirm({
       });
       return;
     }
-    if (
-      shouldConfirmPublicAnyLoggedInSave(
-        visibility,
-        editPermission,
-        note.visibility,
-        note.editPermission,
-      )
-    ) {
-      setConfirmOpen(true);
+    if (shouldConfirmDefaultNotePublicSave(note.isDefault, visibility, note.visibility)) {
+      setDefaultNoteWarningOpen(true);
       return;
     }
-    void performSaveNote();
-  }, [noteId, note, title, visibility, editPermission, performSaveNote, toast, t]);
+    proceedAfterDefaultNoteWarning(note);
+  }, [noteId, note, title, visibility, proceedAfterDefaultNoteWarning, toast, t]);
+
+  const handleConfirmDefaultNoteWarning = useCallback(() => {
+    setDefaultNoteWarningOpen(false);
+    if (!note) return;
+    proceedAfterDefaultNoteWarning(note);
+  }, [note, proceedAfterDefaultNoteWarning]);
 
   const handleConfirmPublicAnyLoggedInSave = useCallback(() => {
     setConfirmOpen(false);
@@ -76,6 +109,9 @@ export function useNoteSettingsSaveWithPublicConfirm({
     confirmOpen,
     setConfirmOpen,
     handleConfirmPublicAnyLoggedInSave,
+    defaultNoteWarningOpen,
+    setDefaultNoteWarningOpen,
+    handleConfirmDefaultNoteWarning,
     isSaving: updateNoteMutation.isPending,
   };
 }

--- a/src/pages/NoteView/NoteViewHeaderActions.test.tsx
+++ b/src/pages/NoteView/NoteViewHeaderActions.test.tsx
@@ -65,6 +65,7 @@ const baseNote: Note = {
   visibility: "private",
   editPermission: "owner_only",
   isOfficial: false,
+  isDefault: false,
   viewCount: 0,
   createdAt: 0,
   updatedAt: 0,

--- a/src/pages/NoteView/ShareModal/NoteShareModal.test.tsx
+++ b/src/pages/NoteView/ShareModal/NoteShareModal.test.tsx
@@ -65,6 +65,7 @@ const baseNote: Note = {
   visibility: "private",
   editPermission: "owner_only",
   isOfficial: false,
+  isDefault: false,
   viewCount: 0,
   createdAt: 0,
   updatedAt: 0,

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -31,6 +31,12 @@ export interface Note {
   visibility: NoteVisibility;
   editPermission: NoteEditPermission;
   isOfficial: boolean;
+  /**
+   * Whether this is the caller's default note (`<users.name>のノート`). Drives
+   * the "マイノート" badge and the public/unlisted save warning dialog.
+   * 既定ノート（マイノート）かどうか。バッジ表示や公開警告ダイアログで使う。
+   */
+  isDefault: boolean;
   viewCount: number;
   createdAt: number;
   updatedAt: number;


### PR DESCRIPTION
## 概要

既定ノート（マイノート）を公開・限定公開に変更する際に、個人メモが流出するリスクを警告するダイアログを追加します。既存の「公開 + any_logged_in」警告と組み合わせて、最大 2 段の警告ダイアログを直列に表示する仕組みを実装しました。

## 変更点

- **新規ダイアログコンポーネント**: `DefaultNotePublicWarningDialog` を追加し、既定ノートの公開化時に警告を表示
- **警告判定ロジック**: `noteSharingRisk.ts` に `shouldConfirmDefaultNotePublicSave()` と `isShareableVisibility()` を追加
- **保存フロー改善**: `useNoteSettingsSaveWithPublicConfirm` を拡張し、既定ノート警告 → 協業警告の 2 段ダイアログをサポート
- **型定義更新**: `Note` 型に `isDefault` フィールドを追加し、API レスポンス型も対応
- **テスト追加**: 新しい保存フローの全パターンをカバーする包括的なテストスイートを追加
- **多言語対応**: 英語・日本語の i18n メッセージを追加
- **既存テスト更新**: `isDefault` フィールドの追加に伴い、既存テストのモックデータを更新

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. 既定ノートの設定画面で公開範囲を「公開」または「限定公開」に変更して保存
   - 警告ダイアログが表示されることを確認
   - キャンセルで保存がスキップされることを確認
   - 確定で保存が進行することを確認

2. 既定ノートを「公開 + any_logged_in」に変更して保存
   - 既定ノート警告が表示される
   - 確定後に協業警告が表示される
   - 両方確定で保存が完了することを確認

3. 通常のノート（非既定）を公開に変更
   - 既定ノート警告が表示されないことを確認

4. 既に公開済みの既定ノートをタイトル変更のみで保存
   - 警告ダイアログが表示されないことを確認

5. 既定ノートをプライベートのままで保存
   - 警告ダイアログが表示されないことを確認

## チェックリスト

- [x] テストがすべてパスする（新規テストスイート 242 行、既存テスト更新）
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した（i18n メッセージ追加）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #830

https://claude.ai/code/session_011eYyc6ydz1X6zt4jrzcHfj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog that alerts users when attempting to make their default note public or unlisted, helping prevent unintended exposure of sensitive content.

* **Localization**
  * Added English and Japanese translations for the default note visibility warning prompt.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/837)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->