### PR TITLE
fix(hocuspocus): repair WebSocket auth after note_pages removal

### DIFF
--- a/server/hocuspocus/src/index.ts
+++ b/server/hocuspocus/src/index.ts
@@ -9,6 +9,13 @@ import {
   warnDevAuthBypassOnce,
 } from "./dev-auth-bypass.js";
 import { buildContentPreview, extractTextFromYXml } from "./extractPlainTextFromYXml.js";
+import {
+  canEditFromRole,
+  resolveNoteRole,
+  type DomainFacts,
+  type MemberFact,
+  type NoteAccessFacts,
+} from "./pageEditPermission.js";
 import { maybeCreateSnapshot } from "./snapshotUtils.js";
 
 const PORT = parseInt(process.env.PORT || "1234", 10);
@@ -62,24 +69,32 @@ function isAuthorizedInternalRequest(req: IncomingMessage): boolean {
 async function verifySession(
   token: string,
 ): Promise<{ userId: string; email?: string; name?: string } | null> {
-  if (!API_INTERNAL_URL) return null;
+  if (!token.trim()) return null;
+  const client = await getPool().connect();
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000);
-    const response = await fetch(`${API_INTERNAL_URL}/api/auth/get-session`, {
-      headers: { cookie: `better-auth.session_token=${token}` },
-      signal: controller.signal,
-    });
-    clearTimeout(timeout);
-    if (!response.ok) return null;
-    const data = (await response.json()) as {
-      user?: { id: string; email?: string; name?: string };
-    };
-    if (!data.user?.id) return null;
-    return { userId: data.user.id, email: data.user.email, name: data.user.name };
+    const result = await client.query<{
+      user_id: string;
+      email: string | null;
+      name: string | null;
+    }>(
+      `
+        SELECT s.user_id, u.email, u.name
+        FROM "session" s
+        JOIN "user" u ON u.id = s.user_id
+        WHERE s.token = $1
+          AND s.expires_at > NOW()
+        LIMIT 1
+      `,
+      [token],
+    );
+    const row = result.rows[0];
+    if (!row?.user_id) return null;
+    return { userId: row.user_id, email: row.email ?? undefined, name: row.name ?? undefined };
   } catch (err) {
     console.error("[Auth] Session verification failed:", err);
     return null;
+  } finally {
+    client.release();
   }
 }
 
@@ -94,69 +109,149 @@ async function getCurrentUserById(client: PoolClient, userId: string): Promise<D
 }
 
 /**
- * Allows edit when user is owner; when editor member and `edit_permission` is not
- * `owner_only`; or when the user has no membership row and the note allows
- * `any_logged_in` guests (`public` / `unlisted`). Viewer members are not guests.
- * Matches API `getNoteRole` → `canEdit`.
+ * `email` のドメイン部を小文字で返す。形式が不正な場合は `null`。
+ * `note_domain_access` 突合用なので、API 側 `extractEmailDomain` と同じく
+ * 末尾の `@` 以降だけを抽出し、空ドメインや `@` の位置不正は弾く。
  *
- * オーナー、または `edit_permission` が `owner_only` 以外のときの編集メンバー、
- * またはメンバー行がなく `any_logged_in` かつ `public`/`unlisted` のゲスト（閲覧メンバーは含めない）。
- * API の getNoteRole → canEdit と整合。
+ * Lower-cased email domain (after the last `@`), or `null` for malformed
+ * inputs. Mirrors the API's `extractEmailDomain` so domain-rule lookups
+ * agree with REST endpoints.
  */
