### PR TITLE
Dedupe note API calls and optimize page listing queries

### DIFF
--- a/server/api/drizzle/0024_add_pages_note_active_updated_index.sql
+++ b/server/api/drizzle/0024_add_pages_note_active_updated_index.sql
@@ -1,0 +1,20 @@
+-- 0024: `pages` テーブルに `(note_id, updated_at DESC) WHERE is_deleted = false`
+-- の部分複合インデックスを追加する。`GET /api/notes/:id` のページ列挙クエリ
+-- (`WHERE note_id = $1 AND is_deleted = false ORDER BY updated_at DESC`)
+-- 用に、ソート段を Sort ノードからインデックススキャンに切り替えるのが目的。
+-- ソフト削除行を WHERE で除外することでインデックスサイズも最小化する。
+-- 詳細は Epic #847 / Issue #850 を参照。
+--
+-- 0024: Add a partial composite index on
+-- `pages (note_id, updated_at DESC) WHERE is_deleted = false`. Backs the page
+-- listing in `GET /api/notes/:id`
+-- (`WHERE note_id = $1 AND is_deleted = false ORDER BY updated_at DESC`) by
+-- letting the note-scoped sort run as an index scan instead of an in-memory
+-- Sort. The partial predicate keeps soft-deleted rows out of the index so the
+-- size stays minimal. See Epic #847 / issue #850 for the rationale.
+--
+-- Idempotent / re-run safety: CREATE INDEX IF NOT EXISTS.
+
+CREATE INDEX IF NOT EXISTS "idx_pages_note_active_updated"
+  ON "pages" ("note_id", "updated_at" DESC)
+  WHERE "is_deleted" = false;

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1778630400000,
       "tag": "0023_migrate_personal_pages_drop_note_pages",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1778716800000,
+      "tag": "0024_add_pages_note_active_updated_index",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/src/__tests__/routes/notes/crud.test.ts
+++ b/server/api/src/__tests__/routes/notes/crud.test.ts
@@ -423,7 +423,9 @@ describe("GET /api/notes/:noteId", () => {
     expect(page).toHaveProperty("id", "page-abc");
     expect(page).toHaveProperty("owner_id");
     expect(page).toHaveProperty("source_page_id");
-    expect(page).toHaveProperty("content_preview");
+    // Issue #849 移行措置: レスポンス軽量化のため `content_preview` は常に `null`。
+    // Migration step for #849: `content_preview` is always `null` on the wire.
+    expect(page).toHaveProperty("content_preview", null);
     expect(page).toHaveProperty("thumbnail_url");
     expect(page).toHaveProperty("note_id", mockNote.id);
   });

