### PR TITLE
feat(pdf): foundation for local PDF knowledge ingestion (#389)

### DIFF
--- a/server/api/drizzle/0025_add_pdf_source_metadata.sql
+++ b/server/api/drizzle/0025_add_pdf_source_metadata.sql
@@ -1,0 +1,22 @@
+-- Add file-backed metadata columns to `sources` so a `kind="pdf_local"` row can
+-- carry display name, byte size, page count, and free-form metadata without
+-- introducing a separate `documents` table.
+-- ローカル PDF などのファイル系ソース向けに `sources` に表示用メタ列を追加する。
+-- 別途 `documents` テーブルを作らず、kind="pdf_local" の行に NULL 可能な列を
+-- 載せる方針。
+--
+-- 重要: PDF の実体パスは絶対にここに保存しない。実パスは Tauri 側のローカル
+-- レジストリ (`pdf_sources.json`) のみが保持する。
+-- IMPORTANT: the actual filesystem path is NEVER stored in this table. The
+-- Tauri-side local registry (`pdf_sources.json`) is the only place that knows
+-- where the bytes live, so PDF binaries stay out of the sync surface.
+--
+-- See parent issue otomatty/zedi#389.
+
+ALTER TABLE "sources" ADD COLUMN IF NOT EXISTS "display_name" text;
+--> statement-breakpoint
+ALTER TABLE "sources" ADD COLUMN IF NOT EXISTS "byte_size" bigint;
+--> statement-breakpoint
+ALTER TABLE "sources" ADD COLUMN IF NOT EXISTS "page_count" integer;
+--> statement-breakpoint
+ALTER TABLE "sources" ADD COLUMN IF NOT EXISTS "metadata" jsonb;

--- a/server/api/drizzle/0026_add_pdf_highlights.sql
+++ b/server/api/drizzle/0026_add_pdf_highlights.sql
@@ -1,0 +1,60 @@
+-- Add the `pdf_highlights` table for the PDF knowledge ingestion feature.
+-- ローカル PDF のハイライト（テキスト選択範囲 + 任意メモ）を保持するテーブル。
+--
+-- 1 行 = 1 ハイライト。`source_id` は `sources.id` (kind="pdf_local") を参照する。
+-- `derived_page_id` はそのハイライトから派生した Zedi ページへの逆参照（オプション）。
+-- 正準の「ページ ↔ ソース」関係は引き続き `page_sources` を介して表現する。
+--
+-- One row = one highlight. `source_id` references `sources(id)` for the parent
+-- PDF source. `derived_page_id` is an optional back-pointer to the Zedi page
+-- created from this highlight; the canonical page↔source linkage continues to
+-- live in `page_sources`.
+--
+-- See parent issue otomatty/zedi#389.
+
+CREATE TABLE IF NOT EXISTS "pdf_highlights" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    "source_id" uuid NOT NULL,
+    "owner_id" text NOT NULL,
+    "derived_page_id" uuid,
+    "pdf_page" integer NOT NULL,
+    "rects" jsonb NOT NULL,
+    "text" text NOT NULL,
+    "color" text DEFAULT 'yellow' NOT NULL,
+    "note" text,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+    ALTER TABLE "pdf_highlights"
+        ADD CONSTRAINT "pdf_highlights_source_id_sources_id_fk"
+        FOREIGN KEY ("source_id") REFERENCES "sources"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+    ALTER TABLE "pdf_highlights"
+        ADD CONSTRAINT "pdf_highlights_owner_id_user_id_fk"
+        FOREIGN KEY ("owner_id") REFERENCES "user"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+    ALTER TABLE "pdf_highlights"
+        ADD CONSTRAINT "pdf_highlights_derived_page_id_pages_id_fk"
+        FOREIGN KEY ("derived_page_id") REFERENCES "pages"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_pdf_highlights_source_id"
+    ON "pdf_highlights" ("source_id", "pdf_page");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_pdf_highlights_owner_id"
+    ON "pdf_highlights" ("owner_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_pdf_highlights_derived_page_id"
+    ON "pdf_highlights" ("derived_page_id");

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -169,6 +169,20 @@
       "when": 1778716800000,
       "tag": "0024_add_pages_note_active_updated_index",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1778803200000,
+      "tag": "0025_add_pdf_source_metadata",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1778889600000,
+      "tag": "0026_add_pdf_highlights",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/src/app.ts
+++ b/server/api/src/app.ts
@@ -18,6 +18,7 @@ import searchRoutes from "./routes/search.js";
 import mediaRoutes from "./routes/media.js";
 import clipRoutes from "./routes/clip.js";
 import ingestRoutes from "./routes/ingest.js";
+import pdfSourcesRoutes from "./routes/pdfSources.js";
 import wikiSchemaRoutes from "./routes/wikiSchema.js";
 import extRoutes from "./routes/ext.js";
 import mcpRoutes from "./routes/mcp.js";
@@ -153,6 +154,10 @@ export function createApp(): Hono<AppEnv> {
 
   // Ingest (LLM Wiki pattern, P1)
   app.route("/api/ingest", ingestRoutes);
+
+  // Local PDF sources + highlights (issue otomatty/zedi#389).
+  // PDF binaries never reach the server — only hashes / page counts / highlights.
+  app.route("/api/sources", pdfSourcesRoutes);
 
   // Wiki Schema (P3 — user-defined wiki "constitution")
   app.route("/api/wiki-schema", wikiSchemaRoutes);

--- a/server/api/src/app.ts
+++ b/server/api/src/app.ts
@@ -157,6 +157,8 @@ export function createApp(): Hono<AppEnv> {
 
   // Local PDF sources + highlights (issue otomatty/zedi#389).
   // PDF binaries never reach the server — only hashes / page counts / highlights.
+  // ローカル PDF のソース行とハイライト (issue otomatty/zedi#389)。
+  // PDF バイナリ自体はサーバに渡さず、ハッシュ・ページ数・ハイライトのみを扱う。
   app.route("/api/sources", pdfSourcesRoutes);
 
   // Wiki Schema (P3 — user-defined wiki "constitution")

--- a/server/api/src/routes/pdfSources.ts
+++ b/server/api/src/routes/pdfSources.ts
@@ -1,0 +1,506 @@
+/**
+ * /api/sources/pdf — ローカル PDF をソースとして登録し、ハイライト CRUD と
+ * 「ハイライトから派生ページを作る」フローを提供する。
+ *
+ * `/api/sources/pdf` — register a local PDF as a `kind="pdf_local"` source,
+ * manage its highlights, and derive Zedi pages from highlights.
+ *
+ * 重要 / Important:
+ *   元 PDF のファイルパス（実体）は決してサーバに渡らない。本ルートが受け取るのは
+ *   ハッシュ・サイズ・ページ数・任意のメタ情報のみ。バイナリ送信は許容しない。
+ *
+ *   The original PDF path/bytes never reach the server. This route only
+ *   accepts content hash, byte size, page count, and optional metadata. The
+ *   Tauri-side local registry is the sole place that knows where the file
+ *   actually lives on disk (issue otomatty/zedi#389).
+ */
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { and, eq } from "drizzle-orm";
+import { authRequired } from "../middleware/auth.js";
+import { rateLimit } from "../middleware/rateLimit.js";
+import { sources } from "../schema/sources.js";
+import { pdfHighlights, PDF_HIGHLIGHT_COLORS } from "../schema/pdfHighlights.js";
+import type { PdfHighlightColor, PdfHighlightRect } from "../schema/pdfHighlights.js";
+import type { PdfSourceMetadata } from "../schema/sources.js";
+import { pageSources } from "../schema/pageSources.js";
+import { pages } from "../schema/pages.js";
+import { ensureDefaultNote } from "../services/defaultNoteService.js";
+import type { AppEnv } from "../types/index.js";
+
+const app = new Hono<AppEnv>();
+
+const PDF_SOURCE_KIND = "pdf_local" as const;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * 矩形配列の入力バリデーション。
+ * Runtime validation for an incoming highlight rect array.
+ */
+function validateRects(value: unknown): PdfHighlightRect[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new HTTPException(400, { message: "rects must be a non-empty array" });
+  }
+  if (value.length > 64) {
+    throw new HTTPException(400, { message: "rects has too many entries (max 64)" });
+  }
+  return value.map((raw, idx) => {
+    if (typeof raw !== "object" || raw === null) {
+      throw new HTTPException(400, { message: `rects[${idx}] must be an object` });
+    }
+    const r = raw as Record<string, unknown>;
+    const x1 = Number(r.x1);
+    const y1 = Number(r.y1);
+    const x2 = Number(r.x2);
+    const y2 = Number(r.y2);
+    if (![x1, y1, x2, y2].every(Number.isFinite)) {
+      throw new HTTPException(400, { message: `rects[${idx}] has non-finite coordinates` });
+    }
+    return { x1, y1, x2, y2 };
+  });
+}
+
+/**
+ * highlight color の入力バリデーション。
+ * Validates `color` against the allowed enum.
+ */
+function validateColor(value: unknown): PdfHighlightColor {
+  if (typeof value !== "string") {
+    throw new HTTPException(400, { message: "color must be a string" });
+  }
+  if (!(PDF_HIGHLIGHT_COLORS as readonly string[]).includes(value)) {
+    throw new HTTPException(400, {
+      message: `color must be one of ${PDF_HIGHLIGHT_COLORS.join(", ")}`,
+    });
+  }
+  return value as PdfHighlightColor;
+}
+
+/**
+ * `sources` 行が当該ユーザー所有の PDF ソースか確認する。
+ * Ensures the source row exists, is `kind="pdf_local"`, and is owned by the user.
+ */
+async function loadOwnedPdfSourceOrThrow(
+  db: AppEnv["Variables"]["db"],
+  sourceId: string,
+  userId: string,
+) {
+  const [row] = await db
+    .select({
+      id: sources.id,
+      kind: sources.kind,
+      ownerId: sources.ownerId,
+      displayName: sources.displayName,
+    })
+    .from(sources)
+    .where(and(eq(sources.id, sourceId), eq(sources.ownerId, userId)))
+    .limit(1);
+  if (!row) throw new HTTPException(404, { message: "PDF source not found" });
+  if (row.kind !== PDF_SOURCE_KIND) {
+    throw new HTTPException(400, { message: "Source is not a local PDF" });
+  }
+  return row;
+}
+
+// ── POST /api/sources/pdf ───────────────────────────────────────────────────
+// PDF ソース行を登録（再投入はハッシュで dedup）。サーバには絶対パスを渡さない。
+// Register a PDF source row. Re-registration of the same file dedups via the
+// `(owner, kind="pdf_local", content_hash)` partial unique index — no path
+// fields are accepted.
+
+interface RegisterPdfSourceBody {
+  /** PDF バイト列の SHA-256 16進文字列。SHA-256 hex of the PDF bytes. */
+  sha256?: string;
+  /** PDF のバイトサイズ。Byte size of the PDF. */
+  byteSize?: number;
+  /** PDF の総ページ数（pdfjs から取得）。Total PDF page count from pdf.js. */
+  pageCount?: number;
+  /** ユーザーに表示するファイル名。Filename shown in UI. */
+  displayName?: string;
+  /** 任意のメタデータ（PDF Info / XMP 由来）。Free-form metadata. */
+  metadata?: PdfSourceMetadata;
+}
+
+app.post("/pdf", authRequired, rateLimit(), async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+
+  let body: RegisterPdfSourceBody;
+  try {
+    body = await c.req.json<RegisterPdfSourceBody>();
+  } catch {
+    throw new HTTPException(400, { message: "Invalid JSON body" });
+  }
+
+  if (typeof body.sha256 !== "string" || !/^[0-9a-f]{64}$/i.test(body.sha256)) {
+    throw new HTTPException(400, { message: "sha256 must be a 64-char hex string" });
+  }
+  const sha256 = body.sha256.toLowerCase();
+  const byteSize = typeof body.byteSize === "number" && body.byteSize >= 0 ? body.byteSize : null;
+  const pageCount =
+    typeof body.pageCount === "number" && body.pageCount > 0 && Number.isInteger(body.pageCount)
+      ? body.pageCount
+      : null;
+  const displayName =
+    typeof body.displayName === "string" && body.displayName.trim()
+      ? body.displayName.trim().slice(0, 255)
+      : null;
+  const metadata = body.metadata && typeof body.metadata === "object" ? body.metadata : null;
+
+  const now = new Date();
+
+  // 既存ソースを先に SELECT。本実装は ON CONFLICT DO NOTHING + 再 SELECT で
+  // 並行登録にも収束する（既存 ingest.ts と同じ流儀）。
+  // Pre-flight SELECT + ON CONFLICT DO NOTHING + re-SELECT mirrors the ingest
+  // route so concurrent registrations converge on a single winner.
+  const [existing] = await db
+    .select({ id: sources.id })
+    .from(sources)
+    .where(
+      and(
+        eq(sources.ownerId, userId),
+        eq(sources.kind, PDF_SOURCE_KIND),
+        eq(sources.contentHash, sha256),
+      ),
+    )
+    .limit(1);
+
+  if (existing) {
+    return c.json({ sourceId: existing.id, deduped: true });
+  }
+
+  const [inserted] = await db
+    .insert(sources)
+    .values({
+      ownerId: userId,
+      kind: PDF_SOURCE_KIND,
+      url: null,
+      title: displayName,
+      contentHash: sha256,
+      excerpt: null,
+      extractedAt: now,
+      createdAt: now,
+      displayName,
+      byteSize,
+      pageCount,
+      metadata,
+    })
+    .onConflictDoNothing()
+    .returning({ id: sources.id });
+
+  if (inserted) {
+    return c.json({ sourceId: inserted.id, deduped: false }, 201);
+  }
+
+  // Race lost — pick up the winner.
+  const [winner] = await db
+    .select({ id: sources.id })
+    .from(sources)
+    .where(
+      and(
+        eq(sources.ownerId, userId),
+        eq(sources.kind, PDF_SOURCE_KIND),
+        eq(sources.contentHash, sha256),
+      ),
+    )
+    .limit(1);
+  if (!winner) throw new HTTPException(500, { message: "Failed to register PDF source" });
+  return c.json({ sourceId: winner.id, deduped: true });
+});
+
+// ── PATCH /api/sources/pdf/:sourceId/page-count ─────────────────────────────
+// `register_pdf_source` で page_count が分からないケース向けに、後追いで pdfjs
+// 取得値を反映する補助エンドポイント。
+// Helper used after pdf.js has loaded the document and learned its page count
+// (the Rust side does not parse PDFs to keep dependencies minimal).
+
+app.patch("/pdf/:sourceId/page-count", authRequired, rateLimit(), async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+  const sourceId = c.req.param("sourceId");
+  await loadOwnedPdfSourceOrThrow(db, sourceId, userId);
+
+  let body: { pageCount?: unknown };
+  try {
+    body = await c.req.json<{ pageCount?: unknown }>();
+  } catch {
+    throw new HTTPException(400, { message: "Invalid JSON body" });
+  }
+  const pageCount = Number(body.pageCount);
+  if (!Number.isInteger(pageCount) || pageCount <= 0 || pageCount > 100_000) {
+    throw new HTTPException(400, { message: "pageCount must be a positive integer" });
+  }
+
+  await db.update(sources).set({ pageCount }).where(eq(sources.id, sourceId));
+  return c.json({ sourceId, pageCount });
+});
+
+// ── GET /api/sources/pdf/:sourceId/highlights ───────────────────────────────
+
+app.get("/pdf/:sourceId/highlights", authRequired, async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+  const sourceId = c.req.param("sourceId");
+  await loadOwnedPdfSourceOrThrow(db, sourceId, userId);
+
+  const rows = await db
+    .select()
+    .from(pdfHighlights)
+    .where(eq(pdfHighlights.sourceId, sourceId))
+    .orderBy(pdfHighlights.pdfPage, pdfHighlights.createdAt);
+
+  return c.json({ highlights: rows });
+});
+
+// ── POST /api/sources/pdf/:sourceId/highlights ──────────────────────────────
+
+interface CreateHighlightBody {
+  pdfPage?: unknown;
+  rects?: unknown;
+  text?: unknown;
+  color?: unknown;
+  note?: unknown;
+}
+
+app.post("/pdf/:sourceId/highlights", authRequired, rateLimit(), async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+  const sourceId = c.req.param("sourceId");
+  await loadOwnedPdfSourceOrThrow(db, sourceId, userId);
+
+  let body: CreateHighlightBody;
+  try {
+    body = await c.req.json<CreateHighlightBody>();
+  } catch {
+    throw new HTTPException(400, { message: "Invalid JSON body" });
+  }
+
+  const pdfPage = Number(body.pdfPage);
+  if (!Number.isInteger(pdfPage) || pdfPage <= 0) {
+    throw new HTTPException(400, { message: "pdfPage must be a positive integer" });
+  }
+  const rects = validateRects(body.rects);
+  if (typeof body.text !== "string" || !body.text.trim()) {
+    throw new HTTPException(400, { message: "text is required" });
+  }
+  const text = body.text.slice(0, 10_000);
+  const color: PdfHighlightColor = body.color === undefined ? "yellow" : validateColor(body.color);
+  const note = typeof body.note === "string" ? body.note.slice(0, 4_000) : null;
+
+  const [row] = await db
+    .insert(pdfHighlights)
+    .values({
+      sourceId,
+      ownerId: userId,
+      pdfPage,
+      rects,
+      text,
+      color,
+      note,
+    })
+    .returning();
+  if (!row) throw new HTTPException(500, { message: "Failed to create highlight" });
+
+  return c.json({ highlight: row }, 201);
+});
+
+// ── PATCH /api/sources/pdf/:sourceId/highlights/:highlightId ─────────────────
+
+app.patch("/pdf/:sourceId/highlights/:highlightId", authRequired, rateLimit(), async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+  const sourceId = c.req.param("sourceId");
+  const highlightId = c.req.param("highlightId");
+  await loadOwnedPdfSourceOrThrow(db, sourceId, userId);
+
+  let body: { color?: unknown; note?: unknown };
+  try {
+    body = await c.req.json<{ color?: unknown; note?: unknown }>();
+  } catch {
+    throw new HTTPException(400, { message: "Invalid JSON body" });
+  }
+
+  const patch: Record<string, unknown> = { updatedAt: new Date() };
+  if (body.color !== undefined) patch.color = validateColor(body.color);
+  if (body.note !== undefined) {
+    if (body.note !== null && typeof body.note !== "string") {
+      throw new HTTPException(400, { message: "note must be a string or null" });
+    }
+    patch.note = body.note === null ? null : (body.note as string).slice(0, 4_000);
+  }
+  if (Object.keys(patch).length === 1) {
+    throw new HTTPException(400, { message: "no patchable fields supplied" });
+  }
+
+  const [row] = await db
+    .update(pdfHighlights)
+    .set(patch)
+    .where(
+      and(
+        eq(pdfHighlights.id, highlightId),
+        eq(pdfHighlights.sourceId, sourceId),
+        eq(pdfHighlights.ownerId, userId),
+      ),
+    )
+    .returning();
+  if (!row) throw new HTTPException(404, { message: "Highlight not found" });
+  return c.json({ highlight: row });
+});
+
+// ── DELETE /api/sources/pdf/:sourceId/highlights/:highlightId ───────────────
+
+app.delete("/pdf/:sourceId/highlights/:highlightId", authRequired, rateLimit(), async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+  const sourceId = c.req.param("sourceId");
+  const highlightId = c.req.param("highlightId");
+  await loadOwnedPdfSourceOrThrow(db, sourceId, userId);
+
+  const deleted = await db
+    .delete(pdfHighlights)
+    .where(
+      and(
+        eq(pdfHighlights.id, highlightId),
+        eq(pdfHighlights.sourceId, sourceId),
+        eq(pdfHighlights.ownerId, userId),
+      ),
+    )
+    .returning({ id: pdfHighlights.id });
+  if (deleted.length === 0) throw new HTTPException(404, { message: "Highlight not found" });
+  return c.json({ deleted: deleted[0]?.id });
+});
+
+// ── POST /api/sources/pdf/:sourceId/highlights/:highlightId/derive-page ─────
+// 出典付きの新規 Zedi ページを 1 トランザクションで作る。
+// Create a derived Zedi page in one transaction:
+//   1. INSERT pages
+//   2. INSERT page_sources (carries "pdf:v1:<highlightId>")
+//   3. UPDATE pdf_highlights.derived_page_id
+
+interface DerivePageBody {
+  /** 派生ページを作るノート ID（省略時は default note）。Target note id, defaults to user's default note. */
+  noteId?: string | null;
+  /** ページタイトル（クライアントの buildDerivedPageTitle の結果を渡す）。Page title. */
+  title?: string;
+  /** 検索用プレビュー（先頭 120 字）。Search preview, first 120 chars. */
+  contentPreview?: string;
+  /** クライアント側で組み立てた Tiptap JSON 文字列。後続の初回オープン時に seed する。
+   *  Stringified Tiptap JSON to seed the new page's content on first open. */
+  templateContent?: string;
+}
+
+app.post(
+  "/pdf/:sourceId/highlights/:highlightId/derive-page",
+  authRequired,
+  rateLimit(),
+  async (c) => {
+    const userId = c.get("userId");
+    const db = c.get("db");
+    const sourceId = c.req.param("sourceId");
+    const highlightId = c.req.param("highlightId");
+    await loadOwnedPdfSourceOrThrow(db, sourceId, userId);
+
+    const [highlightRow] = await db
+      .select()
+      .from(pdfHighlights)
+      .where(
+        and(
+          eq(pdfHighlights.id, highlightId),
+          eq(pdfHighlights.sourceId, sourceId),
+          eq(pdfHighlights.ownerId, userId),
+        ),
+      )
+      .limit(1);
+    if (!highlightRow) throw new HTTPException(404, { message: "Highlight not found" });
+    if (highlightRow.derivedPageId) {
+      // 既に派生ページがあるので冪等に既存 ID を返す。
+      // Idempotent: a derived page already exists.
+      return c.json({ pageId: highlightRow.derivedPageId, alreadyDerived: true });
+    }
+
+    let body: DerivePageBody = {};
+    try {
+      body = await c.req.json<DerivePageBody>();
+    } catch {
+      // body 省略を許容（必須フィールド無し）。Body is optional.
+    }
+
+    const requestedNoteId =
+      typeof body.noteId === "string" && body.noteId.trim() !== "" ? body.noteId.trim() : null;
+    const title =
+      typeof body.title === "string" && body.title.trim() ? body.title.trim().slice(0, 255) : null;
+    const contentPreview =
+      typeof body.contentPreview === "string"
+        ? body.contentPreview.slice(0, 240)
+        : highlightRow.text.slice(0, 240);
+
+    // ノート所属を解決（default に寄せる）。ノート権限の細かなチェックは
+    // /api/pages POST と同等のロジックを将来 import で共有してもよい。
+    // Resolve note membership; default to the user's default note.
+    const resolvedNoteId: string = requestedNoteId ?? (await ensureDefaultNote(db, userId)).id;
+
+    const sectionAnchor = `pdf:v1:${highlightRow.id}`;
+
+    // 1 トランザクションで全ての書き込みを行い、いずれかの失敗で全体を巻き戻す。
+    // Perform all writes in one transaction so a failure rolls everything back.
+    const result = await db.transaction(async (tx) => {
+      const [page] = await tx
+        .insert(pages)
+        .values({
+          ownerId: userId,
+          noteId: resolvedNoteId,
+          title,
+          contentPreview,
+          sourceUrl: null,
+        })
+        .returning({
+          id: pages.id,
+          title: pages.title,
+          contentPreview: pages.contentPreview,
+          createdAt: pages.createdAt,
+        });
+      if (!page) {
+        throw new HTTPException(500, { message: "Failed to create derived page" });
+      }
+
+      // page_sources は冪等に登録（同一 sectionAnchor の再投入を許容）。
+      // Idempotently insert the page_sources row.
+      await tx
+        .insert(pageSources)
+        .values({
+          pageId: page.id,
+          sourceId,
+          sectionAnchor,
+          citationText: highlightRow.text.slice(0, 4_000),
+        })
+        .onConflictDoNothing();
+
+      await tx
+        .update(pdfHighlights)
+        .set({ derivedPageId: page.id, updatedAt: new Date() })
+        .where(eq(pdfHighlights.id, highlightRow.id));
+
+      return page;
+    });
+
+    return c.json(
+      {
+        pageId: result.id,
+        noteId: resolvedNoteId,
+        sectionAnchor,
+        // テンプレートは v1 では echo するだけ。クライアントが「派生直後の初回オープン」で
+        // pageContents へ seed する責務を担う。
+        // v1 echoes the template back; the client is responsible for seeding
+        // it into pageContents on the first open of the new page.
+        templateContent: body.templateContent ?? null,
+        title: result.title ?? null,
+        contentPreview: result.contentPreview ?? null,
+        createdAt: result.createdAt.toISOString(),
+      },
+      201,
+    );
+  },
+);
+
+export default app;

