### PR TITLE
test(e2e): add PDF knowledge ingestion E2E suite for #863

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,52 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Total: $TOTAL**" >> $GITHUB_STEP_SUMMARY
 
+  e2e-web:
+    name: E2E (web)
+    # PDF 知識化フローの Web (非 Tauri) 側を Playwright で守るための job。
+    # 現状は issue #863 で追加した `pdf-knowledge.spec.ts` のみを実行する。
+    # 既存の他 spec (web-clipper, page-editor, ...) は CI 未通過のものが
+    # 混ざっている可能性が高いため、別 PR で順次取り込む。
+    #
+    # Phase 2 (issue #863 follow-up): Tauri デスクトップ E2E は `tauri-driver`
+    # を要するため、本 job ではなく専用の job (`e2e-tauri`) として追加予定。
+    #
+    # Playwright job guarding the web-side (non-Tauri) of the PDF knowledge
+    # ingestion flow added by #863. Limited to the new `pdf-knowledge.spec.ts`
+    # for now; the existing e2e specs (web-clipper, page-editor, …) have not
+    # been wired into CI before and may regress separately — they are queued
+    # for a follow-up PR rather than risking a noisy first integration.
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3"
+
+      - run: bun install --frozen-lockfile
+
+      # Playwright のブラウザバイナリ + 必要な OS 依存を入れる。
+      # Install Playwright's browser binaries plus the matching OS deps.
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run PDF knowledge E2E
+        run: bunx playwright test e2e/pdf-knowledge.spec.ts
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-pdf-knowledge
+          path: playwright-report/
+          retention-days: 7
+
   api-typecheck:
     name: API Type Check
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft

--- a/e2e/fixtures/README.md
+++ b/e2e/fixtures/README.md
@@ -1,0 +1,20 @@
+# E2E Fixtures
+
+E2E テストで使う固定リソース。Issue [#863](https://github.com/otomatty/zedi/issues/863)
+の PDF 知識化フローの E2E 用フィクスチャを置く。
+
+Static assets consumed by Playwright specs. Files here MUST stay small
+(< 1 MB target per #863) so the repo doesn't bloat.
+
+## `sample.pdf`
+
+- **生成方法 / How it's built:** `bun run scripts/gen-pdf-fixture.ts`
+  (`scripts/gen-pdf-fixture.ts` がバイト単位で組み立てる)
+- **特徴 / Characteristics:**
+  - 2 ページ、テキストのみ（画像なし）。Two text-only pages.
+  - 1 ページ目: `Hello Zedi E2E PDF` / `Page one body text`
+  - 2 ページ目: `Second page heading` / `Page two body text`
+  - サイズ: ~941 バイト
+- **再生成 / Regenerate:** content を変えたいときはスクリプト側を編集して
+  `bun run scripts/gen-pdf-fixture.ts` で上書きする。手で PDF を編集しない
+  （xref のバイトオフセットがずれて pdf.js が読めなくなる）。

--- a/e2e/fixtures/sample.pdf
+++ b/e2e/fixtures/sample.pdf
@@ -1,0 +1,56 @@
+%PDF-1.4
+%âãÏÓ
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 5 0 R] /Count 2 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 7 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 83 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+(Hello Zedi E2E PDF) Tj
+0 -36 Td
+(Page one body text) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 6 0 R /Resources << /Font << /F1 7 0 R >> >> >>
+endobj
+6 0 obj
+<< /Length 84 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+(Second page heading) Tj
+0 -36 Td
+(Page two body text) Tj
+ET
+endstream
+endobj
+7 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000019 00000 n 
+0000000068 00000 n 
+0000000131 00000 n 
+0000000257 00000 n 
+0000000389 00000 n 
+0000000515 00000 n 
+0000000648 00000 n 
+trailer
+<< /Size 8 /Root 1 0 R >>
+startxref
+718
+%%EOF

--- a/e2e/pdf-knowledge.spec.ts
+++ b/e2e/pdf-knowledge.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * E2E: PDF 知識化フロー (issue otomatty/zedi#863, follow-up to #389 / #858).
+ *
+ * このスペックは「PDF 本体のバイト列は絶対にサーバへ送られない」を前提とした
+ * Phase 1 のフローを守るためのテスト群を集約する。実際の登録 → ハイライト →
+ * 派生ページ → backlink → リロード後永続性、というフルフロー (1〜6) は Tauri
+ * デスクトップランタイム＋tauri-driver を必要とするため、現状の Chromium 専用
+ * Playwright 環境では `test.fixme()` で骨格だけ用意し、Tauri E2E 基盤の整備を
+ * 別 issue に切り出すまでは pending として残す。
+ *
+ * Coverage map for #863 / Phase 1 acceptance criteria:
+ *   ✅ Active here:
+ *       - Web (non-Tauri) ターゲットで `/sources/:id/pdf` → `PdfReaderUnsupported`
+ *         の文言が出る最小テスト。
+ *       - PDF バイナリがネットワーク送信されていないことを E2E 内で確認する
+ *         sentinel テスト（ルート遷移時に PDF body を含む POST が無いことを assert）。
+ *       - フィクスチャ PDF (`e2e/fixtures/sample.pdf`) の存在チェック（後段の
+ *         Tauri E2E が依存するため、欠落は早期に検知したい）。
+ *   ⏳ Pending (`test.fixme`, requires tauri-driver + native Tauri build):
+ *       - シナリオ 1: ファイルダイアログから PDF を登録 → ビューアに遷移
+ *       - シナリオ 2: テキスト選択 → 「ハイライト保存」 → 一覧に出現
+ *       - シナリオ 3: 「保存して新規ページ」 → 派生ページ + 引用ブロック + 出典リンク
+ *       - シナリオ 4: 出典リンク → `#page=N` ディープリンク
+ *       - シナリオ 5: リロード（ウィンドウ再起動）後の永続性
+ *       - シナリオ 6: ファイル移動 → `MissingPdfBanner` → 「再アタッチ」
+ *
+ * The pending block is intentionally `test.fixme`, not `test.skip`, so it shows
+ * up in CI reports as work-to-do rather than being silently hidden.
+ */
+import { existsSync, statSync } from "node:fs";
+import type { Request } from "@playwright/test";
+import { test, expect } from "./auth-mock";
+
+/**
+ * Playwright は project root (cwd) から spec を起動するため、ここでは
+ * リポジトリルートからの相対パスで十分。`__dirname` は ESM/CJS の差で罠が
+ * 多いので避ける。
+ * Playwright launches specs from the project root, so a cwd-relative path is
+ * the most portable way to refer to the fixture without fighting ESM/CJS.
+ */
+const SAMPLE_PDF_PATH = "e2e/fixtures/sample.pdf";
+
+/**
+ * `/api/sources/pdf` 系のエンドポイント名。Phase 1 ではバイナリ本体を受け取らない
+ * 設計なので、ここに大きな body を持つ POST が飛んだら設計違反として fail する。
+ *
+ * Endpoints that must never receive raw PDF bytes. Phase 1's contract is that
+ * the server only gets hashes + metadata + highlights — the actual bytes stay
+ * on the user's disk via the Tauri-side registry.
+ */
+const PDF_API_PATH_PATTERN = /\/api\/sources\/pdf(?:$|\/)/u;
+
+/**
+ * 8 KiB をしきい値として「明らかにバイナリを送ってる」リクエストを検知する。
+ * メタデータのみの POST は数百バイトに収まるので、これより大きい body は
+ * 誤って PDF バイナリを混入させた疑いがある、というシグナルにする。
+ *
+ * 8 KiB is comfortably above metadata-only payloads (sha256 + filename +
+ * counts ≈ a few hundred bytes) but well below even the smallest practical PDF.
+ * Anything larger than this on a `/api/sources/pdf*` request is treated as a
+ * regression of the "no binary on the wire" Phase 1 invariant.
+ */
+const BINARY_BODY_THRESHOLD_BYTES = 8 * 1024;
+
+/**
+ * 与えられた request の body サイズを安全に計測する。
+ * Returns the request body size in bytes, defensively handling the (older)
+ * Playwright shape where `postDataBuffer()` may return `null`.
+ */
+function postBodySize(request: Request): number {
+  const buf = request.postDataBuffer();
+  if (!buf) return 0;
+  return buf.byteLength;
+}
+
+test.describe("PDF knowledge ingestion — fixtures sanity", () => {
+  test.setTimeout(30_000);
+
+  test("sample fixture PDF is present and below 1 MB", () => {
+    // `bun run scripts/gen-pdf-fixture.ts` を回し忘れた場合、後段の Tauri 用
+    // テスト群がデバッグしづらい形で落ちる。早い段階で明確に失敗させる。
+    // Fail loudly when the fixture is missing, so a developer who forgot to
+    // regenerate it doesn't waste time chasing opaque downstream errors.
+    expect(existsSync(SAMPLE_PDF_PATH)).toBe(true);
+    const { size } = statSync(SAMPLE_PDF_PATH);
+    expect(size).toBeGreaterThan(0);
+    expect(size).toBeLessThan(1024 * 1024);
+  });
+});
+
+test.describe("PDF knowledge ingestion — web (non-Tauri) target", () => {
+  test.setTimeout(60_000);
+
+  test("/sources/:id/pdf shows the desktop-only placeholder in a regular browser", async ({
+    page,
+  }) => {
+    // モック認証下の通常 Chromium には `__TAURI_INTERNALS__` が無いので
+    // `isTauriDesktop()` が false → `PdfReaderUnsupported` が描画される想定。
+    // The mock-auth Chromium target has no `__TAURI_INTERNALS__`, so
+    // `isTauriDesktop()` returns false and `PdfReaderUnsupported` should render.
+    await page.goto("/sources/nonexistent-source-id/pdf");
+    await page.waitForLoadState("networkidle");
+
+    // 日本語・英語の両方を確認する（プロジェクト規約上どちらも併記される）。
+    // Assert both Japanese and English copy — both are part of the contract.
+    await expect(page.getByText("PDF 知識化はデスクトップ版のみ対応")).toBeVisible();
+    await expect(page.getByText(/Desktop-only/i)).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /ノートに戻る|Back to your notes/i }),
+    ).toBeVisible();
+  });
+
+  test("does not POST any PDF binary to /api/sources/pdf* on web", async ({ page }) => {
+    // ネットワークインターセプト sentinel。Phase 1 設計違反を early-detect する。
+    // Network-level sentinel that detects a regression of the Phase 1 contract.
+    const offendingRequests: { url: string; size: number; method: string }[] = [];
+    page.on("request", (request) => {
+      const url = request.url();
+      if (!PDF_API_PATH_PATTERN.test(new URL(url).pathname)) return;
+      const size = postBodySize(request);
+      if (size > BINARY_BODY_THRESHOLD_BYTES) {
+        offendingRequests.push({ url, size, method: request.method() });
+      }
+    });
+
+    // Web 側からは結局 `/sources/:id/pdf` がアンサポート画面になるが、それでも
+    // 念のためフルロードまで待ってから assertion する。
+    // Even though the web path is unsupported, wait for full load before
+    // asserting so any rogue request has time to fire.
+    await page.goto("/sources/nonexistent-source-id/pdf");
+    await page.waitForLoadState("networkidle");
+
+    expect(
+      offendingRequests,
+      `Phase 1 では PDF バイナリを /api/sources/pdf* に送ってはいけない。検知: ${JSON.stringify(
+        offendingRequests,
+      )}`,
+    ).toEqual([]);
+  });
+});
+
+test.describe("PDF knowledge ingestion — Tauri desktop scenarios", () => {
+  // ─────────────────────────────────────────────────────────────────────────
+  // これらのシナリオは「実 Tauri デスクトップ + tauri-driver」を必要とする。
+  // 現在の playwright.config.ts は Chromium のみ + Vite dev server で動作する
+  // ため、ここでフルフローを再現すると `__TAURI_INTERNALS__` 偽装の信頼性が
+  // 低く、テストが脆い偽陽性を量産する恐れがある。
+  //
+  // 取るべきフォローアップ:
+  //   1. `tauri-driver` ベースの別 Playwright プロジェクト or 別 spec を追加
+  //      (e.g. `playwright.tauri.config.ts`).
+  //   2. CI でデスクトップ Linux runner を用意し、`bun run tauri build` した
+  //      バイナリに対して webdriver セッションを張る。
+  //   3. ファイルダイアログは `WebDriverIO` の Tauri プラグイン or 環境変数で
+  //      明示的にバイパスする（real OS dialog は CI で扱えない）。
+  //
+  // それまではここの本文をフルで再構築せず、`test.fixme()` で「未完了として
+  // 可視化」する。`test.skip` だと PR レポートで沈黙するため避ける。
+  //
+  // These scenarios need a real Tauri webview + tauri-driver. Until that
+  // infrastructure ships (tracked as a follow-up to #863), keep them
+  // `test.fixme` so they show up in CI reports as outstanding work instead of
+  // being silently skipped.
+  // ─────────────────────────────────────────────────────────────────────────
+  test.setTimeout(120_000);
+
+  test.fixme("registers a PDF via the file dialog and lands on the viewer", async () => {
+    // TODO(#863 follow-up): drive `OpenPdfButton` through tauri-driver, mock
+    // the OS file dialog to return `e2e/fixtures/sample.pdf`, then assert that
+    // the URL settles on `/sources/:sourceId/pdf` and the canvas renders.
+  });
+
+  test.fixme("selects text and saves a highlight that appears in the sidebar", async () => {
+    // TODO(#863 follow-up): select a known string from page 1 of
+    // `e2e/fixtures/sample.pdf` (e.g. "Hello Zedi E2E PDF"), click
+    // `[data-testid="pdf-highlight-toolbar"] [data-action="save"]`, then assert
+    // the highlight row appears in `HighlightSidebar`.
+  });
+
+  test.fixme("'save and derive' creates a derived page with citation + source link", async () => {
+    // TODO(#863 follow-up): trigger the save-and-derive flow, follow the
+    // navigation, and assert that the rendered page contains both a citation
+    // block (excerpt) and a source link pointing back to the original PDF.
+  });
+
+  test.fixme("the source link deep-links back to the original PDF page (#page=N)", async () => {
+    // TODO(#863 follow-up): click the source link from the derived page and
+    // assert the resulting URL hash matches `#page=2` (or whichever page the
+    // highlight lives on), and that the viewer actually scrolls there.
+  });
+
+  test.fixme("highlights and derived pages survive a window reload", async () => {
+    // TODO(#863 follow-up): after the create-and-derive flow, reload the
+    // Tauri window (or close+reopen via tauri-driver) and re-assert that the
+    // highlight + derived page + citation are still visible.
+  });
+
+  test.fixme("missing file triggers MissingPdfBanner and re-attach restores the viewer", async () => {
+    // TODO(#863 follow-up): rename / move the fixture PDF on disk, restart the
+    // viewer, assert `MissingPdfBanner` is shown, then re-attach via the file
+    // dialog mock and assert the viewer recovers.
+  });
+});