--- a/server/api/src/routes/notes/crud.ts
+++ b/server/api/src/routes/notes/crud.ts
@@ -303,11 +303,22 @@ app.get("/:noteId", authOptional, async (c) => {
   if (!note) throw new HTTPException(404, { message: "Note not found" });
   if (!role) throw new HTTPException(403, { message: "Forbidden" });
 
+  // 非オーナーのアクセスごとに `view_count` をインクリメントするが、UPDATE は
+  // レスポンスをブロックしないよう投げっぱなしにする（Issue #849）。失敗時は
+  // ログのみで継続し、Discover の並び替えに使うカウンタは最終的に整合する。
+  //
+  // Increment `view_count` on every non-owner visit, but fire-and-forget the
+  // UPDATE so it does not add a DB round trip to the response (Issue #849).
+  // Errors are logged and swallowed; the counter that backs Discover's sort
+  // converges eventually.
   if (role !== "owner") {
-    await db
+    void db
       .update(notes)
       .set({ viewCount: sql`${notes.viewCount} + 1` })
-      .where(eq(notes.id, noteId));
+      .where(eq(notes.id, noteId))
+      .catch((error) => {
+        console.error(`[api] noteViewCountUpdateFailed noteId=${noteId}`, error);
+      });
   }
 
   const pagesResult = await db
@@ -317,7 +328,6 @@ app.get("/:noteId", authOptional, async (c) => {
       noteId: pages.noteId,
       sourcePageId: pages.sourcePageId,
       title: pages.title,
-      contentPreview: pages.contentPreview,
       thumbnailUrl: pages.thumbnailUrl,
       sourceUrl: pages.sourceUrl,
       createdAt: pages.createdAt,
@@ -339,7 +349,12 @@ app.get("/:noteId", authOptional, async (c) => {
         note_id: p.noteId,
         source_page_id: p.sourcePageId,
         title: p.title,
-        content_preview: p.contentPreview,
+        // Issue #849 移行措置: レスポンス軽量化のため常に `null`。プレビューが
+        // 必要な箇所は専用エンドポイント or 個別ページ取得を使う。
+        // Migration step for #849: always `null` to keep the response slim.
+        // Callers that need the preview should hit a dedicated endpoint or
+        // fetch the page individually.
+        content_preview: null,
         thumbnail_url: p.thumbnailUrl,
         source_url: p.sourceUrl,
         created_at: p.createdAt,

--- a/server/api/src/routes/notes/types.ts
+++ b/server/api/src/routes/notes/types.ts
@@ -77,6 +77,16 @@ export interface NotePageApiItem {
   note_id: string;
   source_page_id: string | null;
   title: string | null;
+  /**
+   * Issue #849 移行措置: レスポンス軽量化のため、サーバは常に `null` を返す。
+   * 型は後段で削除される予定。プレビュー本文が必要な呼び出し元は個別ページ取得
+   * (`GET /api/pages/:id`) や検索結果 (`GET /api/search`) を使う。
+   *
+   * Migration step for #849: the server now always returns `null` to keep the
+   * response slim. The field is slated for removal in a follow-up. Callers
+   * that need the body preview should hit `GET /api/pages/:id` or the search
+   * endpoint instead.
+   */
   content_preview: string | null;
   thumbnail_url: string | null;
   source_url: string | null;

--- a/server/api/src/schema/pages.ts
+++ b/server/api/src/schema/pages.ts
@@ -114,6 +114,23 @@ export const pages = pgTable(
      */
     index("idx_pages_note_id").on(table.noteId),
     /**
+     * `GET /api/notes/:id` のページ列挙クエリ
+     * (`WHERE note_id = $1 AND is_deleted = false ORDER BY updated_at DESC`)
+     * 専用の部分複合インデックス。ソフト削除行を除外してインデックスサイズを
+     * 最小化しつつ、ノート単位のソートをインメモリではなくインデックススキャン
+     * で解決する。Issue #850。
+     *
+     * Partial composite index that backs the page listing in
+     * `GET /api/notes/:id`
+     * (`WHERE note_id = $1 AND is_deleted = false ORDER BY updated_at DESC`).
+     * Excluding soft-deleted rows keeps the index small and lets the
+     * note-scoped sort run as an index scan instead of an in-memory sort.
+     * Issue #850.
+     */
+    index("idx_pages_note_active_updated")
+      .on(table.noteId, table.updatedAt.desc())
+      .where(sql`${table.isDeleted} = false`),
+    /**
      * オーナーごとに有効なウェルカムページは最大 1 件であることを担保する部分
      * ユニーク index。`welcomePageService.insertWelcomePage` の `onConflictDoNothing`
      * が target としてこの index に依拠している。実 DDL は

--- a/src/components/page/PageCard.tsx
+++ b/src/components/page/PageCard.tsx
@@ -194,7 +194,11 @@ const PageCard: React.FC<PageCardProps> = ({ page, index = 0, noteId, canDelete 
       )}
       style={{
         animationFillMode: "forwards",
-        animationDelay: `${index * 50}ms`,
+        // ノート内のページが多くても末尾カードのフェードイン待ちが伸び続けない
+        // よう、stagger は 8 枚（400ms）で頭打ちにする（Issue #848）。
+        // Cap the stagger at 8 cards (400ms) so large notes don't trail the
+        // last card behind a multi-second fade-in queue (Issue #848).
+        animationDelay: `${Math.min(index, 8) * 50}ms`,
       }}
     >
       {/* Title - Top */}

--- a/src/hooks/useNoteQueries.ts
+++ b/src/hooks/useNoteQueries.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query";
 import { useAuth, useUser } from "@/hooks/useAuth";
 import { createApiClient } from "@/lib/api";
 import type {
@@ -37,10 +37,22 @@ export const noteKeys = {
   details: () => [...noteKeys.all, "detail"] as const,
   detail: (noteId: string, userId?: string, userEmail?: string) =>
     [...noteKeys.details(), noteId, userId ?? "", userEmail ?? ""] as const,
+  /**
+   * `noteId` 配下のすべての detail エントリ（任意の `userId` / `userEmail`）に
+   * 一致するプレフィックスキー。`invalidateQueries` のターゲットとして使う。
+   * Issue #848 で `useNotePages` を `useNote` と同じキーに統一した結果、
+   * 旧 `pageList(noteId)` 無効化はこちらに置き換えられる。
+   *
+   * Prefix key matching every detail entry for `noteId` regardless of caller
+   * `userId` / `userEmail`. Used as the `invalidateQueries` target after
+   * mutations that change the page list. Issue #848 collapsed `useNotePages`
+   * onto the same key as `useNote`, so the old `pageList(noteId)` invalidator
+   * is replaced by this one.
+   */
+  detailsByNoteId: (noteId: string) => [...noteKeys.details(), noteId] as const,
   publicList: (sort: string, limit: number, offset: number) =>
     [...noteKeys.all, "public", sort, limit, offset] as const,
   pages: () => [...noteKeys.all, "pages"] as const,
-  pageList: (noteId: string) => [...noteKeys.pages(), noteId] as const,
   page: (noteId: string, pageId: string) => [...noteKeys.pages(), noteId, pageId] as const,
   members: () => [...noteKeys.all, "members"] as const,
   memberList: (noteId: string) => [...noteKeys.members(), noteId] as const,
@@ -281,19 +293,31 @@ type UseNoteOptions = { allowRemote?: boolean };
 /**
  * 単一の Note とアクセス権情報を取得するフック。
  * Hook that fetches a single Note alongside the caller's access context.
+ *
+ * `useNotePages` と同じ `queryKey` / `queryFn` を共有し、`select` で
+ * `{ note, access }` を導出する。これにより `GET /api/notes/:id` の
+ * 重複フェッチが回避される（Issue #848）。
+ *
+ * Shares the `queryKey` / `queryFn` with `useNotePages` and derives
+ * `{ note, access }` via `select`. This dedupes `GET /api/notes/:id` so the
+ * heavy JSON is fetched only once per note (Issue #848).
  */
 export function useNote(noteId: string, _options?: UseNoteOptions) {
   const { api, userId, userEmail, isLoaded, isSignedIn } = useNoteApi();
 
   const query = useQuery({
     queryKey: noteKeys.detail(noteId, userId, userEmail),
-    queryFn: async (): Promise<NoteWithAccess> => {
-      const res = await api.getNote(noteId);
+    queryFn: () => api.getNote(noteId),
+    enabled: isLoaded && !!noteId,
+    // 別ノートへ遷移しても前ノートのデータを残し、白画面を回避する。
+    // Keep showing the previous note while fetching the next one to avoid the
+    // blank loading state on navigation between notes.
+    placeholderData: keepPreviousData,
+    select: (res): NoteWithAccess => {
       const note = apiNoteToNote(res);
       const access = buildAccessFromApi(note, res.current_user_role, userId);
       return { note, access };
     },
-    enabled: isLoaded && !!noteId,
   });
 
   const noteWithAccess = query.data ?? null;
@@ -324,25 +348,34 @@ export function usePublicNotes(sort: "updated" | "popular" = "updated", limit = 
 
 /**
  * 指定ノートに含まれるページ一覧（ノート画面用）を取得するフック。
+ *
+ * `useNote` と同じ `queryKey` / `queryFn` を使い、`select` でページ配列のみを
+ * 切り出す。React Query が同一キーでフェッチをディデュープするので、
+ * `useNote` と同居しても `GET /api/notes/:id` は 1 回しか走らない
+ * （Issue #848）。
+ *
  * Hook that fetches pages belonging to the given note for the note view.
+ * Reuses the `queryKey` / `queryFn` of `useNote` and extracts the pages slice
+ * through `select`, so co-locating both hooks yields a single
+ * `GET /api/notes/:id` round trip (Issue #848).
  */
 export function useNotePages(
   noteId: string,
   _source?: "local" | "remote",
   enabled: boolean = true,
 ) {
-  const { api, isLoaded } = useNoteApi();
+  const { api, userId, userEmail, isLoaded } = useNoteApi();
 
   return useQuery({
-    queryKey: noteKeys.pageList(noteId),
-    queryFn: async (): Promise<NotePageSummary[]> => {
-      const res = await api.getNote(noteId);
-      return res.pages.map((p) => ({
+    queryKey: noteKeys.detail(noteId, userId, userEmail),
+    queryFn: () => api.getNote(noteId),
+    enabled: enabled && isLoaded && !!noteId,
+    placeholderData: keepPreviousData,
+    select: (res): NotePageSummary[] =>
+      res.pages.map((p) => ({
         ...apiPageToPageSummary(p),
         addedByUserId: p.added_by_user_id,
-      }));
-    },
-    enabled: enabled && isLoaded && !!noteId,
+      })),
   });
 }
 
@@ -489,7 +522,7 @@ export function useAddPageToNote() {
       await api.addNotePage(noteId, { pageId, title });
     },
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: noteKeys.pageList(variables.noteId) });
+      queryClient.invalidateQueries({ queryKey: noteKeys.detailsByNoteId(variables.noteId) });
       queryClient.invalidateQueries({ queryKey: noteKeys.details() });
     },
   });
@@ -512,7 +545,7 @@ export function useCopyPersonalPageToNote() {
       return api.copyPersonalPageToNote(noteId, sourcePageId);
     },
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: noteKeys.pageList(variables.noteId) });
+      queryClient.invalidateQueries({ queryKey: noteKeys.detailsByNoteId(variables.noteId) });
       queryClient.invalidateQueries({ queryKey: noteKeys.details() });
     },
   });
@@ -612,7 +645,7 @@ export function useRemovePageFromNote() {
       await api.removeNotePage(noteId, pageId);
     },
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: noteKeys.pageList(variables.noteId) });
+      queryClient.invalidateQueries({ queryKey: noteKeys.detailsByNoteId(variables.noteId) });
       queryClient.invalidateQueries({ queryKey: noteKeys.details() });
     },
   });

