### PR TITLE
fix(editor): suppress slash menu inside inline code and code blocks

### DIFF
--- a/src/components/editor/extensions/slashSuggestionPlugin.test.ts
+++ b/src/components/editor/extensions/slashSuggestionPlugin.test.ts
@@ -28,7 +28,21 @@ const schema = new Schema({
       content: "text*",
       toDOM: () => ["p", 0],
     },
+    code_block: {
+      group: "block",
+      content: "text*",
+      code: true,
+      defining: true,
+      marks: "",
+      toDOM: () => ["pre", ["code", 0]],
+    },
     text: { group: "inline" },
+  },
+  marks: {
+    code: {
+      code: true,
+      toDOM: () => ["code", 0],
+    },
   },
 });
 
@@ -59,6 +73,30 @@ function makeState(text: string, plugin: Plugin): EditorState {
   const state = EditorState.create({ doc, schema, plugins: [plugin] });
   // 段落内末尾にキャレットを置く: pos 1 が段落 open、pos 1+text.length が末尾。
   // Place the caret at the end of the paragraph (pos 1 + text length).
+  const tr = state.tr.setSelection(TextSelection.create(state.doc, 1 + text.length));
+  return state.apply(tr);
+}
+
+/**
+ * Inline `code` mark over full paragraph text; caret at end (matches tag plugin tests).
+ * 段落全文にインライン `code` を掛け、キャレットを末尾へ。
+ */
+function makeInlineCodeState(text: string, plugin: Plugin): EditorState {
+  const codeMark = schema.marks.code.create();
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, text ? [schema.text(text, [codeMark])] : []),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [plugin] });
+  const tr = state.tr.setSelection(TextSelection.create(state.doc, 1 + text.length));
+  return state.apply(tr);
+}
+
+/** Caret at end of text inside a `code_block`. / code_block 内末尾にキャレット */
+function makeCodeBlockState(text: string, plugin: Plugin): EditorState {
+  const doc = schema.node("doc", null, [
+    schema.node("code_block", null, text ? [schema.text(text)] : []),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [plugin] });
   const tr = state.tr.setSelection(TextSelection.create(state.doc, 1 + text.length));
   return state.apply(tr);
 }
