### PR TITLE
feat: implement keyset cursor pagination for note pages (issue #860 Phase 3)

### DIFF
--- a/src/components/page/PageGrid.test.tsx
+++ b/src/components/page/PageGrid.test.tsx
@@ -24,9 +24,18 @@ const personalQueryData: { current: PageSummary[] | undefined; isLoading: boolea
   current: undefined,
   isLoading: false,
 };
-const noteQueryData: { current: PageSummary[] | undefined; isLoading: boolean } = {
+const noteInfiniteData: {
+  current: PageSummary[] | undefined;
+  isLoading: boolean;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: ReturnType<typeof vi.fn>;
+} = {
   current: undefined,
   isLoading: false,
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  fetchNextPage: vi.fn(),
 };
 
 vi.mock("@/hooks/usePageQueries", () => ({
@@ -38,7 +47,17 @@ vi.mock("@/hooks/usePageQueries", () => ({
 }));
 
 vi.mock("@/hooks/useNoteQueries", () => ({
-  useNotePages: () => ({ data: noteQueryData.current, isLoading: noteQueryData.isLoading }),
+  useInfiniteNotePages: () => ({
+    pages: noteInfiniteData.current ?? [],
+    rawPages: [],
+    isLoading: noteInfiniteData.isLoading,
+    isFetching: false,
+    isFetchingNextPage: noteInfiniteData.isFetchingNextPage,
+    hasNextPage: noteInfiniteData.hasNextPage,
+    fetchNextPage: noteInfiniteData.fetchNextPage,
+    refetch: vi.fn(),
+    error: null,
+  }),
 }));
 
 vi.mock("./PageCard", () => ({
@@ -94,8 +113,11 @@ function makePages(n: number): PageSummary[] {
 beforeEach(() => {
   personalQueryData.current = undefined;
   personalQueryData.isLoading = false;
-  noteQueryData.current = undefined;
-  noteQueryData.isLoading = false;
+  noteInfiniteData.current = undefined;
+  noteInfiniteData.isLoading = false;
+  noteInfiniteData.hasNextPage = false;
+  noteInfiniteData.isFetchingNextPage = false;
+  noteInfiniteData.fetchNextPage = vi.fn();
 });
 
 describe("PageGrid", () => {
@@ -114,7 +136,7 @@ describe("PageGrid", () => {
   });
 
   it("renders a small bounded number of PageCards for a 1000-page note", () => {
-    noteQueryData.current = makePages(1000);
+    noteInfiniteData.current = makePages(1000);
     render(<PageGrid noteId="note-1" />);
 
     const cards = screen.queryAllByTestId("page-card");
@@ -126,7 +148,7 @@ describe("PageGrid", () => {
 
   it("renders only the visible window of pages, not all of them", () => {
     const allPages = makePages(500);
-    noteQueryData.current = allPages;
+    noteInfiniteData.current = allPages;
     render(<PageGrid noteId="note-2" />);
 
     const cards = screen.queryAllByTestId("page-card");
@@ -138,12 +160,55 @@ describe("PageGrid", () => {
   });
 
   it("renders the first page first (sorted by updatedAt desc)", () => {
-    noteQueryData.current = makePages(20);
+    noteInfiniteData.current = makePages(20);
     render(<PageGrid noteId="note-3" />);
 
     const cards = screen.queryAllByTestId("page-card");
     // 先頭のカードは最新の updatedAt = page-0。
     // First rendered card is the most-recently-updated (page-0 in our mock).
     expect(cards[0]?.dataset.pageId).toBe("page-0");
+  });
+
+  it("calls fetchNextPage when virtual range nears the tail and more pages exist", () => {
+    // 仮想化モックは先頭から `VIRTUAL_VISIBLE + overscan` 行を返す（合計 14 行 ≒
+    // 14 行分のページ）。`hasNextPage` を true にすると、infinite query の末尾
+    // 検知が走り `fetchNextPage` を呼ぶ。columns=4 / 14 行 → 56 件以下の少量
+    // データで、虚像 range の末尾が `rowCount - threshold` を超える条件を作る。
+    //
+    // The virtualizer mock returns the first `VIRTUAL_VISIBLE + overscan`
+    // rows. With `hasNextPage: true` and a page count small enough that the
+    // tail of the virtual range crosses `rowCount - threshold`, PageGrid
+    // should request the next infinite window.
+    noteInfiniteData.current = makePages(20);
+    noteInfiniteData.hasNextPage = true;
+    const fetchNextPage = vi.fn();
+    noteInfiniteData.fetchNextPage = fetchNextPage;
+
+    render(<PageGrid noteId="note-tail" />);
+
+    expect(fetchNextPage).toHaveBeenCalled();
+  });
+
+  it("does not call fetchNextPage while a window is already being fetched", () => {
+    noteInfiniteData.current = makePages(20);
+    noteInfiniteData.hasNextPage = true;
+    noteInfiniteData.isFetchingNextPage = true;
+    const fetchNextPage = vi.fn();
+    noteInfiniteData.fetchNextPage = fetchNextPage;
+
+    render(<PageGrid noteId="note-tail-busy" />);
+
+    expect(fetchNextPage).not.toHaveBeenCalled();
+  });
+
+  it("does not call fetchNextPage when hasNextPage is false", () => {
+    noteInfiniteData.current = makePages(20);
+    noteInfiniteData.hasNextPage = false;
+    const fetchNextPage = vi.fn();
+    noteInfiniteData.fetchNextPage = fetchNextPage;
+
+    render(<PageGrid noteId="note-end" />);
+
+    expect(fetchNextPage).not.toHaveBeenCalled();
   });
 });

--- a/src/components/page/PageGrid.tsx
+++ b/src/components/page/PageGrid.tsx
@@ -247,6 +247,20 @@ const PageGrid: React.FC<PageGridProps> = ({
   const virtualRows = rowVirtualizer.getVirtualItems();
   const totalHeight = rowVirtualizer.getTotalSize();
 
+  // `getVirtualItems()` はスクロールごとに新しい配列を返すため、依存配列に
+  // そのまま入れるとエフェクトが毎フレーム再評価される。実際に末尾検知に
+  // 必要なのは「最後に見えている row の index」だけなので、それだけを派生
+  // 値として取り出して依存にする（gemini-code-assist PR #866 review）。
+  // `virtualRows` が空のときは `-1` にフォールバックして無効化する。
+  //
+  // `getVirtualItems()` returns a fresh array on every scroll, so depending
+  // on it re-runs the effect every frame. Only the trailing virtual index
+  // matters for tail detection — derive it once and depend on that scalar
+  // instead (gemini-code-assist on PR #866). Empty windows fall back to
+  // `-1`, which the effect treats as "no last row, do nothing".
+  const lastVirtualIndex =
+    virtualRows.length > 0 ? (virtualRows[virtualRows.length - 1]?.index ?? -1) : -1;
+
   // 仮想 range の末尾が `rowCount - threshold` を超えたら次の window を取りに
   // 行く（issue #860 Phase 3）。`hasNextPage` と `isFetchingNextPage` でガード
   // することで、末尾到達後の追加呼び出しと in-flight 中の重複呼び出しを抑止
@@ -260,10 +274,8 @@ const PageGrid: React.FC<PageGridProps> = ({
   useEffect(() => {
     if (!isNoteContext) return;
     if (!noteInfinite.hasNextPage || noteInfinite.isFetchingNextPage) return;
-    if (virtualRows.length === 0) return;
-    const lastVisibleRow = virtualRows[virtualRows.length - 1];
-    if (!lastVisibleRow) return;
-    if (lastVisibleRow.index >= rowCount - INFINITE_FETCH_THRESHOLD_ROWS) {
+    if (lastVirtualIndex === -1) return;
+    if (lastVirtualIndex >= rowCount - INFINITE_FETCH_THRESHOLD_ROWS) {
       noteInfinite.fetchNextPage();
     }
   }, [
@@ -271,7 +283,7 @@ const PageGrid: React.FC<PageGridProps> = ({
     noteInfinite.hasNextPage,
     noteInfinite.isFetchingNextPage,
     noteInfinite.fetchNextPage,
-    virtualRows,
+    lastVirtualIndex,
     rowCount,
   ]);
 

--- a/src/components/page/PageGrid.tsx
+++ b/src/components/page/PageGrid.tsx
@@ -3,12 +3,24 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { useAuth } from "@/hooks/useAuth";
 import { useContainerColumns } from "@/hooks/useContainerColumns";
 import { usePagesSummary, useSyncStatus } from "@/hooks/usePageQueries";
-import { useNotePages } from "@/hooks/useNoteQueries";
+import { useInfiniteNotePages } from "@/hooks/useNoteQueries";
 import PageCard from "./PageCard";
 import EmptyState from "./EmptyState";
 import { cn, Skeleton } from "@zedi/ui";
 import { hasNeverSynced } from "@/lib/sync";
 import type { PageSummary } from "@/types/page";
+
+/**
+ * 末尾検知の前倒し量（行数）。virtual range の末尾がリストの末尾から
+ * `INFINITE_FETCH_THRESHOLD_ROWS` 行以内に入ったら次の window をフェッチする。
+ * 数値が大きいほどスクロール体感は滑らかになる代わりに余分なリクエストが
+ * 増えるため、virtualizer の `overscan` (4) と同じオーダーに揃える。
+ *
+ * Number of rows from the tail at which we trigger the next infinite fetch.
+ * Matches the virtualizer's `overscan`, so the next window is requested
+ * roughly as the user enters the overscan zone.
+ */
+const INFINITE_FETCH_THRESHOLD_ROWS = 4;
 
 const skeletonItems = Array.from({ length: 20 }, (_, index) => index);
 
@@ -159,19 +171,35 @@ const PageGrid: React.FC<PageGridProps> = ({
   // Personal pages source. Always invoked to satisfy hook rules, but ignored
   // when a `noteId` is provided.
   const personalQuery = usePagesSummary({ enabled: !isNoteContext });
-  const noteQuery = useNotePages(noteId ?? "", undefined, isNoteContext);
+  // ノート文脈では keyset cursor pagination 経路 (`GET /api/notes/:id/pages`)
+  // を `useInfiniteQuery` で段階取得する（issue #860 Phase 3）。サーバ順は
+  // `updated_at DESC, id DESC` で固定されているため、ここで再ソートはしない。
+  // In a note context, fetch the page list as a keyset-paginated infinite
+  // query (issue #860 Phase 3). The server's `updated_at DESC, id DESC` order
+  // is preserved verbatim; no client-side resort.
+  const noteInfinite = useInfiniteNotePages(noteId ?? "", { enabled: isNoteContext });
 
-  const pages: PageSummary[] = isNoteContext
-    ? ((noteQuery.data ?? []) as PageSummary[])
-    : (personalQuery.data ?? []);
-  const isLoading = isNoteContext ? noteQuery.isLoading : personalQuery.isLoading;
+  const pages: PageSummary[] = isNoteContext ? noteInfinite.pages : (personalQuery.data ?? []);
+  const isLoading = isNoteContext ? noteInfinite.isLoading : personalQuery.isLoading;
 
   const syncStatus = useSyncStatus();
   const { isSignedIn } = useAuth();
 
+  // 個人ページ集合は IndexedDB から「全件」が返るので、未取得の差分を埋める
+  // ためにここで `updatedAt DESC` ソート + `isDeleted` フィルタが必要。
+  // ノート文脈ではサーバが既に `(updated_at DESC, id DESC)` で返し、`is_deleted`
+  // も除外済みなので、フィルタ・ソートを再適用しない（issue #860 Phase 3 の
+  // 「PageGrid 側で再 sort せず、サーバ順を信頼する」要件）。
+  //
+  // Personal pages come straight from IndexedDB so the client still has to
+  // filter soft-deleted rows and reapply `updatedAt DESC`. For note pages we
+  // trust the server's `(updated_at DESC, id DESC)` ordering and the
+  // `is_deleted = false` predicate enforced by `GET /api/notes/:id/pages`,
+  // matching the Phase 3 requirement to stop re-sorting on the client.
   const sortedPages = useMemo(() => {
+    if (isNoteContext) return pages;
     return [...pages].filter((p) => !p.isDeleted).sort((a, b) => b.updatedAt - a.updatedAt);
-  }, [pages]);
+  }, [isNoteContext, pages]);
 
   // 同期スケルトンは個人ページ向けの初回同期インジケータなのでノート文脈では出さない。
   // The sync-driven skeleton is a personal-pages first-sync indicator and is
@@ -218,6 +246,34 @@ const PageGrid: React.FC<PageGridProps> = ({
 
   const virtualRows = rowVirtualizer.getVirtualItems();
   const totalHeight = rowVirtualizer.getTotalSize();
+
+  // 仮想 range の末尾が `rowCount - threshold` を超えたら次の window を取りに
+  // 行く（issue #860 Phase 3）。`hasNextPage` と `isFetchingNextPage` でガード
+  // することで、末尾到達後の追加呼び出しと in-flight 中の重複呼び出しを抑止
+  // する。`infiniteHook` は個人ページ文脈では呼ばない（`useInfiniteNotePages`
+  // 自身が `enabled` ガードしているのでフックは安全）。
+  //
+  // Trigger `fetchNextPage()` once the rendered virtual range gets within
+  // `INFINITE_FETCH_THRESHOLD_ROWS` of the loaded tail (issue #860 Phase 3).
+  // `hasNextPage` / `isFetchingNextPage` guard against fetching past the end
+  // of the list and against duplicate in-flight calls.
+  useEffect(() => {
+    if (!isNoteContext) return;
+    if (!noteInfinite.hasNextPage || noteInfinite.isFetchingNextPage) return;
+    if (virtualRows.length === 0) return;
+    const lastVisibleRow = virtualRows[virtualRows.length - 1];
+    if (!lastVisibleRow) return;
+    if (lastVisibleRow.index >= rowCount - INFINITE_FETCH_THRESHOLD_ROWS) {
+      noteInfinite.fetchNextPage();
+    }
+  }, [
+    isNoteContext,
+    noteInfinite.hasNextPage,
+    noteInfinite.isFetchingNextPage,
+    noteInfinite.fetchNextPage,
+    virtualRows,
+    rowCount,
+  ]);
 
   return (
     <div ref={containerRef} className="pb-24">

--- a/src/hooks/useInfiniteNotePages.test.tsx
+++ b/src/hooks/useInfiniteNotePages.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * `useInfiniteNotePages` unit tests (issue #860 Phase 3).
+ *
+ * keyset cursor を辿る経路、`next_cursor: null` 終端、include / pageSize の
+ * クエリ反映、フラット化したサマリの順序を検証する。
+ *
+ * Verifies the keyset-cursor pagination flow, terminal `next_cursor: null`
+ * handling, propagation of `include` / `pageSize` to the API client, and the
+ * flattened summary ordering returned by the hook.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { NotePageWindowItem, NotePageWindowResponse } from "@/lib/api/types";
+
+const mockGetNotePages = vi.fn();
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({
+    getToken: vi.fn().mockResolvedValue(null),
+    isSignedIn: true,
+    userId: "user-1",
+    isLoaded: true,
+  }),
+  useUser: () => ({
+    user: { primaryEmailAddress: { emailAddress: "user-1@example.com" } },
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  createApiClient: () => ({
+    getNotePages: (
+      noteId: string,
+      params: {
+        cursor?: string | null;
+        limit?: number;
+        include?: ReadonlyArray<"preview" | "thumbnail">;
+      },
+    ) => mockGetNotePages(noteId, params),
+  }),
+}));
+
+// `pageKeys` / `useRepository` は他のミューテーション系で参照されるだけで、
+// `useInfiniteNotePages` 単体テストでは触らないので空モックで十分。
+// `pageKeys` / `useRepository` only matter for the mutation hooks; stub them so
+// importing the module under test does not pull in IndexedDB plumbing.
+vi.mock("@/hooks/usePageQueries", () => ({
+  pageKeys: { list: () => [], summary: () => [], byTitles: () => [], all: [] },
+  useRepository: () => ({ getRepository: vi.fn() }),
+}));
+
+import { useInfiniteNotePages } from "./useNoteQueries";
+
+function makeItem(id: string, updatedAt: string): NotePageWindowItem {
+  return {
+    id,
+    owner_id: "user-1",
+    note_id: "note-1",
+    source_page_id: null,
+    title: `Title ${id}`,
+    content_preview: `preview ${id}`,
+    thumbnail_url: null,
+    source_url: null,
+    created_at: updatedAt,
+    updated_at: updatedAt,
+    is_deleted: false,
+  };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function wrapperWithClient(client: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+beforeEach(() => {
+  mockGetNotePages.mockReset();
+});
+
+describe("useInfiniteNotePages", () => {
+  it("issues the first request without a cursor and with default include / pageSize", async () => {
+    const resp: NotePageWindowResponse = {
+      items: [makeItem("p1", "2026-05-13T10:00:00.000000Z")],
+      next_cursor: null,
+    };
+    mockGetNotePages.mockResolvedValueOnce(resp);
+
+    const { result } = renderHook(() => useInfiniteNotePages("note-1"), {
+      wrapper: wrapperWithClient(makeQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockGetNotePages).toHaveBeenCalledTimes(1);
+    expect(mockGetNotePages).toHaveBeenCalledWith("note-1", {
+      cursor: null,
+      limit: 50,
+      include: ["preview", "thumbnail"],
+    });
+    expect(result.current.pages).toHaveLength(1);
+    expect(result.current.pages[0]?.id).toBe("p1");
+    expect(result.current.pages[0]?.contentPreview).toBe("preview p1");
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("threads next_cursor into the next request and flattens both windows", async () => {
+    mockGetNotePages
+      .mockResolvedValueOnce({
+        items: [makeItem("p1", "2026-05-13T10:00:00.000000Z")],
+        next_cursor: "cursor-abc",
+      })
+      .mockResolvedValueOnce({
+        items: [makeItem("p2", "2026-05-13T09:00:00.000000Z")],
+        next_cursor: null,
+      });
+
+    const { result } = renderHook(
+      () => useInfiniteNotePages("note-1", { pageSize: 25, include: ["preview"] }),
+      { wrapper: wrapperWithClient(makeQueryClient()) },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.hasNextPage).toBe(true);
+    expect(mockGetNotePages).toHaveBeenLastCalledWith("note-1", {
+      cursor: null,
+      limit: 25,
+      include: ["preview"],
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(result.current.isFetchingNextPage).toBe(false));
+    expect(mockGetNotePages).toHaveBeenCalledTimes(2);
+    expect(mockGetNotePages).toHaveBeenLastCalledWith("note-1", {
+      cursor: "cursor-abc",
+      limit: 25,
+      include: ["preview"],
+    });
+    expect(result.current.pages.map((p) => p.id)).toEqual(["p1", "p2"]);
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("does not fetch when disabled via the enabled option", async () => {
+    mockGetNotePages.mockResolvedValue({ items: [], next_cursor: null });
+
+    const { result } = renderHook(() => useInfiniteNotePages("note-1", { enabled: false }), {
+      wrapper: wrapperWithClient(makeQueryClient()),
+    });
+
+    // 同期的に何も読みに行かないことを最低限確認する。`useQuery` の `enabled:
+    // false` 経路は `isLoading` が `false` のまま保たれる。
+    // Verify the disabled gate keeps the query inert; `useQuery({ enabled:
+    // false })` reports `isLoading: false` and never invokes the queryFn.
+    expect(mockGetNotePages).not.toHaveBeenCalled();
+    expect(result.current.pages).toEqual([]);
+  });
+
+  it("does not fetch when noteId is empty", async () => {
+    mockGetNotePages.mockResolvedValue({ items: [], next_cursor: null });
+
+    renderHook(() => useInfiniteNotePages(""), {
+      wrapper: wrapperWithClient(makeQueryClient()),
+    });
+
+    expect(mockGetNotePages).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useNoteQueries.ts
+++ b/src/hooks/useNoteQueries.ts
@@ -626,7 +626,19 @@ export interface UseInfiniteNotePagesOptions {
   enabled?: boolean;
 }
 
-/** ISO 文字列 → ms 整数。パースできなければ 0 を返す。 */
+/**
+ * `NotePageWindowItem`（snake_case の API 行）を `NotePageSummary`（camelCase の
+ * フロント型）に正規化する。ISO 文字列の timestamp は `parseTs` で ms に
+ * 落とし、`addedByUserId` には `owner_id` を流す（issue #823 以降ページ
+ * オーナー＝追加者と等価で、サーバ window レスポンスも legacy
+ * `added_by_user_id` を返さないため）。
+ *
+ * Maps a `NotePageWindowItem` (snake_case API row) to the camelCase
+ * `NotePageSummary` consumed by the grid. ISO timestamps go through
+ * `parseTs` to millisecond integers, and `addedByUserId` is populated from
+ * `owner_id` since after issue #823 page owner ≡ adder and the windowed
+ * response no longer carries the legacy `added_by_user_id` field.
+ */
 function notePageWindowItemToSummary(p: NotePageWindowItem): NotePageSummary {
   return {
     id: p.id,

--- a/src/hooks/useNoteQueries.ts
+++ b/src/hooks/useNoteQueries.ts
@@ -1,7 +1,10 @@
+import { useMemo } from "react";
 import {
-  useQuery,
+  useInfiniteQuery,
   useMutation,
+  useQuery,
   useQueryClient,
+  type InfiniteData,
   type QueryFunctionContext,
 } from "@tanstack/react-query";
 import { useAuth, useUser } from "@/hooks/useAuth";
@@ -12,6 +15,9 @@ import type {
   NoteMemberItem,
   DiscoverResponse,
   CopyNotePageToPersonalResponse,
+  NotePageWindowInclude,
+  NotePageWindowItem,
+  NotePageWindowResponse,
 } from "@/lib/api/types";
 import type { Note, NoteAccess, NoteMember, NoteMemberRole } from "@/types/note";
 import type { Page, PageSummary } from "@/types/page";
@@ -59,6 +65,44 @@ export const noteKeys = {
     [...noteKeys.all, "public", sort, limit, offset] as const,
   pages: () => [...noteKeys.all, "pages"] as const,
   page: (noteId: string, pageId: string) => [...noteKeys.pages(), noteId, pageId] as const,
+  /**
+   * `useInfiniteNotePages` の queryKey ファクトリ。`useNote` 系の detail キーとは
+   * 別系統で持ち、include トークンと pageSize までキーに含めることで、同一
+   * ノートでも異なる include / pageSize で同居できるようにする（issue #860
+   * Phase 3）。
+   *
+   * Query-key factory for `useInfiniteNotePages`. Kept separate from the
+   * `useNote` detail key so the windowed list does not collide with the legacy
+   * shell payload. `include` and `pageSize` are part of the key so different
+   * call sites can co-exist without cross-contaminating cached pages
+   * (issue #860 Phase 3).
+   */
+  pagesWindow: (
+    noteId: string,
+    userId: string,
+    userEmail: string | undefined,
+    include: ReadonlyArray<NotePageWindowInclude>,
+    pageSize: number,
+  ) =>
+    [
+      ...noteKeys.pages(),
+      "window",
+      noteId,
+      userId,
+      userEmail ?? "",
+      [...include].sort().join(","),
+      pageSize,
+    ] as const,
+  /**
+   * `noteId` 配下のすべての window エントリ（任意の include / pageSize / 認証
+   * プリンシパル）にマッチするプレフィックスキー。Mutation 後の
+   * `invalidateQueries` ターゲットに使う。
+   *
+   * Prefix key matching every window entry for a note regardless of include
+   * tokens, page size, or auth principal. Used as the invalidation target
+   * after mutations that change the note's page list.
+   */
+  pagesWindowByNoteId: (noteId: string) => [...noteKeys.pages(), "window", noteId] as const,
   members: () => [...noteKeys.all, "members"] as const,
   memberList: (noteId: string) => [...noteKeys.members(), noteId] as const,
 };
@@ -528,6 +572,167 @@ export function useNotePages(
 }
 
 /**
+ * `useInfiniteNotePages` のデフォルト 1 ページサイズ（issue #860 Phase 3）。
+ * サーバ側上限 ({@link MAX_PAGES_LIMIT}) と整合させる。
+ *
+ * Default page size for `useInfiniteNotePages` (issue #860 Phase 3). Aligned
+ * with the server-side cap defined in
+ * `server/api/src/routes/notes/pages.ts` (`MAX_PAGES_LIMIT = 100`).
+ */
+export const DEFAULT_INFINITE_NOTE_PAGES_SIZE = 50;
+
+/**
+ * `useInfiniteNotePages` のデフォルト include。一覧カード描画には preview と
+ * thumbnail が必要なため、両方とも要求する。
+ *
+ * Default `include` set for `useInfiniteNotePages`. The grid cards render the
+ * head preview and the thumbnail, so both extras are requested.
+ */
+const DEFAULT_INFINITE_NOTE_PAGES_INCLUDE: ReadonlyArray<NotePageWindowInclude> = [
+  "preview",
+  "thumbnail",
+];
+
+/**
+ * `useInfiniteNotePages` のオプション。
+ *
+ * Options for {@link useInfiniteNotePages}.
+ */
+export interface UseInfiniteNotePagesOptions {
+  /**
+   * 取得する追加フィールド。デフォルトでは `preview` と `thumbnail` の両方を
+   * 要求する。サーバは未指定トークンを無視するため、将来追加された値も後方
+   * 互換に渡せる。
+   *
+   * Optional extra fields to request via `?include=`. Defaults to both
+   * `preview` and `thumbnail`. The server silently drops unknown tokens, so
+   * passing future values stays backward compatible.
+   */
+  include?: ReadonlyArray<NotePageWindowInclude>;
+  /**
+   * 1 ページあたりの取得件数（1..100）。省略時は {@link DEFAULT_INFINITE_NOTE_PAGES_SIZE}。
+   *
+   * Items per request (1..100). Defaults to
+   * {@link DEFAULT_INFINITE_NOTE_PAGES_SIZE}.
+   */
+  pageSize?: number;
+  /**
+   * 取得を抑止するゲート。`noteId` がまだ確定していない、もしくは権限判定が
+   * 終わるまで遅らせたい呼び出し側で使う。
+   *
+   * Gate to suppress fetching, e.g. while `noteId` is still being resolved or
+   * before the caller has confirmed view permission.
+   */
+  enabled?: boolean;
+}
+
+/** ISO 文字列 → ms 整数。パースできなければ 0 を返す。 */
+function notePageWindowItemToSummary(p: NotePageWindowItem): NotePageSummary {
+  return {
+    id: p.id,
+    ownerUserId: p.owner_id,
+    noteId: p.note_id,
+    title: p.title ?? "",
+    contentPreview: p.content_preview ?? undefined,
+    thumbnailUrl: p.thumbnail_url ?? undefined,
+    sourceUrl: p.source_url ?? undefined,
+    createdAt: parseTs(p.created_at),
+    updatedAt: parseTs(p.updated_at),
+    isDeleted: p.is_deleted,
+    // issue #823 以降「ページを追加した人」 ≒ ページの owner。
+    // After issue #823 the page owner is effectively the "adder", so reuse
+    // `owner_id` to keep the `addedByUserId` slot populated for delete-guard UX.
+    addedByUserId: p.owner_id,
+  };
+}
+
+/**
+ * ノート配下のページ一覧を keyset cursor pagination で段階取得するフック
+ * （issue #860 Phase 3）。サーバの `GET /api/notes/:noteId/pages` 経路に
+ * 対応し、`fetchNextPage()` で `next_cursor` を辿る。React Query の
+ * `useInfiniteQuery` を使うので、UI 側は仮想スクロールの末尾検知から
+ * 続きを要求するだけで済む。
+ *
+ * 戻り値の `pages` は全 window をフラット化した {@link NotePageSummary} 配列
+ * （サーバ順 `updated_at DESC, id DESC` を維持）。`hasNextPage` /
+ * `isFetchingNextPage` は仮想スクロール側で「これ以上要求しない」「重複呼び
+ * 出しを抑止する」ためにそのまま使う。
+ *
+ * Step-paginated infinite query for a note's page list (issue #860 Phase 3).
+ * Wraps `GET /api/notes/:noteId/pages` and threads the opaque `next_cursor`
+ * back into the next request via `useInfiniteQuery`. UI consumers can flip
+ * the `pages` array directly into a virtualized list and trigger
+ * `fetchNextPage()` when the visible window approaches the tail.
+ *
+ * Returned `pages` is the flattened, server-ordered (`updated_at DESC,
+ * id DESC`) array of {@link NotePageSummary}. `hasNextPage` /
+ * `isFetchingNextPage` are surfaced so the caller can debounce repeated
+ * tail-trigger fetches.
+ */
+export function useInfiniteNotePages(noteId: string, options: UseInfiniteNotePagesOptions = {}) {
+  const { api, userId, userEmail, isLoaded } = useNoteApi();
+  const include = options.include ?? DEFAULT_INFINITE_NOTE_PAGES_INCLUDE;
+  const pageSize = options.pageSize ?? DEFAULT_INFINITE_NOTE_PAGES_SIZE;
+  const enabled = (options.enabled ?? true) && isLoaded && !!noteId;
+
+  const query = useInfiniteQuery<
+    NotePageWindowResponse,
+    Error,
+    InfiniteData<NotePageWindowResponse, string | null>,
+    readonly unknown[],
+    string | null
+  >({
+    queryKey: noteKeys.pagesWindow(noteId, userId, userEmail, include, pageSize),
+    queryFn: async (ctx): Promise<NotePageWindowResponse> => {
+      const cursor = ctx.pageParam ?? null;
+      return api.getNotePages(noteId, {
+        cursor,
+        limit: pageSize,
+        include,
+      });
+    },
+    enabled,
+    // 先頭リクエストは cursor 無し。サーバが `next_cursor: null` を返したら
+    // `getNextPageParam` は `undefined` を返して infinite query が終端を認識する。
+    // First request has no cursor; once the server returns `next_cursor: null`
+    // we report `undefined` to mark the end of the list to React Query.
+    initialPageParam: null,
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+  });
+
+  // `select` を使わずに導出してメモ化する。`useInfiniteQuery` の `select` は
+  // 各 page を変換するか、全体を変換するか型が複雑になりやすいので、
+  // ここでは導出値だけ `useMemo` で計算する。
+  // Derive the flattened summary list outside `select` to keep the generic
+  // types simple; `useInfiniteQuery` re-runs the selector on every cache
+  // update, so wrapping the work in `useMemo` keeps render churn bounded.
+  const flattened = useMemo<NotePageSummary[]>(() => {
+    if (!query.data) return [];
+    const out: NotePageSummary[] = [];
+    for (const window of query.data.pages) {
+      for (const item of window.items) {
+        out.push(notePageWindowItemToSummary(item));
+      }
+    }
+    return out;
+  }, [query.data]);
+
+  return {
+    /** Flattened, server-ordered page summaries across all fetched windows. */
+    pages: flattened,
+    /** Raw infinite-query pages, exposed for advanced callers that need cursor state. */
+    rawPages: query.data?.pages ?? [],
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    isFetchingNextPage: query.isFetchingNextPage,
+    hasNextPage: query.hasNextPage,
+    fetchNextPage: query.fetchNextPage,
+    refetch: query.refetch,
+    error: query.error,
+  };
+}
+
+/**
  * ノート内の単一ページ（noteId + pageId）を取得するフック。
  * Hook that fetches a single page within a note by noteId + pageId.
  */
@@ -672,6 +877,12 @@ export function useAddPageToNote() {
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: noteKeys.detailsByNoteId(variables.noteId) });
       queryClient.invalidateQueries({ queryKey: noteKeys.details() });
+      // issue #860 Phase 3: 新規ページは window の先頭に来るので、すべての
+      // include / pageSize 組合せをまとめて再フェッチさせる。
+      // Issue #860 Phase 3: invalidate every windowed cache for this note so
+      // the newly created page shows up at the top regardless of include /
+      // pageSize variant.
+      queryClient.invalidateQueries({ queryKey: noteKeys.pagesWindowByNoteId(variables.noteId) });
     },
   });
 }
@@ -695,6 +906,9 @@ export function useCopyPersonalPageToNote() {
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: noteKeys.detailsByNoteId(variables.noteId) });
       queryClient.invalidateQueries({ queryKey: noteKeys.details() });
+      // issue #860 Phase 3: window 経路の infinite cache も合わせて更新。
+      // Issue #860 Phase 3: also refresh the windowed infinite cache.
+      queryClient.invalidateQueries({ queryKey: noteKeys.pagesWindowByNoteId(variables.noteId) });
     },
   });
 }
@@ -795,6 +1009,9 @@ export function useRemovePageFromNote() {
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: noteKeys.detailsByNoteId(variables.noteId) });
       queryClient.invalidateQueries({ queryKey: noteKeys.details() });
+      // issue #860 Phase 3: 削除後の window を再フェッチする。
+      // Issue #860 Phase 3: refresh the windowed infinite cache after deletion.
+      queryClient.invalidateQueries({ queryKey: noteKeys.pagesWindowByNoteId(variables.noteId) });
     },
   });
 }

--- a/src/lib/api/apiClient.test.ts
+++ b/src/lib/api/apiClient.test.ts
@@ -856,4 +856,118 @@ describe("apiClient", () => {
       expect((init.headers as Record<string, string>)["If-None-Match"]).toBeUndefined();
     });
   });
+
+  // ── getNotePages (keyset cursor pagination, Issue #860 Phase 1/3) ──────────
+  describe("getNotePages", () => {
+    function emptyWindowBody() {
+      return JSON.stringify({ items: [], next_cursor: null });
+    }
+
+    it("omits cursor / limit / include query params when not supplied", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: emptyWindowBody(),
+          headers: new Headers(),
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+      await client.getNotePages("note-1");
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const parsed = new URL(url);
+      expect(parsed.pathname).toBe("/api/notes/note-1/pages");
+      expect(parsed.searchParams.has("cursor")).toBe(false);
+      expect(parsed.searchParams.has("limit")).toBe(false);
+      expect(parsed.searchParams.has("include")).toBe(false);
+    });
+
+    it("encodes cursor, limit, and include as query params", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: emptyWindowBody(),
+          headers: new Headers(),
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+      await client.getNotePages("note-1", {
+        cursor: "cursor-abc",
+        limit: 25,
+        include: ["preview", "thumbnail"],
+      });
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get("cursor")).toBe("cursor-abc");
+      expect(parsed.searchParams.get("limit")).toBe("25");
+      // 順序はクライアント側で `sort` していないため、`include` の出力順は入力順に従う。
+      // The client does not sort `include` tokens, so the value preserves call order.
+      expect(parsed.searchParams.get("include")).toBe("preview,thumbnail");
+    });
+
+    it("deduplicates repeated include tokens", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: emptyWindowBody(),
+          headers: new Headers(),
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+      await client.getNotePages("note-1", {
+        include: ["preview", "preview", "thumbnail"],
+      });
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get("include")).toBe("preview,thumbnail");
+    });
+
+    it("returns the parsed { items, next_cursor } body", async () => {
+      const body = {
+        items: [
+          {
+            id: "p1",
+            owner_id: "u1",
+            note_id: "note-1",
+            source_page_id: null,
+            title: "Page 1",
+            content_preview: "preview",
+            thumbnail_url: null,
+            source_url: null,
+            created_at: "2026-05-13T00:00:00.000000Z",
+            updated_at: "2026-05-13T00:00:00.000000Z",
+            is_deleted: false,
+          },
+        ],
+        next_cursor: "next-cursor",
+      };
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: JSON.stringify(body),
+          headers: new Headers(),
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+      const result = await client.getNotePages("note-1");
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.id).toBe("p1");
+      expect(result.next_cursor).toBe("next-cursor");
+    });
+  });
 });

--- a/src/lib/api/apiClient.ts
+++ b/src/lib/api/apiClient.ts
@@ -32,6 +32,8 @@ import type {
   InviteLinkRow,
   DomainAccessRow,
   CreateDomainAccessBody,
+  NotePageWindowInclude,
+  NotePageWindowResponse,
 } from "./types";
 
 export type { NoteListItem };
@@ -401,6 +403,47 @@ export function createApiClient(options?: Partial<ApiClientOptions>) {
           offset: String(opts?.offset ?? 0),
         },
       });
+    },
+
+    /**
+     * `GET /api/notes/:noteId/pages` — keyset cursor pagination で一覧を取得する
+     * 軽量ノートページ window 経路（issue #860 Phase 1）。`include` で
+     * `content_preview` / `thumbnail_url` の同梱を要求する。`cursor` を
+     * 省略すると先頭から取得し、レスポンスの `next_cursor` を次回呼び出しに
+     * そのまま渡す。`next_cursor` が `null` なら末尾まで読み切った状態。
+     * `authOptional` なので、公開 / unlisted ノートは未ログインでも取得できる。
+     *
+     * Keyset-paginated window of a note's pages (issue #860 Phase 1). Echo the
+     * previous response's `next_cursor` back into `cursor` for the next page;
+     * a `null` `next_cursor` means the end has been reached. `include` opts
+     * the heavy `content_preview` / `thumbnail_url` columns back into the row.
+     * The endpoint is `authOptional`, so guests can browse public / unlisted
+     * notes without sign-in.
+     */
+    async getNotePages(
+      noteId: string,
+      params: {
+        cursor?: string | null;
+        limit?: number;
+        include?: ReadonlyArray<NotePageWindowInclude>;
+      } = {},
+    ): Promise<NotePageWindowResponse> {
+      const query: Record<string, string> = {};
+      if (params.cursor) query.cursor = params.cursor;
+      if (params.limit !== undefined) query.limit = String(params.limit);
+      if (params.include && params.include.length > 0) {
+        // 重複トークンは集合化して落とす。サーバ側は未知トークンを無視するが、
+        // URL を簡潔に保つためクライアントでも先に正規化する。
+        // De-duplicate include tokens; the server tolerates unknown values but
+        // keeping the query string tidy avoids confusing log entries.
+        const tokens = Array.from(new Set(params.include));
+        query.include = tokens.join(",");
+      }
+      return reqOptionalAuth<NotePageWindowResponse>(
+        "GET",
+        `/api/notes/${encodeURIComponent(noteId)}/pages`,
+        { query },
+      );
     },
 
     /** GET /api/notes/:id/members — list members. */

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -317,6 +317,49 @@ export interface GetNoteResponse {
   }>;
 }
 
+/**
+ * `?include=` トークンで追加できるオプションフィールド（issue #860 Phase 1）。
+ * `preview` は `content_preview`、`thumbnail` は `thumbnail_url` の同梱を要求する。
+ *
+ * Optional field tokens for `?include=` on `GET /api/notes/:noteId/pages`
+ * (issue #860 Phase 1). `preview` toggles `content_preview` and `thumbnail`
+ * toggles `thumbnail_url`.
+ */
+export type NotePageWindowInclude = "preview" | "thumbnail";
+
+/**
+ * `GET /api/notes/:noteId/pages` のページ行（keyset window）。`content_preview`
+ * と `thumbnail_url` は `?include=` で要求された場合のみ非 null。
+ *
+ * Page summary row from `GET /api/notes/:noteId/pages`. `content_preview` /
+ * `thumbnail_url` are populated only when the matching `?include=` token is set.
+ */
+export interface NotePageWindowItem {
+  id: string;
+  owner_id: string;
+  note_id: string;
+  source_page_id: string | null;
+  title: string | null;
+  content_preview: string | null;
+  thumbnail_url: string | null;
+  source_url: string | null;
+  created_at: string;
+  updated_at: string;
+  is_deleted: boolean;
+}
+
+/**
+ * `GET /api/notes/:noteId/pages` の keyset cursor pagination レスポンス。
+ * `next_cursor` が `null` の場合は末尾まで到達済み。
+ *
+ * Keyset cursor pagination response. A `null` `next_cursor` means the caller
+ * has reached the end of the list.
+ */
+export interface NotePageWindowResponse {
+  items: NotePageWindowItem[];
+  next_cursor: string | null;
+}
+
 /** GET /api/pages/:id/snapshots response. */
 export interface SnapshotListResponse {
   snapshots: SnapshotListItem[];

--- a/src/pages/NoteView/NoteAddPageDialog.tsx
+++ b/src/pages/NoteView/NoteAddPageDialog.tsx
@@ -4,17 +4,28 @@ import { Dialog, DialogContent, useToast } from "@zedi/ui";
 import { useAddPageToNote, useCopyPersonalPageToNote } from "@/hooks/useNoteQueries";
 import { usePagesSummary } from "@/hooks/usePageQueries";
 import { NoteViewAddPageDialogContent } from "./NoteViewAddPageDialogContent";
-import type { PageSummary } from "@/types/page";
 
 /**
  * Props for the controlled add-page dialog.
  * ページ追加ダイアログ（親で開閉制御）の Props。
+ *
+ * Issue #860 Phase 3 で `notePages: PageSummary[]` を除去した。旧コードは
+ * `notePageIds` Set を作って `allPages` から除外していたが、issue #823 以降
+ * ノートネイティブページは個人ページとは別 ID 体系で、一致は発生しないため
+ * 実質 no-op になっていた。重複タイトル判定は将来的に note-scoped 検索 API
+ * に寄せる方針で、ここでは全件配列の依存を断つ。
+ *
+ * Issue #860 Phase 3 dropped the `notePages` prop. The previous implementation
+ * built a `notePageIds` Set and filtered personal pages by it, but since
+ * issue #823 note-native pages live in a different id space from personal
+ * pages so the filter never excluded anything. The duplicate-title check will
+ * move to a note-scoped lookup API later; until then we just stop pulling in
+ * the full note pages array.
  */
 export interface NoteAddPageDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   noteId: string;
-  notePages: PageSummary[];
   canEdit: boolean;
 }
 
@@ -27,13 +38,7 @@ export interface NoteAddPageDialogProps {
  * 検索フィルタ／新規タイトル状態とミューテーションを内部で完結させ、親は
  * ノート情報と開閉制御のみを渡す。
  */
-export function NoteAddPageDialog({
-  open,
-  onOpenChange,
-  noteId,
-  notePages,
-  canEdit,
-}: NoteAddPageDialogProps) {
+export function NoteAddPageDialog({ open, onOpenChange, noteId, canEdit }: NoteAddPageDialogProps) {
   const { t } = useTranslation();
   const { toast } = useToast();
   const addPageMutation = useAddPageToNote();
@@ -43,16 +48,11 @@ export function NoteAddPageDialog({
   const [pageFilter, setPageFilter] = useState("");
   const [newPageTitle, setNewPageTitle] = useState("");
 
-  const notePageIds = useMemo(() => new Set(notePages.map((p) => p.id)), [notePages]);
-  const availablePages = useMemo(
-    () => allPages.filter((p) => !notePageIds.has(p.id)),
-    [allPages, notePageIds],
-  );
   const filteredPages = useMemo(() => {
     const query = pageFilter.trim().toLowerCase();
-    if (!query) return availablePages;
-    return availablePages.filter((p) => (p.title || "").toLowerCase().includes(query));
-  }, [availablePages, pageFilter]);
+    if (!query) return allPages;
+    return allPages.filter((p) => (p.title || "").toLowerCase().includes(query));
+  }, [allPages, pageFilter]);
 
   const runAddPage = async (params: { pageId: string } | { title: string }) => {
     try {

--- a/src/pages/NoteView/NoteView.test.tsx
+++ b/src/pages/NoteView/NoteView.test.tsx
@@ -7,7 +7,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import NoteView from "./index";
-import { useNote, useNotePages } from "@/hooks/useNoteQueries";
+import { useNote } from "@/hooks/useNoteQueries";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -24,7 +24,6 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("@/hooks/useNoteQueries", () => ({
   useNote: vi.fn(),
-  useNotePages: vi.fn(() => ({ data: [], isLoading: false })),
   useAddPageToNote: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useCopyPersonalPageToNote: () => ({
     mutateAsync: vi.fn().mockResolvedValue({ created: true, page_id: "pg", sort_order: 1 }),
@@ -165,7 +164,6 @@ describe("NoteView", () => {
       source: "local",
       isLoading: false,
     } as never);
-    vi.mocked(useNotePages).mockReturnValue({ data: [], isLoading: false } as never);
   });
 
   it("shows loading message when note is loading", () => {
@@ -214,7 +212,6 @@ describe("NoteView", () => {
       source: "local",
       isLoading: false,
     } as never);
-    vi.mocked(useNotePages).mockReturnValue({ data: [], isLoading: false } as never);
     renderNoteView("note-1");
     expect(screen.getByRole("heading", { name: "My Note" })).toBeInTheDocument();
     expect(screen.getByTestId("note-view-header-actions")).toBeInTheDocument();

--- a/src/pages/NoteView/index.tsx
+++ b/src/pages/NoteView/index.tsx
@@ -8,7 +8,7 @@ import { NoteTitleSwitcher } from "@/components/note/NoteTitleSwitcher";
 import { NoteVisibilityBadge } from "@/components/note/NoteVisibilityBadge";
 import { Badge } from "@zedi/ui";
 import { NoteAddPageDialog } from "./NoteAddPageDialog";
-import { useNote, useNotePages } from "@/hooks/useNoteQueries";
+import { useNote } from "@/hooks/useNoteQueries";
 import { useTranslation } from "react-i18next";
 import { getNoteViewPermissions } from "./noteViewHelpers";
 import { PageLoadingOrDenied } from "@/components/layout/PageLoadingOrDenied";
@@ -53,11 +53,13 @@ const NoteView: React.FC = () => {
   const isLoading = isNoteLoading;
   const isNotFound = !note || !access?.canView;
 
-  // `NoteAddPageDialog` の重複検出に使う。グリッド自体は `PageGrid` 内部で
-  // 同じクエリキーを引くので二重フェッチにはならない。
-  // Used for `NoteAddPageDialog` dedup; the grid reuses the same React Query
-  // key, so this is a cache hit.
-  const { data: notePages = [] } = useNotePages(noteId ?? "", noteSource, Boolean(access?.canView));
+  // issue #860 Phase 3: `NoteAddPageDialog` は `notePages` 配列を受け取らなくなった
+  // （重複判定の no-op 化に伴い prop ごと除去）。ノートのページ一覧は `PageGrid`
+  // 配下の `useInfiniteNotePages` だけが取りに行く。
+  // Issue #860 Phase 3: `NoteAddPageDialog` no longer takes a `notePages`
+  // array — the duplicate filter was a no-op and the prop was removed. The
+  // note's page list is now fetched only by `useInfiniteNotePages` inside
+  // `PageGrid`.
 
   const [isAddPageOpen, setIsAddPageOpen] = useState(false);
 
@@ -170,7 +172,6 @@ const NoteView: React.FC = () => {
           open={isAddPageOpen}
           onOpenChange={setIsAddPageOpen}
           noteId={note.id}
-          notePages={notePages}
           canEdit={canEdit}
         />
       )}


### PR DESCRIPTION
## 概要

ノートのページ一覧取得を keyset cursor pagination で段階取得する機能を実装しました。`useInfiniteNotePages` フックを新規追加し、React Query の `useInfiniteQuery` を使用して大規模ノートでも効率的にページを読み込めるようにしました。

## 変更点

- **新規フック `useInfiniteNotePages`**: keyset cursor pagination で段階取得するフック。`fetchNextPage()` で次の window を取得でき、仮想スクロール対応が容易
- **API クライアント拡張**: `getNotePages()` メソッドを追加。`cursor`, `limit`, `include` パラメータをサポート
- **Query key ファクトリ拡張**: `noteKeys.pagesWindow()` と `noteKeys.pagesWindowByNoteId()` を追加。include / pageSize の組み合わせごとにキャッシュを分離
- **PageGrid 更新**: `useNotePages()` から `useInfiniteNotePages()` に切り替え。仮想スクロール末尾検知で自動的に次の window を取得
- **Mutation 後の無効化**: ページ追加・削除時に `pagesWindowByNoteId` キーで全 window キャッシュを無効化
- **NoteAddPageDialog 簡素化**: 全ページ配列の依存を削除。note-scoped 検索 API への移行を見据えた設計

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `bun run test` で単体テストが全てパス
   - `useInfiniteNotePages.test.tsx`: cursor スレッド、フラット化、include / pageSize 反映を検証
   - `apiClient.test.ts`: `getNotePages()` のクエリパラメータ エンコーディングを検証
   - `PageGrid.test.tsx`: 仮想スクロール末尾検知で `fetchNextPage()` が呼ばれることを検証
2. `bun run lint` と `bun run format:check` が通る
3. 大規模ノート（100+ ページ）でスクロール時に段階取得が動作することを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した（JSDoc / TSDoc を併記）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #860 Phase 3

https://claude.ai/code/session_013vsh2Xaig91WcEvsKCzzDb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Note pages support infinite, cursor-based loading with on-demand fetching as you scroll.

* **Refactor**
  * Page grid now relies on server ordering for note-scoped views and virtualized loading for reduced rendering.

* **Behavior**
  * Add-page dialog checks available pages from the global list (duplicate-title logic updated).

* **Tests**
  * Expanded test coverage for pagination, API page retrieval, and infinite scrolling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/866)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->