### PR TITLE
fix(api): coerce MAX(pages.updated_at) to Date in GET /api/notes/:id (#857)

### DIFF
--- a/server/api/src/__tests__/routes/notes/crud.test.ts
+++ b/server/api/src/__tests__/routes/notes/crud.test.ts
@@ -44,6 +44,22 @@ function mockPagesSignal(maxUpdatedAt: Date | null = null, count = 0) {
   return [{ maxUpdatedAt, count }];
 }
 
+/**
+ * `pg` ドライバが `timestamptz` を Date ではなく ISO 文字列のまま返してくる
+ * 本番挙動を再現するためのモック。Issue #857 (PR #856 regression) で観測された
+ * ケース: drizzle の `sql<Date | null>` テンプレートタグは型ヒントだけで、
+ * ランタイムでは string がそのまま素通しされうる。
+ *
+ * Mocks the pg driver path where `timestamptz` aggregates arrive as raw ISO
+ * strings instead of `Date` instances (Issue #857 / PR #856 regression).
+ * drizzle's `sql<Date | null>` template tag is compile-time only and does
+ * not decode the driver value, so the production runtime occasionally yields
+ * a string here.
+ */
+function mockPagesSignalRaw(maxUpdatedAt: string | null = null, count = 0) {
+  return [{ maxUpdatedAt, count }];
+}
+
 // ── ifNoneMatchMatches (Issue #853, PR #856 review) ─────────────────────────
 
 describe("ifNoneMatchMatches", () => {
@@ -742,6 +758,66 @@ describe("GET /api/notes/:noteId", () => {
       const body = (await res.json()) as Record<string, unknown>;
       expect(body).toHaveProperty("id", mockNote.id);
       expect(res.headers.get("ETag")).toBeTruthy();
+    });
+
+    // ── Issue #857 (PR #856 regression) ────────────────────────────────
+    // drizzle の `sql<Date | null>`MAX(...)`` は型ヒントだけで、本番の pg
+    // ドライバ経路では集約値が ISO 文字列のまま返ってくる場合がある。修正前は
+    // `makeNoteETag` 内の `.getTime()` が落ちて 500 になっていた。
+    // 修正は (A) query 側で `.mapWith()` により Date 化、(B) ETag ヘルパー側で
+    // `Date | string | null` を受けて defensive に正規化、の二段構え。
+    //
+    // drizzle's `sql<Date | null>`MAX(...)`` is compile-time only and the pg
+    // driver path can yield the aggregate as a raw ISO string. Pre-fix code
+    // threw `TypeError` inside `makeNoteETag` and returned 500. The fix has
+    // two layers: (A) the query coerces via `.mapWith()`, and (B) the ETag
+    // helper defensively accepts `Date | string | null`.
+    it("should compute ETag without throwing when MAX(pages.updated_at) is returned as a string (Issue #857)", async () => {
+      const mockNote = createMockNote();
+      const mockPage = createMockPageRow();
+      const { app } = createTestApp([
+        [mockNote],
+        mockPagesSignalRaw("2026-01-01T00:00:00.000Z", 1),
+        [mockPage],
+      ]);
+
+      const res = await app.request(`/api/notes/${mockNote.id}`, {
+        headers: authHeaders(),
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("ETag")).toMatch(/^W\/".+"$/);
+    });
+
+    it("should produce the same ETag whether MAX(pages.updated_at) is a Date or an ISO string (Issue #857)", async () => {
+      // 同一の瞬間を `Date` で渡したケースと `string` で渡したケースで
+      // ETag が一致することを確認する。境界正規化が effective であることの確認。
+      // Verifies that the boundary normalization renders driver representation
+      // irrelevant: the same instant must hash to the same ETag whether the
+      // mock yields a `Date` or an ISO string.
+      const mockNote = createMockNote();
+      const sameInstant = new Date("2026-01-01T00:00:00.000Z");
+      const { app } = createTestApp([
+        [mockNote],
+        mockPagesSignal(sameInstant, 1),
+        [],
+        [mockNote],
+        mockPagesSignalRaw("2026-01-01T00:00:00.000Z", 1),
+        [],
+      ]);
+
+      const resDate = await app.request(`/api/notes/${mockNote.id}`, {
+        headers: authHeaders(),
+      });
+      const resString = await app.request(`/api/notes/${mockNote.id}`, {
+        headers: authHeaders(),
+      });
+
+      const etagDate = resDate.headers.get("ETag");
+      const etagString = resString.headers.get("ETag");
+      expect(etagDate).toBeTruthy();
+      expect(etagString).toBeTruthy();
+      expect(etagDate).toBe(etagString);
     });
   });
 });