--- a/e2e/pdf-knowledge.spec.ts
+++ b/e2e/pdf-knowledge.spec.ts
@@ -42,7 +42,7 @@ const SAMPLE_PDF_PATH = "e2e/fixtures/sample.pdf";
 
 /**
  * `/api/sources/pdf` 系のエンドポイント名。Phase 1 ではバイナリ本体を受け取らない
- * 設計なので、ここに大きな body を持つ POST が飛んだら設計違反として fail する。
+ * 設計なので、ここに PDF バイト列を含む POST が飛んだら設計違反として fail する。
  *
  * Endpoints that must never receive raw PDF bytes. Phase 1's contract is that
  * the server only gets hashes + metadata + highlights — the actual bytes stay
@@ -51,26 +51,45 @@ const SAMPLE_PDF_PATH = "e2e/fixtures/sample.pdf";
 const PDF_API_PATH_PATTERN = /\/api\/sources\/pdf(?:$|\/)/u;
 
 /**
- * 8 KiB をしきい値として「明らかにバイナリを送ってる」リクエストを検知する。
- * メタデータのみの POST は数百バイトに収まるので、これより大きい body は
- * 誤って PDF バイナリを混入させた疑いがある、というシグナルにする。
+ * 「raw PDF」「base64 化された PDF」のどちらでも本文先頭に現れるマジック文字列。
+ * 単なるサイズしきい値だと、本 PR の sample.pdf (~941 B) のような小さい
+ * フィクスチャが誤って POST されたとき false negative になる。代わりに
+ * PDF シグネチャ (`%PDF-`) と、その base64 表現 (`JVBERi0`) を直接探す。
  *
- * 8 KiB is comfortably above metadata-only payloads (sha256 + filename +
- * counts ≈ a few hundred bytes) but well below even the smallest practical PDF.
- * Anything larger than this on a `/api/sources/pdf*` request is treated as a
- * regression of the "no binary on the wire" Phase 1 invariant.
+ * Both raw and base64-encoded PDFs start with one of these markers. The Phase 1
+ * invariant is "no PDF bytes on the wire" regardless of payload size, so a
+ * size-only threshold is too lax — a regression that uploads even the 941-byte
+ * `sample.pdf` fixture would slip past one. Magic-byte matching closes that
+ * gap (see review feedback on #871).
  */
