### PR TITLE
fix: restore content_preview in note detail API (Issue #860 Phase 0)

### DIFF
--- a/server/api/src/__tests__/routes/notes/crud.test.ts
+++ b/server/api/src/__tests__/routes/notes/crud.test.ts
@@ -477,7 +477,11 @@ describe("GET /api/notes/:noteId", () => {
 
   it("should include page data in snake_case within pages array", async () => {
     const mockNote = createMockNote();
-    const mockPage = createMockPageRow({ id: "page-abc", title: "Page Title" });
+    const mockPage = createMockPageRow({
+      id: "page-abc",
+      title: "Page Title",
+      contentPreview: "Preview body...",
+    });
 
     const { app } = createTestApp([
       [mockNote], // getNoteRole
@@ -496,11 +500,39 @@ describe("GET /api/notes/:noteId", () => {
     expect(page).toHaveProperty("id", "page-abc");
     expect(page).toHaveProperty("owner_id");
     expect(page).toHaveProperty("source_page_id");
-    // Issue #849 移行措置: レスポンス軽量化のため `content_preview` は常に `null`。
-    // Migration step for #849: `content_preview` is always `null` on the wire.
-    expect(page).toHaveProperty("content_preview", null);
+    // Issue #860 Phase 0: `content_preview` を一覧レスポンスに復旧。保存時に
+    // 算出した先頭抜粋がそのまま返る。
+    // Issue #860 Phase 0: `content_preview` is restored on the list response;
+    // the stored head-of-body excerpt comes back verbatim.
+    expect(page).toHaveProperty("content_preview", "Preview body...");
     expect(page).toHaveProperty("thumbnail_url");
     expect(page).toHaveProperty("note_id", mockNote.id);
+  });
+
+  it("should return content_preview as null when the page has no stored preview", async () => {
+    // 保存時にプレビューが未生成 (`content_preview IS NULL`) のページでも
+    // ワイヤ上は `null` のまま素通しすることを保証する。Issue #860 Phase 0 の
+    // 復旧は「常に null」をやめるだけで、空ページのセマンティクスは維持する。
+    //
+    // Even when the stored preview is absent (`content_preview IS NULL`), the
+    // wire value must remain `null`. Issue #860 Phase 0 only stops the
+    // "always null" override; empty-page semantics are preserved.
+    const mockNote = createMockNote();
+    const mockPage = createMockPageRow({ id: "page-empty", contentPreview: null });
+
+    const { app } = createTestApp([
+      [mockNote],
+      mockPagesSignal(mockPage.updatedAt as Date, 1),
+      [mockPage],
+    ]);
+
+    const res = await app.request(`/api/notes/${mockNote.id}`, {
+      headers: authHeaders(),
+    });
+
+    const body = (await res.json()) as Record<string, unknown>;
+    const page = (body.pages as Record<string, unknown>[])[0];
+    expect(page).toHaveProperty("content_preview", null);
   });
 
   it("should return 404 for non-existent note", async () => {

--- a/server/api/src/routes/notes/crud.ts
+++ b/server/api/src/routes/notes/crud.ts
@@ -42,6 +42,19 @@ const ALLOWED_EDIT_PERMISSION = new Set<NoteEditPermission>([
   "any_logged_in",
 ]);
 
+/**
+ * `GET /api/notes/:noteId` のレスポンス形状バージョン。ETag に混ぜることで、
+ * サーバ側のレスポンス形状を変えた直後にクライアントが古い `If-None-Match`
+ * を送ってきても 304 で旧 body をキャッシュ再利用させない（Issue #860 Phase 0）。
+ * 形状を変更したら必ずこの値を bump する。
+ *
+ * Response-shape version for `GET /api/notes/:noteId`. Mixed into the ETag so
+ * that when the server's response shape changes, stale `If-None-Match`
+ * validators from clients cannot revive an outdated cached body via 304
+ * (Issue #860 Phase 0). Bump this whenever the wire shape changes.
+ */
+const NOTE_DETAIL_RESPONSE_VERSION = "v2";
+
 function validateVisibility(value: string | undefined): NoteVisibility {
   if (value === undefined) return "private";
   if (!ALLOWED_VISIBILITY.has(value as NoteVisibility)) {
@@ -143,7 +156,7 @@ function makeNoteETag(
 ): string {
   const hash = createHash("sha1")
     .update(
-      `${noteId}:${toEpochMillis(noteUpdatedAt)}:${role}:${toEpochMillis(pagesMaxUpdatedAt)}:${pagesCount}`,
+      `${NOTE_DETAIL_RESPONSE_VERSION}:${noteId}:${toEpochMillis(noteUpdatedAt)}:${role}:${toEpochMillis(pagesMaxUpdatedAt)}:${pagesCount}`,
     )
     .digest("base64url")
     .slice(0, 22);
@@ -478,6 +491,7 @@ app.get("/:noteId", authOptional, async (c) => {
       noteId: pages.noteId,
       sourcePageId: pages.sourcePageId,
       title: pages.title,
+      contentPreview: pages.contentPreview,
       thumbnailUrl: pages.thumbnailUrl,
       sourceUrl: pages.sourceUrl,
       createdAt: pages.createdAt,
@@ -499,12 +513,15 @@ app.get("/:noteId", authOptional, async (c) => {
         note_id: p.noteId,
         source_page_id: p.sourcePageId,
         title: p.title,
-        // Issue #849 移行措置: レスポンス軽量化のため常に `null`。プレビューが
-        // 必要な箇所は専用エンドポイント or 個別ページ取得を使う。
-        // Migration step for #849: always `null` to keep the response slim.
-        // Callers that need the preview should hit a dedicated endpoint or
-        // fetch the page individually.
-        content_preview: null,
+        // Issue #860 Phase 0: `pages.content_preview` を戻し、カード描画で
+        // 本文 fetch を伴わないプレビュー表示を復旧する。Phase 1 以降で
+        // ノートシェルとページ一覧の API を分割するまでの暫定経路。
+        //
+        // Issue #860 Phase 0: restore `pages.content_preview` so list cards
+        // can render the preview without fetching full page bodies. This is
+        // the interim path until Phase 1 splits the note-shell and page-list
+        // APIs.
+        content_preview: p.contentPreview ?? null,
         thumbnail_url: p.thumbnailUrl,
         source_url: p.sourceUrl,
         created_at: p.createdAt,

--- a/server/api/src/routes/notes/types.ts
+++ b/server/api/src/routes/notes/types.ts
@@ -78,14 +78,17 @@ export interface NotePageApiItem {
   source_page_id: string | null;
   title: string | null;
   /**
-   * Issue #849 移行措置: レスポンス軽量化のため、サーバは常に `null` を返す。
-   * 型は後段で削除される予定。プレビュー本文が必要な呼び出し元は個別ページ取得
-   * (`GET /api/pages/:id`) や検索結果 (`GET /api/search`) を使う。
+   * 一覧カード描画用の先頭プレビュー (`pages.content_preview`)。本文 fetch を
+   * 伴わずにカードへ表示するために、保存時に算出した短い抜粋を返す。Issue #849
+   * で一時的に常時 `null` 化していたが、Issue #860 Phase 0 で復旧した。
+   * Phase 1 以降でノートシェルとページ一覧の API が分離されたら、本フィールド
+   * は `GET /api/notes/:noteId/pages?include=preview` 側で提供される予定。
    *
-   * Migration step for #849: the server now always returns `null` to keep the
-   * response slim. The field is slated for removal in a follow-up. Callers
-   * that need the body preview should hit `GET /api/pages/:id` or the search
-   * endpoint instead.
+   * Short head-of-body preview (`pages.content_preview`) used to render list
+   * cards without fetching full page bodies. Temporarily forced to `null` by
+   * Issue #849 and restored by Issue #860 Phase 0. Once Phase 1 splits the
+   * note-shell and page-list APIs, this field will live on
+   * `GET /api/notes/:noteId/pages?include=preview` instead.
    */
   content_preview: string | null;
   thumbnail_url: string | null;


### PR DESCRIPTION
## 概要

Issue #849 で一時的に常時 `null` に設定していた `content_preview` フィールドを、Issue #860 Phase 0 として復旧します。保存時に算出した先頭抜粋をそのまま返すことで、ノート一覧カードの描画時に本文 fetch を伴わないプレビュー表示が可能になります。

## 変更点

- **`GET /api/notes/:noteId` レスポンス形状の変更**: `pages` 配列内の各ページオブジェクトに `content_preview` フィールドを復旧。保存時に生成された値（または `null`）をそのまま返す
- **ETag バージョニング**: レスポンス形状の変更に対応するため、`NOTE_DETAIL_RESPONSE_VERSION` を導入し ETag に混ぜることで、クライアント側の古いキャッシュが 304 で再利用されるのを防止
- **テスト追加**: `content_preview` が正しく返される場合と、保存時にプレビューが未生成の場合（`null`）の両方をカバーするテストを追加

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `bun test server/api/src/__tests__/routes/notes/crud.test.ts` を実行し、新規テストを含むすべてのテストが通ることを確認
2. 既存の `"should include page data in snake_case within pages array"` テストが `content_preview: "Preview body..."` を期待値として検証
3. 新規テスト `"should return content_preview as null when the page has no stored preview"` が `content_preview: null` のセマンティクスを保証

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] コメント・ドキュメントを日本語・英語で併記

## 関連 Issue

Closes #860 (Phase 0)

https://claude.ai/code/session_01Qnb9N6EkHwHCTQQGRv4Psz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the `content_preview` field in note page responses, allowing content previews to display correctly in the API
  * Updated response caching to invalidate outdated cached data

* **Documentation**
  * Updated API documentation to clarify the `content_preview` field behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/861)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->