--- a/server/api/src/schema/index.ts
+++ b/server/api/src/schema/index.ts
@@ -79,8 +79,16 @@ export {
   type ApiErrorStatus,
   type ApiErrorSuspectedFile,
 } from "./apiErrors.js";
-export { sources, type Source, type NewSource } from "./sources.js";
+export { sources, type Source, type NewSource, type PdfSourceMetadata } from "./sources.js";
 export { pageSources, type PageSource, type NewPageSource } from "./pageSources.js";
+export {
+  pdfHighlights,
+  PDF_HIGHLIGHT_COLORS,
+  type PdfHighlight,
+  type NewPdfHighlight,
+  type PdfHighlightRect,
+  type PdfHighlightColor,
+} from "./pdfHighlights.js";
 export {
   lintFindings,
   type LintFinding,
@@ -117,6 +125,7 @@ export {
   aiMonthlyUsageRelations,
   sourcesRelations,
   pageSourcesRelations,
+  pdfHighlightsRelations,
   lintFindingsRelations,
   activityLogRelations,
 } from "./relations.js";

--- a/server/api/src/schema/pdfHighlights.ts
+++ b/server/api/src/schema/pdfHighlights.ts
@@ -1,0 +1,94 @@
+/**
+ * `pdf_highlights` — Highlights captured on a `kind="pdf_local"` source.
+ *
+ * 「ローカル PDF 上のハイライト」を保持するテーブル。
+ * 1 行 = 1 ハイライト。Excerpt-centric な派生ページとは 1:0..1 で対応する。
+ * 一つのハイライトから派生したページの id を `derivedPageId` で持ち戻せる
+ * が、正準の「派生 ↔ 出典」関係は `page_sources` 経由で表現する。
+ *
+ * One row = one highlight on a local PDF. With the excerpt-centric flow
+ * (otomatty/zedi#389), a highlight maps to at most one derived Zedi page;
+ * the canonical "page ↔ source" relation lives in `page_sources` and the
+ * `derivedPageId` column on this table is a convenience back-pointer.
+ */
+import { pgTable, uuid, text, integer, jsonb, timestamp, index } from "drizzle-orm/pg-core";
+import { users } from "./users.js";
+import { pages } from "./pages.js";
+import { sources } from "./sources.js";
+
+/**
+ * PDF 上の矩形領域（ハイライト範囲）。PDF のポイント空間で表現する。
+ * Bounding rect in PDF point space, used by viewer to render highlight quads.
+ *
+ * @property x1 - 左下 x（PDF user-space）。Bottom-left x.
+ * @property y1 - 左下 y。Bottom-left y.
+ * @property x2 - 右上 x。Top-right x.
+ * @property y2 - 右上 y。Top-right y.
+ */
+export interface PdfHighlightRect {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+/**
+ * 許容するハイライト色の列挙。UI と一致させる。
+ * Allowed highlight colors (kept in sync with the toolbar UI).
+ */
+export const PDF_HIGHLIGHT_COLORS = ["yellow", "green", "blue", "red", "purple"] as const;
+export type PdfHighlightColor = (typeof PDF_HIGHLIGHT_COLORS)[number];
+
+/**
+ * `pdf_highlights` テーブル定義。
+ * Drizzle definition for the `pdf_highlights` table.
+ *
+ * @property id - ハイライトの一意 ID。Unique ID.
+ * @property sourceId - 紐づく `sources.id`（`kind="pdf_local"`）。Owning source.
+ * @property ownerId - 所有ユーザー ID（所有検索用に非正規化）。Denormalized owner.
+ * @property derivedPageId - 派生 Zedi ページ ID（存在する場合）。Derived page id.
+ * @property pdfPage - 1 始まりの PDF ページ番号。1-indexed PDF page.
+ * @property rects - 選択範囲の矩形配列（複数行選択を 1 つにまとめる）。Rect array.
+ * @property text - 抽出した本文テキスト。Extracted highlight text.
+ * @property color - ハイライト色。Highlight color.
+ * @property note - 任意のメモ（ハイライトに直接付与する短文）。Optional inline note.
+ * @property createdAt - 作成時刻。Created at.
+ * @property updatedAt - 更新時刻。Updated at.
+ */
+export const pdfHighlights = pgTable(
+  "pdf_highlights",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    sourceId: uuid("source_id")
+      .notNull()
+      .references(() => sources.id, { onDelete: "cascade" }),
+    ownerId: text("owner_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    derivedPageId: uuid("derived_page_id").references(() => pages.id, { onDelete: "set null" }),
+    pdfPage: integer("pdf_page").notNull(),
+    rects: jsonb("rects").$type<PdfHighlightRect[]>().notNull(),
+    text: text("text").notNull(),
+    color: text("color").notNull().default("yellow"),
+    note: text("note"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    index("idx_pdf_highlights_source_id").on(table.sourceId, table.pdfPage),
+    index("idx_pdf_highlights_owner_id").on(table.ownerId),
+    index("idx_pdf_highlights_derived_page_id").on(table.derivedPageId),
+  ],
+);
+
+/**
+ * pdf_highlights テーブルの SELECT 型。
+ * Select type for the pdf_highlights table.
+ */
+export type PdfHighlight = typeof pdfHighlights.$inferSelect;
+
+/**
+ * pdf_highlights テーブルの INSERT 型。
+ * Insert type for the pdf_highlights table.
+ */
+export type NewPdfHighlight = typeof pdfHighlights.$inferInsert;

--- a/server/api/src/schema/relations.ts
+++ b/server/api/src/schema/relations.ts
@@ -17,6 +17,7 @@ import { subscriptions } from "./subscriptions.js";
 import { aiUsageLogs, aiMonthlyUsage } from "./aiModels.js";
 import { sources } from "./sources.js";
 import { pageSources } from "./pageSources.js";
+import { pdfHighlights } from "./pdfHighlights.js";
 import { lintFindings } from "./lintFindings.js";
 import { activityLog } from "./activityLog.js";
 
@@ -286,6 +287,26 @@ export const sourcesRelations = relations(sources, ({ one, many }) => ({
     references: [users.id],
   }),
   citations: many(pageSources),
+  highlights: many(pdfHighlights),
+}));
+
+/**
+ * `pdf_highlights` のリレーション定義。所有者・ソース・派生ページに繋がる。
+ * Relations for `pdf_highlights`: owner, source, and (optional) derived page.
+ */
+export const pdfHighlightsRelations = relations(pdfHighlights, ({ one }) => ({
+  owner: one(users, {
+    fields: [pdfHighlights.ownerId],
+    references: [users.id],
+  }),
+  source: one(sources, {
+    fields: [pdfHighlights.sourceId],
+    references: [sources.id],
+  }),
+  derivedPage: one(pages, {
+    fields: [pdfHighlights.derivedPageId],
+    references: [pages.id],
+  }),
 }));
 
 /**

--- a/server/api/src/schema/sources.ts
+++ b/server/api/src/schema/sources.ts
@@ -12,23 +12,59 @@
  *
  * @see https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
  */
-import { pgTable, uuid, text, timestamp, index, uniqueIndex } from "drizzle-orm/pg-core";
+import {
+  pgTable,
+  uuid,
+  text,
+  bigint,
+  integer,
+  jsonb,
+  timestamp,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import { users } from "./users.js";
 
 /**
- * 外部から取り込んだ素材（URL / 会話 等）。不変・AI による書き換え対象外。
- * External material ingested from URL or conversation. Immutable.
+ * `kind="pdf_local"` のソースに付随するメタ情報。
+ * Optional metadata attached to a `pdf_local` source row.
+ *
+ * 元 PDF のファイルパスは決してこの構造には含めない。実体パスは Tauri 側の
+ * ローカルレジストリ (`pdf_sources.json`) にのみ保持する。
+ * The original PDF file path is NEVER stored here; only the Tauri-side local
+ * registry (`pdf_sources.json`) knows where the bytes actually live.
+ */
+export interface PdfSourceMetadata {
+  /** PDF メタデータの title（XMP / Info dictionary 由来）。PDF title from XMP / Info. */
+  pdfTitle?: string;
+  /** PDF メタデータの author。PDF author. */
+  pdfAuthor?: string;
+  /** PDF メタデータの作成日時 ISO 文字列。Creation date in ISO 8601. */
+  pdfCreatedAt?: string;
+  /** 任意の追加プロパティ。Free-form extension fields. */
+  [key: string]: unknown;
+}
+
+/**
+ * 外部から取り込んだ素材（URL / 会話 / ローカル PDF 等）。不変・AI による書き換え対象外。
+ * External material ingested from URL, conversation, or a local PDF file.
+ * Immutable; AI never rewrites a row in this table.
  *
  * @property id - ソースの一意 ID。Unique ID.
  * @property ownerId - 所有ユーザー ID。Owner user ID.
- * @property kind - ソース種別。"url" | "conversation"（将来拡張可能）。Source kind.
+ * @property kind - ソース種別。"url" | "conversation" | "pdf_local"。Source kind.
  * @property url - 取得元 URL（kind="url" のとき）。Source URL (when kind="url").
- * @property title - ソースのタイトル（OGP / Readability 抽出）。Source title.
+ * @property title - ソースのタイトル（OGP / Readability / PDF Info 抽出）。Source title.
  * @property contentHash - 本文の SHA-256 等。重複検出用。Content hash for dedup.
- * @property excerpt - 先頭の要約プレビュー（重い本文を別カラムに分けず軽量化）。Short excerpt.
+ * @property excerpt - 先頭の要約プレビュー。Short excerpt.
  * @property extractedAt - 抽出を行った時刻。When extraction happened.
  * @property createdAt - レコード作成時刻。Row created at.
+ * @property displayName - UI で表示するファイル名（kind="pdf_local" のとき設定）。
+ *   Filename shown in UI (set when kind="pdf_local").
+ * @property byteSize - PDF のバイトサイズ（kind="pdf_local" のみ）。PDF byte size.
+ * @property pageCount - PDF の総ページ数（kind="pdf_local" のみ）。PDF page count.
+ * @property metadata - フォーマット固有メタデータ。Format-specific metadata.
  */
 export const sources = pgTable(
   "sources",
@@ -44,6 +80,12 @@ export const sources = pgTable(
     excerpt: text("excerpt"),
     extractedAt: timestamp("extracted_at", { withTimezone: true }).defaultNow().notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    // PDF / ローカルファイル系ソースで使うメタ情報。他 kind では NULL のまま。
+    // Metadata columns used by file-backed sources (e.g. "pdf_local"). NULL for others.
+    displayName: text("display_name"),
+    byteSize: bigint("byte_size", { mode: "number" }),
+    pageCount: integer("page_count"),
+    metadata: jsonb("metadata").$type<PdfSourceMetadata | null>(),
   },
   (table) => [
     index("idx_sources_owner_id").on(table.ownerId),

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["sync", "time", "macros", "rt-multi-thread"] }
 uuid = { version = "1", features = ["v4"] }
+# SHA-256 over local PDF bytes (issue otomatty/zedi#389).
+# ローカル PDF のバイト列ハッシュに使う（otomatty/zedi#389）。
+sha2 = "0.10"
 
 [profile.dev]
 incremental = true

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod claude_sidecar;
+mod pdf_sources;
 mod workspace_paths;
 
 /// Tauri アプリケーション共通エントリポイント。
@@ -26,6 +27,11 @@ pub fn run() {
             workspace_paths::clear_note_workspace_root,
             workspace_paths::read_note_workspace_file,
             workspace_paths::list_note_workspace_entries,
+            pdf_sources::register_pdf_source,
+            pdf_sources::attach_pdf_source_path,
+            pdf_sources::verify_pdf_source,
+            pdf_sources::forget_pdf_source,
+            pdf_sources::read_pdf_bytes,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/pdf_sources.rs
+++ b/src-tauri/src/pdf_sources.rs
@@ -1,0 +1,441 @@
+//! Local PDF source registry and bytes provider (issue otomatty/zedi#389).
+//!
+//! ローカル PDF のレジストリとバイト返却（issue otomatty/zedi#389）。
+//!
+//! 設計 / Design:
+//!   - 元 PDF の絶対パスは **このプロセス内** だけで保持する。サーバには絶対に送らない。
+//!   - The absolute path of a PDF lives ONLY inside this process. Never sent to
+//!     the server (otherwise the local-first promise breaks).
+//!   - レジストリは `$DATA_DIR/zedi/pdf_sources.json` に atomic-write で永続化。
+//!   - The registry file `$DATA_DIR/zedi/pdf_sources.json` is written atomically.
+//!   - SHA-256 は最初の登録時のみ計算し、以降は `mtime+size` で高速一致判定する。
+//!   - SHA-256 is computed once at register time; later opens use mtime+size as
+//!     a fast-equivalence check.
+
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// PDF レジストリの read-modify-write を直列化する。
+/// Serialize read-modify-write on the PDF registry file (concurrent IPC).
+static PDF_REGISTRY_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn pdf_registry_mutex() -> &'static Mutex<()> {
+    PDF_REGISTRY_MUTEX.get_or_init(|| Mutex::new(()))
+}
+
+fn with_pdf_registry_lock<F, R>(f: F) -> Result<R, String>
+where
+    F: FnOnce() -> Result<R, String>,
+{
+    let _guard = pdf_registry_mutex()
+        .lock()
+        .map_err(|e| format!("pdf registry mutex poisoned: {e}"))?;
+    f()
+}
+
+/// 同一ディレクトリの一時ファイル + rename によるアトミック書き込み。
+/// Atomic write via same-directory temp file + rename.
+fn atomic_write_file(path: &Path, contents: &[u8]) -> Result<(), String> {
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| "pdf registry path has no file name".to_string())?;
+    let mut tmp_name = file_name.to_os_string();
+    tmp_name.push(".tmp");
+    let parent = path
+        .parent()
+        .ok_or_else(|| "pdf registry path has no parent".to_string())?;
+    let tmp_path = parent.join(tmp_name);
+    fs::write(&tmp_path, contents).map_err(|e| e.to_string())?;
+    fs::rename(&tmp_path, path).map_err(|e| e.to_string())
+}
+
+/// PDF の最大バイトサイズ（IPC ペイロード制約 + メモリ保護）。
+/// Maximum allowed PDF size — both an IPC payload cap and a memory guard.
+const MAX_PDF_BYTES: u64 = 200 * 1024 * 1024; // 200 MiB
+
+/// レジストリエントリ。`source_id` をキーとして使う。
+/// Persisted entry keyed by `source_id`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PdfRegistryEntry {
+    absolute_path: String,
+    last_seen_sha256: String,
+    last_seen_size: u64,
+    last_seen_mtime_ms: i128,
+}
+
+/// レジストリ全体の JSON 形（version で将来移行できるようにする）。
+/// Top-level registry shape; carries a version for future migrations.
+#[derive(Debug, Serialize, Deserialize)]
+struct PdfRegistry {
+    version: u32,
+    sources: HashMap<String, PdfRegistryEntry>,
+}
+
+impl Default for PdfRegistry {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            sources: HashMap::new(),
+        }
+    }
+}
+
+fn pdf_registry_file() -> Result<PathBuf, String> {
+    let dir = dirs::data_dir()
+        .ok_or_else(|| "no data directory".to_string())?
+        .join("zedi");
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    Ok(dir.join("pdf_sources.json"))
+}
+
+fn load_pdf_registry() -> Result<PdfRegistry, String> {
+    let path = pdf_registry_file()?;
+    if !path.exists() {
+        return Ok(PdfRegistry::default());
+    }
+    let raw = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    serde_json::from_str(&raw).map_err(|e| e.to_string())
+}
+
+fn save_pdf_registry(reg: &PdfRegistry) -> Result<(), String> {
+    let path = pdf_registry_file()?;
+    let raw = serde_json::to_string_pretty(reg).map_err(|e| e.to_string())?;
+    atomic_write_file(&path, raw.as_bytes())
+}
+
+/// 予約キーの拒否 + 空文字拒否。
+/// Reject reserved keys and empty strings.
+fn parse_source_id(source_id: &str) -> Result<String, String> {
+    let t = source_id.trim();
+    if t.is_empty() {
+        return Err("invalid source id".into());
+    }
+    match t {
+        "__proto__" | "prototype" | "constructor" => Err("invalid source id".into()),
+        _ => Ok(t.to_string()),
+    }
+}
+
+/// PDF ファイルか / 通常ファイルか / サイズ上限内か を検証して canonical path を返す。
+/// Validate the absolute path: regular file, `.pdf` extension, size cap.
+fn validate_pdf_path(absolute_path: &str) -> Result<(PathBuf, u64), String> {
+    let trimmed = absolute_path.trim();
+    if trimmed.is_empty() {
+        return Err("absolute path is empty".into());
+    }
+    let p = PathBuf::from(trimmed);
+    let canon = p.canonicalize().map_err(|e| format!("canonicalize: {e}"))?;
+    let meta = fs::metadata(&canon).map_err(|e| e.to_string())?;
+    if !meta.is_file() {
+        return Err("not a regular file".into());
+    }
+    // OS のシンボリックリンクは canonicalize で剥がれるが、念のため file_type で確認。
+    // canonicalize already follows symlinks; this is a defense-in-depth check.
+    let ft = fs::symlink_metadata(&canon).map_err(|e| e.to_string())?.file_type();
+    if ft.is_symlink() {
+        return Err("symlinks are not allowed".into());
+    }
+    let ext = canon
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase());
+    if ext.as_deref() != Some("pdf") {
+        return Err("not a .pdf file".into());
+    }
+    if meta.len() > MAX_PDF_BYTES {
+        return Err(format!(
+            "pdf exceeds size cap ({} bytes > {} bytes)",
+            meta.len(),
+            MAX_PDF_BYTES
+        ));
+    }
+    Ok((canon, meta.len()))
+}
+
+/// 64KiB チャンクで SHA-256 を計算する。
+/// Streaming SHA-256 over 64 KiB chunks.
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let f = File::open(path).map_err(|e| e.to_string())?;
+    let mut reader = BufReader::with_capacity(64 * 1024, f);
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = reader.read(&mut buf).map_err(|e| e.to_string())?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// ファイルの更新時刻（ms）と size を取得する。
+/// Read file size and mtime in milliseconds since UNIX epoch.
+fn file_size_and_mtime(path: &Path) -> Result<(u64, i128), String> {
+    let meta = fs::metadata(path).map_err(|e| e.to_string())?;
+    let size = meta.len();
+    let mtime = meta
+        .modified()
+        .map_err(|e| e.to_string())?
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i128)
+        .unwrap_or(0);
+    Ok((size, mtime))
+}
+
+// ── Public command response types ───────────────────────────────────────────
+
+/// `register_pdf_source` の戻り値。
+/// Return shape for {@link register_pdf_source}.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegisteredPdfSource {
+    pub sha256: String,
+    pub byte_size: u64,
+    pub display_name: String,
+}
+
+/// `verify_pdf_source` の戻り値。
+/// Return shape for {@link verify_pdf_source}.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PdfVerifyResult {
+    pub exists: bool,
+    pub size_changed: bool,
+    pub mtime_changed: bool,
+    pub absolute_path_known: bool,
+}
+
+// ── Tauri commands ──────────────────────────────────────────────────────────
+
+/// ローカル PDF を「登録準備」する: パス検証 + SHA-256 計算 + 表示名取得。
+/// この時点ではレジストリには書き込まない。サーバ側で `sourceId` が確定したら
+/// `attach_pdf_source_path` を呼んでレジストリへ記録する。
+///
+/// "Register-prepare" a local PDF: validate the path, compute SHA-256, and
+/// extract the display name. The registry is NOT yet updated. Once the server
+/// returns the canonical `sourceId`, the client must call
+/// {@link attach_pdf_source_path} to persist the mapping.
+#[tauri::command]
+pub fn register_pdf_source(absolute_path: String) -> Result<RegisteredPdfSource, String> {
+    let (canon, byte_size) = validate_pdf_path(&absolute_path)?;
+    let sha256 = sha256_file(&canon)?;
+    let display_name = canon
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "untitled.pdf".to_string());
+    Ok(RegisteredPdfSource {
+        sha256,
+        byte_size,
+        display_name,
+    })
+}
+
+/// `sourceId` ↔ 絶対パスをレジストリに紐づける（サーバ確定後に呼ぶ）。
+/// Persist the `sourceId → absolutePath` mapping after the server has returned
+/// the canonical source id from `/api/sources/pdf`.
+#[tauri::command]
+pub fn attach_pdf_source_path(
+    source_id: String,
+    absolute_path: String,
+    sha256: String,
+) -> Result<(), String> {
+    let source_id = parse_source_id(&source_id)?;
+    let (canon, _) = validate_pdf_path(&absolute_path)?;
+    if !is_sha256_hex(&sha256) {
+        return Err("sha256 must be 64-char hex".into());
+    }
+    let (size, mtime) = file_size_and_mtime(&canon)?;
+    with_pdf_registry_lock(|| {
+        let mut reg = load_pdf_registry()?;
+        reg.sources.insert(
+            source_id,
+            PdfRegistryEntry {
+                absolute_path: canon.to_string_lossy().to_string(),
+                last_seen_sha256: sha256.to_ascii_lowercase(),
+                last_seen_size: size,
+                last_seen_mtime_ms: mtime,
+            },
+        );
+        save_pdf_registry(&reg)
+    })
+}
+
+/// 64 文字の hex か簡易判定（regex crate を入れずに）。
+/// Inline check for a 64-char hex string (avoids pulling in `regex`).
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// 登録済み PDF を `read_pdf_bytes` 等で開く前にチェックする。
+/// 戻り値:
+///   - `exists`: 実ファイルが残っているか
+///   - `size_changed` / `mtime_changed`: 前回 attach 時から変化したか
+///   - `absolute_path_known`: レジストリにエントリが残っているか
+///
+/// Used by the viewer to render the missing-file banner / file-changed warning.
+#[tauri::command]
+pub fn verify_pdf_source(source_id: String) -> Result<PdfVerifyResult, String> {
+    let source_id = parse_source_id(&source_id)?;
+    let reg = load_pdf_registry()?;
+    let entry = match reg.sources.get(&source_id) {
+        Some(e) => e.clone(),
+        None => {
+            return Ok(PdfVerifyResult {
+                exists: false,
+                size_changed: false,
+                mtime_changed: false,
+                absolute_path_known: false,
+            });
+        }
+    };
+    let path = PathBuf::from(&entry.absolute_path);
+    let canon = match path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => {
+            return Ok(PdfVerifyResult {
+                exists: false,
+                size_changed: false,
+                mtime_changed: false,
+                absolute_path_known: true,
+            });
+        }
+    };
+    let meta = match fs::metadata(&canon) {
+        Ok(m) => m,
+        Err(_) => {
+            return Ok(PdfVerifyResult {
+                exists: false,
+                size_changed: false,
+                mtime_changed: false,
+                absolute_path_known: true,
+            });
+        }
+    };
+    let (size, mtime) = file_size_and_mtime(&canon).unwrap_or((meta.len(), 0));
+    Ok(PdfVerifyResult {
+        exists: true,
+        size_changed: size != entry.last_seen_size,
+        mtime_changed: mtime != entry.last_seen_mtime_ms,
+        absolute_path_known: true,
+    })
+}
+
+/// レジストリエントリを削除する（ファイルは触らない）。
+/// Remove the registry entry only; the underlying file is left untouched.
+#[tauri::command]
+pub fn forget_pdf_source(source_id: String) -> Result<(), String> {
+    let source_id = parse_source_id(&source_id)?;
+    with_pdf_registry_lock(|| {
+        let mut reg = load_pdf_registry()?;
+        reg.sources.remove(&source_id);
+        save_pdf_registry(&reg)
+    })
+}
+
+/// 登録済み PDF のバイト列を返す。viewer は Uint8Array を pdf.js に渡す。
+/// Return the bytes of a registered PDF. The viewer hands the Uint8Array to
+/// pdf.js. Note: IPC encodes the Vec<u8> as a base64-ish payload which roughly
+/// doubles memory; for v1 we cap at 200 MiB and revisit via a custom URI scheme
+/// later if performance demands it.
+#[tauri::command]
+pub fn read_pdf_bytes(source_id: String) -> Result<Vec<u8>, String> {
+    let source_id = parse_source_id(&source_id)?;
+    let reg = load_pdf_registry()?;
+    let entry = reg
+        .sources
+        .get(&source_id)
+        .cloned()
+        .ok_or_else(|| "pdf source not registered".to_string())?;
+    let path = PathBuf::from(&entry.absolute_path);
+    let canon = path.canonicalize().map_err(|e| format!("canonicalize: {e}"))?;
+    // 拡張子 / 通常ファイル / サイズ上限 を再検証する（attach 後にファイルが置換された場合の保険）。
+    // Re-validate so a swapped-out file post-attach cannot trick us.
+    let (re_canon, byte_size) = validate_pdf_path(&canon.to_string_lossy())?;
+    debug_assert_eq!(re_canon, canon);
+    let mut bytes = Vec::with_capacity(byte_size as usize);
+    File::open(&re_canon)
+        .map_err(|e| e.to_string())?
+        .take(MAX_PDF_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|e| e.to_string())?;
+    if bytes.len() as u64 > MAX_PDF_BYTES {
+        return Err("pdf exceeds size cap".into());
+    }
+    Ok(bytes)
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_temp_pdf(dir: &Path, name: &str, contents: &[u8]) -> PathBuf {
+        let p = dir.join(name);
+        let mut f = File::create(&p).unwrap();
+        f.write_all(contents).unwrap();
+        p
+    }
+
+    #[test]
+    fn validate_pdf_path_rejects_non_pdf_extension() {
+        let dir = TempDir::new().unwrap();
+        let p = write_temp_pdf(dir.path(), "not-a-pdf.txt", b"hello");
+        let err = validate_pdf_path(p.to_str().unwrap()).unwrap_err();
+        assert!(err.contains("not a .pdf"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_pdf_path_accepts_a_pdf() {
+        let dir = TempDir::new().unwrap();
+        let p = write_temp_pdf(dir.path(), "ok.pdf", b"%PDF-1.4 fake");
+        let (canon, size) = validate_pdf_path(p.to_str().unwrap()).unwrap();
+        assert!(canon.to_string_lossy().ends_with("ok.pdf"));
+        assert_eq!(size, 13);
+    }
+
+    #[test]
+    fn validate_pdf_path_rejects_empty_path() {
+        assert!(validate_pdf_path("").is_err());
+        assert!(validate_pdf_path("    ").is_err());
+    }
+
+    #[test]
+    fn sha256_file_is_stable() {
+        let dir = TempDir::new().unwrap();
+        let p = write_temp_pdf(dir.path(), "x.pdf", b"abc");
+        let h = sha256_file(&p).unwrap();
+        // sha256("abc") の既知値
+        assert_eq!(
+            h,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn parse_source_id_rejects_reserved_keys() {
+        assert!(parse_source_id("__proto__").is_err());
+        assert!(parse_source_id("").is_err());
+        assert!(parse_source_id("ok").is_ok());
+    }
+
+    #[test]
+    fn is_sha256_hex_validates_64_hex_chars() {
+        assert!(is_sha256_hex(&"0".repeat(64)));
+        assert!(is_sha256_hex(
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        ));
+        assert!(!is_sha256_hex("too-short"));
+        assert!(!is_sha256_hex(&"z".repeat(64)));
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import ExtensionAuth from "./pages/ExtensionAuth";
 import ExtensionAuthCallback from "./pages/ExtensionAuthCallback";
 import McpAuthorize from "./pages/McpAuthorize";
 import PageEditorPage from "./pages/PageEditor";
+import PdfReaderPage from "./pages/pdfKnowledge/PdfReaderPage";
 import Settings from "./pages/Settings";
 import WikiSchemaPage from "./pages/WikiSchemaPage";
 import IndexPage from "./pages/IndexPage";
@@ -261,6 +262,11 @@ const App = () => (
                       {/* Legacy singular path — redirect to plural.
                           旧単数形パス — 複数形にリダイレクト。 */}
                       <Route path="/page/:id" element={<LegacyPageRedirect />} />
+                      {/* PDF 知識化ビューア (issue otomatty/zedi#389).
+                          Web から開いた場合は `PdfReaderUnsupported` を表示。
+                          PDF knowledge viewer; web falls back to the
+                          desktop-only placeholder. */}
+                      <Route path="/sources/:sourceId/pdf" element={<PdfReaderPage />} />
                       <Route path="/settings" element={<Settings />} />
                       <Route path="/wiki-schema" element={<WikiSchemaPage />} />
                       <Route path="/index" element={<IndexPage />} />

--- a/src/components/pdf-reader/MissingPdfBanner.tsx
+++ b/src/components/pdf-reader/MissingPdfBanner.tsx
@@ -1,0 +1,125 @@
+/**
+ * 元 PDF ファイルが見つからない（移動・削除された）ときに表示するバナー。
+ *
+ * Banner shown over the reader when the registered PDF cannot be located on
+ * the user's filesystem. The highlights and derived pages stay readable (they
+ * live in Postgres), so this surface is non-destructive — the user can:
+ *   1. Re-attach the file via a file dialog (preferred)
+ *   2. Forget the source (registry only; the `sources` row is preserved so
+ *      citations on derived pages keep working)
+ *
+ * Phase 1 (issue otomatty/zedi#389) の Open Question #1 への回答。
+ */
+import { useState } from "react";
+import {
+  attachPdfSourcePath,
+  forgetPdfSource,
+  registerPdfSource,
+  type RegisteredPdfSource,
+} from "@/lib/pdfKnowledge/tauriBridge";
+
+/**
+ * Props for the missing-PDF banner.
+ * 欠損バナーの Props 型。
+ */
+export interface MissingPdfBannerProps {
+  sourceId: string;
+  /** Called after a successful re-attach so the parent re-runs `verify_pdf_source`. */
+  onReattachComplete?: () => void;
+  /** Called after the user chooses to forget the source. */
+  onForget?: () => void;
+}
+
+/**
+ * Banner component shown over the reader when the underlying PDF cannot be
+ * located. Offers two non-destructive actions: re-attach (re-runs
+ * `register_pdf_source` + `attach_pdf_source_path`) and forget (registry
+ * entry only; the `sources` row stays so citations on derived pages keep
+ * working).
+ * 欠損時のバナー UI。再アタッチ / 忘却の 2 アクションを提供する。
+ */
+export function MissingPdfBanner({
+  sourceId,
+  onReattachComplete,
+  onForget,
+}: MissingPdfBannerProps) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleReattach() {
+    setError(null);
+    setPending(true);
+    try {
+      // 動的 import: Tauri ランタイム外では拾わない。
+      // Dynamic import so the web bundle never resolves @tauri-apps/plugin-dialog.
+      const dialog = (await import("@tauri-apps/plugin-dialog")) as {
+        open: (opts: {
+          multiple?: boolean;
+          filters?: { name: string; extensions: string[] }[];
+        }) => Promise<string | string[] | null>;
+      };
+      const picked = await dialog.open({
+        multiple: false,
+        filters: [{ name: "PDF", extensions: ["pdf"] }],
+      });
+      if (!picked || Array.isArray(picked)) {
+        setPending(false);
+        return;
+      }
+      const info: RegisteredPdfSource = await registerPdfSource(picked);
+      await attachPdfSourcePath({
+        sourceId,
+        absolutePath: picked,
+        sha256: info.sha256,
+      });
+      onReattachComplete?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function handleForget() {
+    setError(null);
+    setPending(true);
+    try {
+      await forgetPdfSource(sourceId);
+      onForget?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div
+      role="alert"
+      className="flex flex-wrap items-center gap-3 border-b border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100"
+    >
+      <p className="min-w-[280px] flex-1">
+        元 PDF ファイルが見つかりません。再アタッチしてください。
+        <br />
+        The original PDF file could not be found on this device. Re-attach to keep using it.
+      </p>
+      <button
+        type="button"
+        onClick={handleReattach}
+        disabled={pending}
+        className="rounded bg-amber-600 px-3 py-1.5 text-white disabled:opacity-50"
+      >
+        {pending ? "…" : "PDF を再アタッチ / Re-attach"}
+      </button>
+      <button
+        type="button"
+        onClick={handleForget}
+        disabled={pending}
+        className="rounded border border-amber-400 px-3 py-1.5 disabled:opacity-50"
+      >
+        このソースを忘れる / Forget
+      </button>
+      {error && <p className="text-destructive basis-full text-xs">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/pdf-reader/PdfReader.tsx
+++ b/src/components/pdf-reader/PdfReader.tsx
@@ -116,7 +116,11 @@ export function PdfReader() {
           <h2 className="mb-2 font-medium">ハイライト / Highlights</h2>
           {highlightsQuery.isLoading && <p className="text-muted-foreground">読み込み中…</p>}
           {highlightsQuery.error && (
-            <p className="text-destructive text-xs">{(highlightsQuery.error as Error).message}</p>
+            <p className="text-destructive text-xs">
+              {highlightsQuery.error instanceof Error
+                ? highlightsQuery.error.message
+                : String(highlightsQuery.error)}
+            </p>
           )}
           {highlightsQuery.data?.highlights.length === 0 && (
             <p className="text-muted-foreground">まだハイライトはありません。</p>

--- a/src/components/pdf-reader/PdfReader.tsx
+++ b/src/components/pdf-reader/PdfReader.tsx
@@ -1,0 +1,127 @@
+/**
+ * PDF 知識化ビューアのルートコンポーネント。
+ *
+ * Phase 1 (issue otomatty/zedi#389) のスキャフォールド: ルート + プラットフォーム
+ * ガード + 「次の PR で pdf.js ビューアを実装」のプレースホルダ。
+ *
+ * Scaffold for the PDF knowledge viewer. The full pdf.js integration ships in
+ * the follow-up PR; this component currently:
+ *   - Routes the user from `/sources/:sourceId/pdf` into the right shell
+ *   - Gates non-Tauri platforms to {@link PdfReaderUnsupported}
+ *   - Exercises the Tauri bridge with `verify_pdf_source` so the missing-file
+ *     banner path is wired even before the canvas viewer lands
+ */
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { isTauriDesktop } from "@/lib/platform";
+import {
+  type PdfVerifyResult,
+  verifyPdfSource,
+  PdfKnowledgeUnsupportedError,
+} from "@/lib/pdfKnowledge/tauriBridge";
+import { usePdfHighlights } from "@/lib/pdfKnowledge/highlightsApi";
+import { PdfReaderUnsupported } from "./PdfReaderUnsupported";
+import { MissingPdfBanner } from "./MissingPdfBanner";
+
+/**
+ * 機能の入り口となる React コンポーネント。プラットフォームガードと
+ * 起動時 verify、欠損バナーをこの 1 つにまとめる。
+ * Top-level component for the PDF knowledge feature; centralises the platform
+ * gate, startup verify, and the missing-file banner.
+ */
+export function PdfReader() {
+  const { sourceId } = useParams<{ sourceId: string }>();
+  const [verify, setVerify] = useState<PdfVerifyResult | null>(null);
+  const [verifyError, setVerifyError] = useState<string | null>(null);
+  const highlightsQuery = usePdfHighlights(sourceId);
+
+  useEffect(() => {
+    if (!sourceId || !isTauriDesktop()) return;
+    let cancelled = false;
+    verifyPdfSource(sourceId)
+      .then((result) => {
+        if (!cancelled) setVerify(result);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof PdfKnowledgeUnsupportedError) return;
+        setVerifyError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sourceId]);
+
+  if (!isTauriDesktop()) {
+    return <PdfReaderUnsupported />;
+  }
+
+  if (!sourceId) {
+    return (
+      <div className="text-muted-foreground p-6 text-sm">
+        sourceId が指定されていません / Missing sourceId in route.
+      </div>
+    );
+  }
+
+  const fileMissing = verify !== null && !verify.exists;
+
+  return (
+    <div className="flex h-full flex-col">
+      {fileMissing && (
+        <MissingPdfBanner sourceId={sourceId} onReattachComplete={() => setVerify(null)} />
+      )}
+      <div className="grid h-full grid-cols-[1fr_320px] gap-0">
+        <main className="overflow-auto p-6">
+          {/*
+            TODO(issue #389 follow-up): pdf.js (`pdfjs-dist`) を導入して
+            `readPdfBytes(sourceId)` → Uint8Array → `pdfjsLib.getDocument(...)` の
+            初期化、ページごとのキャンバスレンダリング、テキスト選択レイヤを
+            実装する。本 PR は足場のみ。
+            TODO(follow-up): wire up `pdfjs-dist` to render canvases from the
+            bytes returned by `readPdfBytes`, attach the text-selection layer,
+            and surface a HighlightToolbar on selection. The current PR is
+            scaffold-only.
+          */}
+          <div className="text-muted-foreground rounded-md border border-dashed p-8 text-center text-sm">
+            <p className="font-medium">
+              PDF ビューアは次の PR で実装予定 / PDF viewer comes in a follow-up PR.
+            </p>
+            <p className="mt-2">
+              データモデル・Tauri ブリッジ・API・派生ページ生成は配線済みです。
+            </p>
+            <p className="mt-2">
+              The data model, Tauri bridge, API, and derive-page flow are already wired; only the
+              rendering layer is pending.
+            </p>
+            {verifyError && <p className="text-destructive mt-4">verify error: {verifyError}</p>}
+            {verify && (
+              <p className="mt-4 text-xs">
+                verify: exists={String(verify.exists)} sizeChanged={String(verify.sizeChanged)}{" "}
+                mtimeChanged={String(verify.mtimeChanged)}
+              </p>
+            )}
+          </div>
+        </main>
+        <aside className="overflow-auto border-l p-4 text-sm">
+          <h2 className="mb-2 font-medium">ハイライト / Highlights</h2>
+          {highlightsQuery.isLoading && <p className="text-muted-foreground">読み込み中…</p>}
+          {highlightsQuery.error && (
+            <p className="text-destructive text-xs">{(highlightsQuery.error as Error).message}</p>
+          )}
+          {highlightsQuery.data?.highlights.length === 0 && (
+            <p className="text-muted-foreground">まだハイライトはありません。</p>
+          )}
+          <ul className="space-y-2">
+            {highlightsQuery.data?.highlights.map((h) => (
+              <li key={h.id} className="rounded border p-2">
+                <p className="text-muted-foreground text-xs">p.{h.pdfPage}</p>
+                <p className="text-sm">{h.text.slice(0, 200)}</p>
+              </li>
+            ))}
+          </ul>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pdf-reader/PdfReader.tsx
+++ b/src/components/pdf-reader/PdfReader.tsx
@@ -33,6 +33,10 @@ export function PdfReader() {
   const { sourceId } = useParams<{ sourceId: string }>();
   const [verify, setVerify] = useState<PdfVerifyResult | null>(null);
   const [verifyError, setVerifyError] = useState<string | null>(null);
+  // Bumped after a successful re-attach so the verify effect re-runs and
+  // reflects the file's new state (Gemini review on PR #858).
+  // 再アタッチ成功時にこのカウンタを進めて verify を再実行する。
+  const [verifyCounter, setVerifyCounter] = useState(0);
   const highlightsQuery = usePdfHighlights(sourceId);
 
   useEffect(() => {
@@ -40,7 +44,9 @@ export function PdfReader() {
     let cancelled = false;
     verifyPdfSource(sourceId)
       .then((result) => {
-        if (!cancelled) setVerify(result);
+        if (cancelled) return;
+        setVerify(result);
+        setVerifyError(null);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -50,7 +56,7 @@ export function PdfReader() {
     return () => {
       cancelled = true;
     };
-  }, [sourceId]);
+  }, [sourceId, verifyCounter]);
 
   if (!isTauriDesktop()) {
     return <PdfReaderUnsupported />;
@@ -69,7 +75,10 @@ export function PdfReader() {
   return (
     <div className="flex h-full flex-col">
       {fileMissing && (
-        <MissingPdfBanner sourceId={sourceId} onReattachComplete={() => setVerify(null)} />
+        <MissingPdfBanner
+          sourceId={sourceId}
+          onReattachComplete={() => setVerifyCounter((c) => c + 1)}
+        />
       )}
       <div className="grid h-full grid-cols-[1fr_320px] gap-0">
         <main className="overflow-auto p-6">

--- a/src/components/pdf-reader/PdfReaderUnsupported.tsx
+++ b/src/components/pdf-reader/PdfReaderUnsupported.tsx
@@ -1,0 +1,38 @@
+/**
+ * Phase 1 で PDF 知識化機能が Web ブラウザから呼ばれた際の案内表示。
+ *
+ * Placeholder shown when the user navigates to the PDF reader from a non-Tauri
+ * runtime. Phase 1 (issue otomatty/zedi#389) intentionally restricts the
+ * feature to the desktop app because PDF binaries stay on the user's local
+ * filesystem rather than being uploaded.
+ */
+import { Link } from "react-router-dom";
+
+/**
+ * Renders a centered, bilingual message explaining that the PDF feature is
+ * desktop-only in Phase 1 and links back to the user's notes.
+ * デスクトップ専用案内を中央寄せで表示し、ユーザーのノートに戻るリンクを出す。
+ */
+export function PdfReaderUnsupported() {
+  return (
+    <div className="mx-auto max-w-xl space-y-4 px-6 py-16 text-center">
+      <h1 className="text-xl font-semibold">
+        {/* JP first per project convention. JP-first per project convention. */}
+        PDF 知識化はデスクトップ版のみ対応 / Desktop-only
+      </h1>
+      <p className="text-muted-foreground text-sm leading-6">
+        Phase 1 では PDF ファイルをローカルに保持したまま閲覧・ハイライト・派生ページ化します。
+        この処理はデスクトップアプリ（Tauri）が必要です。Web では利用できません。
+      </p>
+      <p className="text-muted-foreground text-sm leading-6">
+        Phase 1 keeps each PDF on your local filesystem and never uploads its bytes. That requires
+        the desktop app (Tauri); the web client cannot provide this feature.
+      </p>
+      <p>
+        <Link to="/notes/me" className="text-primary underline">
+          ノートに戻る / Back to your notes
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/src/lib/pdfKnowledge/derivedPageTemplate.test.ts
+++ b/src/lib/pdfKnowledge/derivedPageTemplate.test.ts
@@ -20,6 +20,13 @@ describe("buildPdfSourceDeepLink", () => {
       "/sources/a%2Fb%20c/pdf#page=1",
     );
   });
+
+  it("throws on non-1-indexed-integer pdfPage so invalid deep links never propagate", () => {
+    expect(() => buildPdfSourceDeepLink({ sourceId: "s", pdfPage: 0 })).toThrow();
+    expect(() => buildPdfSourceDeepLink({ sourceId: "s", pdfPage: -1 })).toThrow();
+    expect(() => buildPdfSourceDeepLink({ sourceId: "s", pdfPage: 1.5 })).toThrow();
+    expect(() => buildPdfSourceDeepLink({ sourceId: "s", pdfPage: Number.NaN })).toThrow();
+  });
 });
 
 describe("buildDerivedPageTitle", () => {

--- a/src/lib/pdfKnowledge/derivedPageTemplate.test.ts
+++ b/src/lib/pdfKnowledge/derivedPageTemplate.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDerivedPageTemplate,
+  buildDerivedPageTitle,
+  buildPdfSourceDeepLink,
+} from "./derivedPageTemplate";
+
+describe("buildPdfSourceDeepLink", () => {
+  it("encodes the source id and page number as a viewer route with a #page= fragment", () => {
+    expect(
+      buildPdfSourceDeepLink({
+        sourceId: "0d6c5d20-7e9b-4a3f-9d63-7f4b2c11ab90",
+        pdfPage: 12,
+      }),
+    ).toBe("/sources/0d6c5d20-7e9b-4a3f-9d63-7f4b2c11ab90/pdf#page=12");
+  });
+
+  it("URI-encodes a non-canonical source id (defense-in-depth)", () => {
+    expect(buildPdfSourceDeepLink({ sourceId: "a/b c", pdfPage: 1 })).toBe(
+      "/sources/a%2Fb%20c/pdf#page=1",
+    );
+  });
+});
+
+describe("buildDerivedPageTitle", () => {
+  it("uses a short prefix of the highlight text when present", () => {
+    const title = buildDerivedPageTitle({ highlightText: "The cost of context switching is real" });
+    expect(title.length).toBeLessThanOrEqual(80);
+    expect(title).toContain("The cost of context switching");
+  });
+
+  it("falls back to the display name when highlight text is empty", () => {
+    expect(buildDerivedPageTitle({ highlightText: "", displayName: "Deep Work.pdf" })).toBe(
+      "Deep Work.pdf",
+    );
+  });
+
+  it("falls back to a generic label when nothing is known", () => {
+    expect(buildDerivedPageTitle({ highlightText: "" })).toBe("Untitled PDF excerpt");
+  });
+
+  it("collapses whitespace and strips trailing punctuation introduced by selection edges", () => {
+    expect(buildDerivedPageTitle({ highlightText: "  hello\n  world.  " })).toBe("hello world");
+  });
+});
+
+describe("buildDerivedPageTemplate", () => {
+  const highlight = {
+    sourceId: "0d6c5d20-7e9b-4a3f-9d63-7f4b2c11ab90",
+    pdfPage: 12,
+    text: "Reading does not equal understanding",
+    displayName: "Deep Work.pdf",
+  };
+
+  it("returns a Tiptap doc as a stringified JSON document", () => {
+    const tiptapJson = buildDerivedPageTemplate(highlight);
+    const parsed = JSON.parse(tiptapJson);
+    expect(parsed.type).toBe("doc");
+    expect(Array.isArray(parsed.content)).toBe(true);
+  });
+
+  it("starts with a blockquote of the highlight text — the immutable raw material", () => {
+    const parsed = JSON.parse(buildDerivedPageTemplate(highlight));
+    const first = parsed.content[0];
+    expect(first.type).toBe("blockquote");
+    // blockquote > paragraph > text
+    const textNode = first.content?.[0]?.content?.[0];
+    expect(textNode?.type).toBe("text");
+    expect(textNode?.text).toContain("Reading does not equal understanding");
+  });
+
+  it("includes a citation line linking back to the PDF source at the right page", () => {
+    const parsed = JSON.parse(buildDerivedPageTemplate(highlight));
+    // Walk every node and find at least one link mark to the deep link.
+    const expectedHref = "/sources/0d6c5d20-7e9b-4a3f-9d63-7f4b2c11ab90/pdf#page=12";
+    let foundLink = false;
+    const visit = (node: { content?: unknown[]; marks?: unknown[] }) => {
+      const marks = (node.marks ?? []) as Array<{ type?: string; attrs?: { href?: string } }>;
+      for (const m of marks) {
+        if (m.type === "link" && m.attrs?.href === expectedHref) {
+          foundLink = true;
+        }
+      }
+      for (const child of (node.content ?? []) as Array<{
+        content?: unknown[];
+        marks?: unknown[];
+      }>) {
+        visit(child);
+      }
+    };
+    visit(parsed);
+    expect(foundLink).toBe(true);
+  });
+
+  it("ends with an empty paragraph so the cursor lands on a writable line", () => {
+    const parsed = JSON.parse(buildDerivedPageTemplate(highlight));
+    const last = parsed.content[parsed.content.length - 1];
+    expect(last.type).toBe("paragraph");
+    expect(last.content).toBeUndefined();
+  });
+
+  it("is deterministic for the same inputs (snapshot-friendly)", () => {
+    const a = buildDerivedPageTemplate(highlight);
+    const b = buildDerivedPageTemplate(highlight);
+    expect(a).toBe(b);
+  });
+});

--- a/src/lib/pdfKnowledge/derivedPageTemplate.ts
+++ b/src/lib/pdfKnowledge/derivedPageTemplate.ts
@@ -62,8 +62,17 @@ export function buildDerivedPageTitle(input: BuildDerivedPageTitleInput): string
  * PDF.js の URL fragment convention に合わせている。
  * Format `/sources/<sourceId>/pdf#page=<pdfPage>`; the fragment follows the
  * PDF.js URL fragment convention.
+ *
+ * @throws Error - `pdfPage` が 1 以上の整数でない場合。`pdfPage` must be a
+ *   1-indexed positive integer; otherwise the function throws so callers
+ *   surface the bug instead of producing an invalid deep link.
  */
 export function buildPdfSourceDeepLink(params: { sourceId: string; pdfPage: number }): string {
+  if (!Number.isInteger(params.pdfPage) || params.pdfPage < 1) {
+    throw new Error(
+      `buildPdfSourceDeepLink: pdfPage must be a positive integer, got ${String(params.pdfPage)}`,
+    );
+  }
   return `/sources/${encodeURIComponent(params.sourceId)}/pdf#page=${params.pdfPage}`;
 }
 

--- a/src/lib/pdfKnowledge/derivedPageTemplate.ts
+++ b/src/lib/pdfKnowledge/derivedPageTemplate.ts
@@ -1,0 +1,135 @@
+/**
+ * PDF ハイライトから派生 Zedi ページを作る際の **テンプレート生成**ロジック。
+ * Template generator for the Zedi page produced from a PDF highlight.
+ *
+ * Phase 1 のデフォルトは Excerpt-centric: 1 ハイライト → 1 ページ。
+ * ページ本文は以下の構成を持つ:
+ *   1. 引用ブロック (blockquote) — ハイライト本文。"不変な素材"を視認可能に。
+ *   2. 出典行 — `From: \<filename\> p.\<n\>` を PDF ビューアへのディープリンクとして
+ *      貼る。Zedi の「出典トレース」原則に従う。
+ *   3. 空の段落 — ユーザーが自分の言葉で書き始めるためのカーソル位置。
+ *
+ * Phase 1 default is excerpt-centric (1 highlight → 1 page). The body has:
+ *   1. blockquote of the highlight text (immutable raw material)
+ *   2. citation paragraph linking back to the PDF reader at the correct page
+ *   3. an empty paragraph so the cursor lands on a writable line
+ */
+
+/**
+ * 派生ページのタイトル生成に使う入力。
+ * Input for {@link buildDerivedPageTitle}.
+ */
+export interface BuildDerivedPageTitleInput {
+  /** ハイライト本文。Highlight body text. */
+  highlightText: string;
+  /** ソースの表示名（PDF ファイル名）。Source display name (PDF filename). */
+  displayName?: string;
+}
+
+/** タイトル最大長。Tiptap のページタイトル列に合わせて 80 文字。Max title length. */
+const TITLE_MAX_LENGTH = 80;
+
+/**
+ * 派生ページのデフォルトタイトルを組み立てる。
+ * Build a default title for the derived page.
+ *
+ * 規則 / Rules:
+ *  1. `highlightText` が空でなければ、先頭から最大 80 文字を、空白圧縮と末尾の句読点除去して返す。
+ *  2. `highlightText` が空で `displayName` があるならそれを返す。
+ *  3. どちらも無ければ汎用ラベルを返す。
+ */
+export function buildDerivedPageTitle(input: BuildDerivedPageTitleInput): string {
+  const collapsed = input.highlightText.replace(/\s+/g, " ").trim();
+  if (collapsed) {
+    const truncated =
+      collapsed.length > TITLE_MAX_LENGTH
+        ? `${collapsed.slice(0, TITLE_MAX_LENGTH - 1).trimEnd()}…`
+        : collapsed;
+    // 末尾の句読点を 1 文字だけ落とす（カット位置で切れた "." や "、" がタイトルに残る違和感を回避）
+    // Drop a single trailing punctuation mark so a selection cut mid-sentence
+    // does not bleed into the title.
+    return truncated.replace(/[.,。、!?！？:;：；]$/u, "");
+  }
+  if (input.displayName?.trim()) return input.displayName.trim();
+  return "Untitled PDF excerpt";
+}
+
+/**
+ * 派生ページから元 PDF のページにジャンプするためのディープリンクを組み立てる。
+ * Build the deep-link URL that opens the PDF reader at the highlight's page.
+ *
+ * 形式は `/sources/<sourceId>/pdf#page=<pdfPage>`。フラグメントは
+ * PDF.js の URL fragment convention に合わせている。
+ * Format `/sources/<sourceId>/pdf#page=<pdfPage>`; the fragment follows the
+ * PDF.js URL fragment convention.
+ */
+export function buildPdfSourceDeepLink(params: { sourceId: string; pdfPage: number }): string {
+  return `/sources/${encodeURIComponent(params.sourceId)}/pdf#page=${params.pdfPage}`;
+}
+
+/**
+ * 派生ページ生成のための入力。
+ * Input for {@link buildDerivedPageTemplate}.
+ */
+export interface BuildDerivedPageTemplateInput {
+  /** 親 PDF ソースの ID。Owning PDF source id. */
+  sourceId: string;
+  /** 1 始まりの PDF ページ番号。1-indexed PDF page number. */
+  pdfPage: number;
+  /** ハイライト本文。Highlight body text. */
+  text: string;
+  /** ソースの表示名。Display name shown in the citation line. */
+  displayName?: string;
+}
+
+/**
+ * 派生 Zedi ページ用の Tiptap JSON ドキュメントを文字列で返す。
+ * Returns the Tiptap JSON document (stringified) for a derived Zedi page.
+ *
+ * @returns `pages.content` 列に直接書き込める JSON 文字列。
+ *   A JSON string ready to be persisted into the `pages.content` column.
+ */
+export function buildDerivedPageTemplate(input: BuildDerivedPageTemplateInput): string {
+  const displayName = input.displayName?.trim() || "PDF";
+  const href = buildPdfSourceDeepLink({ sourceId: input.sourceId, pdfPage: input.pdfPage });
+
+  const doc = {
+    type: "doc",
+    content: [
+      // 1. 引用ブロック: ハイライト本文を不変な素材として残す。
+      // 1. Blockquote: the highlight body kept as immutable raw material.
+      {
+        type: "blockquote",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: input.text }],
+          },
+        ],
+      },
+      // 2. 出典行: "From: <displayName>, p.<pdfPage>" を PDF へディープリンク。
+      // 2. Citation line — links back to the PDF reader at the right page.
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "From: " },
+          {
+            type: "text",
+            text: `${displayName}, p.${input.pdfPage}`,
+            marks: [
+              {
+                type: "link",
+                attrs: { href, target: "_self", rel: "noopener noreferrer" },
+              },
+            ],
+          },
+        ],
+      },
+      // 3. 空の段落: ユーザーがここから書き始める。
+      // 3. Empty paragraph where the user starts writing.
+      { type: "paragraph" },
+    ],
+  };
+
+  return JSON.stringify(doc);
+}

--- a/src/lib/pdfKnowledge/highlightsApi.ts
+++ b/src/lib/pdfKnowledge/highlightsApi.ts
@@ -1,0 +1,290 @@
+/**
+ * `/api/sources/pdf` クライアントと React Query フック群。
+ *
+ * Client + React Query hooks for the PDF source / highlight endpoints.
+ *
+ * 設計上の注意 / Design notes:
+ *   - PDF 本体（バイナリ）はここでは触らない。サーバが受け取るのはハッシュ・サイズ・
+ *     ページ数・ハイライト / メモのみ。バイナリは Tauri 側ローカルレジストリに留まる。
+ *   - PDF binaries are never sent through these endpoints — only highlight
+ *     metadata, page counts, and content hashes. The bytes live exclusively on
+ *     the user's filesystem via the Tauri registry.
+ */
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+/** Allowed highlight colors (mirrors the server enum). */
+export const PDF_HIGHLIGHT_COLORS = ["yellow", "green", "blue", "red", "purple"] as const;
+/** Highlight color literal type derived from {@link PDF_HIGHLIGHT_COLORS}. */
+export type PdfHighlightColor = (typeof PDF_HIGHLIGHT_COLORS)[number];
+
+/** Rect in PDF user-space coordinates. Mirrors the server `PdfHighlightRect`. */
+export interface PdfHighlightRect {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+/** Highlight row as returned by the API. */
+export interface PdfHighlight {
+  id: string;
+  sourceId: string;
+  ownerId: string;
+  derivedPageId: string | null;
+  pdfPage: number;
+  rects: PdfHighlightRect[];
+  text: string;
+  color: PdfHighlightColor;
+  note: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Free-form PDF metadata extracted from XMP / Info dictionary. */
+export interface PdfSourceMetadata {
+  pdfTitle?: string;
+  pdfAuthor?: string;
+  pdfCreatedAt?: string;
+  [key: string]: unknown;
+}
+
+/** POST /api/sources/pdf request body. */
+export interface RegisterPdfSourceBody {
+  sha256: string;
+  byteSize: number;
+  pageCount?: number;
+  displayName?: string;
+  metadata?: PdfSourceMetadata;
+}
+
+/** POST /api/sources/pdf response. */
+export interface RegisterPdfSourceResponse {
+  sourceId: string;
+  deduped: boolean;
+}
+
+/** POST /api/sources/pdf/:sourceId/highlights request body. */
+export interface CreatePdfHighlightBody {
+  pdfPage: number;
+  rects: PdfHighlightRect[];
+  text: string;
+  color?: PdfHighlightColor;
+  note?: string | null;
+}
+
+/** Patchable fields on a highlight. */
+export interface UpdatePdfHighlightBody {
+  color?: PdfHighlightColor;
+  note?: string | null;
+}
+
+/** POST /derive-page body. */
+export interface DerivePageBody {
+  noteId?: string | null;
+  title?: string;
+  contentPreview?: string;
+  templateContent?: string;
+}
+
+/**
+ * POST /derive-page response.
+ *
+ * Two shapes are returned:
+ *   - `alreadyDerived: true` → only `pageId` is guaranteed (idempotent path).
+ *   - First-time derivation → every field is populated.
+ *
+ * 冪等で再呼び出しした場合は pageId のみが必須、初回時は全フィールドが入る。
+ */
+export interface DerivePageResponse {
+  pageId: string;
+  alreadyDerived?: boolean;
+  noteId?: string | null;
+  sectionAnchor?: string;
+  templateContent?: string | null;
+  title?: string | null;
+  contentPreview?: string | null;
+  createdAt?: string;
+}
+
+// ── HTTP helpers ────────────────────────────────────────────────────────────
+
+function apiBase(): string {
+  return (import.meta.env.VITE_API_BASE_URL as string) ?? "";
+}
+
+async function jsonFetch<T>(path: string, init: RequestInit & { json?: unknown } = {}): Promise<T> {
+  const { json, headers, ...rest } = init;
+  const res = await fetch(`${apiBase()}${path}`, {
+    credentials: "include",
+    headers: {
+      ...(json !== undefined ? { "Content-Type": "application/json" } : {}),
+      ...(headers ?? {}),
+    },
+    body: json !== undefined ? JSON.stringify(json) : undefined,
+    ...rest,
+  });
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const body = (await res.json()) as { message?: string } | null;
+      if (body?.message) message = body.message;
+    } catch {
+      // ignore
+    }
+    throw new Error(`API ${res.status}: ${message}`);
+  }
+  return (await res.json()) as T;
+}
+
+// ── Low-level API calls ─────────────────────────────────────────────────────
+
+/**
+ * PDF ソースを登録する（ハッシュで dedup）。
+ * Register a PDF source (dedup by content hash).
+ */
+export function registerPdfSourceApi(
+  body: RegisterPdfSourceBody,
+): Promise<RegisterPdfSourceResponse> {
+  return jsonFetch<RegisterPdfSourceResponse>("/api/sources/pdf", {
+    method: "POST",
+    json: body,
+  });
+}
+
+/** PDF ソースの page_count を後追いで反映する。Backfill page_count from pdf.js. */
+export function patchPdfSourcePageCount(
+  sourceId: string,
+  pageCount: number,
+): Promise<{ sourceId: string; pageCount: number }> {
+  return jsonFetch<{ sourceId: string; pageCount: number }>(
+    `/api/sources/pdf/${encodeURIComponent(sourceId)}/page-count`,
+    {
+      method: "PATCH",
+      json: { pageCount },
+    },
+  );
+}
+
+/** PDF ソースのハイライト一覧を取得する。Fetch all highlights for a source. */
+export function listPdfHighlightsApi(sourceId: string): Promise<{ highlights: PdfHighlight[] }> {
+  return jsonFetch<{ highlights: PdfHighlight[] }>(
+    `/api/sources/pdf/${encodeURIComponent(sourceId)}/highlights`,
+  );
+}
+
+/** ハイライトを作成する。Create a highlight. */
+export function createPdfHighlightApi(
+  sourceId: string,
+  body: CreatePdfHighlightBody,
+): Promise<{ highlight: PdfHighlight }> {
+  return jsonFetch<{ highlight: PdfHighlight }>(
+    `/api/sources/pdf/${encodeURIComponent(sourceId)}/highlights`,
+    { method: "POST", json: body },
+  );
+}
+
+/** ハイライトを部分更新する。Patch color / note on an existing highlight. */
+export function updatePdfHighlightApi(
+  sourceId: string,
+  highlightId: string,
+  body: UpdatePdfHighlightBody,
+): Promise<{ highlight: PdfHighlight }> {
+  return jsonFetch<{ highlight: PdfHighlight }>(
+    `/api/sources/pdf/${encodeURIComponent(sourceId)}/highlights/${encodeURIComponent(highlightId)}`,
+    { method: "PATCH", json: body },
+  );
+}
+
+/** ハイライトを削除する。Delete a highlight. */
+export function deletePdfHighlightApi(
+  sourceId: string,
+  highlightId: string,
+): Promise<{ deleted?: string }> {
+  return jsonFetch<{ deleted?: string }>(
+    `/api/sources/pdf/${encodeURIComponent(sourceId)}/highlights/${encodeURIComponent(highlightId)}`,
+    { method: "DELETE" },
+  );
+}
+
+/** ハイライトから派生 Zedi ページを作成する。Derive a Zedi page from a highlight. */
+export function derivePageFromHighlightApi(
+  sourceId: string,
+  highlightId: string,
+  body: DerivePageBody,
+): Promise<DerivePageResponse> {
+  return jsonFetch<DerivePageResponse>(
+    `/api/sources/pdf/${encodeURIComponent(sourceId)}/highlights/${encodeURIComponent(highlightId)}/derive-page`,
+    { method: "POST", json: body },
+  );
+}
+
+// ── React Query hooks ───────────────────────────────────────────────────────
+
+/** Query key factory for PDF resources. */
+export const pdfKnowledgeKeys = {
+  all: ["pdfKnowledge"] as const,
+  highlights: (sourceId: string) => [...pdfKnowledgeKeys.all, "highlights", sourceId] as const,
+};
+
+/** ハイライト一覧を購読する。Subscribe to a source's highlights. */
+export function usePdfHighlights(sourceId: string | undefined) {
+  return useQuery({
+    queryKey: pdfKnowledgeKeys.highlights(sourceId ?? ""),
+    queryFn: () => {
+      // `enabled` ガード越しでしか呼ばれないため、ここで未定義 sourceId に到達したら
+      // 上流の呼び出し側のバグ。型から `!` を取り除くために明示的に throw する。
+      // `enabled` below guards this; throw if we ever get here without a sourceId
+      // so the bug surfaces instead of being hidden by a non-null assertion.
+      if (!sourceId) throw new Error("usePdfHighlights: sourceId is required");
+      return listPdfHighlightsApi(sourceId);
+    },
+    enabled: Boolean(sourceId),
+    staleTime: 30_000,
+  });
+}
+
+/** ハイライト作成 mutation。Mutation: create a highlight. */
+export function useCreatePdfHighlight(sourceId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreatePdfHighlightBody) => createPdfHighlightApi(sourceId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: pdfKnowledgeKeys.highlights(sourceId) });
+    },
+  });
+}
+
+/** ハイライト更新 mutation。Mutation: patch a highlight. */
+export function useUpdatePdfHighlight(sourceId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ highlightId, body }: { highlightId: string; body: UpdatePdfHighlightBody }) =>
+      updatePdfHighlightApi(sourceId, highlightId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: pdfKnowledgeKeys.highlights(sourceId) });
+    },
+  });
+}
+
+/** ハイライト削除 mutation。Mutation: delete a highlight. */
+export function useDeletePdfHighlight(sourceId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (highlightId: string) => deletePdfHighlightApi(sourceId, highlightId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: pdfKnowledgeKeys.highlights(sourceId) });
+    },
+  });
+}
+
+/** 派生ページ作成 mutation。Mutation: derive a Zedi page from a highlight. */
+export function useDerivePageFromHighlight(sourceId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ highlightId, body }: { highlightId: string; body: DerivePageBody }) =>
+      derivePageFromHighlightApi(sourceId, highlightId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: pdfKnowledgeKeys.highlights(sourceId) });
+    },
+  });
+}

