### PR TITLE
security: disable internal eval in PDF.js for untrusted PDFs

### DIFF
--- a/src/lib/pdfKnowledge/pdfjsLoader.ts
+++ b/src/lib/pdfKnowledge/pdfjsLoader.ts
@@ -70,6 +70,9 @@ export function getPdfDocument(data: Uint8Array): Promise<PdfDocumentProxy> {
     cMapUrl: CMAP_URL,
     cMapPacked: true,
     standardFontDataUrl: STANDARD_FONT_DATA_URL,
+    // 信頼できない PDF を扱うため、内部 eval を明示的に無効化する（多層防御）。
+    // Disable internal eval for untrusted PDFs as a defense-in-depth measure.
+    isEvalSupported: false,
     // Workers are configured globally; using a fresh task per call is fine.
   }).promise;
 }


### PR DESCRIPTION
## 概要

PDF.js の設定に `isEvalSupported: false` を追加し、信頼できない PDF ファイルの処理時に内部 eval を明示的に無効化します。これは多層防御（defense-in-depth）の一環として、潜在的なセキュリティリスクを軽減します。

## 変更点

- `src/lib/pdfKnowledge/pdfjsLoader.ts` の `getPdfDocument` 関数内で、PDF.js の初期化オプションに `isEvalSupported: false` を追加
- 日本語と英語の両方でコメントを記載し、変更の意図を明確化

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

既存の PDF 処理機能が正常に動作することを確認：

1. `bun run lint` と `bun run format:check` が通ることを確認
2. 既存の PDF 読み込みテストが引き続きパスすることを確認
3. 信頼できない PDF ファイルを含むテストケースで、eval が無効化されていることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

https://claude.ai/code/session_011hmASvXRnwrELKn4XGrBiD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved PDF document loading security and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->