--- a/src/hooks/useNoteQueries.ts
+++ b/src/hooks/useNoteQueries.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth, useUser } from "@/hooks/useAuth";
 import { createApiClient } from "@/lib/api";
 import type {
@@ -291,6 +291,38 @@ export function useMyNote(options: UseMyNoteOptions = {}) {
 type UseNoteOptions = { allowRemote?: boolean };
 
 /**
+ * `useNote` / `useNotePages` 共通の `placeholderData` ファクトリ。
+ * `noteId` をまたぐ遷移では前ノートの結果を残して白画面を回避するが、
+ * 認証コンテキスト (`userId` / `userEmail`) が変化する遷移
+ * （ログアウト・別アカウントへの切替）では前ユーザーのデータを残さない
+ * よう `undefined` を返す。Issue #855 review (Codex P1)。
+ *
+ * Shared `placeholderData` factory for `useNote` and `useNotePages`. The
+ * previous result is preserved across `noteId` transitions to avoid the
+ * blank loading state, but it is discarded when the auth principal
+ * (`userId` / `userEmail`) changes (sign-out, account switch) so a private
+ * note that becomes inaccessible stops rendering the previous user's data
+ * mid-transition.
+ */
+function notePlaceholderDataIfSamePrincipal(userId: string, userEmail: string | undefined) {
+  const currentEmail = userEmail ?? "";
+  return (
+    previousData: GetNoteResponse | undefined,
+    previousQuery?: { queryKey: readonly unknown[] },
+  ): GetNoteResponse | undefined => {
+    if (!previousData || !previousQuery) return undefined;
+    const key = previousQuery.queryKey;
+    // `noteKeys.detail(noteId, userId, userEmail)` produces
+    // [..., noteId, userId, userEmail]; the principal lives in the last two
+    // slots regardless of any future prefix changes.
+    if (key.length < 2) return undefined;
+    const prevUserId = key[key.length - 2];
+    const prevUserEmail = key[key.length - 1];
+    return prevUserId === userId && prevUserEmail === currentEmail ? previousData : undefined;
+  };
+}
+
+/**
  * 単一の Note とアクセス権情報を取得するフック。
  * Hook that fetches a single Note alongside the caller's access context.
  *
@@ -309,10 +341,14 @@ export function useNote(noteId: string, _options?: UseNoteOptions) {
     queryKey: noteKeys.detail(noteId, userId, userEmail),
     queryFn: () => api.getNote(noteId),
     enabled: isLoaded && !!noteId,
-    // 別ノートへ遷移しても前ノートのデータを残し、白画面を回避する。
+    // 別ノートへ遷移しても前ノートのデータを残し、白画面を回避する。ただし
+    // ログアウト・アカウント切替時に前ユーザーのデータを引き継がないよう、
+    // `userId` / `userEmail` が同一の場合に限って placeholder を返す。
+    //
     // Keep showing the previous note while fetching the next one to avoid the
-    // blank loading state on navigation between notes.
-    placeholderData: keepPreviousData,
+    // blank loading state, gated on a matching auth principal so logout /
+    // account switches do not carry the previous user's data forward.
+    placeholderData: notePlaceholderDataIfSamePrincipal(userId, userEmail),
     select: (res): NoteWithAccess => {
       const note = apiNoteToNote(res);
       const access = buildAccessFromApi(note, res.current_user_role, userId);
@@ -370,11 +406,20 @@ export function useNotePages(
     queryKey: noteKeys.detail(noteId, userId, userEmail),
     queryFn: () => api.getNote(noteId),
     enabled: enabled && isLoaded && !!noteId,
-    placeholderData: keepPreviousData,
+    placeholderData: notePlaceholderDataIfSamePrincipal(userId, userEmail),
+    // Issue #823 以降、ページは 1 つのノートにのみ所属し、API レスポンスは
+    // 旧 `note_pages` の `added_by_user_id` を返さない。ページのオーナーが
+    // 実質「ページを追加した人」なので `owner_id` を採用する（Issue #855
+    // review fix; gemini-code-assist HIGH）。
+    //
+    // Since #823 every page lives in exactly one note and the API stopped
+    // returning the legacy `note_pages.added_by_user_id`. The page owner is
+    // effectively the adder, so we surface `owner_id` here. Fixes the
+    // gemini-code-assist HIGH finding on PR #855.
     select: (res): NotePageSummary[] =>
       res.pages.map((p) => ({
         ...apiPageToPageSummary(p),
-        addedByUserId: p.added_by_user_id,
+        addedByUserId: p.owner_id,
       })),
   });
 }

--- a/src/pages/NotePageView.test.tsx
+++ b/src/pages/NotePageView.test.tsx
@@ -68,7 +68,7 @@ vi.mock("@/hooks/useNoteQueries", () => ({
   })),
   noteKeys: {
     page: (noteId: string, pageId: string) => ["notes", "pages", noteId, pageId],
-    pageList: (noteId: string) => ["notes", "pages", noteId],
+    detailsByNoteId: (noteId: string) => ["notes", "detail", noteId],
   },
 }));
 

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -173,7 +173,7 @@ function NotePageEditorEditable({
       // `noteKeys.*` にあるため、タイトル変更をノート表示やサイドバーに反映
       // させるには明示的に無効化する必要がある。
       queryClient.invalidateQueries({ queryKey: noteKeys.page(noteId, page.id) });
-      queryClient.invalidateQueries({ queryKey: noteKeys.pageList(noteId) });
+      queryClient.invalidateQueries({ queryKey: noteKeys.detailsByNoteId(noteId) });
     } catch (error) {
       if (pendingTitleRef.current === null) {
         setTitle(previousTitle);


### PR DESCRIPTION
## 概要

React Query のキー統一と `select` オプションを活用して `useNote` と `useNotePages` の API 呼び出しをディデュープします。また、ページ列挙クエリのパフォーマンス最適化とレスポンス軽量化を実施します。

## 変更点

- **フロントエンド**
  - `useNote` と `useNotePages` が同じ `queryKey` / `queryFn` を共有し、`select` で異なるデータを抽出するように統一
  - `keepPreviousData` を導入してノート間遷移時の白画面を回避
  - `noteKeys.pageList()` を廃止し、`noteKeys.detailsByNoteId()` に統一（ページリスト変更時の無効化対象）
  - ページカードのアニメーション stagger を 8 枚（400ms）で頭打ちにして大規模ノートでの遅延を防止

- **バックエンド**
  - `GET /api/notes/:id` レスポンスから `content_preview` を常に `null` に変更（軽量化）
  - ページ列挙クエリ用の部分複合インデックス `idx_pages_note_active_updated` を追加
    - `(note_id, updated_at DESC) WHERE is_deleted = false` で、ソート処理をインデックススキャンに最適化
  - ページビュー数カウント更新を fire-and-forget 化（レスポンス時間に影響させない）

- **テスト**
  - `content_preview` が常に `null` であることを確認するテスト更新
  - `noteKeys` の変更に対応したモック更新

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)

## テスト方法

1. 既存テストスイートが全てパスすることを確認
2. ノート画面でページ一覧が正常に表示されることを確認
3. ノート間を遷移する際に白画面が表示されないことを確認
4. ページカードのフェードインアニメーションが大規模ノートでも適切に動作することを確認
5. ネットワークタブで `GET /api/notes/:id` が 1 回のみ呼び出されることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

- Closes #847 (Epic: ノート API パフォーマンス最適化)
- Closes #848 (useNote と useNotePages の API 呼び出しディデュープ)
- Closes #849 (レスポンス軽量化)
- Closes #850 (ページ列挙クエリのインデックス最適化)

https://claude.ai/code/session_018bc6foYx9Uquk43E4eyGBE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized note page loading and display performance
  * Improved animation responsiveness when viewing multiple pages
  * Reduced network calls through enhanced data caching
  * Faster page detail responses

* **Changes**
  * Page content preview field now always returns null

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/855)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->