--- a/src/lib/pdfKnowledge/sectionAnchor.test.ts
+++ b/src/lib/pdfKnowledge/sectionAnchor.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  encodePdfSectionAnchor,
+  decodePdfSectionAnchor,
+  isPdfSectionAnchor,
+  PDF_SECTION_ANCHOR_PREFIX,
+  PdfSectionAnchorError,
+  MAX_PDF_SECTION_ANCHOR_LENGTH,
+} from "./sectionAnchor";
+
+describe("sectionAnchor", () => {
+  const highlightId = "0d6c5d20-7e9b-4a3f-9d63-7f4b2c11ab90";
+
+  describe("encodePdfSectionAnchor", () => {
+    it("prefixes with pdf:v1: and embeds the highlight id", () => {
+      expect(encodePdfSectionAnchor({ highlightId })).toBe(`pdf:v1:${highlightId}`);
+    });
+
+    it("rejects non-UUID highlight ids to avoid anchor collisions or injection", () => {
+      expect(() => encodePdfSectionAnchor({ highlightId: "not-a-uuid" })).toThrow(
+        PdfSectionAnchorError,
+      );
+      expect(() => encodePdfSectionAnchor({ highlightId: "" })).toThrow(PdfSectionAnchorError);
+    });
+
+    it("stays under the length budget used by the page_sources composite PK", () => {
+      const encoded = encodePdfSectionAnchor({ highlightId });
+      expect(encoded.length).toBeLessThanOrEqual(MAX_PDF_SECTION_ANCHOR_LENGTH);
+    });
+  });
+
+  describe("decodePdfSectionAnchor", () => {
+    it("round-trips encode/decode", () => {
+      const encoded = encodePdfSectionAnchor({ highlightId });
+      expect(decodePdfSectionAnchor(encoded)).toEqual({ version: 1, highlightId });
+    });
+
+    it("returns null for non-pdf anchors so callers can ignore unrelated rows", () => {
+      expect(decodePdfSectionAnchor("")).toBeNull();
+      expect(decodePdfSectionAnchor("heading-foo")).toBeNull();
+      expect(decodePdfSectionAnchor("epub:v1:something")).toBeNull();
+    });
+
+    it("throws on a malformed pdf anchor (corrupted payload)", () => {
+      expect(() => decodePdfSectionAnchor("pdf:v1:")).toThrow(PdfSectionAnchorError);
+      expect(() => decodePdfSectionAnchor("pdf:v1:not-a-uuid")).toThrow(PdfSectionAnchorError);
+    });
+
+    it("throws on an unknown anchor version so older clients refuse new shapes", () => {
+      expect(() => decodePdfSectionAnchor(`pdf:v2:${highlightId}`)).toThrow(PdfSectionAnchorError);
+    });
+  });
+
+  describe("isPdfSectionAnchor", () => {
+    it("returns true only for the well-formed pdf:v1 prefix", () => {
+      expect(isPdfSectionAnchor(`${PDF_SECTION_ANCHOR_PREFIX}${highlightId}`)).toBe(true);
+      expect(isPdfSectionAnchor("epub:v1:x")).toBe(false);
+      expect(isPdfSectionAnchor("")).toBe(false);
+    });
+  });
+});