-const BINARY_BODY_THRESHOLD_BYTES = 8 * 1024;
+const PDF_BODY_MARKERS = ["%PDF-", "JVBERi0"] as const;
 
 /**
- * 与えられた request の body サイズを安全に計測する。
- * Returns the request body size in bytes, defensively handling the (older)
- * Playwright shape where `postDataBuffer()` may return `null`.
+ * リクエスト body の中に PDF バイナリ (生 / base64) が混入していないか調べる。
+ * Phase 1 contract: PDF bytes must never be uploaded to the server. Inspect
+ * the raw post body for the PDF magic bytes — both the literal `%PDF-` header
+ * and the `JVBERi0` prefix that a base64-encoded PDF starts with.
+ *
+ * @returns 検出時は判定根拠を含むオブジェクト、未検出時は `null`。
  */
-function postBodySize(request: Request): number {
+function detectPdfBytesInBody(
+  request: Request,
+): { marker: string; bodySize: number; method: string } | null {
   const buf = request.postDataBuffer();
-  if (!buf) return 0;
-  return buf.byteLength;
+  if (!buf) return null;
+  // latin1 でデコードすると 0x00-0xFF が 1:1 で文字に写るため、バイナリの中に
+  // 紛れた ASCII シグネチャを安全に探せる。utf-8 だと不正なシーケンスで早期に
+  // 切れる可能性があるため避ける。
+  // latin1 maps every byte 1:1 to a code point, so ASCII signatures embedded
+  // in arbitrary binary survive the decode. utf-8 can silently truncate on
+  // invalid sequences, which would let a regression slip past.
+  const text = buf.toString("latin1");
+  for (const marker of PDF_BODY_MARKERS) {
+    if (text.includes(marker)) {
+      return { marker, bodySize: buf.byteLength, method: request.method() };
+    }
+  }
+  return null;
 }
 
 test.describe("PDF knowledge ingestion — fixtures sanity", () => {
@@ -112,15 +131,22 @@ test.describe("PDF knowledge ingestion — web (non-Tauri) target", () => {
 
   test("does not POST any PDF binary to /api/sources/pdf* on web", async ({ page }) => {
     // ネットワークインターセプト sentinel。Phase 1 設計違反を early-detect する。
-    // Network-level sentinel that detects a regression of the Phase 1 contract.
-    const offendingRequests: { url: string; size: number; method: string }[] = [];
+    // サイズ依存ではなく PDF マジックバイトで判定するので、本 PR の 941 バイト
+    // フィクスチャのような小サイズの regression も確実にフラグできる。
+    // Network-level sentinel for the "no PDF bytes on the wire" Phase 1
+    // contract. Uses magic-byte detection rather than a size threshold so a
+    // regression that uploads even the ~941-byte fixture is still caught.
+    const offendingRequests: {
+      url: string;
+      method: string;
+      marker: string;
+      bodySize: number;
+    }[] = [];
     page.on("request", (request) => {
       const url = request.url();
       if (!PDF_API_PATH_PATTERN.test(new URL(url).pathname)) return;
-      const size = postBodySize(request);
-      if (size > BINARY_BODY_THRESHOLD_BYTES) {
-        offendingRequests.push({ url, size, method: request.method() });
-      }
+      const hit = detectPdfBytesInBody(request);
+      if (hit) offendingRequests.push({ url, ...hit });
     });
 
     // Web 側からは結局 `/sources/:id/pdf` がアンサポート画面になるが、それでも

--- a/scripts/gen-pdf-fixture.ts
+++ b/scripts/gen-pdf-fixture.ts
@@ -1,0 +1,127 @@
+/**
+ * E2E 用のテキスト中心ミニ PDF を生成する。
+ *
+ * Generates the deterministic, text-only fixture PDF consumed by
+ * `e2e/pdf-knowledge.spec.ts` (issue otomatty/zedi#863).
+ *
+ * 目的 / Why a generator instead of a committed binary:
+ *   - PDF は xref テーブルにバイト単位のオフセットが必要なので、手書きすると
+ *     diff レビューが事実上不可能になる。生成スクリプトを残しておけば、内容を
+ *     変えたいときに再生成すればよく、レビューも script の diff だけで済む。
+ *   - PDFs embed exact byte offsets in the xref table, so a hand-edited binary
+ *     is unreviewable. Keeping the generator lets contributors regenerate the
+ *     fixture from a readable script when the test corpus needs to change.
+ *
+ * 使い方 / Usage:
+ *   bun run scripts/gen-pdf-fixture.ts
+ *   → writes `e2e/fixtures/sample.pdf` (well below the 1 MB cap in #863).
+ */
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const OUTPUT_PATH = "e2e/fixtures/sample.pdf";
+
+/**
+ * 「Hello Zedi E2E PDF」を 2 ページ表示するだけのミニ PDF を組み立てる。
+ *
+ * Builds a tiny 2-page text-only PDF rendering deterministic strings on each
+ * page so the E2E spec can assert on selectable text and deep-link to `#page=2`.
+ *
+ * 戻り値 / Returns: 完成した PDF のバイト列 (Uint8Array)。
+ */
+function buildSamplePdf(): Uint8Array {
+  // 各ページのコンテンツストリーム本文を別途組み立て、Length を正確に計算する。
+  // Build the per-page content streams separately so we can attach an exact
+  // `/Length` value to each stream dict (pdf.js will refuse mismatched lengths).
+  const page1Content =
+    "BT\n/F1 24 Tf\n72 720 Td\n(Hello Zedi E2E PDF) Tj\n0 -36 Td\n(Page one body text) Tj\nET\n";
+  const page2Content =
+    "BT\n/F1 24 Tf\n72 720 Td\n(Second page heading) Tj\n0 -36 Td\n(Page two body text) Tj\nET\n";
+
+  // 各 obj を文字列の配列として生成する。xref で参照するバイトオフセットは
+  // 後段で連結時に計測する。
+  // Each object's body. The xref byte offsets are computed below as we
+  // concatenate the actual file bytes.
+  const objects: string[] = [
+    // 1: Catalog
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    // 2: Pages
+    "<< /Type /Pages /Kids [3 0 R 5 0 R] /Count 2 >>",
+    // 3: Page 1
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] " +
+      "/Contents 4 0 R /Resources << /Font << /F1 7 0 R >> >> >>",
+    // 4: Page 1 content stream
+    `<< /Length ${page1Content.length} >>\nstream\n${page1Content}endstream`,
+    // 5: Page 2
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] " +
+      "/Contents 6 0 R /Resources << /Font << /F1 7 0 R >> >> >>",
+    // 6: Page 2 content stream
+    `<< /Length ${page2Content.length} >>\nstream\n${page2Content}endstream`,
+    // 7: Font
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+  ];
+
+  const encoder = new TextEncoder();
+  const parts: Uint8Array[] = [];
+  const offsets: number[] = [];
+  let byteCursor = 0;
+
+  /**
+   * 任意のバイト列を出力ストリームに追加し、byteCursor を進める。
+   * Appends raw bytes to the output stream and advances the cursor.
+   */
+  const push = (bytes: Uint8Array | string) => {
+    const buf = typeof bytes === "string" ? encoder.encode(bytes) : bytes;
+    parts.push(buf);
+    byteCursor += buf.byteLength;
+  };
+
+  // PDF ヘッダ。バイナリビューアで識別されるよう「%」コメント行も入れる。
+  // PDF header line + binary-marker comment (PDF 1.4 spec recommendation).
+  push("%PDF-1.4\n%âãÏÓ\n");
+
+  // 各 obj を出力し、それぞれの開始バイトオフセットを記録する。
+  // Emit each object and remember its starting byte offset for the xref table.
+  objects.forEach((body, index) => {
+    const objNumber = index + 1;
+    offsets.push(byteCursor);
+    push(`${objNumber} 0 obj\n${body}\nendobj\n`);
+  });
+
+  // xref テーブルの開始位置を覚えておき、trailer から参照する。
+  // Record the xref table's offset before we start writing it.
+  const xrefStart = byteCursor;
+
+  // xref テーブル本体。行長は PDF 仕様で 20 バイト固定。
+  // The xref table; each entry must be exactly 20 bytes including the newline.
+  let xref = `xref\n0 ${objects.length + 1}\n`;
+  xref += "0000000000 65535 f \n";
+  for (const offset of offsets) {
+    xref += `${offset.toString().padStart(10, "0")} 00000 n \n`;
+  }
+  push(xref);
+
+  // trailer。/Root と /Size を必須で含める。startxref は xrefStart を指す。
+  // Trailer dict referencing the catalog + size, then the startxref pointer.
+  push(`trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF\n`);
+
+  // 全パーツを連結して返す。
+  // Concatenate every part into a single contiguous buffer.
+  const total = parts.reduce((sum, p) => sum + p.byteLength, 0);
+  const out = new Uint8Array(total);
+  let cursor = 0;
+  for (const part of parts) {
+    out.set(part, cursor);
+    cursor += part.byteLength;
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const bytes = buildSamplePdf();
+  await mkdir(dirname(OUTPUT_PATH), { recursive: true });
+  await Bun.write(OUTPUT_PATH, bytes);
+  console.log(`Wrote ${OUTPUT_PATH} (${bytes.byteLength} bytes)`);
+}
+
+await main();


### PR DESCRIPTION
## 概要

Issue #863 の PDF 知識化フロー（Phase 1）に対応する E2E テストスイートを追加します。Web（非 Tauri）環境での動作確認と、PDF バイナリがサーバに送信されないことを保証するネットワークレベルの sentinel テストを実装しました。

## 変更点

- **`e2e/pdf-knowledge.spec.ts`** (新規)
  - Web 環境で `/sources/:id/pdf` が `PdfReaderUnsupported` を表示することを確認
  - `/api/sources/pdf*` エンドポイントへの大きなバイナリ POST がないことを sentinel テストで検証
  - フィクスチャ PDF の存在チェック
  - Tauri デスクトップシナリオ 6 つを `test.fixme()` で骨格化（tauri-driver 整備待ち）

- **`scripts/gen-pdf-fixture.ts`** (新規)
  - E2E 用の決定論的なミニ PDF を生成するスクリプト
  - 2 ページ、テキストのみ、~941 バイト
  - xref テーブルのバイトオフセットを正確に計算して出力

- **`e2e/fixtures/sample.pdf`** (新規)
  - `gen-pdf-fixture.ts` で生成されたテスト用 PDF

- **`e2e/fixtures/README.md`** (新規)
  - フィクスチャの説明と再生成方法を記載

- **`.github/workflows/ci.yml`** (修正)
  - `e2e-web` ジョブを追加
  - `pdf-knowledge.spec.ts` を Playwright で実行
  - ブラウザバイナリのインストール + レポート生成

## 変更の種類

- [x] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bun run scripts/gen-pdf-fixture.ts` でフィクスチャを生成
2. `bunx playwright test e2e/pdf-knowledge.spec.ts` で E2E テストを実行
3. CI の `e2e-web` ジョブが自動実行され、Playwright レポートが生成される

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #863（Phase 1 の E2E テスト基盤）

https://claude.ai/code/session_01NnGeqvZ6z2qFNdnDjY5gNi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests covering PDF-related UI flows, network request validation, and desktop scenario placeholders; includes fixture sanity checks.
* **Documentation**
  * Added documentation describing the E2E static fixture and regeneration instructions.
* **Chores**
  * Added CI job to run the E2E suite and upload test reports; added deterministic PDF fixture generation tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->