--- a/server/api/src/routes/notes/crud.ts
+++ b/server/api/src/routes/notes/crud.ts
@@ -83,6 +83,28 @@ function parseIsOfficialForUpdate(value: unknown): boolean | undefined {
 }
 
 /**
+ * `Date | string | null` のいずれで来ても安全に epoch ms に正規化するヘルパー。
+ * drizzle の `sql<T>` テンプレートタグは型ヒントだけで runtime 変換しないため、
+ * `MAX(pages.updated_at)` のような raw SQL 集約は pg ドライバ次第で
+ * `Date` ではなく ISO 文字列で返ってくることがある (Issue #857 / PR #856 regression)。
+ * SQL 境界側でも `.mapWith()` で Date 化しているが、ここでも defensive に
+ * 受けておくことで将来同種の罠が再発しても 500 を避けられる。
+ *
+ * Normalizes `Date | string | null` to an epoch-ms number. drizzle's
+ * `sql<T>` template tag is a compile-time-only hint and does not coerce
+ * driver values, so raw aggregates like `MAX(pages.updated_at)` can arrive
+ * as ISO strings depending on the pg driver path (Issue #857 / PR #856
+ * regression). The query call site already normalizes via `.mapWith()`,
+ * but accepting strings here too keeps the ETag path resilient against
+ * similar bugs in the future.
+ */
+function toEpochMillis(value: Date | string | null | undefined): number {
+  if (value === null || value === undefined) return 0;
+  if (value instanceof Date) return value.getTime();
+  return new Date(value).getTime();
+}
+
+/**
  * Note 詳細レスポンス用の weak ETag を生成する。`note.updatedAt` と role に
  * 加えて、ページの最大 `updated_at` と件数も混ぜることで、`notes.updated_at`
  * を経由しないページ単体編集（`PUT /api/pages/:id/content`・タイトル変更・
@@ -101,14 +123,14 @@ function parseIsOfficialForUpdate(value: unknown): boolean | undefined {
  */
 function makeNoteETag(
   noteId: string,
-  noteUpdatedAt: Date,
+  noteUpdatedAt: Date | string,
   role: string,
-  pagesMaxUpdatedAt: Date | null,
+  pagesMaxUpdatedAt: Date | string | null,
   pagesCount: number,
 ): string {
   const hash = createHash("sha1")
     .update(
-      `${noteId}:${noteUpdatedAt.getTime()}:${role}:${pagesMaxUpdatedAt?.getTime() ?? 0}:${pagesCount}`,
+      `${noteId}:${toEpochMillis(noteUpdatedAt)}:${role}:${toEpochMillis(pagesMaxUpdatedAt)}:${pagesCount}`,
     )
     .digest("base64url")
     .slice(0, 22);
@@ -373,7 +395,20 @@ app.get("/:noteId", authOptional, async (c) => {
   // resolve this from the index alone, keeping the cost negligible.
   const pagesSignalRows = await db
     .select({
-      maxUpdatedAt: sql<Date | null>`MAX(${pages.updatedAt})`,
+      // drizzle の `sql<Date | null>\`...\`` は型ヒントだけで、raw SQL 集約 (typed
+      // column ではない式) の戻り値に decoder を持たない。pg ドライバ経路次第で
+      // `timestamptz` の集約値が ISO 文字列のまま返ってくることがあり、その場合
+      // 下流の `makeNoteETag` で `.getTime()` が落ちて 500 になる (Issue #857)。
+      // `.mapWith()` で境界側で Date | null に強制正規化する。
+      //
+      // `sql<Date | null>` is a compile-time-only hint and drizzle has no decoder
+      // for raw aggregate expressions, so the pg driver can hand the result back
+      // as an ISO string (Issue #857 / PR #856 regression). `.mapWith()` coerces
+      // the driver value to `Date | null` at the query boundary.
+      maxUpdatedAt: sql<Date | null>`MAX(${pages.updatedAt})`.mapWith((value): Date | null => {
+        if (value === null || value === undefined) return null;
+        return value instanceof Date ? value : new Date(value as string);
+      }),
       count: sql<number>`COUNT(*)::int`,
     })
     .from(pages)

--- a/server/api/src/routes/notes/crud.ts
+++ b/server/api/src/routes/notes/crud.ts
@@ -100,8 +100,21 @@ function parseIsOfficialForUpdate(value: unknown): boolean | undefined {
  */
 function toEpochMillis(value: Date | string | null | undefined): number {
   if (value === null || value === undefined) return 0;
-  if (value instanceof Date) return value.getTime();
-  return new Date(value).getTime();
+  const parsed = value instanceof Date ? value : new Date(value);
+  const ms = parsed.getTime();
+  // 不正な文字列 (`new Date("not a date")`) や Invalid Date オブジェクトは
+  // `NaN` を返す。テンプレートリテラルでハッシュに混ぜると "NaN" がそのまま
+  // 文字列として入り、入力が壊れていても "同じ NaN" として ETag が安定して
+  // しまう (= 別の壊れ方を区別できない)。0 に正規化することで `null` と同じ
+  // 扱いになり、少なくとも安全側に倒れる (gemini-code-assist review on #859)。
+  //
+  // Invalid input (e.g. `new Date("bogus")` or an `Invalid Date`) yields
+  // `NaN` from `getTime()`. Embedding it into the template literal would
+  // splice the literal string `"NaN"` into the hash, which silently
+  // collapses *different* malformed inputs into the same digest. Normalize
+  // to 0 so the ETag at least falls back to the `null` branch behavior
+  // (gemini-code-assist review on PR #859).
+  return Number.isNaN(ms) ? 0 : ms;
 }
 
 /**


### PR DESCRIPTION
PR #856 で導入した ETag 計算が `pagesSignal.maxUpdatedAt` を Date として
扱っていたが、drizzle の `sql<Date | null>` は型ヒントだけで runtime 変換を
行わないため、pg ドライバ次第で集約値が ISO 文字列のまま返り、
`makeNoteETag` 内の `.getTime()` が TypeError を投げて 500 になっていた。

- crud.ts: `.mapWith()` で SQL 境界側で Date | null に正規化
- crud.ts: `makeNoteETag` を `Date | string | null` 受けの defensive 実装に
- crud.test.ts: pg ドライバが string を返すケースの回帰テストを 2 件追加

Fixes #857

https://claude.ai/code/session_01GJyw6kjQxSteiXukkCyExx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regression in notes API ETag generation when page timestamps are returned in different formats; ETags are now consistent across driver variations.
  * Improved timestamp normalization to prevent ETag computation errors.

* **Tests**
  * Added tests covering ETag generation with timestamps provided as Date objects and as ISO strings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/859)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->