--- a/src/lib/pdfKnowledge/sectionAnchor.ts
+++ b/src/lib/pdfKnowledge/sectionAnchor.ts
@@ -1,0 +1,126 @@
+/**
+ * `page_sources.section_anchor` 上で「派生ページの出典がどの PDF ハイライトか」を
+ * 表現するためのエンコード/デコードユーティリティ。
+ *
+ * Utility for encoding/decoding the `page_sources.section_anchor` column when
+ * the source is a local PDF highlight (`sources.kind = "pdf_local"`).
+ *
+ * 形式: `pdf:v1:<highlightId>`
+ *   - `pdf` … スキーマ名（将来 `epub` / `slide` などに拡張可能）。
+ *   - `v1`  … バージョン。互換性破壊時に v2 を導入する。
+ *   - `<highlightId>` … `pdf_highlights.id` (UUID v4)。
+ *
+ * `page_sources` のプライマリキーは `(page_id, source_id, section_anchor)`
+ * なので anchor は短く保つ必要がある。本実装は **highlight id だけ**を埋め、
+ * 矩形 / ページ番号などの詳細情報は `pdf_highlights` 行を引いて取得する。
+ *
+ * The `page_sources` composite PK includes `section_anchor`, so we keep the
+ * anchor short. Only the highlight UUID is embedded here; rects / page numbers
+ * live on the `pdf_highlights` row and are looked up by id.
+ */
+
+/**
+ * Anchor 文字列の先頭プレフィックス（バージョン込み）。
+ * Header of the encoded anchor string (includes the version).
+ */
+export const PDF_SECTION_ANCHOR_PREFIX = "pdf:v1:" as const;
+
+/**
+ * Anchor 文字列の最大長。`page_sources.section_anchor` の PK 制約で
+ * 過剰に長い値を入れないようガードする。
+ * Upper bound for the encoded anchor length; protects the composite PK on
+ * `page_sources` from overly long values.
+ */
+export const MAX_PDF_SECTION_ANCHOR_LENGTH = 64;
+
+/**
+ * UUID v1〜v8 の許容パターン（厳密版より緩く、`gen_random_uuid()` 出力を受け入れる）。
+ * UUID pattern accepting v1〜v8; relaxed enough for `gen_random_uuid()` output.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * sectionAnchor の解析・整形時のエラー。
+ * Error thrown by encode/decode when the input shape is invalid.
+ */
+export class PdfSectionAnchorError extends Error {
+  /** Build the error and tag the class name for instanceof checks. */
+  constructor(message: string) {
+    super(message);
+    this.name = "PdfSectionAnchorError";
+  }
+}
+
+/**
+ * デコード結果。バージョンとハイライト ID を返す。
+ * Decoded payload — version + highlight id.
+ */
+export interface DecodedPdfSectionAnchor {
+  version: 1;
+  highlightId: string;
+}
+
+/**
+ * `pdf:v1:<highlightId>` を組み立てる。
+ * Encode a highlight id into a `pdf:v1:` section anchor.
+ *
+ * @throws PdfSectionAnchorError - 入力 ID が UUID でない場合。If id is not a UUID.
+ */
+export function encodePdfSectionAnchor(params: { highlightId: string }): string {
+  if (!UUID_RE.test(params.highlightId)) {
+    throw new PdfSectionAnchorError(
+      `highlightId must be a UUID, got: ${JSON.stringify(params.highlightId)}`,
+    );
+  }
+  const anchor = `${PDF_SECTION_ANCHOR_PREFIX}${params.highlightId}`;
+  if (anchor.length > MAX_PDF_SECTION_ANCHOR_LENGTH) {
+    // 防衛的: UUID は固定長なので通常は到達しないが、念のため。
+    // Defensive: a well-formed UUID never exceeds the budget, but guard anyway.
+    throw new PdfSectionAnchorError(
+      `encoded anchor exceeds budget (${anchor.length} > ${MAX_PDF_SECTION_ANCHOR_LENGTH})`,
+    );
+  }
+  return anchor;
+}
+
+/**
+ * Anchor 文字列が `pdf:v1:` で始まる PDF アンカーかを判定する。
+ * Returns true iff the input is shaped like a `pdf:v1:` section anchor.
+ */
+export function isPdfSectionAnchor(value: string): boolean {
+  return value.startsWith(PDF_SECTION_ANCHOR_PREFIX);
+}
+
+/**
+ * `pdf:v1:<highlightId>` をデコードする。PDF アンカーでなければ `null`。
+ * Decode a PDF section anchor; returns `null` for non-PDF anchors so callers
+ * can iterate over heterogeneous `page_sources` rows without try/catch.
+ *
+ * @throws PdfSectionAnchorError - prefix が `pdf:` でバージョンや payload が
+ *   壊れている場合（不明バージョン・空 payload・非 UUID）。
+ *   Thrown when the prefix looks like a PDF anchor but the payload is invalid
+ *   (unknown version, empty payload, non-UUID id) — these indicate a corrupted
+ *   row that the caller should surface rather than silently ignore.
+ */
+export function decodePdfSectionAnchor(value: string): DecodedPdfSectionAnchor | null {
+  if (!value.startsWith("pdf:")) {
+    return null;
+  }
+  const remainder = value.slice("pdf:".length);
+  const colonIdx = remainder.indexOf(":");
+  if (colonIdx < 0) {
+    throw new PdfSectionAnchorError(`malformed pdf anchor (missing version separator): ${value}`);
+  }
+  const version = remainder.slice(0, colonIdx);
+  const payload = remainder.slice(colonIdx + 1);
+  if (version !== "v1") {
+    throw new PdfSectionAnchorError(`unsupported pdf anchor version: ${version}`);
+  }
+  if (!payload) {
+    throw new PdfSectionAnchorError(`pdf anchor payload is empty: ${value}`);
+  }
+  if (!UUID_RE.test(payload)) {
+    throw new PdfSectionAnchorError(`pdf anchor payload is not a UUID: ${payload}`);
+  }
+  return { version: 1, highlightId: payload };
+}