-async function canEditNotePage(client: PoolClient, pageId: string, user: DbUser): Promise<boolean> {
-  const result = await client.query(
+function extractEmailDomain(email: string | undefined | null): string | null {
+  if (typeof email !== "string") return null;
+  const atIndex = email.lastIndexOf("@");
+  if (atIndex <= 0 || atIndex === email.length - 1) return null;
+  const domain = email
+    .slice(atIndex + 1)
+    .trim()
+    .toLowerCase();
+  return domain.length === 0 ? null : domain;
+}
+
+interface PageNoteRow {
+  pageDeleted: boolean;
+  noteId: string | null;
+  noteFound: boolean;
+  note: NoteAccessFacts | null;
+}
+
+/**
+ * `pages` 行と所属ノートを 1 クエリで取得する。Issue #823 以降ページは必ず
+ * `note_id` を持つので、`pages` を起点に `notes` を LEFT JOIN し、ページ削除済み
+ * 状態とノートの基本属性を一度に拾う。
+ *
+ * Fetch the page row and its owning note in one round-trip. After issue #823
+ * every `pages` row carries a `note_id`, so we start from `pages` and
+ * `LEFT JOIN notes` to surface both the soft-delete flag and the note's
+ * authorization fields together.
+ */
+async function fetchPageNoteState(client: PoolClient, pageId: string): Promise<PageNoteRow | null> {
+  const result = await client.query<{
+    page_deleted: boolean;
+    note_id: string | null;
+    note_deleted: boolean | null;
+    owner_id: string | null;
+    visibility: string | null;
+    edit_permission: string | null;
+  }>(
     `
-      SELECT 1
-      FROM note_pages np
-      JOIN notes n
-        ON n.id = np.note_id
-       AND n.is_deleted = FALSE
-      LEFT JOIN note_members nm
-        ON nm.note_id = np.note_id
-       AND nm.member_email = $3
-       AND nm.is_deleted = FALSE
-       AND nm.status = 'accepted'
-      WHERE np.page_id = $1
-        AND np.is_deleted = FALSE
-        AND (
-          n.owner_id = $2
-          OR (
-            nm.role = 'editor'
-            AND COALESCE(n.edit_permission, 'owner_only') <> 'owner_only'
-          )
-          OR (
-            nm.note_id IS NULL
-            AND COALESCE(n.edit_permission, 'owner_only') = 'any_logged_in'
-            AND n.visibility IN ('public', 'unlisted')
-          )
-        )
+      SELECT
+        p.is_deleted        AS page_deleted,
+        n.id                AS note_id,
+        n.is_deleted        AS note_deleted,
+        n.owner_id,
+        n.visibility,
+        n.edit_permission
+      FROM pages p
+      LEFT JOIN notes n ON n.id = p.note_id
+      WHERE p.id = $1
       LIMIT 1
     `,
-    [pageId, user.id, user.email],
-  );
-  return result.rows.length > 0;
-}
-
-async function pageBelongsToAnyNote(client: PoolClient, pageId: string): Promise<boolean> {
-  const result = await client.query(
-    "SELECT 1 FROM note_pages WHERE page_id = $1 AND is_deleted = FALSE LIMIT 1",
     [pageId],
   );
-  return result.rows.length > 0;
+  const row = result.rows[0];
+  if (!row) return null;
+
+  if (
+    row.note_id === null ||
+    row.note_deleted === null ||
+    row.note_deleted === true ||
+    row.owner_id === null ||
+    row.visibility === null ||
+    row.edit_permission === null
+  ) {
+    return {
+      pageDeleted: row.page_deleted,
+      noteId: row.note_id,
+      noteFound: false,
+      note: null,
+    };
+  }
+
+  return {
+    pageDeleted: row.page_deleted,
+    noteId: row.note_id,
+    noteFound: true,
+    note: {
+      ownerId: row.owner_id,
+      visibility: row.visibility as NoteAccessFacts["visibility"],
+      editPermission: row.edit_permission as NoteAccessFacts["editPermission"],
+    },
+  };
 }
 
-async function isPersonalPageOwner(
+async function fetchAcceptedMember(
   client: PoolClient,
-  pageId: string,
-  userId: string,
-): Promise<boolean> {
-  const result = await client.query(
-    "SELECT 1 FROM pages WHERE id = $1 AND owner_id = $2 AND is_deleted = FALSE LIMIT 1",
-    [pageId, userId],
+  noteId: string,
+  emailLower: string,
+): Promise<MemberFact> {
+  const result = await client.query<{ role: "viewer" | "editor" }>(
+    `
+      SELECT role
+      FROM note_members
+      WHERE note_id = $1
+        AND LOWER(member_email) = $2
+        AND is_deleted = FALSE
+        AND status = 'accepted'
+      LIMIT 1
+    `,
+    [noteId, emailLower],
   );
-  return result.rows.length > 0;
+  const row = result.rows[0];
+  return row ? { role: row.role } : null;
 }
 
+async function fetchDomainRules(
+  client: PoolClient,
+  noteId: string,
+  emailLower: string,
+): Promise<DomainFacts> {
+  const domain = extractEmailDomain(emailLower);
+  if (!domain) return { rules: [] };
+  const result = await client.query<{ role: "viewer" | "editor" }>(
+    `
+      SELECT role
+      FROM note_domain_access
+      WHERE note_id = $1
+        AND domain = $2
+        AND is_deleted = FALSE
+    `,
+    [noteId, domain],
+  );
+  return { rules: result.rows.map((r) => ({ role: r.role })) };
+}
+
+/**
+ * Hocuspocus 認証用の編集権限チェック。すべてのページが `pages.note_id` で
+ * ちょうど 1 件のノートに所属する前提（Issue #823 / migration `0023`）で、
+ * API 側 `assertPageEditAccess` と同じ意味論（owner → member → domain rule →
+ * guest）でロールを解決し、`canEdit` で編集可否を判定する。
+ *
+ * Permission gate for the Hocuspocus `onAuthenticate` hook. After
+ * issue #823 every page is anchored to exactly one note via `pages.note_id`,
+ * so we resolve the role on that note (owner → member → domain → guest) and
+ * call `canEditFromRole`, matching the REST `assertPageEditAccess` contract.
+ */
 async function assertEditPermission(pageId: string, userId: string): Promise<void> {
   const client = await getPool().connect();
   try {
@@ -165,20 +260,38 @@ async function assertEditPermission(pageId: string, userId: string): Promise<voi
       throw new Error("User not found");
     }
 
-    if (await canEditNotePage(client, pageId, currentUser)) {
-      return;
+    const pageNote = await fetchPageNoteState(client, pageId);
+    if (!pageNote || pageNote.pageDeleted) {
+      throw new Error("Page not found");
+    }
+    if (!pageNote.noteFound || !pageNote.note || !pageNote.noteId) {
+      throw new Error("Note not found");
     }
 
-    const isShared = await pageBelongsToAnyNote(client, pageId);
-    if (isShared) {
+    const note = pageNote.note;
+    const noteId = pageNote.noteId;
+
+    // owner はそれだけで編集可。owner 判定で短絡することで、member / domain の
+    // 追加クエリを大半のケースでスキップできる（自分のデフォルトノート上では
+    // この経路を必ず通る）。
+    // Owner shortcut keeps the common case (editing in your own default note)
+    // down to a single round-trip.
+    if (note.ownerId === currentUser.id) return;
+
+    const [member, domain] = await Promise.all([
+      fetchAcceptedMember(client, noteId, currentUser.email),
+      fetchDomainRules(client, noteId, currentUser.email),
+    ]);
+
+    const role = resolveNoteRole(
+      note,
+      { userId: currentUser.id, emailLower: currentUser.email },
+      member,
+      domain,
+    );
+    if (!canEditFromRole(role, note)) {
       throw new Error("Forbidden");
     }
-
-    if (await isPersonalPageOwner(client, pageId, currentUser.id)) {
-      return;
-    }
-
-    throw new Error("Forbidden");
   } finally {
     client.release();
   }

--- a/server/hocuspocus/src/pageEditPermission.test.ts
+++ b/server/hocuspocus/src/pageEditPermission.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveNoteRole,
+  canEditFromRole,
+  type NoteAccessFacts,
+  type DomainFacts,
+} from "./pageEditPermission.js";
+
+const OWNER_ID = "user-owner";
+const SELF_ID = "user-self";
+
+const baseNote: NoteAccessFacts = {
+  ownerId: OWNER_ID,
+  visibility: "private",
+  editPermission: "owner_only",
+};
+
+const noDomain: DomainFacts = { rules: [] };
+
+describe("resolveNoteRole", () => {
+  it("returns 'owner' when the caller owns the note", () => {
+    const role = resolveNoteRole(
+      { ...baseNote, ownerId: SELF_ID },
+      { userId: SELF_ID, emailLower: "self@example.com" },
+      null,
+      noDomain,
+    );
+    expect(role).toBe("owner");
+  });
+
+  it("returns the member role when an accepted membership row exists", () => {
+    const role = resolveNoteRole(
+      baseNote,
+      { userId: SELF_ID, emailLower: "self@example.com" },
+      { role: "editor" },
+      noDomain,
+    );
+    expect(role).toBe("editor");
+  });
+
+  it("prefers an explicit member role over a stronger domain rule", () => {
+    // ドメインルールで editor 相当だが本人は viewer メンバーとして招待されている
+    // → 明示的なメンバーシップが勝つ（API の getNoteRole と整合）。
+    const role = resolveNoteRole(
+      baseNote,
+      { userId: SELF_ID, emailLower: "self@example.com" },
+      { role: "viewer" },
+      { rules: [{ role: "editor" }] },
+    );
+    expect(role).toBe("viewer");
+  });
+
+  it("returns 'editor' when any matching domain rule is editor (editor wins over viewer)", () => {
+    const role = resolveNoteRole(
+      baseNote,
+      { userId: SELF_ID, emailLower: "self@example.com" },
+      null,
+      { rules: [{ role: "viewer" }, { role: "editor" }] },
+    );
+    expect(role).toBe("editor");
+  });
+
+  it("returns 'viewer' when only viewer-level domain rules match", () => {
+    const role = resolveNoteRole(
+      baseNote,
+      { userId: SELF_ID, emailLower: "self@example.com" },
+      null,
+      { rules: [{ role: "viewer" }] },
+    );
+    expect(role).toBe("viewer");
+  });
+
+  it("returns 'guest' on public/unlisted notes when no role is otherwise resolved", () => {
+    expect(
+      resolveNoteRole(
+        { ...baseNote, visibility: "public" },
+        { userId: SELF_ID, emailLower: "self@example.com" },
+        null,
+        noDomain,
+      ),
+    ).toBe("guest");
+    expect(
+      resolveNoteRole(
+        { ...baseNote, visibility: "unlisted" },
+        { userId: SELF_ID, emailLower: "self@example.com" },
+        null,
+        noDomain,
+      ),
+    ).toBe("guest");
+  });
+
+  it("returns null when a private/restricted note has no matching role", () => {
+    expect(
+      resolveNoteRole(
+        { ...baseNote, visibility: "private" },
+        { userId: SELF_ID, emailLower: "self@example.com" },
+        null,
+        noDomain,
+      ),
+    ).toBeNull();
+    expect(
+      resolveNoteRole(
+        { ...baseNote, visibility: "restricted" },
+        { userId: SELF_ID, emailLower: "self@example.com" },
+        null,
+        noDomain,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("canEditFromRole", () => {
+  it("owner can always edit regardless of edit_permission / visibility", () => {
+    for (const ep of ["owner_only", "members_editors", "any_logged_in"] as const) {
+      for (const vis of ["private", "public", "unlisted", "restricted"] as const) {
+        expect(canEditFromRole("owner", { ...baseNote, editPermission: ep, visibility: vis })).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  it("editor can edit when edit_permission is not owner_only", () => {
+    expect(canEditFromRole("editor", { ...baseNote, editPermission: "members_editors" })).toBe(
+      true,
+    );
+    expect(canEditFromRole("editor", { ...baseNote, editPermission: "any_logged_in" })).toBe(true);
+  });
+
+  it("editor cannot edit when edit_permission is owner_only", () => {
+    expect(canEditFromRole("editor", { ...baseNote, editPermission: "owner_only" })).toBe(false);
+  });
+
+  it("viewer cannot edit", () => {
+    for (const ep of ["owner_only", "members_editors", "any_logged_in"] as const) {
+      expect(canEditFromRole("viewer", { ...baseNote, editPermission: ep })).toBe(false);
+    }
+  });
+
+  it("guest can edit only on public/unlisted notes with any_logged_in", () => {
+    expect(
+      canEditFromRole("guest", {
+        ...baseNote,
+        editPermission: "any_logged_in",
+        visibility: "public",
+      }),
+    ).toBe(true);
+    expect(
+      canEditFromRole("guest", {
+        ...baseNote,
+        editPermission: "any_logged_in",
+        visibility: "unlisted",
+      }),
+    ).toBe(true);
+  });
+
+  it("guest cannot edit when edit_permission is not any_logged_in", () => {
+    expect(
+      canEditFromRole("guest", {
+        ...baseNote,
+        editPermission: "members_editors",
+        visibility: "public",
+      }),
+    ).toBe(false);
+    expect(
+      canEditFromRole("guest", {
+        ...baseNote,
+        editPermission: "owner_only",
+        visibility: "unlisted",
+      }),
+    ).toBe(false);
+  });
+
+  it("null role cannot edit", () => {
+    expect(canEditFromRole(null, baseNote)).toBe(false);
+  });
+});

--- a/server/hocuspocus/src/pageEditPermission.ts
+++ b/server/hocuspocus/src/pageEditPermission.ts
@@ -1,0 +1,128 @@
+/**
+ * Hocuspocus WebSocket 認証から呼ばれるページ編集権限の純粋判定ロジック。
+ *
+ * Issue #823 でサーバ側のページモデルが「個人ページ (`note_id IS NULL`) + 共有
+ * ノート (`note_pages` リンク)」から「すべてのページが `pages.note_id` でちょうど
+ * 1 ノートに所属する」モデルへ移行し、`note_pages` は migration `0023` で
+ * DROP された。Hocuspocus 側の旧 SQL は `note_pages` を JOIN したままだったため、
+ * マイグレーション適用後の develop 環境で WebSocket 認証が PostgreSQL の
+ * `relation "note_pages" does not exist` で失敗していた。本モジュールは
+ * API 側 `routes/notes/helpers.ts` の `getNoteRole` / `canEdit` と同じ意味論を
+ * 維持しながら、DB アクセスを呼び出し側に切り出して単体テスト可能にしたもの。
+ *
+ * Pure (DB-free) edit-permission decisions used by the Hocuspocus
+ * `onAuthenticate` hook. Issue #823 retired the `note_pages` link table in
+ * favour of `pages.note_id`; this module mirrors the API's
+ * `getNoteRole` / `canEdit` precedence so that WebSocket auth and the REST
+ * routes stay aligned. Keeping the logic DB-free makes the precedence
+ * (owner → member → domain → guest → none) directly unit-testable.
+ */
+
+/**
+ * `notes` テーブル由来のアクセス判定に必要な最小情報。
+ * Minimal note state required for edit-permission decisions.
+ */
+export interface NoteAccessFacts {
+  /** `notes.owner_id`. */
+  ownerId: string;
+  /** `notes.visibility`. */
+  visibility: "private" | "public" | "unlisted" | "restricted";
+  /** `notes.edit_permission`. */
+  editPermission: "owner_only" | "members_editors" | "any_logged_in";
+}
+
+/**
+ * 呼び出し元ユーザーの識別情報。`emailLower` は小文字化済みであることを前提と
+ * する（`note_members` / `note_domain_access` 突合に使う）。
+ *
+ * Identity of the caller. `emailLower` must already be lower-cased so member
+ * and domain lookups can use case-insensitive equality.
+ */
+export interface UserFacts {
+  userId: string;
+  emailLower: string;
+}
+
+/**
+ * 呼び出し元の `note_members` 行（`status='accepted'`、`is_deleted=false` 前提）。
+ * 該当行が無ければ `null`。
+ *
+ * Active accepted membership row, or `null` when absent.
+ */
+export type MemberFact = { role: "viewer" | "editor" } | null;
+
+/**
+ * 呼び出し元のメールドメインに一致した `note_domain_access` ルール群
+ * （`is_deleted=false` 前提）。複数ルールがある場合は editor 優先で解決する。
+ *
+ * Domain access rules that match the caller's email domain. Multiple rules
+ * resolve to `editor` if any rule grants editor.
+ */
+export interface DomainFacts {
+  rules: ReadonlyArray<{ role: "viewer" | "editor" }>;
+}
+
+/**
+ * 解決済みロール。`null` は「アクセス権なし」。
+ * Resolved access role; `null` means no access at all.
+ */
+export type ResolvedRole = "owner" | "editor" | "viewer" | "guest" | null;
+
+/**
+ * API 側 `getNoteRole` と同じ優先順位でロールを解決する。
+ *   owner → accepted member → domain rule → guest (public/unlisted) → null
+ *
+ * メンバー行が明示的に存在する場合はドメインルールより優先する（例: ドメイン
+ * editor のチームに所属していても、本人だけ viewer として招待されている場合
+ * は viewer 扱い）。
+ *
+ * Resolve the caller's role using the same precedence as the API's
+ * `getNoteRole`. An explicit accepted membership row always wins over a
+ * matching domain rule, even when the domain rule would grant a stronger
+ * role — this mirrors the API contract so the WebSocket and REST sides agree.
+ */
+export function resolveNoteRole(
+  note: NoteAccessFacts,
+  user: UserFacts,
+  member: MemberFact,
+  domain: DomainFacts,
+): ResolvedRole {
+  if (note.ownerId === user.userId) return "owner";
+  if (member) return member.role;
+  if (domain.rules.length > 0) {
+    const hasEditor = domain.rules.some((r) => r.role === "editor");
+    return hasEditor ? "editor" : "viewer";
+  }
+  if (note.visibility === "public" || note.visibility === "unlisted") {
+    return "guest";
+  }
+  return null;
+}
+
+/**
+ * API 側 `canEdit(role, note)` と同じ意味論で編集可否を判定する。
+ *
+ * - owner: 常に編集可
+ * - editor: `editPermission` が `owner_only` 以外で編集可
+ * - guest: `visibility` が `public`/`unlisted` かつ `editPermission` が
+ *   `any_logged_in` のときのみ編集可
+ * - viewer / null: 編集不可
+ *
+ * Mirror of the API's `canEdit` helper:
+ * - owner: always edits
+ * - editor: edits unless `edit_permission = owner_only`
+ * - guest: only on public/unlisted notes with `edit_permission = any_logged_in`
+ * - viewer / null: never edits
+ */
+export function canEditFromRole(role: ResolvedRole, note: NoteAccessFacts): boolean {
+  if (role === "owner") return true;
+  if (role === "editor" && note.editPermission !== "owner_only") return true;
+  if (
+    role === "guest" &&
+    note.editPermission === "any_logged_in" &&
+    (note.visibility === "public" || note.visibility === "unlisted")
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5312,6 +5312,7 @@ dependencies = [
  "dirs 5.0.1",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",


### PR DESCRIPTION
## 概要

develop 環境でページを開いてもエディタ本文が空になる問題を修正します。Railway の `hocuspocus-dev` ログでは WebSocket 認証が `Invalid session` で失敗しており、原因は (1) Better Auth の生セッショントークンを署名付き cookie として誤検証していたこと、(2) migration `0023` で DROP 済みの `note_pages` を参照していたことの 2 点でした。

## 変更点

### `server/hocuspocus/`
- `verifySession`: `/api/auth/get-session` への cookie 転送をやめ、`session.token` を DB で直接検証
- `assertEditPermission`: `pages.note_id` ベースの権限判定に刷新（`note_pages` 参照を削除）
- `pageEditPermission.ts` / `pageEditPermission.test.ts`: API の `getNoteRole` / `canEdit` と同じ意味論の純粋関数と単体テストを追加

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. Railway `hocuspocus-dev` にデプロイ後、develop フロント（またはローカル Vite + develop API）でログインする
2. デフォルトノート内の既存ページを開き、タイトル・本文が表示されることを確認する
3. Railway ログで `[onAuthenticate] Invalid session` や `relation "note_pages" does not exist` が出ないことを確認する
4. （任意）`cd server/hocuspocus && bun run test` で 34 件パスを確認

## チェックリスト

- [x] テストがすべてパスする（`server/hocuspocus`: 34 passed）
- [x] Lint エラーがない（pre-commit: eslint + prettier）
- [ ] 必要に応じてドキュメントを更新した（不要）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

該当なし（サーバーのみ）

## 関連 Issue

Related to #823

Made with [Cursor](https://cursor.com)