@@ -139,6 +177,51 @@ describe("slashSuggestionPlugin — non-trigger inputs", () => {
     const state = makeState("plain text", plugin);
     const pluginState = slashSuggestionPluginKey.getState(state);
     expect(pluginState?.active).toBe(false);
+  });
+
+  it("does not activate when `/` follows a literal backtick (opening `` ` ``)", () => {
+    // Markdown がコードマーク化する前でも直前が `\s` ではないのでトリガしない。
+    // Before closing backticks, `/` is not after (^|\s); regression for phase (A).
+    const plugin = getPlugin();
+    const state = makeState("`/analyze", plugin);
+    expect(slashSuggestionPluginKey.getState(state)?.active).toBe(false);
+  });
+});
+
+describe("slashSuggestionPlugin — code suppression", () => {
+  it("does not activate inside an inline `code` mark", () => {
+    const plugin = getPlugin();
+    const state = makeInlineCodeState("/analyze", plugin);
+    expect(slashSuggestionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("does not activate inside a code_block", () => {
+    const plugin = getPlugin();
+    const state = makeCodeBlockState("/analyze", plugin);
+    expect(slashSuggestionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("does not notify subscribers when inactive inside inline code", () => {
+    const onStateChange = vi.fn();
+    const plugin = getPlugin(onStateChange);
+    makeInlineCodeState("/run", plugin);
+    expect(onStateChange).not.toHaveBeenCalled();
+  });
+
+  it("closes an active suggestion when paragraph text gains inline code marks", () => {
+    const onStateChange = vi.fn();
+    const plugin = getPlugin(onStateChange);
+
+    let state = makeState("/foo", plugin);
+    expect(slashSuggestionPluginKey.getState(state)?.active).toBe(true);
+    onStateChange.mockClear();
+
+    const codeMark = schema.marks.code.create();
+    const tr = state.tr.replaceWith(1, 5, schema.text("/foo", [codeMark]));
+    state = state.apply(tr);
+    expect(slashSuggestionPluginKey.getState(state)?.active).toBe(false);
+    expect(onStateChange).toHaveBeenCalledTimes(1);
+    expect(onStateChange).toHaveBeenCalledWith(slashSuggestionPluginKey.getState(state));
   });
 });
 

--- a/src/components/editor/extensions/slashSuggestionPlugin.ts
+++ b/src/components/editor/extensions/slashSuggestionPlugin.ts
@@ -1,4 +1,5 @@
 import { Extension } from "@tiptap/core";
+import type { MarkType, ResolvedPos } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 
@@ -29,12 +30,31 @@ export interface SlashSuggestionOptions {
 }
 
 /**
+ * Returns true when the caret sits inside an inline `code` mark (Markdown `` ` ``).
+ * Mirrors {@link TagSuggestionPlugin}'s helper so slash behaviour stays aligned.
+ *
+ * インライン `code` マーク（Markdown のバッククォート）内かどうか。
+ * `TagSuggestionPlugin` と同じ判定でスラッシュとタグの契約を揃える。
+ */
+function isInsideInlineCode($from: ResolvedPos, schemaMarks: Record<string, MarkType>): boolean {
+  const codeMark = schemaMarks.code;
+  if (!codeMark) return false;
+  return Boolean(codeMark.isInSet($from.marks()));
+}
+
+/**
  * Slash suggestion plugin for "/ command" menu.
  * Triggers on:
  *   1. "/" at the start of a line
  *   2. " /" (space followed by slash) in the middle of text
  *
  * The text after "/" is treated as a filter query.
+ *
+ * Does **not** activate inside an inline `code` mark or a `code_block` node, so
+ * literals such as `` `/analyze` `` stay plain text (same rationale as tag suggestions).
+ *
+ * インライン `code` マーク・`code_block` ノード内では起動しない。
+ * `` `/analyze` `` のようにスラッシュをテキストとして書くためのエスケープ口。
  */
 export const SlashSuggestionPlugin = Extension.create<SlashSuggestionOptions>({
   name: "slashSuggestion",
@@ -77,11 +97,28 @@ export const SlashSuggestionPlugin = Extension.create<SlashSuggestionOptions>({
               return nextState;
             }
 
-            const { selection } = newState;
+            const { selection, schema } = newState;
             const { $from } = selection;
 
             // Only activate on cursor (not range) selections
             if (!selection.empty) {
+              if (prev.active) {
+                const nextState: SlashSuggestionState = {
+                  active: false,
+                  query: "",
+                  range: null,
+                  decorations: DecorationSet.empty,
+                };
+                onStateChange?.(nextState);
+                return nextState;
+              }
+              return prev;
+            }
+
+            // Suppress inside code blocks / inline code so `/token` stays literal text.
+            // `textBetween` strips marks; without this check `/run` inside `` `…` `` would still match (^|\s)/.
+            // コードブロック・インラインコード内では抑止。マーク無視でマッチしてしまうのを防ぐ。
+            if ($from.parent.type.spec.code || isInsideInlineCode($from, schema.marks)) {
               if (prev.active) {
                 const nextState: SlashSuggestionState = {
                   active: false,


### PR DESCRIPTION
## 概要

インライン `code`（バッククォート）および `code_block` 内では `SlashSuggestionPlugin` がメニューを起動しないようにした。`textBetween` はマークを剥がすため、従来は `/analyze` のようなリテラルが誤検知されていた。

## 変更点

- `slashSuggestionPlugin.ts`: `tagSuggestionPlugin` と同様に `$from.parent.type.spec.code` とインライン `code` マークをチェックし、アクティブ中なら `onStateChange` でクローズ。
- `slashSuggestionPlugin.test.ts`: 最小スキーマに `code_block`／`code` マークを追加し、抑止・バッククォート直後・マーク付与によるクローズをテスト。

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bunx vitest run --pool=forks --fileParallelism=false src/components/editor/extensions/slashSuggestionPlugin.test.ts`
2. エディタでインラインコード ``/analyze`` を入力し、スラッシュメニューが開かないことを確認。

## チェックリスト

- [x] テストがすべてパスする（上記ファイル）
- [x] Lint エラーがない（lint-staged / eslint --fix がコミット時に実行済み）
- [ ] 必要に応じてドキュメントを更新した（TSDoc をプラグインに追記済み）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

<!-- なし -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed slash command menu from incorrectly triggering when the cursor is inside code blocks or inline code. The menu now correctly remains inactive in code contexts.

* **Tests**
  * Extended test coverage to validate slash command suppression and proper handling when the cursor is positioned inside code blocks or inline code marks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/869)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->