--- a/src/lib/pdfKnowledge/tauriBridge.ts
+++ b/src/lib/pdfKnowledge/tauriBridge.ts
@@ -1,0 +1,121 @@
+/**
+ * Tauri 側 `pdf_sources.rs` への型付きブリッジ。
+ *
+ * Typed wrappers around the Tauri `#[tauri::command]` entries defined in
+ * `src-tauri/src/pdf_sources.rs`. Web (non-Tauri) callers will receive a
+ * {@link PdfKnowledgeUnsupportedError} so the UI can render the
+ * desktop-only placeholder instead of silently failing.
+ *
+ * Phase 1 では PDF 関連機能は Tauri デスクトップ専用。Web からの呼び出しは
+ * {@link PdfKnowledgeUnsupportedError} を throw する。
+ */
+import { isTauriDesktop } from "@/lib/platform";
+
+/**
+ * Web / 非 Tauri 環境で PDF 関連コマンドを呼んだときに throw されるエラー。
+ * Thrown when a PDF command is invoked outside a Tauri desktop runtime.
+ */
+export class PdfKnowledgeUnsupportedError extends Error {
+  /** Build the error with the canonical Phase-1 message. */
+  constructor() {
+    super("PDF knowledge ingestion is only available on Tauri desktop in Phase 1");
+    this.name = "PdfKnowledgeUnsupportedError";
+  }
+}
+
+/**
+ * `register_pdf_source` の戻り値。Rust 側は camelCase serde で吐く。
+ * Return shape of `register_pdf_source`; Rust uses camelCase via serde.
+ */
+export interface RegisteredPdfSource {
+  sha256: string;
+  byteSize: number;
+  displayName: string;
+}
+
+/**
+ * `verify_pdf_source` の戻り値。
+ * Return shape of `verify_pdf_source`.
+ */
+export interface PdfVerifyResult {
+  exists: boolean;
+  sizeChanged: boolean;
+  mtimeChanged: boolean;
+  absolutePathKnown: boolean;
+}
+
+/**
+ * `@tauri-apps/api/core` の `invoke` を動的 import で呼ぶ。
+ * Dynamically import `invoke` so the web bundle doesn't fail when the Tauri
+ * runtime is absent.
+ */
+async function tauriInvoke<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+  if (!isTauriDesktop()) {
+    throw new PdfKnowledgeUnsupportedError();
+  }
+  // 動的 import で web ビルドからは外す（Tauri runtime 側でのみ解決される）。
+  // Dynamic import so the web build does not require @tauri-apps/api at all.
+  const mod = (await import("@tauri-apps/api/core")) as {
+    invoke: <R>(cmd: string, args?: Record<string, unknown>) => Promise<R>;
+  };
+  return mod.invoke<T>(command, args);
+}
+
+/**
+ * ファイルダイアログ等で取得した絶対パスを「登録準備」する: SHA-256 と表示名を返す。
+ * Validates the path, computes SHA-256, and returns display name.
+ * Does NOT update the Tauri-side registry — call {@link attachPdfSourcePath} after
+ * the server has returned the canonical `sourceId`.
+ */
+export function registerPdfSource(absolutePath: string): Promise<RegisteredPdfSource> {
+  return tauriInvoke<RegisteredPdfSource>("register_pdf_source", { absolutePath });
+}
+
+/**
+ * サーバから受け取った `sourceId` とローカル絶対パスを Tauri レジストリに紐づける。
+ * Persist the `sourceId ↔ absolutePath` mapping in the Tauri-side registry.
+ */
+export async function attachPdfSourcePath(params: {
+  sourceId: string;
+  absolutePath: string;
+  sha256: string;
+}): Promise<void> {
+  await tauriInvoke<null>("attach_pdf_source_path", {
+    sourceId: params.sourceId,
+    absolutePath: params.absolutePath,
+    sha256: params.sha256,
+  });
+}
+
+/**
+ * ファイル欠損 / 変更検知。ビューア起動直後に呼ぶ。
+ * Probe the registered file before opening the viewer.
+ */
+export function verifyPdfSource(sourceId: string): Promise<PdfVerifyResult> {
+  return tauriInvoke<PdfVerifyResult>("verify_pdf_source", { sourceId });
+}
+
+/**
+ * レジストリエントリを削除（実ファイルは触らない）。
+ * Forget the registry entry; the underlying file is untouched.
+ */
+export async function forgetPdfSource(sourceId: string): Promise<void> {
+  await tauriInvoke<null>("forget_pdf_source", { sourceId });
+}
+
+/**
+ * 登録済み PDF のバイト列を取得する。pdf.js へ Uint8Array として渡す前提。
+ * Returns the raw bytes of the registered PDF, ready to be fed to pdf.js.
+ *
+ * Tauri v2 の IPC は `Vec<u8>` を数値配列 / バイナリで返す。型のゆるさを吸収するため
+ * Uint8Array に正規化して返す。
+ * Tauri v2 IPC may surface the Rust `Vec<u8>` as either an array of numbers or
+ * an ArrayBuffer; normalize to `Uint8Array` for the caller.
+ */
+export async function readPdfBytes(sourceId: string): Promise<Uint8Array> {
+  const raw = await tauriInvoke<unknown>("read_pdf_bytes", { sourceId });
+  if (raw instanceof Uint8Array) return raw;
+  if (raw instanceof ArrayBuffer) return new Uint8Array(raw);
+  if (Array.isArray(raw)) return Uint8Array.from(raw as number[]);
+  throw new Error("read_pdf_bytes returned an unexpected shape");
+}

