### PR TITLE
feat(search): surface PDF highlight bodies in Global Search (#864)

### DIFF
--- a/server/api/src/__tests__/routes/search.test.ts
+++ b/server/api/src/__tests__/routes/search.test.ts
@@ -508,6 +508,97 @@ describe("GET /api/search", () => {
     expect(body.results.length).toBeLessThanOrEqual(20);
   });
 
+  it("reserves slots for pdf_highlights so pages never starve them out (PR #873 review: CodeRabbit)", async () => {
+    // ページが limit を埋め切る場合でも、ハイライトに最低限の枠
+    // (ceil(limit / 4) = 5 件) が確保される。
+    //
+    // Even when pages would fill `limit` on their own, the merge reserves
+    // a minimum slot count (`ceil(limit / 4)` = 5) for highlights so the
+    // feature stays visible (PR #873 review: CodeRabbit).
+    const pageRows = Array.from({ length: 20 }, (_, i) => ({
+      id: `p-${i}`,
+      title: `Page ${i}`,
+      content_preview: null,
+      updated_at: new Date(2026, 3, 1, 0, i).toISOString(),
+      note_id: "default-note-search-mock",
+    }));
+    const highlightRows = Array.from({ length: 20 }, (_, i) => ({
+      highlight_id: `h-${i}`,
+      source_id: `s-${i}`,
+      owner_id: TEST_USER_ID,
+      pdf_page: i + 1,
+      text: "hit",
+      derived_page_id: null,
+      updated_at: new Date(2026, 3, 2, 0, i).toISOString(),
+      source_display_name: "doc.pdf",
+      source_title: null,
+    }));
+    const { app } = createSearchApp([{ rows: pageRows }, { rows: highlightRows }]);
+
+    const res = await app.request("/api/search?q=hit&scope=own&limit=20", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: Array<Record<string, unknown>> };
+    const highlights = body.results.filter((r) => r.kind === "pdf_highlight");
+    const pages = body.results.filter((r) => r.kind === "page");
+    expect(highlights.length).toBe(5);
+    expect(pages.length).toBe(15);
+    expect(body.results.length).toBe(20);
+  });
+
+  it("spills the highlight reserve back to pages when there are no highlights", async () => {
+    // ハイライトが 0 件のケースではページが limit までフルに載る。
+    // When there are no highlights, pages get the full `limit` budget.
+    const pageRows = Array.from({ length: 20 }, (_, i) => ({
+      id: `p-${i}`,
+      title: `Page ${i}`,
+      content_preview: null,
+      updated_at: new Date(2026, 3, 1, 0, i).toISOString(),
+      note_id: "default-note-search-mock",
+    }));
+    const { app } = createSearchApp([{ rows: pageRows }, { rows: [] }]);
+
+    const res = await app.request("/api/search?q=hit&scope=own&limit=20", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: Array<Record<string, unknown>> };
+    expect(body.results.length).toBe(20);
+    expect(body.results.every((r) => r.kind === "page")).toBe(true);
+  });
+
+  it("fills the merge with highlights when there are no pages", async () => {
+    // ページが 0 件のケースではハイライトが limit までフルに載る。
+    // When there are no pages, highlights take the full `limit` budget.
+    const highlightRows = Array.from({ length: 20 }, (_, i) => ({
+      highlight_id: `h-${i}`,
+      source_id: `s-${i}`,
+      owner_id: TEST_USER_ID,
+      pdf_page: i + 1,
+      text: "hit",
+      derived_page_id: null,
+      updated_at: new Date(2026, 3, 2, 0, i).toISOString(),
+      source_display_name: "doc.pdf",
+      source_title: null,
+    }));
+    const { app } = createSearchApp([{ rows: [] }, { rows: highlightRows }]);
+
+    const res = await app.request("/api/search?q=hit&scope=own&limit=20", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: Array<Record<string, unknown>> };
+    expect(body.results.length).toBe(20);
+    expect(body.results.every((r) => r.kind === "pdf_highlight")).toBe(true);
+  });
+
   it("merges page rows (kind='page') and highlight rows (kind='pdf_highlight') in one response", async () => {
     const pageId = "33333333-3333-3333-3333-333333333333";
     const { app } = createSearchApp([

--- a/server/api/src/__tests__/routes/search.test.ts
+++ b/server/api/src/__tests__/routes/search.test.ts
@@ -414,6 +414,100 @@ describe("GET /api/search", () => {
     expect(serialised).not.toContain("pdf_highlights");
   });
 
+  it("does not leak content_text into the API response (PR #873 review: CodeRabbit)", async () => {
+    // SQL から `pc.content_text` を引っ張る場合でも、レスポンスには含めない。
+    // Even when the SQL row carries `content_text`, it must not appear in the
+    // outbound JSON.
+    const pageId = "55555555-5555-5555-5555-555555555555";
+    const { app } = createSearchApp([
+      {
+        rows: [
+          {
+            id: pageId,
+            title: "Page",
+            content_preview: "snippet",
+            updated_at: new Date("2026-04-01T00:00:00Z").toISOString(),
+            note_id: "default-note-search-mock",
+            // 仮に過去の SELECT が content_text を含んでいた場合のシミュレーション。
+            // Simulate a row that still carries full body text.
+            content_text: "FULL PAGE BODY MUST NOT LEAK",
+          },
+        ],
+      },
+      { rows: [] },
+    ]);
+
+    const res = await app.request("/api/search?q=hello&scope=own", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: Array<Record<string, unknown>> };
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]).not.toHaveProperty("content_text");
+    expect(JSON.stringify(body)).not.toContain("FULL PAGE BODY");
+  });
+
+  it("page-query SELECT no longer pulls pc.content_text into the outbound payload", async () => {
+    // WHERE には残るが、SELECT 列から content_text が消えている。
+    // The WHERE clause still references `content_text`, but the SELECT list
+    // doesn't carry it anymore (PR #873 review: CodeRabbit).
+    const { app, chains } = createSearchApp(emptyDbResults());
+
+    await app.request("/api/search?q=hello&scope=own", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    const executeChains = chains.filter((chain) => chain.startMethod === "execute");
+    const pagesChain = executeChains[0];
+    const serialised = JSON.stringify(pagesChain?.startArgs);
+    // WHERE 句では content_text 比較が残っている必要がある (検索可能性は維持)。
+    // The WHERE branch still uses `content_text` (search reach preserved).
+    expect(serialised).toContain("pc.content_text ILIKE");
+    // SELECT 句には `pc.content_text` リストアップが残らない。
+    // The SELECT list no longer references `pc.content_text`.
+    expect(serialised).not.toContain("pc.content_text,");
+    expect(serialised).not.toMatch(/SELECT[\s\S]*pc\.content_text\b[\s\S]*FROM/);
+  });
+
+  it("caps the merged result list at `limit` so page+highlight never exceed the hard bound (PR #873 review: codex)", async () => {
+    // 各クエリが LIMIT を持つので、極端な場合 page+highlight = 2*limit になる。
+    // 結合後に再度クリップしてレスポンス契約 `limit` をハード上限として維持する。
+    //
+    // Each query carries `LIMIT`, so naïve concat could return 2*limit rows.
+    // The merge clip enforces `limit` as a hard cap on the API response.
+    const pageRows = Array.from({ length: 20 }, (_, i) => ({
+      id: `p-${i}`,
+      title: `Page ${i}`,
+      content_preview: null,
+      updated_at: new Date(2026, 3, 1, 0, i).toISOString(),
+      note_id: "default-note-search-mock",
+    }));
+    const highlightRows = Array.from({ length: 20 }, (_, i) => ({
+      highlight_id: `h-${i}`,
+      source_id: `s-${i}`,
+      owner_id: TEST_USER_ID,
+      pdf_page: i + 1,
+      text: "hit",
+      derived_page_id: null,
+      updated_at: new Date(2026, 3, 2, 0, i).toISOString(),
+      source_display_name: "doc.pdf",
+      source_title: null,
+    }));
+    const { app } = createSearchApp([{ rows: pageRows }, { rows: highlightRows }]);
+
+    const res = await app.request("/api/search?q=hit&scope=own&limit=20", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: Array<Record<string, unknown>> };
+    expect(body.results.length).toBeLessThanOrEqual(20);
+  });
+
   it("merges page rows (kind='page') and highlight rows (kind='pdf_highlight') in one response", async () => {
     const pageId = "33333333-3333-3333-3333-333333333333";
     const { app } = createSearchApp([

--- a/server/api/src/__tests__/routes/search.test.ts
+++ b/server/api/src/__tests__/routes/search.test.ts
@@ -9,8 +9,15 @@
  * Issue #823: `scope=own` restricts to the caller's default note; `scope=shared` spans
  * pages in notes reachable via owner / member / domain access. The `note_pages` table
  * is gone.
+ *
+ * Issue #864: ハイライト検索 (`pdf_highlights`) も同エンドポイントから返す。
+ * 所有検証 (`owner_id = userId`) と `kind="pdf_local"` の二重防御を確認する。
+ *
+ * Issue #864: this endpoint now also surfaces `pdf_highlights` rows. The tests
+ * below assert the owner filter and the `kind="pdf_local"` defense-in-depth
+ * check, and that the discriminator (`kind`) is set on every row.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Context, Next } from "hono";
 import type { AppEnv } from "../../types/index.js";
 
@@ -64,9 +71,26 @@ function createSearchApp(dbResults: unknown[]) {
   return { app, chains };
 }
 
+/**
+ * デフォルトのモック DB 結果。1 番目がページ検索、2 番目が pdf_highlights 検索。
+ * いずれも空配列を返すデフォルト。
+ *
+ * Default mock results — first call answers the page query, second answers the
+ * pdf_highlights query. Both default to empty rows.
+ */
+function emptyDbResults() {
+  return [{ rows: [] }, { rows: [] }];
+}
+
 describe("GET /api/search", () => {
+  beforeEach(() => {
+    // テスト間で env がリークしないようキルスイッチを毎回クリア。
+    // Reset the kill switch between tests so env state does not leak.
+    delete process.env.PDF_HIGHLIGHT_SEARCH_DISABLED;
+  });
+
   it("returns 401 without auth header", async () => {
-    const { app } = createSearchApp([{ rows: [] }]);
+    const { app } = createSearchApp(emptyDbResults());
 
     const res = await app.request("/api/search?q=hello", { method: "GET" });
 
@@ -88,7 +112,7 @@ describe("GET /api/search", () => {
   });
 
   it("scope=own binds listing to default note id from getDefaultNoteOrNull (issue #823)", async () => {
-    const { app, chains } = createSearchApp([{ rows: [] }]);
+    const { app, chains } = createSearchApp(emptyDbResults());
 
     const res = await app.request("/api/search?q=hello&scope=own", {
       method: "GET",
@@ -96,9 +120,10 @@ describe("GET /api/search", () => {
     });
 
     expect(res.status).toBe(200);
-    const executeChain = chains.find((chain) => chain.startMethod === "execute");
-    expect(executeChain).toBeDefined();
-    const serialised = JSON.stringify(executeChain?.startArgs);
+    const executeChains = chains.filter((chain) => chain.startMethod === "execute");
+    expect(executeChains.length).toBeGreaterThanOrEqual(1);
+    const pagesChain = executeChains[0];
+    const serialised = JSON.stringify(pagesChain?.startArgs);
     expect(serialised).toContain("default-note-search-mock");
     expect(serialised).toContain("p.note_id");
     expect(serialised).not.toContain("is_default");
@@ -106,7 +131,7 @@ describe("GET /api/search", () => {
   });
 
   it("defaults to scope=own when scope query parameter is omitted", async () => {
-    const { app, chains } = createSearchApp([{ rows: [] }]);
+    const { app, chains } = createSearchApp(emptyDbResults());
 
     const res = await app.request("/api/search?q=hello", {
       method: "GET",
@@ -114,16 +139,18 @@ describe("GET /api/search", () => {
     });
 
     expect(res.status).toBe(200);
-    const executeChain = chains.find((chain) => chain.startMethod === "execute");
-    expect(executeChain).toBeDefined();
-    const serialised = JSON.stringify(executeChain?.startArgs);
+    const executeChains = chains.filter((chain) => chain.startMethod === "execute");
+    const pagesChain = executeChains[0];
+    const serialised = JSON.stringify(pagesChain?.startArgs);
     expect(serialised).toContain("default-note-search-mock");
     expect(serialised).toContain("p.note_id");
   });
 
-  it("scope=own returns empty results when default note is missing", async () => {
+  it("scope=own runs highlight search even when default note is missing", async () => {
     vi.mocked(getDefaultNoteOrNull).mockResolvedValueOnce(null);
-    const { app, chains } = createSearchApp([]);
+    // ページ検索は走らない（default note 無し）が、ハイライト検索は走る。
+    // The page query is skipped (no default note), but the highlight query still runs.
+    const { app, chains } = createSearchApp([{ rows: [] }]);
 
     const res = await app.request("/api/search?q=hello&scope=own", {
       method: "GET",
@@ -133,11 +160,14 @@ describe("GET /api/search", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { results: unknown[] };
     expect(body.results).toEqual([]);
-    expect(chains.find((c) => c.startMethod === "execute")).toBeUndefined();
+    const executeChains = chains.filter((chain) => chain.startMethod === "execute");
+    expect(executeChains).toHaveLength(1);
+    const serialised = JSON.stringify(executeChains[0]?.startArgs);
+    expect(serialised).toContain("pdf_highlights");
   });
 
   it("scope=shared uses note ownership / member / domain EXISTS branches without note_pages", async () => {
-    const { app, chains } = createSearchApp([{ rows: [] }]);
+    const { app, chains } = createSearchApp(emptyDbResults());
 
     const res = await app.request("/api/search?q=hello&scope=shared", {
       method: "GET",
@@ -145,16 +175,16 @@ describe("GET /api/search", () => {
     });
 
     expect(res.status).toBe(200);
-    const executeChain = chains.find((chain) => chain.startMethod === "execute");
-    expect(executeChain).toBeDefined();
-    const serialised = JSON.stringify(executeChain?.startArgs);
+    const executeChains = chains.filter((chain) => chain.startMethod === "execute");
+    const pagesChain = executeChains[0];
+    const serialised = JSON.stringify(pagesChain?.startArgs);
     expect(serialised).not.toContain("note_pages");
     expect(serialised).toContain("note_members");
     expect(serialised).toContain("OR EXISTS");
   });
 
   it("falls back to the default limit when the limit query is non-numeric", async () => {
-    const { app } = createSearchApp([{ rows: [] }]);
+    const { app } = createSearchApp(emptyDbResults());
 
     const res = await app.request("/api/search?q=hello&scope=shared&limit=abc", {
       method: "GET",
@@ -165,7 +195,7 @@ describe("GET /api/search", () => {
   });
 
   it("scope=shared keeps note-scoped EXISTS predicates (no note_pages join)", async () => {
-    const { app, chains } = createSearchApp([{ rows: [] }]);
+    const { app, chains } = createSearchApp(emptyDbResults());
 
     const res = await app.request("/api/search?q=hello&scope=shared", {
       method: "GET",
@@ -173,15 +203,15 @@ describe("GET /api/search", () => {
     });
 
     expect(res.status).toBe(200);
-    const executeChain = chains.find((chain) => chain.startMethod === "execute");
-    expect(executeChain).toBeDefined();
-    const serialised = JSON.stringify(executeChain?.startArgs);
+    const executeChains = chains.filter((chain) => chain.startMethod === "execute");
+    const pagesChain = executeChains[0];
+    const serialised = JSON.stringify(pagesChain?.startArgs);
     expect(serialised).toContain(TEST_USER_ID);
     expect(serialised).not.toContain("note_pages");
     expect(serialised).toContain("p.note_id");
   });
 
-  it("response rows include note_id so callers can distinguish pages by owning note", async () => {
+  it("response page rows are tagged with kind='page' and include note_id", async () => {
     const defaultNotePageId = "11111111-1111-1111-1111-111111111111";
     const { app, chains } = createSearchApp([
       {
@@ -195,6 +225,7 @@ describe("GET /api/search", () => {
           },
         ],
       },
+      { rows: [] },
     ]);
 
     const res = await app.request("/api/search?q=hello&scope=shared", {
@@ -206,9 +237,11 @@ describe("GET /api/search", () => {
     const body = (await res.json()) as { results: Array<Record<string, unknown>> };
     expect(body.results).toHaveLength(1);
     expect(body.results[0]).toHaveProperty("note_id");
+    expect(body.results[0]).toHaveProperty("kind", "page");
 
-    const executeChain = chains.find((chain) => chain.startMethod === "execute");
-    const serialised = JSON.stringify(executeChain?.startArgs);
+    const executeChains = chains.filter((chain) => chain.startMethod === "execute");
+    const pagesChain = executeChains[0];
+    const serialised = JSON.stringify(pagesChain?.startArgs);
     expect(serialised).toContain("p.note_id");
   });
 
@@ -226,6 +259,7 @@ describe("GET /api/search", () => {
           },
         ],
       },
+      { rows: [] },
     ]);
 
     const res = await app.request("/api/search?q=hello&scope=own", {
@@ -237,11 +271,189 @@ describe("GET /api/search", () => {
     const body = (await res.json()) as { results: Array<Record<string, unknown>> };
     expect(body.results).toHaveLength(1);
     expect(body.results[0]).toHaveProperty("note_id", defaultNotePageId);
+    expect(body.results[0]).toHaveProperty("kind", "page");
 
-    const executeChain = chains.find((chain) => chain.startMethod === "execute");
-    const serialised = JSON.stringify(executeChain?.startArgs);
+    const executeChains = chains.filter((chain) => chain.startMethod === "execute");
+    const pagesChain = executeChains[0];
+    const serialised = JSON.stringify(pagesChain?.startArgs);
     expect(serialised).toContain("p.note_id");
     expect(serialised).toContain("default-note-search-mock");
     expect(serialised).not.toContain("is_default");
+  });
+
+  // ── Issue #864: PDF ハイライト統合 ─────────────────────────────────────────
+  // PDF highlight integration tests (Issue #864).
+
+  it("scope=own includes pdf_highlights rows filtered by owner_id (no leak of other users')", async () => {
+    const { app, chains } = createSearchApp([
+      { rows: [] }, // ページ検索 / page query
+      {
+        rows: [
+          {
+            highlight_id: "h-1",
+            source_id: "s-1",
+            owner_id: TEST_USER_ID,
+            pdf_page: 5,
+            text: "highlighted passage about hello",
+            derived_page_id: null,
+            updated_at: new Date("2026-05-01T00:00:00Z").toISOString(),
+            source_display_name: "paper.pdf",
+            source_title: null,
+          },
+        ],
+      },
+    ]);
+
+    const res = await app.request("/api/search?q=hello&scope=own", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: Array<Record<string, unknown>> };
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]).toMatchObject({
+      kind: "pdf_highlight",
+      highlight_id: "h-1",
+      source_id: "s-1",
+      pdf_page: 5,
+      derived_page_id: null,
+      source_display_name: "paper.pdf",
+    });
+
+    // 所有検証 (owner_id = userId) と `kind="pdf_local"` の両方が SQL に存在する。
+    // Both the owner filter and the `kind="pdf_local"` defensive filter live in the SQL.
+    const executeChains = chains.filter((chain) => chain.startMethod === "execute");
+    expect(executeChains.length).toBe(2);
+    const highlightChain = executeChains[1];
+    const serialised = JSON.stringify(highlightChain?.startArgs);
+    expect(serialised).toContain("h.owner_id");
+    expect(serialised).toContain(TEST_USER_ID);
+    expect(serialised).toContain("pdf_local");
+  });
+
+  it("scope=shared still scopes pdf_highlights to the caller's own rows only", async () => {
+    const { app, chains } = createSearchApp([
+      { rows: [] },
+      {
+        rows: [
+          {
+            highlight_id: "h-2",
+            source_id: "s-2",
+            owner_id: TEST_USER_ID,
+            pdf_page: 1,
+            text: "shared lookup result text",
+            derived_page_id: "p-derived-1",
+            updated_at: new Date("2026-05-02T00:00:00Z").toISOString(),
+            source_display_name: "notes.pdf",
+            source_title: "Notes",
+          },
+        ],
+      },
+    ]);
+
+    const res = await app.request("/api/search?q=shared&scope=shared", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: Array<Record<string, unknown>> };
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]).toMatchObject({
+      kind: "pdf_highlight",
+      highlight_id: "h-2",
+      derived_page_id: "p-derived-1",
+    });
+
+    const executeChains = chains.filter((chain) => chain.startMethod === "execute");
+    expect(executeChains).toHaveLength(2);
+    const highlightChain = executeChains[1];
+    const serialised = JSON.stringify(highlightChain?.startArgs);
+    // 他ユーザーのハイライトを掴まないよう owner_id 比較が必ず入る。
+    // The owner filter is always present regardless of scope.
+    expect(serialised).toContain("h.owner_id");
+    expect(serialised).toContain(TEST_USER_ID);
+  });
+
+  it("pdf_highlight branch JOINs sources and restricts to kind='pdf_local'", async () => {
+    const { app, chains } = createSearchApp(emptyDbResults());
+
+    const res = await app.request("/api/search?q=hello&scope=own", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const executeChains = chains.filter((chain) => chain.startMethod === "execute");
+    expect(executeChains).toHaveLength(2);
+    const highlightChain = executeChains[1];
+    const serialised = JSON.stringify(highlightChain?.startArgs);
+    expect(serialised).toContain("pdf_highlights");
+    expect(serialised).toContain("INNER JOIN sources");
+    expect(serialised).toContain("pdf_local");
+  });
+
+  it("PDF_HIGHLIGHT_SEARCH_DISABLED=1 skips the highlight query entirely", async () => {
+    process.env.PDF_HIGHLIGHT_SEARCH_DISABLED = "1";
+    const { app, chains } = createSearchApp([{ rows: [] }]);
+
+    const res = await app.request("/api/search?q=hello&scope=own", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: unknown[] };
+    expect(body.results).toEqual([]);
+    const executeChains = chains.filter((chain) => chain.startMethod === "execute");
+    // ページ検索のみ実行され、ハイライト検索は走らない。
+    // Only the page query runs; the highlight query is short-circuited.
+    expect(executeChains).toHaveLength(1);
+    const serialised = JSON.stringify(executeChains[0]?.startArgs);
+    expect(serialised).not.toContain("pdf_highlights");
+  });
+
+  it("merges page rows (kind='page') and highlight rows (kind='pdf_highlight') in one response", async () => {
+    const pageId = "33333333-3333-3333-3333-333333333333";
+    const { app } = createSearchApp([
+      {
+        rows: [
+          {
+            id: pageId,
+            title: "Page with hello",
+            content_preview: "hello there",
+            updated_at: new Date("2026-04-01T00:00:00Z").toISOString(),
+            note_id: "default-note-search-mock",
+          },
+        ],
+      },
+      {
+        rows: [
+          {
+            highlight_id: "h-3",
+            source_id: "s-3",
+            owner_id: TEST_USER_ID,
+            pdf_page: 7,
+            text: "hello in PDF",
+            derived_page_id: null,
+            updated_at: new Date("2026-04-02T00:00:00Z").toISOString(),
+            source_display_name: "doc.pdf",
+            source_title: null,
+          },
+        ],
+      },
+    ]);
+
+    const res = await app.request("/api/search?q=hello&scope=own", {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: Array<Record<string, unknown>> };
+    expect(body.results).toHaveLength(2);
+    expect(body.results[0]).toMatchObject({ kind: "page", id: pageId });
+    expect(body.results[1]).toMatchObject({ kind: "pdf_highlight", highlight_id: "h-3" });
   });
 });

--- a/server/api/src/routes/search.ts
+++ b/server/api/src/routes/search.ts
@@ -79,8 +79,14 @@ app.get("/", authRequired, async (c) => {
   const limit = clampLimit(c.req.query("limit"));
   const pattern = `%${escapeLike(query)}%`;
 
-  const searchColumns = sql`p.id, p.title, p.content_preview, p.updated_at, p.note_id,
-             pc.content_text`;
+  // 検索条件用にだけ `content_text` を WHERE に登場させるが、SELECT には含めない。
+  // SELECT に流すと API 経由でページ本文が丸ごと露出し得る（PR #873 review:
+  // CodeRabbit）。クライアントが消費するのは `content_preview` のみ。
+  //
+  // `content_text` is used in the WHERE clause for matching but is NOT in the
+  // SELECT list — otherwise the API would leak full page bodies (PR #873 review:
+  // CodeRabbit). Clients only consume `content_preview`.
+  const searchColumns = sql`p.id, p.title, p.content_preview, p.updated_at, p.note_id`;
 
   const normalizedEmail = typeof userEmailRaw === "string" ? userEmailRaw.trim().toLowerCase() : "";
   const emailDomain = extractEmailDomain(normalizedEmail);
@@ -157,16 +163,54 @@ app.get("/", authRequired, async (c) => {
     pageRows = ownResults.rows;
   }
 
-  // 既存ページ行に kind="page" の識別子を付与してから、ハイライト結果と結合する。
-  // Tag every page row with `kind: "page"` before merging with highlight rows.
-  const taggedPageRows = pageRows.map((row) => ({
-    ...(row as Record<string, unknown>),
-    kind: "page" as const,
-  }));
+  // 契約フィールドのみを明示マップして response に流す。SQL の SELECT に直接含まれない
+  // カラム (owner_id / thumbnail_url / source_url) は明示的に null/undefined で埋めて
+  // 型 (`SearchPageResultRow`) との整合を取る。raw row を spread で流すと将来 SELECT
+  // を増やしたとき静かに API が漏れるので、PR #873 review (CodeRabbit) で明示化した。
+  //
+  // Map only the contracted fields explicitly. We do not spread raw SQL rows
+  // because any future SELECT addition would silently widen the API payload
+  // (PR #873 review: CodeRabbit). Columns not in the current SELECT are
+  // emitted as `null`/`undefined` to stay aligned with `SearchPageResultRow`.
+  const taggedPageRows = pageRows.map((row) => {
+    const r = row as {
+      id: string;
+      note_id: string;
+      title: string | null;
+      content_preview: string | null;
+      updated_at: string;
+    };
+    return {
+      kind: "page" as const,
+      id: r.id,
+      note_id: r.note_id,
+      // `owner_id` / `thumbnail_url` / `source_url` は将来 SELECT に追加する想定の
+      // プレースホルダ。現状の SQL では返らないので明示的に null/undefined を入れる。
+      // Placeholders for columns not yet in SELECT; emitted explicitly so the
+      // payload shape stays stable for the discriminated union.
+      owner_id: null,
+      title: r.title,
+      content_preview: r.content_preview,
+      thumbnail_url: null,
+      source_url: null,
+      updated_at: r.updated_at,
+    };
+  });
 
   const highlightRows = await runPdfHighlightSearch(db, userId, pattern, limit);
 
-  return c.json({ results: [...taggedPageRows, ...highlightRows] });
+  // ページ検索とハイライト検索のそれぞれが `LIMIT ${limit}` を持つので、無加工に連結
+  // すると endpoint は最大 2*limit 行返してしまう (PR #873 review: codex)。クライアント
+  // 契約上 `limit` はハード上限なので、結合後に再度クリップする。元の DESC 順は
+  // 種別ごとに維持されるが、種別を跨いだ並び替えはクライアント側のスコアリングに任せる。
+  //
+  // The page query and the highlight query each apply `LIMIT ${limit}`, so a
+  // naïve concat would return up to 2*limit rows (PR #873 review: codex).
+  // We re-clip to `limit` after the merge to keep the contract a hard cap;
+  // cross-kind ordering is left to the client-side scoring layer.
+  const merged = [...taggedPageRows, ...highlightRows].slice(0, limit);
+
+  return c.json({ results: merged });
 });
 
 /**

--- a/server/api/src/routes/search.ts
+++ b/server/api/src/routes/search.ts
@@ -199,18 +199,43 @@ app.get("/", authRequired, async (c) => {
 
   const highlightRows = await runPdfHighlightSearch(db, userId, pattern, limit);
 
-  // ページ検索とハイライト検索のそれぞれが `LIMIT ${limit}` を持つので、無加工に連結
-  // すると endpoint は最大 2*limit 行返してしまう (PR #873 review: codex)。クライアント
-  // 契約上 `limit` はハード上限なので、結合後に再度クリップする。元の DESC 順は
-  // 種別ごとに維持されるが、種別を跨いだ並び替えはクライアント側のスコアリングに任せる。
+  // PR #873 review (codex, CodeRabbit): 両 review の指摘を両立させるため予約枠方式を採る。
   //
-  // The page query and the highlight query each apply `LIMIT ${limit}`, so a
-  // naïve concat would return up to 2*limit rows (PR #873 review: codex).
-  // We re-clip to `limit` after the merge to keep the contract a hard cap;
-  // cross-kind ordering is left to the client-side scoring layer.
-  const merged = [...taggedPageRows, ...highlightRows].slice(0, limit);
+  // - codex: 各クエリが `LIMIT ${limit}` を持ち、連結すると最大 2*limit 行返り得る。
+  //   `limit` をハード上限として尊重する必要がある。
+  // - CodeRabbit: 単純な `.slice(0, limit)` だとページが `limit` 件以上ある状況で
+  //   ハイライトが全て削られ、Issue #864 の目的（ハイライトを検索結果に乗せる）が壊れる。
+  //
+  // 解決策: ハイライトに最低 `ceil(limit / HIGHLIGHT_RESERVED_RATIO)` 件の予約枠を
+  // 確保し、残りをページで埋める。ハイライトが予約枠より少なければ余りはページに
+  // 戻す。結果として `総数 ≤ limit` を守りつつ、ハイライトが必ず一定数は載る。
+  // 種別を跨いだ最終ランキングはクライアント側のスコアリング層に任せる。
+  //
+  // PR #873 review (codex, CodeRabbit): reserved-budget merge that satisfies
+  // both concerns simultaneously.
+  //
+  // - codex: each branch applies `LIMIT ${limit}`, so a naïve concat could
+  //   return up to 2*limit rows and break the contract.
+  // - CodeRabbit: a naïve `.slice(0, limit)` lets pages crowd out highlights
+  //   entirely once there are >= `limit` pages, defeating Issue #864.
+  //
+  // The fix reserves a minimum of `ceil(limit / HIGHLIGHT_RESERVED_RATIO)`
+  // slots for highlights and gives the remainder to pages; the reserved
+  // budget shrinks if there aren't that many highlights so pages can spill
+  // back into it. Total is always <= `limit`, and highlights are never
+  // starved when they exist. Cross-kind ranking still happens on the client.
+  const HIGHLIGHT_RESERVED_RATIO = 4;
+  const highlightReserved = Math.min(
+    highlightRows.length,
+    Math.max(1, Math.ceil(limit / HIGHLIGHT_RESERVED_RATIO)),
+  );
+  const pageQuota = limit - highlightReserved;
+  const cappedPages = taggedPageRows.slice(0, pageQuota);
+  // ページが quota より少なかった場合、余り枠をハイライトに回す。
+  // Spill leftover capacity to highlights when there are fewer pages than the quota.
+  const cappedHighlights = highlightRows.slice(0, limit - cappedPages.length);
 
-  return c.json({ results: merged });
+  return c.json({ results: [...cappedPages, ...cappedHighlights] });
 });
 
 /**

--- a/server/api/src/routes/search.ts
+++ b/server/api/src/routes/search.ts
@@ -12,6 +12,30 @@
  * - `scope=own` restricts to pages under the caller's default note.
  * - `scope=shared` spans pages in notes the caller can access (owner, accepted
  *   member, or domain rule).
+ *
+ * PDF ハイライト統合 (Issue #864 / #389 follow-up):
+ * - 同じ検索 q を用いて `pdf_highlights.text` も対象に含める。
+ * - ハイライトは常に呼び出し元 (`owner_id = userId`) 所有のみを返し、scope に依らず
+ *   他ユーザーに漏れない（テーブル単体で所有者を持つ前提）。
+ * - 元ソースが `kind="pdf_local"` のもののみ対象（JOIN で防御的にフィルタ）。
+ * - レスポンスは `kind` 識別子付きの discriminated union で返す
+ *   (`kind="page"` / `kind="pdf_highlight"`)。クライアントはこれで分岐する。
+ * - 環境変数 `PDF_HIGHLIGHT_SEARCH_DISABLED=1` をセットすると、ハイライト検索だけを
+ *   無効化できる（運用上のセーフティ）。ページ検索には影響しない。
+ *
+ * PDF highlight integration (Issue #864, follow-up to #389):
+ * - The same query string also probes `pdf_highlights.text`.
+ * - Highlights are only returned to their owner — scope does NOT widen this; the
+ *   table has a denormalized `owner_id` precisely for this case.
+ * - Defensive `JOIN sources` ensures we never surface highlights whose owning
+ *   source row is somehow not `kind="pdf_local"` anymore.
+ * - The response is now a discriminated union tagged by `kind`:
+ *   `"page"` (existing rows) and `"pdf_highlight"` (new rows). Clients branch on
+ *   `kind` and the highlight rows carry `source_id` / `pdf_page` / `highlight_id`
+ *   / `derived_page_id` so the UI can deep-link back to the PDF viewer or the
+ *   derived Zedi page.
+ * - Set `PDF_HIGHLIGHT_SEARCH_DISABLED=1` to disable just the highlight part
+ *   (kill switch); page search is unaffected.
  */
 import { Hono } from "hono";
 import { sql } from "drizzle-orm";
@@ -28,6 +52,15 @@ function clampLimit(raw: string | undefined): number {
   const parsed = raw === undefined ? 20 : Number(raw);
   const safe = Number.isFinite(parsed) ? Math.trunc(parsed) : 20;
   return Math.min(Math.max(safe, 1), 100);
+}
+
+/**
+ * ハイライト検索のキルスイッチ。`PDF_HIGHLIGHT_SEARCH_DISABLED=1` or `=true` で有効。
+ * Kill switch for the highlight search branch.
+ */
+function isPdfHighlightSearchDisabled(): boolean {
+  const v = (process.env.PDF_HIGHLIGHT_SEARCH_DISABLED ?? "").trim().toLowerCase();
+  return v === "1" || v === "true";
 }
 
 const app = new Hono<AppEnv>();
@@ -65,10 +98,10 @@ app.get("/", authRequired, async (c) => {
         )`
       : sql``;
 
-  let results;
+  let pageRows: unknown[] = [];
 
   if (scope === "shared") {
-    results = await db.execute(sql`
+    const sharedResults = await db.execute(sql`
       SELECT ${searchColumns}
       FROM pages p
       LEFT JOIN page_contents pc ON pc.page_id = p.id
@@ -98,12 +131,17 @@ app.get("/", authRequired, async (c) => {
       ORDER BY p.updated_at DESC
       LIMIT ${limit}
     `);
+    pageRows = sharedResults.rows;
   } else {
     const defaultNote = await getDefaultNoteOrNull(db, userId);
     if (!defaultNote) {
-      return c.json({ results: [] });
+      // デフォルトノートが無い場合でもハイライト検索は走り得るので、ページ部だけ空配列に。
+      // Even without a default note, highlight search can still run, so only the
+      // page branch short-circuits here.
+      const highlightRows = await runPdfHighlightSearch(db, userId, pattern, limit);
+      return c.json({ results: highlightRows });
     }
-    results = await db.execute(sql`
+    const ownResults = await db.execute(sql`
       SELECT ${searchColumns}
       FROM pages p
       LEFT JOIN page_contents pc ON pc.page_id = p.id
@@ -116,9 +154,65 @@ app.get("/", authRequired, async (c) => {
       ORDER BY p.updated_at DESC
       LIMIT ${limit}
     `);
+    pageRows = ownResults.rows;
   }
 
-  return c.json({ results: results.rows });
+  // 既存ページ行に kind="page" の識別子を付与してから、ハイライト結果と結合する。
+  // Tag every page row with `kind: "page"` before merging with highlight rows.
+  const taggedPageRows = pageRows.map((row) => ({
+    ...(row as Record<string, unknown>),
+    kind: "page" as const,
+  }));
+
+  const highlightRows = await runPdfHighlightSearch(db, userId, pattern, limit);
+
+  return c.json({ results: [...taggedPageRows, ...highlightRows] });
 });
+
+/**
+ * `pdf_highlights` を所有検証付きで検索し、`kind="pdf_highlight"` 行を返す。
+ * 戻り値は `c.json` にそのまま流せる形に整える（snake_case のキー）。
+ *
+ * Searches `pdf_highlights` for the caller's own highlights only and returns
+ * a list of `kind: "pdf_highlight"` rows shaped for `c.json` (snake_case).
+ *
+ * @param db    リクエストの drizzle DB ハンドル。Drizzle DB handle from the request.
+ * @param userId 呼び出し元ユーザー ID。Owner filter — only the caller's rows are returned.
+ * @param pattern ILIKE 用にエスケープ済みのパターン。Pre-escaped ILIKE pattern.
+ * @param limit 結果上限。Maximum number of rows to return.
+ */
+async function runPdfHighlightSearch(
+  db: AppEnv["Variables"]["db"],
+  userId: string,
+  pattern: string,
+  limit: number,
+): Promise<Array<Record<string, unknown>>> {
+  if (isPdfHighlightSearchDisabled()) return [];
+
+  const result = await db.execute(sql`
+    SELECT
+      h.id          AS highlight_id,
+      h.source_id   AS source_id,
+      h.owner_id    AS owner_id,
+      h.pdf_page    AS pdf_page,
+      h.text        AS text,
+      h.derived_page_id AS derived_page_id,
+      h.updated_at  AS updated_at,
+      s.display_name AS source_display_name,
+      s.title       AS source_title
+    FROM pdf_highlights h
+    INNER JOIN sources s ON s.id = h.source_id
+    WHERE h.owner_id = ${userId}
+      AND s.kind = 'pdf_local'
+      AND h.text ILIKE ${pattern}
+    ORDER BY h.updated_at DESC
+    LIMIT ${limit}
+  `);
+
+  return result.rows.map((row) => ({
+    ...(row as Record<string, unknown>),
+    kind: "pdf_highlight" as const,
+  }));
+}
 
 export default app;

--- a/src/components/layout/Header/HeaderSearchBar.tsx
+++ b/src/components/layout/Header/HeaderSearchBar.tsx
@@ -3,6 +3,7 @@ import { Search } from "lucide-react";
 import { Popover, PopoverAnchor } from "@zedi/ui";
 import { Input } from "@zedi/ui";
 import { useGlobalSearchContext } from "@/contexts/GlobalSearchContext";
+import type { GlobalSearchResultItem } from "@/hooks/useGlobalSearch";
 import { useGlobalSearchShortcut } from "@/hooks/useGlobalSearchShortcut";
 import { HeaderSearchDropdownContent } from "./HeaderSearchDropdownContent";
 import { cn } from "@zedi/ui";
@@ -15,10 +16,10 @@ interface SearchKeyDownParams {
   totalItems: number;
   activeIndex: number;
   itemCount: number;
-  searchResults: Array<{ pageId: string; noteId?: string }>;
+  searchResults: GlobalSearchResultItem[];
   setActiveIndex: (value: number | ((prev: number) => number)) => void;
   closeDropdown: () => void;
-  onSelectItem: (pageId: string, noteId?: string) => void;
+  onSelectItem: (item: GlobalSearchResultItem) => void;
   handleSearchSubmit: () => void;
   inputRef: React.RefObject<HTMLInputElement | null>;
 }
@@ -65,7 +66,7 @@ function handleSearchKeyDown(
         handleSearchSubmit();
       } else if (activeIndex >= 0 && activeIndex < itemCount) {
         const item = searchResults[activeIndex];
-        if (item) onSelectItem(item.pageId, item.noteId);
+        if (item) onSelectItem(item);
       }
       break;
     }
@@ -81,61 +82,25 @@ function handleSearchKeyDown(
  *
  */
 export function HeaderSearchBar() {
-  /**
-   *
-   */
   const { query, setQuery, searchResults, hasQuery, handleSelect, handleSearchSubmit } =
     useGlobalSearchContext();
 
-  /**
-   *
-   */
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  /**
-   *
-   */
   const [activeIndex, setActiveIndex] = useState(-1);
-  /**
-   *
-   */
   const inputRef = useRef<HTMLInputElement>(null);
-  /**
-   *
-   */
   const listRef = useRef<HTMLUListElement>(null);
-  /**
-   *
-   */
   const footerRef = useRef<HTMLButtonElement>(null);
 
-  /**
-   *
-   */
   const handleShortcutFocus = useCallback(() => {
     inputRef.current?.focus();
     inputRef.current?.select();
   }, []);
   useGlobalSearchShortcut(handleShortcutFocus);
 
-  /**
-   *
-   */
   const showResults = hasQuery && searchResults.length > 0;
-  /**
-   *
-   */
   const showEmpty = hasQuery && searchResults.length === 0;
-  /**
-   *
-   */
   const hasContent = showResults || showEmpty;
-  /**
-   *
-   */
   const itemCount = showResults ? searchResults.length : 0;
-  /**
-   *
-   */
   const totalItems = hasQuery ? itemCount + 1 : itemCount;
 
   useEffect(() => {
@@ -151,45 +116,30 @@ export function HeaderSearchBar() {
     if (activeIndex === itemCount) {
       footerRef.current?.scrollIntoView({ block: "nearest" });
     } else {
-      /**
-       *
-       */
       const items = listRef.current?.querySelectorAll("[role='option']");
       items?.[activeIndex]?.scrollIntoView({ block: "nearest" });
     }
   }, [activeIndex, itemCount]);
 
-  /**
-   *
-   */
   const closeDropdown = useCallback(() => {
     setDropdownOpen(false);
     setActiveIndex(-1);
   }, []);
 
-  /**
-   *
-   */
   const onSelectItem = useCallback(
-    (pageId: string, noteId?: string) => {
-      handleSelect(pageId, noteId);
+    (item: GlobalSearchResultItem) => {
+      handleSelect(item);
       closeDropdown();
     },
     [handleSelect, closeDropdown],
   );
 
-  /**
-   *
-   */
   const getOptionId = useCallback(
     (index: number) =>
       index === itemCount ? "header-search-footer" : `header-search-option-${index}`,
     [itemCount],
   );
 
-  /**
-   *
-   */
   const activeDescendant = activeIndex >= 0 ? getOptionId(activeIndex) : undefined;
 
   return (

--- a/src/components/layout/Header/HeaderSearchDropdownContent.tsx
+++ b/src/components/layout/Header/HeaderSearchDropdownContent.tsx
@@ -1,6 +1,7 @@
-import { FileText, Link as LinkIcon, ArrowRight } from "lucide-react";
+import { FileText, Link as LinkIcon, ArrowRight, BookOpen } from "lucide-react";
 import { PopoverContent } from "@zedi/ui";
 import { cn } from "@zedi/ui";
+import type { GlobalSearchResultItem } from "@/hooks/useGlobalSearch";
 
 const EMPTY_MESSAGE = "ページが見つかりません";
 
@@ -11,7 +12,7 @@ export interface HeaderSearchDropdownContentProps {
   hasContent: boolean;
   showEmpty: boolean;
   showResults: boolean;
-  searchResults: Array<{ pageId: string; noteId?: string; title: string; sourceUrl?: string }>;
+  searchResults: GlobalSearchResultItem[];
   itemCount: number;
   activeIndex: number;
   query: string;
@@ -19,10 +20,26 @@ export interface HeaderSearchDropdownContentProps {
   listRef: React.RefObject<HTMLUListElement | null>;
   footerRef: React.RefObject<HTMLButtonElement | null>;
   getOptionId: (index: number) => string;
-  onSelectItem: (pageId: string, noteId?: string) => void;
+  onSelectItem: (item: GlobalSearchResultItem) => void;
   setActiveIndex: (value: number | ((prev: number) => number)) => void;
   closeDropdown: () => void;
   handleSearchSubmit: () => void;
+}
+
+/**
+ * Issue #864 でグローバル検索結果に PDF ハイライト型 (`kind="pdf_highlight"`) が
+ * 加わったので、`key` と `aria-label` をアイテム種別ごとに分岐して安定化させる。
+ * 既存ノートページ / 個人ページの key 形式は維持し、追加分だけ別 prefix にする。
+ *
+ * Issue #864 introduced `kind="pdf_highlight"` rows; the React `key` and the
+ * accessible label branch on `kind` so the existing page-row keys stay stable
+ * and the new highlight rows get a distinct, collision-free namespace.
+ */
+function getResultKey(item: GlobalSearchResultItem): string {
+  if (item.kind === "pdf_highlight") {
+    return `pdf-${item.sourceId}-${item.highlightId}`;
+  }
+  return item.noteId ? `shared-${item.noteId}-${item.pageId}` : `personal-${item.pageId}`;
 }
 
 /**
@@ -73,29 +90,37 @@ export function HeaderSearchDropdownContent({
             候補 ({searchResults.length}件)
           </p>
           <ul ref={listRef} className="list-none" role="group" aria-label="検索候補">
-            {searchResults.map(({ pageId, noteId, title, sourceUrl }, index) => (
-              <li key={noteId ? `shared-${noteId}-${pageId}` : `personal-${pageId}`} role="none">
-                <button
-                  id={getOptionId(index)}
-                  type="button"
-                  role="option"
-                  aria-selected={activeIndex === index}
-                  className={cn(
-                    "flex w-full items-center gap-2 px-3 py-2 text-left text-sm outline-none",
-                    activeIndex === index ? "bg-accent text-accent-foreground" : "hover:bg-muted",
-                  )}
-                  onClick={() => onSelectItem(pageId, noteId)}
-                  onMouseEnter={() => setActiveIndex(index)}
-                >
-                  {sourceUrl ? (
-                    <LinkIcon className="text-muted-foreground h-4 w-4 shrink-0" />
-                  ) : (
-                    <FileText className="text-muted-foreground h-4 w-4 shrink-0" />
-                  )}
-                  <span className="flex-1 truncate font-medium">{title}</span>
-                </button>
-              </li>
-            ))}
+            {searchResults.map((item, index) => {
+              const isPdf = item.kind === "pdf_highlight";
+              return (
+                <li key={getResultKey(item)} role="none">
+                  <button
+                    id={getOptionId(index)}
+                    type="button"
+                    role="option"
+                    aria-selected={activeIndex === index}
+                    className={cn(
+                      "flex w-full items-center gap-2 px-3 py-2 text-left text-sm outline-none",
+                      activeIndex === index ? "bg-accent text-accent-foreground" : "hover:bg-muted",
+                    )}
+                    onClick={() => onSelectItem(item)}
+                    onMouseEnter={() => setActiveIndex(index)}
+                  >
+                    {isPdf ? (
+                      <BookOpen className="text-muted-foreground h-4 w-4 shrink-0" />
+                    ) : item.kind === "page" && item.sourceUrl ? (
+                      <LinkIcon className="text-muted-foreground h-4 w-4 shrink-0" />
+                    ) : (
+                      <FileText className="text-muted-foreground h-4 w-4 shrink-0" />
+                    )}
+                    <span className="flex-1 truncate font-medium">{item.title}</span>
+                    {isPdf && (
+                      <span className="text-muted-foreground shrink-0 text-[10px]">PDF</span>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
           </ul>
         </div>
       )}

--- a/src/components/search/SearchResultCard.tsx
+++ b/src/components/search/SearchResultCard.tsx
@@ -1,4 +1,4 @@
-import { FileText, Link as LinkIcon } from "lucide-react";
+import { FileText, Link as LinkIcon, BookOpen } from "lucide-react";
 import { HighlightedSnippet } from "@/components/search/HighlightedSnippet";
 import { MatchTypeBadge } from "@/components/search/MatchTypeBadge";
 import type { MatchType } from "@/lib/searchUtils";
@@ -6,17 +6,37 @@ import { cn } from "@zedi/ui";
 import { useAuthenticatedImageUrl } from "@/hooks/useAuthenticatedImageUrl";
 
 /**
+ * 検索結果カードの表示用アイテム。判別可能 union で `kind` が `"page"` と
+ * `"pdf_highlight"` の 2 種を持つ。`kind="page"` は `pageId` が必須、
+ * `kind="pdf_highlight"` は `sourceId` / `highlightId` / `pdfPage` を持つ。
  *
+ * Discriminated union: `kind="page"` rows must carry `pageId`; PDF highlight
+ * rows carry `sourceId`/`highlightId`/`pdfPage` so the click handler can route
+ * to the derived page or the PDF viewer (Issue #864).
  */
-export interface SearchResultCardItem {
-  pageId: string;
-  noteId?: string;
+export type SearchResultCardItem = SearchResultCardPageItem | SearchResultCardPdfHighlightItem;
+
+interface SearchResultCardBase {
   title: string;
   highlightedSnippet: string;
   matchType: MatchType;
-  sourceUrl?: string;
   thumbnailUrl?: string;
   updatedAt: number;
+}
+
+export interface SearchResultCardPageItem extends SearchResultCardBase {
+  kind: "page";
+  pageId: string;
+  noteId?: string;
+  sourceUrl?: string;
+}
+
+export interface SearchResultCardPdfHighlightItem extends SearchResultCardBase {
+  kind: "pdf_highlight";
+  highlightId: string;
+  sourceId: string;
+  pdfPage: number;
+  derivedPageId: string | null;
 }
 
 function formatDate(ts: number): string {
@@ -38,12 +58,13 @@ interface SearchResultCardProps {
  *
  */
 export function SearchResultCard({ item, onClick }: SearchResultCardProps) {
-  /**
-   *
-   */
   const { resolvedUrl: thumbnailSrc, hasError: thumbnailError } = useAuthenticatedImageUrl(
     item.thumbnailUrl,
   );
+
+  const isPdf = item.kind === "pdf_highlight";
+  const isShared = item.kind === "page" && Boolean(item.noteId);
+  const hasSourceUrl = item.kind === "page" && Boolean(item.sourceUrl);
 
   return (
     <button
@@ -69,14 +90,21 @@ export function SearchResultCard({ item, onClick }: SearchResultCardProps) {
 
         <div className="min-w-0 flex-1">
           <div className="mb-1.5 flex items-center gap-2">
-            {item.sourceUrl ? (
+            {isPdf ? (
+              <BookOpen className="text-muted-foreground h-4 w-4 shrink-0" />
+            ) : hasSourceUrl ? (
               <LinkIcon className="text-muted-foreground h-4 w-4 shrink-0" />
             ) : (
               <FileText className="text-muted-foreground h-4 w-4 shrink-0" />
             )}
             <span className="flex-1 truncate text-base font-medium">{item.title}</span>
             <MatchTypeBadge type={item.matchType} />
-            {item.noteId && (
+            {isPdf && (
+              <span className="shrink-0 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-700 dark:bg-amber-900 dark:text-amber-300">
+                PDF
+              </span>
+            )}
+            {isShared && (
               <span className="shrink-0 rounded bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-700 dark:bg-blue-900 dark:text-blue-300">
                 共有
               </span>

--- a/src/components/search/SearchResultCard.tsx
+++ b/src/components/search/SearchResultCard.tsx
@@ -24,6 +24,16 @@ interface SearchResultCardBase {
   updatedAt: number;
 }
 
+/**
+ * ページ系（個人 / 共有ノート）検索結果用のカード項目。
+ *
+ * Card item for a page-kind search result (personal page or shared note page).
+ *
+ * @property pageId - 対象ページ ID。Target page id.
+ * @property noteId - 共有ノート所属ページの場合に設定されるノート ID。
+ *   Owning note id when the page is note-native (used for /notes/:noteId/:pageId routing).
+ * @property sourceUrl - クリップ系ページに紐づく出典 URL。Source URL for clipped pages.
+ */
 export interface SearchResultCardPageItem extends SearchResultCardBase {
   kind: "page";
   pageId: string;
@@ -31,6 +41,20 @@ export interface SearchResultCardPageItem extends SearchResultCardBase {
   sourceUrl?: string;
 }
 
+/**
+ * Issue #864: PDF ハイライト本文ヒット用のカード項目。
+ * クリック時は派生 Zedi ページがあればそちらへ、なければ PDF ビューアへ deep-link。
+ *
+ * Issue #864: card item for a `pdf_highlights.text` match. Clicking routes to
+ * the derived Zedi page when one exists, otherwise deep-links to the PDF
+ * viewer at `/sources/:sourceId/pdf#page=N`.
+ *
+ * @property highlightId - ハイライトの一意 ID。Highlight UUID.
+ * @property sourceId - 元 PDF ソース ID。Owning PDF source id (`sources.id`).
+ * @property pdfPage - 1 始まりの PDF ページ番号。1-indexed PDF page number.
+ * @property derivedPageId - 派生 Zedi ページがあれば ID、なければ null。
+ *   Derived Zedi page id when one exists, otherwise null.
+ */
 export interface SearchResultCardPdfHighlightItem extends SearchResultCardBase {
   kind: "pdf_highlight";
   highlightId: string;

--- a/src/contexts/GlobalSearchContext.test.ts
+++ b/src/contexts/GlobalSearchContext.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { resolveSearchResultUrl } from "./GlobalSearchContext";
+import type { GlobalSearchResultItem } from "@/hooks/useGlobalSearch";
+
+/**
+ * Issue #864 受け入れ基準: 検索結果クリック時の URL 組み立てが種別ごとに正しく
+ * 行われることを保証する。
+ *
+ * Issue #864 acceptance criteria: URL composition branches correctly on
+ * `kind`. Personal/page/note rows stay on the existing routes; highlight rows
+ * prefer the derived Zedi page when available and otherwise deep-link into
+ * the PDF viewer with a `#page=N` hash.
+ */
+describe("resolveSearchResultUrl (Issue #864)", () => {
+  it("routes personal page rows to /pages/:pageId", () => {
+    const item: GlobalSearchResultItem = {
+      kind: "page",
+      pageId: "p-1",
+      title: "Personal",
+      highlightedText: "x",
+      matchType: "content",
+    };
+    expect(resolveSearchResultUrl(item)).toBe("/pages/p-1");
+  });
+
+  it("routes shared note rows to /notes/:noteId/:pageId", () => {
+    const item: GlobalSearchResultItem = {
+      kind: "page",
+      pageId: "p-2",
+      noteId: "n-9",
+      title: "Shared",
+      highlightedText: "x",
+      matchType: "content",
+    };
+    expect(resolveSearchResultUrl(item)).toBe("/notes/n-9/p-2");
+  });
+
+  it("prefers the derived Zedi page when a pdf_highlight has one", () => {
+    const item: GlobalSearchResultItem = {
+      kind: "pdf_highlight",
+      highlightId: "h-1",
+      sourceId: "src-1",
+      sourceDisplayName: "doc.pdf",
+      pdfPage: 5,
+      derivedPageId: "derived-1",
+      title: "doc.pdf (p.5)",
+      highlightedText: "x",
+      matchType: "content",
+    };
+    expect(resolveSearchResultUrl(item)).toBe("/pages/derived-1");
+  });
+
+  it("deep-links into the PDF viewer when no derived page exists", () => {
+    const item: GlobalSearchResultItem = {
+      kind: "pdf_highlight",
+      highlightId: "h-2",
+      sourceId: "src-2",
+      sourceDisplayName: "spec.pdf",
+      pdfPage: 12,
+      derivedPageId: null,
+      title: "spec.pdf (p.12)",
+      highlightedText: "x",
+      matchType: "content",
+    };
+    expect(resolveSearchResultUrl(item)).toBe("/sources/src-2/pdf#page=12");
+  });
+});

--- a/src/contexts/GlobalSearchContext.tsx
+++ b/src/contexts/GlobalSearchContext.tsx
@@ -8,7 +8,22 @@ interface GlobalSearchContextValue {
   setQuery: (value: string) => void;
   searchResults: GlobalSearchResultItem[];
   hasQuery: boolean;
-  handleSelect: (pageId: string, noteId?: string) => void;
+  /**
+   * 検索結果アイテムを選択したときの遷移ロジック。
+   * Navigation handler for a selected search result item.
+   *
+   * Issue #864:
+   * - `kind="page"`: 従来どおり `/notes/:noteId/:pageId` または `/pages/:pageId`。
+   * - `kind="pdf_highlight"`: 派生 Zedi ページがあればそちらへ、なければ
+   *   `/sources/:sourceId/pdf#page=N` の PDF ビューア（後続 PR で実装）へ。
+   *
+   * - `kind="page"`: same as before — note-scoped or standalone page URL.
+   * - `kind="pdf_highlight"`: route to the derived Zedi page if one exists,
+   *   otherwise deep-link to the PDF viewer at `/sources/:sourceId/pdf#page=N`.
+   *   The hash carries the page number so the viewer (built in a follow-up PR
+   *   tracked by the parent issue otomatty/zedi#389) can scroll to it.
+   */
+  handleSelect: (item: GlobalSearchResultItem) => void;
   /** Enterキーで検索結果ページへ遷移 */
   handleSearchSubmit: () => void;
   /** ⌘K でヘッダー検索バーにフォーカス */
@@ -22,64 +37,48 @@ interface GlobalSearchContextValue {
 const GlobalSearchContext = createContext<GlobalSearchContextValue | null>(null);
 
 /**
+ * Builds the navigation URL for a search result item. Exported pure helper so
+ * URL composition (Issue #864 acceptance criteria) can be unit-tested without
+ * spinning up React Router.
+ *
+ * 検索結果アイテムから遷移先 URL を組み立てる純関数。URL 組み立てロジックを
+ * テストから直接呼べるよう export している（Issue #864 受け入れ基準）。
+ */
+export function resolveSearchResultUrl(item: GlobalSearchResultItem): string {
+  if (item.kind === "page") {
+    if (item.noteId) return `/notes/${item.noteId}/${item.pageId}`;
+    return `/pages/${item.pageId}`;
+  }
+  // kind === "pdf_highlight"
+  if (item.derivedPageId) return `/pages/${item.derivedPageId}`;
+  return `/sources/${item.sourceId}/pdf#page=${item.pdfPage}`;
+}
+
+/**
  *
  */
 export function GlobalSearchProvider({ children }: { children: ReactNode }) {
-  /**
-   *
-   */
   const navigate = useNavigate();
-  /**
-   *
-   */
   const { query, setQuery, searchResults, hasQuery } = useGlobalSearch();
-  /**
-   *
-   */
   const [isOpen, setOpen] = useState(false);
-  /**
-   *
-   */
   const open = useCallback(() => setOpen(true), []);
-  /**
-   *
-   */
   const close = useCallback(() => setOpen(false), []);
 
-  /**
-   *
-   */
   const handleSelect = useCallback(
-    (pageId: string, noteId?: string) => {
-      if (noteId) {
-        navigate(`/notes/${noteId}/${pageId}`);
-      } else {
-        navigate(`/pages/${pageId}`);
-      }
+    (item: GlobalSearchResultItem) => {
+      navigate(resolveSearchResultUrl(item));
     },
     [navigate],
   );
 
-  /**
-   *
-   */
   const handleSearchSubmit = useCallback(() => {
-    /**
-     *
-     */
     const q = query.trim();
     if (q) {
       navigate(`/search?q=${encodeURIComponent(q)}`);
     }
   }, [query, navigate]);
 
-  /**
-   *
-   */
   const focusSearchInput = useCallback(() => {
-    /**
-     *
-     */
     const el = document.getElementById("header-search-input") as HTMLInputElement | null;
     if (el) {
       el.focus();
@@ -87,9 +86,6 @@ export function GlobalSearchProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  /**
-   *
-   */
   const value: GlobalSearchContextValue = {
     query,
     setQuery,
@@ -110,9 +106,6 @@ export function GlobalSearchProvider({ children }: { children: ReactNode }) {
  *
  */
 export function useGlobalSearchContext(): GlobalSearchContextValue {
-  /**
-   *
-   */
   const ctx = useContext(GlobalSearchContext);
   if (!ctx) {
     throw new Error("useGlobalSearchContext must be used within GlobalSearchProvider");

--- a/src/hooks/useGlobalSearch.test.ts
+++ b/src/hooks/useGlobalSearch.test.ts
@@ -2,10 +2,17 @@ import { describe, it, expect } from "vitest";
 import {
   searchPages,
   buildGlobalSearchResults,
+  buildPdfHighlightItem,
   dedupSharedRowsAgainstPersonal,
+  PDF_HIGHLIGHT_BASE_SCORE,
+  type GlobalSearchResultItem,
 } from "./useGlobalSearch";
 import type { Page } from "@/types/page";
-import type { SearchSharedResponse } from "@/lib/api/types";
+import type {
+  SearchPageResultRow,
+  SearchPdfHighlightResultRow,
+  SearchResultRow,
+} from "@/lib/api/types";
 import { createPlainTextContent } from "@/test/testDatabase";
 import { parseSearchQuery } from "@/lib/searchUtils";
 
@@ -271,26 +278,46 @@ describe("searchPages", () => {
 });
 
 /**
- * 共有検索の row 雛形を作るテストヘルパー。サーバーは個人ページも `note_id IS NULL`
- * で返してくる仕様 (Issue #718 Phase 5-1) なので、両方のケースを並べて検証できる
- * よう `note_id` を任意で受け取る。
+ * 共有検索のページ行を作るテストヘルパー。`kind="page"` を default で埋める。
  *
- * Test helper that builds a `SearchSharedResponse` row. The server still
- * returns personal pages with `note_id: null` under `scope=shared`, so the
- * tests below need to construct both shapes side-by-side.
+ * Test helper that builds a `kind="page"` row for the shared-search response.
  */
 function createSharedRow(
-  overrides: Partial<SearchSharedResponse["results"][number]> &
-    Pick<SearchSharedResponse["results"][number], "id">,
-): SearchSharedResponse["results"][number] {
+  overrides: Partial<SearchPageResultRow> & Pick<SearchPageResultRow, "id">,
+): SearchPageResultRow {
   return {
+    kind: "page",
     id: overrides.id,
-    note_id: null,
+    note_id: "note-default" as string,
     owner_id: "u1",
     title: "shared",
     content_preview: "preview",
     thumbnail_url: null,
     source_url: null,
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  } as SearchPageResultRow;
+}
+
+/**
+ * Issue #864: PDF ハイライト行を作るテストヘルパー。
+ *
+ * Issue #864: builds a `kind="pdf_highlight"` row for the shared-search response.
+ */
+function createHighlightRow(
+  overrides: Partial<SearchPdfHighlightResultRow> &
+    Pick<SearchPdfHighlightResultRow, "highlight_id">,
+): SearchPdfHighlightResultRow {
+  return {
+    kind: "pdf_highlight",
+    highlight_id: overrides.highlight_id,
+    source_id: "src-1",
+    owner_id: "u1",
+    pdf_page: 1,
+    text: "highlighted body",
+    derived_page_id: null,
+    source_display_name: "paper.pdf",
+    source_title: null,
     updated_at: new Date().toISOString(),
     ...overrides,
   };
@@ -327,14 +354,17 @@ describe("buildGlobalSearchResults", () => {
       const query = "alpha";
       const keywords = parseSearchQuery(query);
       const personal: Page[] = [createPersonalPage("p1", "alpha")];
-      const shared = [
-        createSharedRow({ id: "p1", note_id: null, title: "alpha" }),
+      const shared: SearchResultRow[] = [
+        createSharedRow({ id: "p1", note_id: "note-1", title: "alpha" }),
         createSharedRow({ id: "p2", note_id: "note-1", title: "alpha note" }),
       ];
 
       const results = buildGlobalSearchResults(personal, shared, query, keywords);
 
-      const ids = results.map((r) => r.pageId).sort();
+      const ids = results
+        .filter((r): r is Extract<GlobalSearchResultItem, { kind: "page" }> => r.kind === "page")
+        .map((r) => r.pageId)
+        .sort();
       // `p1` だけが personal 由来で 1 回、`p2` がノート由来で 1 回。
       // `p1` only appears once (personal), `p2` once (shared note-native).
       expect(ids).toEqual(["p1", "p2"]);
@@ -343,93 +373,186 @@ describe("buildGlobalSearchResults", () => {
     it("keeps note-native shared rows with noteId for canonical /notes/:noteId/:pageId routing", () => {
       const query = "alpha";
       const keywords = parseSearchQuery(query);
-      const shared = [createSharedRow({ id: "p3", note_id: "note-9", title: "alpha shared" })];
+      const shared: SearchResultRow[] = [
+        createSharedRow({ id: "p3", note_id: "note-9", title: "alpha shared" }),
+      ];
 
       const results = buildGlobalSearchResults([], shared, query, keywords);
 
       expect(results).toHaveLength(1);
       expect(results[0]).toMatchObject({
+        kind: "page",
         pageId: "p3",
         noteId: "note-9",
       });
     });
 
-    it("preserves linked personal pages (note_id IS NULL) not present in IDB", () => {
-      // 他ユーザー所有のリンク済み個人ページや、IDB がまだ hydrate されて
-      // いない時点での自分の個人ページ。`note_id IS NULL` だが personal 結果に
-      // 居ないので shared 側に残す必要がある (Codex / CodeRabbit 指摘)。
-      //
-      // Linked personal pages owned by other note members — or the caller's
-      // own personal pages before IDB has hydrated — have `note_id IS NULL`
-      // but are not yet in the personal results, so they must survive the
-      // dedup (Codex / CodeRabbit review).
+    it("does not over-drop when IDB has not loaded yet", () => {
       const query = "alpha";
       const keywords = parseSearchQuery(query);
-      const shared = [
-        createSharedRow({
-          id: "linked-personal",
-          note_id: null,
-          title: "alpha linked personal",
-          owner_id: "other-user",
+      const shared: SearchResultRow[] = [
+        createSharedRow({ id: "a", note_id: "n2", title: "alpha" }),
+        createSharedRow({ id: "b", note_id: "n1", title: "alpha b" }),
+      ];
+
+      const results = buildGlobalSearchResults([], shared, query, keywords);
+
+      const ids = results
+        .filter((r): r is Extract<GlobalSearchResultItem, { kind: "page" }> => r.kind === "page")
+        .map((r) => r.pageId)
+        .sort();
+      expect(ids).toEqual(["a", "b"]);
+    });
+
+    it("returns empty when query is shorter than 3 chars", () => {
+      const query = "ab";
+      const shared: SearchResultRow[] = [createSharedRow({ id: "p1", note_id: "n1" })];
+      const results = buildGlobalSearchResults([], shared, query, parseSearchQuery(query));
+      expect(results).toEqual([]);
+    });
+  });
+
+  // ── Issue #864: PDF ハイライト統合 ─────────────────────────────────────────
+  describe("Issue #864: PDF highlight integration", () => {
+    it("includes pdf_highlight rows as kind='pdf_highlight' items with deep-link fields", () => {
+      const query = "alpha";
+      const keywords = parseSearchQuery(query);
+      const shared: SearchResultRow[] = [
+        createHighlightRow({
+          highlight_id: "h-1",
+          source_id: "src-100",
+          pdf_page: 12,
+          text: "alpha appears in this passage",
+          derived_page_id: "derived-1",
         }),
       ];
 
       const results = buildGlobalSearchResults([], shared, query, keywords);
 
       expect(results).toHaveLength(1);
-      expect(results[0].pageId).toBe("linked-personal");
-      // `noteId` は undefined のままなので、UI 側は /pages/:id にルーティングする。
-      // `noteId` stays undefined so the UI routes to /pages/:id.
-      expect(results[0].noteId).toBeUndefined();
+      const item = results[0];
+      expect(item.kind).toBe("pdf_highlight");
+      if (item.kind !== "pdf_highlight") throw new Error("type narrowing");
+      expect(item).toMatchObject({
+        highlightId: "h-1",
+        sourceId: "src-100",
+        pdfPage: 12,
+        derivedPageId: "derived-1",
+      });
+      expect(item.highlightedText).toContain("【alpha】");
     });
 
-    it("does not over-drop when IDB has not loaded yet", () => {
-      // 初回ロード等で `useSearchPages` が空配列を返す場合、shared 結果は
-      // 何も落とされず全件残るはず。
-      // When IDB has not hydrated and `useSearchPages` returns [], every
-      // shared row must survive — otherwise the user sees no hits at all.
+    it("keeps the priority order: title > content > pdf_highlight body", () => {
       const query = "alpha";
       const keywords = parseSearchQuery(query);
-      const shared = [
-        createSharedRow({ id: "a", note_id: null, title: "alpha" }),
-        createSharedRow({ id: "b", note_id: "n1", title: "alpha b" }),
+      // title 一致のページ / content 一致のページ / pdf_highlight 行
+      // Title match page / content match page / pdf highlight row.
+      const personal: Page[] = [createPersonalPage("page-title", "alpha header")];
+      const shared: SearchResultRow[] = [
+        createSharedRow({
+          id: "page-content",
+          note_id: "n1",
+          title: "shared note",
+          content_preview: "this mentions alpha somewhere",
+        }),
+        createHighlightRow({
+          highlight_id: "h-9",
+          text: "alpha in PDF body",
+        }),
       ];
 
-      const results = buildGlobalSearchResults([], shared, query, keywords);
+      const results = buildGlobalSearchResults(personal, shared, query, keywords);
 
-      expect(results.map((r) => r.pageId).sort()).toEqual(["a", "b"]);
+      expect(results).toHaveLength(3);
+      expect(results[0]).toMatchObject({ kind: "page", pageId: "page-title" });
+      // The shared content-match page should outrank the pdf_highlight row.
+      // 共有のコンテンツ一致ページが PDF ハイライト行より上位に来る。
+      expect(results[1]).toMatchObject({ kind: "page", pageId: "page-content" });
+      expect(results[2]).toMatchObject({ kind: "pdf_highlight", highlightId: "h-9" });
     });
 
-    it("returns empty when query is shorter than 3 chars", () => {
-      const query = "ab";
-      const shared = [createSharedRow({ id: "p1", note_id: "n1" })];
-      const results = buildGlobalSearchResults([], shared, query, parseSearchQuery(query));
-      expect(results).toEqual([]);
+    it("does not dedup pdf_highlight rows against personal page ids (separate entity)", () => {
+      const query = "alpha";
+      const keywords = parseSearchQuery(query);
+      // page id と highlight id が偶然同じ値でも、別エンティティなので両方残る。
+      // Even when a personal page id collides with a highlight id, both
+      // survive — highlights live in their own table.
+      const personal: Page[] = [createPersonalPage("collision-id", "alpha title")];
+      const shared: SearchResultRow[] = [
+        createHighlightRow({ highlight_id: "collision-id", text: "alpha body" }),
+      ];
+
+      const results = buildGlobalSearchResults(personal, shared, query, keywords);
+
+      expect(results).toHaveLength(2);
+      expect(results.some((r) => r.kind === "page" && r.pageId === "collision-id")).toBe(true);
+      expect(
+        results.some((r) => r.kind === "pdf_highlight" && r.highlightId === "collision-id"),
+      ).toBe(true);
     });
+  });
+});
+
+describe("buildPdfHighlightItem", () => {
+  it("builds a UI item with display name, page number, and highlighted text", () => {
+    const row = createHighlightRow({
+      highlight_id: "h-42",
+      source_id: "src-42",
+      pdf_page: 7,
+      text: "the quick brown alpha jumps",
+      source_display_name: "spec.pdf",
+    });
+    const item = buildPdfHighlightItem(row, ["alpha"]);
+
+    expect(item).toMatchObject({
+      kind: "pdf_highlight",
+      highlightId: "h-42",
+      sourceId: "src-42",
+      pdfPage: 7,
+      sourceDisplayName: "spec.pdf",
+      score: PDF_HIGHLIGHT_BASE_SCORE,
+    });
+    expect(item.highlightedText).toContain("【alpha】");
+    // タイトルにファイル名とページ番号が含まれる。
+    // Title includes both the file name and the page number.
+    expect(item.title).toContain("spec.pdf");
+    expect(item.title).toContain("7");
+  });
+
+  it("falls back to PDF title when display name is missing", () => {
+    const row = createHighlightRow({
+      highlight_id: "h-43",
+      source_display_name: null,
+      source_title: "From PDF Metadata",
+    });
+    const item = buildPdfHighlightItem(row, ["body"]);
+    expect(item.sourceDisplayName).toBe("From PDF Metadata");
   });
 });
 
 describe("dedupSharedRowsAgainstPersonal (Issue #718 Phase 5-4)", () => {
   it("drops rows whose id is in the personal id set", () => {
-    const rows = [
-      createSharedRow({ id: "p1", note_id: null }),
+    const rows: SearchResultRow[] = [
+      createSharedRow({ id: "p1", note_id: "n2" }),
       createSharedRow({ id: "p2", note_id: "n1" }),
-      createSharedRow({ id: "p3", note_id: null }),
+      createSharedRow({ id: "p3", note_id: "n3" }),
     ];
     const personalIds = new Set(["p1"]);
 
     const filtered = dedupSharedRowsAgainstPersonal(rows, personalIds);
 
-    // `p1` だけが personal 由来で重複、`p2`/`p3` は残る (リンク済み個人 / ノート)。
-    // Only `p1` overlaps with the personal result set; `p2` (note-native) and
-    // `p3` (linked personal not in IDB) survive.
-    expect(filtered.map((r) => r.id).sort()).toEqual(["p2", "p3"]);
+    expect(
+      filtered
+        .filter((r): r is SearchPageResultRow => r.kind === "page")
+        .map((r) => r.id)
+        .sort(),
+    ).toEqual(["p2", "p3"]);
   });
 
   it("keeps every row when the personal id set is empty (IDB not hydrated)", () => {
-    const rows = [
-      createSharedRow({ id: "p1", note_id: null }),
-      createSharedRow({ id: "p2", note_id: "n1" }),
+    const rows: SearchResultRow[] = [
+      createSharedRow({ id: "p1", note_id: "n1" }),
+      createSharedRow({ id: "p2", note_id: "n2" }),
     ];
     const filtered = dedupSharedRowsAgainstPersonal(rows, new Set());
     expect(filtered).toHaveLength(2);
@@ -437,5 +560,20 @@ describe("dedupSharedRowsAgainstPersonal (Issue #718 Phase 5-4)", () => {
 
   it("handles empty input", () => {
     expect(dedupSharedRowsAgainstPersonal([], new Set(["p1"]))).toEqual([]);
+  });
+
+  // Issue #864: pdf_highlight 行は別エンティティなので、page id とぶつかっても落とさない。
+  // Issue #864: highlight rows live in a separate table; never dropped by page-id dedup.
+  it("never drops pdf_highlight rows by id collision with personal pages", () => {
+    const rows: SearchResultRow[] = [
+      createSharedRow({ id: "shared-page", note_id: "n1" }),
+      createHighlightRow({ highlight_id: "shared-page", text: "body" }),
+    ];
+    const personalIds = new Set(["shared-page"]);
+
+    const filtered = dedupSharedRowsAgainstPersonal(rows, personalIds);
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].kind).toBe("pdf_highlight");
   });
 });

--- a/src/hooks/useGlobalSearch.test.ts
+++ b/src/hooks/useGlobalSearch.test.ts
@@ -4,6 +4,7 @@ import {
   buildGlobalSearchResults,
   buildPdfHighlightItem,
   dedupSharedRowsAgainstPersonal,
+  formatPdfHighlightDisplay,
   PDF_HIGHLIGHT_BASE_SCORE,
   type GlobalSearchResultItem,
 } from "./useGlobalSearch";
@@ -412,7 +413,7 @@ describe("buildGlobalSearchResults", () => {
     });
   });
 
-  // ── Issue #864: PDF ハイライト統合 ─────────────────────────────────────────
+  // ── Issue #864: PDF ハイライト統合 / PDF highlight integration ──────────────
   describe("Issue #864: PDF highlight integration", () => {
     it("includes pdf_highlight rows as kind='pdf_highlight' items with deep-link fields", () => {
       const query = "alpha";
@@ -527,6 +528,73 @@ describe("buildPdfHighlightItem", () => {
     });
     const item = buildPdfHighlightItem(row, ["body"]);
     expect(item.sourceDisplayName).toBe("From PDF Metadata");
+  });
+});
+
+/**
+ * PR #873 review (Gemini): ヘッダードロップダウン (`buildPdfHighlightItem`) と
+ * フル検索画面 (`SearchResults.tsx`) で同じ i18n / snippet 整形ロジックを共有することを
+ * 単独でテストする。Translator 関数を差し替えられるので、デフォルト値の fallback と
+ * snippet 長の上書きを直接アサートできる。
+ *
+ * PR #873 review (Gemini): exercises the shared formatter used by both the
+ * header dropdown (`buildPdfHighlightItem`) and the full search page
+ * (`SearchResults.tsx`). The translator is injected, so the fallback path and
+ * the snippet-length override can be asserted without spinning up i18next.
+ */
+describe("formatPdfHighlightDisplay", () => {
+  const passthroughTranslator = (key: string, options?: Record<string, unknown>) => {
+    if (key === "common.pdfHighlightFallbackName")
+      return (options?.defaultValue as string) ?? "PDF";
+    if (key === "common.pdfHighlightResultTitle") {
+      const file = options?.file as string;
+      const page = options?.page as number;
+      return `${file} (p.${page})`;
+    }
+    return key;
+  };
+
+  it("returns a title combining display name and page number", () => {
+    const row = createHighlightRow({
+      highlight_id: "h-1",
+      source_display_name: "paper.pdf",
+      pdf_page: 9,
+      text: "alpha keyword text",
+    });
+
+    const result = formatPdfHighlightDisplay(row, ["alpha"], passthroughTranslator);
+
+    expect(result.title).toBe("paper.pdf (p.9)");
+    expect(result.displayName).toBe("paper.pdf");
+    expect(result.highlightedText).toContain("【alpha】");
+  });
+
+  it("falls back to the i18n placeholder when both display name and PDF title are missing", () => {
+    const row = createHighlightRow({
+      highlight_id: "h-2",
+      source_display_name: null,
+      source_title: null,
+    });
+
+    const result = formatPdfHighlightDisplay(row, ["body"], passthroughTranslator);
+
+    expect(result.displayName).toBe("PDF");
+    expect(result.title).toBe("PDF (p.1)");
+  });
+
+  it("forwards the snippet length override to extractSmartSnippet (used by the full search page)", () => {
+    // キーワードが見つからない長文では `maxLength` がそのまま境界として効くので、
+    // 短尺 / 長尺の指定で snippet 長が変わることを観察できる。
+    // When the keyword is absent, `extractSmartSnippet` truncates at `maxLength`
+    // directly, so the override is observable as a snippet-length change.
+    const longText = "padding ".repeat(60).trim();
+    const row = createHighlightRow({ highlight_id: "h-3", text: longText });
+
+    const short = formatPdfHighlightDisplay(row, ["nomatch"], passthroughTranslator, 50);
+    const long = formatPdfHighlightDisplay(row, ["nomatch"], passthroughTranslator, 200);
+
+    expect(short.snippet.length).toBeLessThan(long.snippet.length);
+    expect(long.snippet.length).toBeGreaterThan(50);
   });
 });
 

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -185,29 +185,68 @@ export function searchPages(pages: Page[], query: string): SearchResult[] {
 }
 
 /**
+ * PR #873 review (Gemini): PDF ハイライト行の i18n タイトル / snippet 抽出 /
+ * ハイライト本文整形ロジックを単一の helper に集約する。`buildPdfHighlightItem`
+ * とフル検索画面 (`SearchResults.tsx`) の両方がこれを共有する。i18n 関数を
+ * 引数化することで、ヘッダードロップダウン側 (i18next の `i18n.t`) と
+ * フル検索画面側 (react-i18next の `useTranslation` の `t`) の両方で使える。
+ *
+ * PR #873 review (Gemini): centralize the i18n title / snippet extraction /
+ * highlight formatting so the header dropdown (`buildPdfHighlightItem`) and
+ * the full search page (`SearchResults.tsx`) share one implementation. The
+ * translator function is injected so callers can pass either i18next's global
+ * `i18n.t` or the `t` from `useTranslation`.
+ *
+ * @param row - サーバから返ってきた PDF ハイライト行。Highlight row from the API.
+ * @param keywords - 検索キーワード配列。Parsed search keywords.
+ * @param translate - i18n キー解決関数。Translator function.
+ * @param snippetLength - スニペット最大長（既定 120）。Snippet max length (default 120).
+ */
+export function formatPdfHighlightDisplay(
+  row: SearchPdfHighlightResultRow,
+  keywords: string[],
+  translate: (key: string, options?: Record<string, unknown>) => string,
+  snippetLength = 120,
+): {
+  displayName: string;
+  title: string;
+  snippet: string;
+  highlightedText: string;
+} {
+  const snippet = extractSmartSnippet(row.text, keywords, snippetLength);
+  const highlightedText = highlightKeywords(snippet, keywords);
+  const displayName =
+    (row.source_display_name?.trim() || row.source_title?.trim() || null) ??
+    translate("common.pdfHighlightFallbackName", { defaultValue: "PDF" });
+
+  // 表示用タイトル: `<file> (p.<page>)`。i18n リソースが無い環境では英語フォールバック。
+  // Display title: `<file> (p.<page>)`; falls back to English when i18n missing.
+  const title = translate("common.pdfHighlightResultTitle", {
+    defaultValue: "{{file}} (p.{{page}})",
+    file: displayName,
+    page: row.pdf_page,
+  });
+
+  return { displayName, title, snippet, highlightedText };
+}
+
+/**
  * Issue #864: PDF ハイライト行を表示用の `GlobalSearchPdfHighlightResultItem` に変換する。
  *
  * Converts a server `kind="pdf_highlight"` row into the discriminated UI shape.
  * Exported so the snippet / title build-out is easy to unit-test without a
- * React Query harness.
+ * React Query harness. Shared formatting lives in
+ * {@link formatPdfHighlightDisplay} (PR #873 review: Gemini).
  */
 export function buildPdfHighlightItem(
   row: SearchPdfHighlightResultRow,
   keywords: string[],
 ): GlobalSearchPdfHighlightResultItem & { score: number } {
-  const snippet = extractSmartSnippet(row.text, keywords);
-  const highlightedText = highlightKeywords(snippet, keywords);
-  const displayName =
-    (row.source_display_name?.trim() || row.source_title?.trim() || null) ??
-    i18n.t("common.pdfHighlightFallbackName", { defaultValue: "PDF" });
-
-  // 表示用タイトル: `<file> (p.<page>)`。i18n リソースが無い環境では英語フォールバック。
-  // Display title: `<file> (p.<page>)`; falls back to English when i18n missing.
-  const title = i18n.t("common.pdfHighlightResultTitle", {
-    defaultValue: "{{file}} (p.{{page}})",
-    file: displayName,
-    page: row.pdf_page,
-  });
+  const { displayName, title, highlightedText } = formatPdfHighlightDisplay(
+    row,
+    keywords,
+    (key, options) => i18n.t(key, options),
+  );
 
   return {
     kind: "pdf_highlight",

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -12,9 +12,33 @@ import {
   calculateEnhancedScore,
 } from "@/lib/searchUtils";
 import type { Page } from "@/types/page";
-import type { SearchSharedResponse } from "@/lib/api/types";
+import type {
+  SearchPageResultRow,
+  SearchPdfHighlightResultRow,
+  SearchResultRow,
+} from "@/lib/api/types";
 
-type SharedResultRow = SearchSharedResponse["results"][number];
+/**
+ * Issue #864: PDF ハイライト本文ヒットの相対スコア基準点。
+ * 「タイトル一致 \> 派生ページ一致 \> ハイライト本文一致」の序列を維持するため、
+ * 既存のページ系結果より必ず下位に来るよう負値を採る。
+ *
+ * 既存値: 個人ページ title 100+ / content 30+ / 共有ページ (レガシー) 0。
+ * 派生ページ自体は通常のページ検索で拾われ、そこで title/both/content の
+ * スコアが付くので、本値より必ず上位に並ぶ。
+ *
+ * Issue #864: base score for a PDF highlight body match. We use a negative
+ * value so highlight rows always sort below every page-shaped result and the
+ * documented priority — title \> derived page \> highlight body — is preserved.
+ *
+ * Existing scores (for context): personal title 100+, personal content 30+,
+ * shared rows legacy 0. Derived pages still appear via the regular page
+ * search and pick up their normal title/content scores, so they outrank
+ * highlight rows even when both reference the same passage.
+ */
+export const PDF_HIGHLIGHT_BASE_SCORE = -10;
+
+type SharedResultRow = SearchResultRow;
 
 /**
  * Issue #718 Phase 5-4 の dedup 契約を一箇所に集約するヘルパー。
@@ -40,15 +64,24 @@ type SharedResultRow = SearchSharedResponse["results"][number];
  * `note_id` as a proxy — otherwise (2) would silently disappear (Codex
  * review).
  *
- * @param rows shared 検索 API のレスポンス行 / Rows from the shared search API.
- * @param personalIds `useSearchPages` (IDB) で既に出ている page id の集合 /
+ * Issue #864: PDF ハイライト行 (`kind="pdf_highlight"`) は別エンティティで個人
+ * ページとは重複しないため、`page` 種別だけを dedup の対象とする。
+ *
+ * Issue #864: PDF highlight rows are a separate entity, so the dedup pass
+ * only applies to `kind="page"` rows.
+ *
+ * @param rows - shared 検索 API のレスポンス行 / Rows from the shared search API.
+ * @param personalIds - `useSearchPages` (IDB) で既に出ている page id の集合 /
  *   Set of page ids already present in personal search results.
  */
-export function dedupSharedRowsAgainstPersonal<T extends { id: string }>(
+export function dedupSharedRowsAgainstPersonal<T extends SearchResultRow>(
   rows: readonly T[],
   personalIds: ReadonlySet<string>,
 ): T[] {
-  return rows.filter((r) => !personalIds.has(r.id));
+  return rows.filter((r) => {
+    if (r.kind !== "page") return true;
+    return !personalIds.has(r.id);
+  });
 }
 
 /**
@@ -62,16 +95,50 @@ export interface SearchResult {
   score: number;
 }
 
-/** Unified item for global search (personal + shared). C3-8. */
-export interface GlobalSearchResultItem {
-  pageId: string;
-  /** 共有ノート結果で設定される。Set for shared-note results; navigate to /notes/:noteId/:pageId. */
-  noteId?: string;
+/**
+ * 共通のグローバル検索結果フィールド。
+ * Common fields shared across kinds.
+ */
+interface GlobalSearchResultBase {
   title: string;
   highlightedText: string;
   matchType: MatchType;
+}
+
+/**
+ * 通常のページ結果（個人ページ / ノートネイティブ）。Issue #864 までの既存形。
+ * Page-kind result (personal or note-native) — the historical shape.
+ */
+export interface GlobalSearchPageResultItem extends GlobalSearchResultBase {
+  kind: "page";
+  pageId: string;
+  /** 共有ノート結果で設定される。Set for shared-note results; navigate to /notes/:noteId/:pageId. */
+  noteId?: string;
   sourceUrl?: string;
 }
+
+/**
+ * Issue #864: PDF ローカルソースのハイライト本文一致結果。
+ * Issue #864: a `pdf_highlights.text` match against a local PDF source.
+ */
+export interface GlobalSearchPdfHighlightResultItem extends GlobalSearchResultBase {
+  kind: "pdf_highlight";
+  highlightId: string;
+  sourceId: string;
+  /** 表示名（`sources.display_name` / `title` / フォールバック）。Display name. */
+  sourceDisplayName: string;
+  pdfPage: number;
+  /** 派生 Zedi ページ ID（あればクリック時にそちらへ優先遷移）。Optional derived page id. */
+  derivedPageId: string | null;
+}
+
+/**
+ * 統一されたグローバル検索結果アイテム（discriminated union）。
+ * Unified discriminated union for global search results.
+ */
+export type GlobalSearchResultItem =
+  | GlobalSearchPageResultItem
+  | GlobalSearchPdfHighlightResultItem;
 
 /**
  * Search pages by query with multiple keyword support
@@ -118,6 +185,45 @@ export function searchPages(pages: Page[], query: string): SearchResult[] {
 }
 
 /**
+ * Issue #864: PDF ハイライト行を表示用の `GlobalSearchPdfHighlightResultItem` に変換する。
+ *
+ * Converts a server `kind="pdf_highlight"` row into the discriminated UI shape.
+ * Exported so the snippet / title build-out is easy to unit-test without a
+ * React Query harness.
+ */
+export function buildPdfHighlightItem(
+  row: SearchPdfHighlightResultRow,
+  keywords: string[],
+): GlobalSearchPdfHighlightResultItem & { score: number } {
+  const snippet = extractSmartSnippet(row.text, keywords);
+  const highlightedText = highlightKeywords(snippet, keywords);
+  const displayName =
+    (row.source_display_name?.trim() || row.source_title?.trim() || null) ??
+    i18n.t("common.pdfHighlightFallbackName", { defaultValue: "PDF" });
+
+  // 表示用タイトル: `<file> (p.<page>)`。i18n リソースが無い環境では英語フォールバック。
+  // Display title: `<file> (p.<page>)`; falls back to English when i18n missing.
+  const title = i18n.t("common.pdfHighlightResultTitle", {
+    defaultValue: "{{file}} (p.{{page}})",
+    file: displayName,
+    page: row.pdf_page,
+  });
+
+  return {
+    kind: "pdf_highlight",
+    highlightId: row.highlight_id,
+    sourceId: row.source_id,
+    sourceDisplayName: displayName,
+    pdfPage: row.pdf_page,
+    derivedPageId: row.derived_page_id,
+    title,
+    highlightedText,
+    matchType: "content",
+    score: PDF_HIGHLIGHT_BASE_SCORE,
+  };
+}
+
+/**
  * 個人ページ (IDB) と shared 検索結果 (API) を統合してグローバル検索結果に
  * 整形する pure 関数。`useGlobalSearch` がメモ化して呼ぶが、振る舞いを
  * 単独でテストできるようエクスポートする (Issue #718 Phase 5-4)。
@@ -136,6 +242,14 @@ export function searchPages(pages: Page[], query: string): SearchResult[] {
  * **重複排除の契約**: dedup は `pageId` 一致でのみ行う
  * ({@link dedupSharedRowsAgainstPersonal})。`note_id IS NULL` の中には IDB に
  * 載っていないリンク済み個人ページが混ざるので、`note_id` での絞り込みは不可。
+ *
+ * Issue #864: shared 結果には `kind="pdf_highlight"` 行も混ざる。dedup は
+ * `kind="page"` のみに作用し、ハイライトはスコア順序を保ったまま末尾に並ぶ。
+ *
+ * Issue #864: shared results now also include `kind="pdf_highlight"` rows.
+ * The dedup pass leaves them alone (they aren't represented in IDB) and they
+ * sort into the final list by score, which places them after title/content
+ * page matches by design.
  */
 export function buildGlobalSearchResults(
   personalPages: Page[],
@@ -148,7 +262,7 @@ export function buildGlobalSearchResults(
 
   // 中間 sort は不要（最後にまとめて score 降順で並べ直す）。Gemini レビュー指摘。
   // No intermediate sort here — the final merge sorts by score (Gemini review).
-  const personal: Array<GlobalSearchResultItem & { score: number }> = personalPages
+  const personal: Array<GlobalSearchPageResultItem & { score: number }> = personalPages
     .filter((page) => !page.isDeleted)
     .map((page) => {
       const content = extractPlainText(page.content);
@@ -157,6 +271,7 @@ export function buildGlobalSearchResults(
       const matchedText = extractSmartSnippet(content, keywords);
       const highlightedText = highlightKeywords(matchedText, keywords);
       return {
+        kind: "page",
         pageId: page.id,
         title: page.title || i18n.t("common.untitledPage"),
         highlightedText,
@@ -167,28 +282,35 @@ export function buildGlobalSearchResults(
     });
 
   const personalIds = new Set(personal.map((p) => p.pageId));
-  const shared: Array<GlobalSearchResultItem & { score: number }> = dedupSharedRowsAgainstPersonal(
-    sharedRows,
-    personalIds,
-  ).map((r) => {
-    const preview = r.content_preview ?? "";
-    const highlightedText = highlightKeywords(preview, keywords);
-    return {
-      pageId: r.id,
-      // ノートネイティブ / リンク済みノート所属ページのみ /notes ルーティングに乗せる。
-      // 単なるリンク済み個人ページ (`note_id IS NULL`) は note 側に飛ばさず /pages へ。
-      // Only note-native rows route under /notes; bare linked personal rows
-      // (`note_id IS NULL`) keep the personal /pages destination.
-      noteId: r.note_id ?? undefined,
-      title: r.title?.trim() ? r.title : i18n.t("common.untitledPage"),
-      highlightedText: highlightedText || i18n.t("common.sharedNoteContext"),
-      matchType: "content" as MatchType,
-      sourceUrl: r.source_url ?? undefined,
-      score: 0,
-    };
-  });
+  const dedupedShared = dedupSharedRowsAgainstPersonal(sharedRows, personalIds);
 
-  return [...personal, ...shared]
+  const sharedPages: Array<GlobalSearchPageResultItem & { score: number }> = dedupedShared
+    .filter((r): r is SearchPageResultRow => r.kind === "page")
+    .map((r) => {
+      const preview = r.content_preview ?? "";
+      const highlightedText = highlightKeywords(preview, keywords);
+      return {
+        kind: "page",
+        pageId: r.id,
+        // ノートネイティブ / リンク済みノート所属ページのみ /notes ルーティングに乗せる。
+        // 単なるリンク済み個人ページ (`note_id IS NULL`) は note 側に飛ばさず /pages へ。
+        // Only note-native rows route under /notes; bare linked personal rows
+        // (`note_id IS NULL`) keep the personal /pages destination.
+        noteId: r.note_id ?? undefined,
+        title: r.title?.trim() ? r.title : i18n.t("common.untitledPage"),
+        highlightedText: highlightedText || i18n.t("common.sharedNoteContext"),
+        matchType: "content" as MatchType,
+        sourceUrl: r.source_url ?? undefined,
+        score: 0,
+      };
+    });
+
+  const sharedHighlights: Array<GlobalSearchPdfHighlightResultItem & { score: number }> =
+    dedupedShared
+      .filter((r): r is SearchPdfHighlightResultRow => r.kind === "pdf_highlight")
+      .map((r) => buildPdfHighlightItem(r, keywords));
+
+  return [...personal, ...sharedPages, ...sharedHighlights]
     .sort((a, b) => b.score - a.score)
     .slice(0, limit)
     .map(({ score: _s, ...item }) => item);

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -181,23 +181,68 @@ export interface CopyNotePageToPersonalResponse {
  * ノートに所属する。共有検索でもこの不変条件は変わらないため、`note_id` は常に
  * 非 null。Issue #825 で型を non-null に揃えた。
  *
+ * Issue #864 (PDF ハイライト統合): レスポンス行は `kind` で識別する判別可能 union
+ * になった。`kind="page"` は従来のページ結果、`kind="pdf_highlight"` は PDF ローカル
+ * ソース上のハイライト本文一致を表す。クライアントは `kind` で分岐すること。
+ *
  * Response of GET /api/search?q=&scope=shared.
  *
  * After issue #823 every page belongs to exactly one note (the caller's
  * default note for legacy "personal" rows), so `note_id` is always present
  * even in shared search results. Issue #825 tightened the type accordingly.
+ *
+ * Issue #864 (PDF highlight integration): result rows are now a discriminated
+ * union keyed on `kind`. `kind="page"` is the existing page result; the new
+ * `kind="pdf_highlight"` row carries the source id, PDF page number and
+ * optional derived page id so the UI can deep-link back to where the user was
+ * reading. Clients must branch on `kind` before reading kind-specific fields.
  */
+export type SearchPageResultRow = {
+  kind: "page";
+  id: string;
+  note_id: string;
+  owner_id: string;
+  title: string | null;
+  content_preview: string | null;
+  thumbnail_url: string | null;
+  source_url: string | null;
+  updated_at: string;
+};
+
+/**
+ * Issue #864: PDF ハイライト本文がヒットした結果行。所有検証 (`owner_id` フィルタ)
+ * 済みなので、他ユーザーのハイライトは決して含まれない。
+ *
+ * Issue #864: a result row for a `pdf_highlights.text` match. The server
+ * enforces ownership (`owner_id = userId`) before returning, so other users'
+ * highlights cannot appear here.
+ *
+ * @property highlight_id   ハイライトの一意 ID。Highlight UUID.
+ * @property source_id      元 PDF ソースの ID。Owning `sources.id` (kind="pdf_local").
+ * @property pdf_page       1 始まり PDF ページ番号。1-indexed PDF page.
+ * @property text           ハイライト本文テキスト（プレビュー用）。Highlight body text.
+ * @property derived_page_id 派生 Zedi ページがあればその ID。Optional derived page id.
+ * @property source_display_name UI 用ファイル名。Display filename.
+ * @property source_title   PDF メタデータ由来のタイトル（あれば）。Optional PDF title.
+ * @property updated_at     ハイライトの最終更新時刻 ISO。Highlight `updated_at` ISO.
+ */
+export type SearchPdfHighlightResultRow = {
+  kind: "pdf_highlight";
+  highlight_id: string;
+  source_id: string;
+  owner_id: string;
+  pdf_page: number;
+  text: string;
+  derived_page_id: string | null;
+  source_display_name: string | null;
+  source_title: string | null;
+  updated_at: string;
+};
+
+export type SearchResultRow = SearchPageResultRow | SearchPdfHighlightResultRow;
+
 export interface SearchSharedResponse {
-  results: Array<{
-    id: string;
-    note_id: string;
-    owner_id: string;
-    title: string | null;
-    content_preview: string | null;
-    thumbnail_url: string | null;
-    source_url: string | null;
-    updated_at: string;
-  }>;
+  results: SearchResultRow[];
 }
 
 /**

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -3,7 +3,10 @@ import { useSearchParams, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import Container from "@/components/layout/Container";
 import { SearchResultCard } from "@/components/search/SearchResultCard";
-import type { SearchResultCardItem } from "@/components/search/SearchResultCard";
+import type {
+  SearchResultCardPageItem,
+  SearchResultCardPdfHighlightItem,
+} from "@/components/search/SearchResultCard";
 import { SearchResultsLoadingSkeleton } from "@/components/search/SearchResultsLoadingSkeleton";
 import { SearchResultsEmptyState } from "@/components/search/SearchResultsEmptyState";
 import { useSearchPages, useSearchSharedNotes } from "@/hooks/usePageQueries";
@@ -16,18 +19,32 @@ import {
   highlightKeywords,
   calculateEnhancedScore,
 } from "@/lib/searchUtils";
-import { useGlobalSearchContext } from "@/contexts/GlobalSearchContext";
-import { dedupSharedRowsAgainstPersonal } from "@/hooks/useGlobalSearch";
+import { resolveSearchResultUrl, useGlobalSearchContext } from "@/contexts/GlobalSearchContext";
+import { PDF_HIGHLIGHT_BASE_SCORE, dedupSharedRowsAgainstPersonal } from "@/hooks/useGlobalSearch";
+import type { SearchPageResultRow, SearchPdfHighlightResultRow } from "@/lib/api/types";
 
-interface SearchResultItem extends SearchResultCardItem {
+type PageSearchResultItem = SearchResultCardPageItem & {
   snippet: string;
   score: number;
-}
+};
+
+type PdfHighlightSearchResultItem = SearchResultCardPdfHighlightItem & {
+  snippet: string;
+  score: number;
+};
+
+type SearchResultItem = PageSearchResultItem | PdfHighlightSearchResultItem;
 
 /**
  * Renders global search results for the `q` query string (personal pages and shared notes).
  *
  * クエリ `q` に対するグローバル検索結果（個人ページと共有ノート）を表示する。
+ *
+ * Issue #864: `kind="pdf_highlight"` 行も同じ結果リストに混ぜて表示する。クリック時の
+ * 遷移先は派生 Zedi ページ（あれば）または PDF ビューアの該当ページ。
+ *
+ * Issue #864: highlight rows from `pdf_highlights` are merged into the same
+ * results list and routed via the shared `resolveSearchResultUrl` helper.
  */
 export default function SearchResults() {
   const [searchParams] = useSearchParams();
@@ -50,7 +67,7 @@ export default function SearchResults() {
   const results = useMemo((): SearchResultItem[] => {
     if (searchQuery.length < 3 || keywords.length === 0) return [];
 
-    const personal: SearchResultItem[] = personalResults
+    const personal: PageSearchResultItem[] = personalResults
       .filter((page) => !page.isDeleted)
       .map((page) => {
         const content = extractPlainText(page.content);
@@ -59,6 +76,7 @@ export default function SearchResults() {
         const snippet = extractSmartSnippet(content, keywords, 200);
         const highlightedSnippet = highlightKeywords(snippet, keywords);
         return {
+          kind: "page",
           pageId: page.id,
           title: page.title || t("common.untitledPage"),
           snippet,
@@ -81,53 +99,120 @@ export default function SearchResults() {
     // pages owned by other note members (which IDB does not have) survive
     // (Codex / CodeRabbit review).
     const personalIds = new Set(personal.map((item) => item.pageId));
-    const shared: SearchResultItem[] = dedupSharedRowsAgainstPersonal(
-      sharedResults,
-      personalIds,
-    ).map((r) => {
-      const preview = r.content_preview ?? "";
-      const snippet = extractSmartSnippet(preview, keywords, 200);
-      const highlightedSnippet = highlightKeywords(
-        snippet || t("common.sharedNoteContext"),
-        keywords,
-      );
-      return {
-        pageId: r.id,
-        noteId: r.note_id ?? undefined,
-        title: r.title?.trim() ? r.title : t("common.untitledPage"),
-        snippet,
-        highlightedSnippet,
-        matchType: "content" as MatchType,
-        sourceUrl: r.source_url ?? undefined,
-        thumbnailUrl: r.thumbnail_url ?? undefined,
-        updatedAt: new Date(r.updated_at).getTime(),
-        score: 0,
-      };
-    });
+    const dedupedShared = dedupSharedRowsAgainstPersonal(sharedResults, personalIds);
 
-    return [...personal, ...shared].sort((a, b) => b.score - a.score);
+    const sharedPages: PageSearchResultItem[] = dedupedShared
+      .filter((r): r is SearchPageResultRow => r.kind === "page")
+      .map((r) => {
+        const preview = r.content_preview ?? "";
+        const snippet = extractSmartSnippet(preview, keywords, 200);
+        const highlightedSnippet = highlightKeywords(
+          snippet || t("common.sharedNoteContext"),
+          keywords,
+        );
+        return {
+          kind: "page",
+          pageId: r.id,
+          noteId: r.note_id ?? undefined,
+          title: r.title?.trim() ? r.title : t("common.untitledPage"),
+          snippet,
+          highlightedSnippet,
+          matchType: "content" as MatchType,
+          sourceUrl: r.source_url ?? undefined,
+          thumbnailUrl: r.thumbnail_url ?? undefined,
+          updatedAt: new Date(r.updated_at).getTime(),
+          score: 0,
+        };
+      });
+
+    // Issue #864: PDF ハイライト行はカードのプレビューに本文抜粋を、タイトルに
+    // 「<ファイル名> (p.<ページ番号>)」を出す。スコアは {@link PDF_HIGHLIGHT_BASE_SCORE}
+    // で「タイトル一致 > 派生ページ一致 > ハイライト本文」の序列を保つ。
+    //
+    // Issue #864: PDF highlight rows render with the file name + page number
+    // as title and the body excerpt as snippet. They sit at
+    // {@link PDF_HIGHLIGHT_BASE_SCORE} so title and content page hits outrank
+    // them, preserving the priority documented in the issue.
+    const sharedHighlights: PdfHighlightSearchResultItem[] = dedupedShared
+      .filter((r): r is SearchPdfHighlightResultRow => r.kind === "pdf_highlight")
+      .map((r) => {
+        const snippet = extractSmartSnippet(r.text, keywords, 200);
+        const highlightedSnippet = highlightKeywords(snippet, keywords);
+        const file =
+          (r.source_display_name?.trim() || r.source_title?.trim() || null) ??
+          t("common.pdfHighlightFallbackName", { defaultValue: "PDF" });
+        return {
+          kind: "pdf_highlight",
+          highlightId: r.highlight_id,
+          sourceId: r.source_id,
+          pdfPage: r.pdf_page,
+          derivedPageId: r.derived_page_id,
+          title: t("common.pdfHighlightResultTitle", {
+            defaultValue: "{{file}} (p.{{page}})",
+            file,
+            page: r.pdf_page,
+          }),
+          snippet,
+          highlightedSnippet,
+          matchType: "content" as MatchType,
+          thumbnailUrl: undefined,
+          updatedAt: new Date(r.updated_at).getTime(),
+          score: PDF_HIGHLIGHT_BASE_SCORE,
+        };
+      });
+
+    return [...personal, ...sharedPages, ...sharedHighlights].sort((a, b) => b.score - a.score);
   }, [personalResults, sharedResults, searchQuery, keywords, t]);
 
   /**
-   * Navigates to the note page or standalone page for the clicked result.
+   * Navigates based on the clicked result's kind. Delegates URL composition
+   * to `resolveSearchResultUrl` so deep-link behavior stays consistent with
+   * the header dropdown (Issue #864).
    *
-   * クリックされた結果に応じてノート配下または単体ページへ遷移する。
+   * クリックされた結果の種別に応じて遷移する。URL 組み立てはヘッダードロップダウン
+   * と共通の `resolveSearchResultUrl` に委譲する（Issue #864）。
    */
   const handleResultClick = (item: SearchResultItem) => {
-    if (item.noteId) {
-      navigate(`/notes/${item.noteId}/${item.pageId}`);
-    } else {
-      navigate(`/pages/${item.pageId}`);
+    if (item.kind === "pdf_highlight") {
+      navigate(
+        resolveSearchResultUrl({
+          kind: "pdf_highlight",
+          highlightId: item.highlightId,
+          sourceId: item.sourceId,
+          sourceDisplayName: "",
+          pdfPage: item.pdfPage,
+          derivedPageId: item.derivedPageId,
+          title: item.title,
+          highlightedText: item.highlightedSnippet,
+          matchType: item.matchType,
+        }),
+      );
+      return;
     }
+    navigate(
+      resolveSearchResultUrl({
+        kind: "page",
+        pageId: item.pageId,
+        noteId: item.noteId,
+        title: item.title,
+        highlightedText: item.highlightedSnippet,
+        matchType: item.matchType,
+        sourceUrl: item.sourceUrl,
+      }),
+    );
   };
 
   /**
-   * Stable React `key` for list items (shared vs personal).
+   * Stable React `key` for list items (shared vs personal vs PDF highlight).
    *
-   * リスト項目用の安定した React `key`（共有／個人の区別）。
+   * リスト項目用の安定した React `key`（共有／個人／PDF ハイライト）。
    */
-  const resultKey = (item: SearchResultItem) =>
-    item.noteId ? `shared-${item.noteId}-${item.pageId}` : `personal-${item.pageId}`;
+  const resultKey = (item: SearchResultItem): string => {
+    if (item.kind === "pdf_highlight") {
+      return `pdf-${item.sourceId}-${item.highlightId}`;
+    }
+    return item.noteId ? `shared-${item.noteId}-${item.pageId}` : `personal-${item.pageId}`;
+  };
 
   return (
     <div className="min-h-0 flex-1 py-6">

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -20,7 +20,11 @@ import {
   calculateEnhancedScore,
 } from "@/lib/searchUtils";
 import { resolveSearchResultUrl, useGlobalSearchContext } from "@/contexts/GlobalSearchContext";
-import { PDF_HIGHLIGHT_BASE_SCORE, dedupSharedRowsAgainstPersonal } from "@/hooks/useGlobalSearch";
+import {
+  PDF_HIGHLIGHT_BASE_SCORE,
+  dedupSharedRowsAgainstPersonal,
+  formatPdfHighlightDisplay,
+} from "@/hooks/useGlobalSearch";
 import type { SearchPageResultRow, SearchPdfHighlightResultRow } from "@/lib/api/types";
 
 type PageSearchResultItem = SearchResultCardPageItem & {
@@ -136,24 +140,24 @@ export default function SearchResults() {
     const sharedHighlights: PdfHighlightSearchResultItem[] = dedupedShared
       .filter((r): r is SearchPdfHighlightResultRow => r.kind === "pdf_highlight")
       .map((r) => {
-        const snippet = extractSmartSnippet(r.text, keywords, 200);
-        const highlightedSnippet = highlightKeywords(snippet, keywords);
-        const file =
-          (r.source_display_name?.trim() || r.source_title?.trim() || null) ??
-          t("common.pdfHighlightFallbackName", { defaultValue: "PDF" });
+        // PR #873 review (Gemini): タイトル / snippet / 表示名は `formatPdfHighlightDisplay`
+        // に集約され、ヘッダードロップダウンと同じ整形ロジックを共有する。
+        // 検索結果ページではカード幅が広いので snippet を 200 字に延ばす。
+        //
+        // Title / snippet / display name are produced by the shared
+        // `formatPdfHighlightDisplay` helper so the dropdown and this page
+        // stay in lockstep. The card is wider here, so we widen the snippet
+        // to 200 chars.
+        const display = formatPdfHighlightDisplay(r, keywords, t, 200);
         return {
           kind: "pdf_highlight",
           highlightId: r.highlight_id,
           sourceId: r.source_id,
           pdfPage: r.pdf_page,
           derivedPageId: r.derived_page_id,
-          title: t("common.pdfHighlightResultTitle", {
-            defaultValue: "{{file}} (p.{{page}})",
-            file,
-            page: r.pdf_page,
-          }),
-          snippet,
-          highlightedSnippet,
+          title: display.title,
+          snippet: display.snippet,
+          highlightedSnippet: display.highlightedText,
           matchType: "content" as MatchType,
           thumbnailUrl: undefined,
           updatedAt: new Date(r.updated_at).getTime(),


### PR DESCRIPTION
Extend /api/search to also probe pdf_highlights.text with owner-scoping
and a defensive sources.kind='pdf_local' check, then plumb the new
discriminated rows through the client merge logic so the global search
dropdown and /search page render highlight hits and deep-link to either
the derived Zedi page or /sources/:sourceId/pdf#page=N.

- Server: add highlight query gated by PDF_HIGHLIGHT_SEARCH_DISABLED env
  kill switch; tag every result row with kind ("page" / "pdf_highlight").
- Client: turn SearchSharedResponse into a discriminated union, route
  highlight rows via resolveSearchResultUrl, and score them below page
  matches to preserve "title > derived page > highlight body" ordering.
- Tests: add unit coverage for owner-scoping, kind="pdf_local" filter,
  feature-flag kill switch, URL composition, and the merged result shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now returns combined page and PDF-highlight results (each tagged by kind); highlights show a PDF badge/icon and deep-linking to PDF or a derived page.
  * Navigation updated to route directly from any result kind.

* **Bug Fixes**
  * API no longer exposes full content text in page responses; merged results enforce hard limits.
  * PDF-highlight search can be disabled via an environment flag.

* **Tests**
  * Expanded coverage for PDF highlights, scope/access behavior, deduplication, merging/allocation, and limit enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->