--- a/src/pages/pdfKnowledge/PdfReaderPage.tsx
+++ b/src/pages/pdfKnowledge/PdfReaderPage.tsx
@@ -1,0 +1,16 @@
+/**
+ * `/sources/:sourceId/pdf` のルートエントリ。
+ *
+ * Route entry point for `/sources/:sourceId/pdf` — defers to the reader
+ * component, which handles platform gating + missing-file UX.
+ */
+import { PdfReader } from "@/components/pdf-reader/PdfReader";
+
+/**
+ * Route element for `/sources/:sourceId/pdf` — thin wrapper around the
+ * {@link PdfReader} feature component so the router has a default export.
+ * `/sources/:sourceId/pdf` 用の route element。
+ */
+export default function PdfReaderPage() {
+  return <PdfReader />;
+}


### PR DESCRIPTION
Phase 1 scaffolding for the PDF -> Zedi page workflow (otomatty/zedi#389).
PDF binaries stay on the user's local filesystem; only highlights, notes,
and derived pages reach the server.

Data model (no new "documents" table — extends existing sources/page_sources):
- sources: add display_name/byte_size/page_count/metadata for kind="pdf_local"
- pdf_highlights: new table (source_id, owner_id, pdf_page, rects jsonb, text,
  color, note, optional derived_page_id back-pointer)
- page_sources.section_anchor uses "pdf:v1:<highlightId>" so the existing
  page <-> source relation handles citation lookups without schema churn
- migrations 0025_add_pdf_source_metadata.sql, 0026_add_pdf_highlights.sql

Server (Hono):
- /api/sources/pdf: register/dedup by content_hash; never receives a path
- /api/sources/pdf/:id/highlights: CRUD
- /api/sources/pdf/:id/highlights/:id/derive-page: single-tx page + page_sources
  + derived_page_id back-pointer; defaults to user's default note

Tauri (desktop-only per #389):
- pdf_sources.rs commands: register_pdf_source, attach_pdf_source_path,
  verify_pdf_source, forget_pdf_source, read_pdf_bytes (200 MiB cap)
- ~/zedi/pdf_sources.json local-only registry (atomic write + mutex), so the
  absolute path never leaves the device
- sha2 dep added; pdf parsing intentionally deferred to pdf.js on the client

Frontend:
- src/lib/pdfKnowledge/: typed Tauri bridge, React Query highlight hooks,
  sectionAnchor encode/decode, excerpt-centric derived page template
- src/components/pdf-reader/: scaffold (PdfReader, MissingPdfBanner,
  PdfReaderUnsupported); the full pdf.js viewer ships in a follow-up PR
- /sources/:sourceId/pdf route with desktop-only gate via isTauriDesktop()

Tests: 19 vitest unit tests covering sectionAnchor + derivedPageTemplate;
Rust unit tests covering path validation + sha256 + hex parsing.

https://claude.ai/code/session_01DM2g1PxPyZmRf8PBaBEeLg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local PDF support: register/verify/read local PDFs, create/list/update/delete highlights, and derive notes from highlights
  * Desktop-only PDF reader route with UI for missing-file re-attach and forget actions
  * Deep-linkable excerpt generation and derived-note templates for highlights

* **Database**
  * Built-in storage for PDF source metadata and per-highlight records with query indexes

* **Tests**
  * Unit tests covering derived-page templates and section-anchor encoding/decoding

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/858)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->