### PR TITLE
fix(api): add missing page snapshots migration

### DIFF
--- a/server/api/drizzle/0028_add_page_snapshots.sql
+++ b/server/api/drizzle/0028_add_page_snapshots.sql
@@ -1,0 +1,39 @@
+-- 0028: Add `page_snapshots`, the storage table used by page version history.
+-- ページ履歴・復元・Hocuspocus 自動スナップショットで利用する
+-- `page_snapshots` テーブルを追加する。
+--
+-- `server/api/src/schema/pageSnapshots.ts` and Hocuspocus `snapshotUtils.ts`
+-- already reference this table. Without this migration, develop Railway logs
+-- show `relation "page_snapshots" does not exist` during auto-save.
+--
+-- `server/api/src/schema/pageSnapshots.ts` と Hocuspocus の `snapshotUtils.ts`
+-- は既にこのテーブルを参照しているため、migration が無い環境では自動保存時に
+-- `relation "page_snapshots" does not exist` が発生する。
+--
+-- Idempotent / re-run safety: CREATE TABLE/INDEX IF NOT EXISTS and duplicate
+-- FK constraints are ignored.
+
+CREATE TABLE IF NOT EXISTS "page_snapshots" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    "page_id" uuid NOT NULL,
+    "version" bigint NOT NULL,
+    "ydoc_state" bytea NOT NULL,
+    "content_text" text,
+    "created_by" text,
+    "trigger" text DEFAULT 'auto' NOT NULL,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+    ALTER TABLE "page_snapshots"
+        ADD CONSTRAINT "page_snapshots_page_id_pages_id_fk"
+        FOREIGN KEY ("page_id") REFERENCES "pages"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_page_snapshots_page_id"
+    ON "page_snapshots" ("page_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_page_snapshots_page_created"
+    ON "page_snapshots" ("page_id", "created_at");

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1778976000000,
       "tag": "0027_add_pages_note_active_updated_id_index",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1779062400000,
+      "tag": "0028_add_page_snapshots",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## 概要

`page_snapshots` テーブルの作成 migration を追加します。Railway の `hocuspocus-dev` ログで、ページ本文の保存後に自動スナップショット作成が `relation "page_snapshots" does not exist` で失敗していたため、既存の Drizzle schema / API route / Hocuspocus 実装に DB を追従させます。

## 変更点

### `server/api/drizzle/`
- `0028_add_page_snapshots.sql` を追加し、`page_snapshots` テーブル・FK・index を作成
- `meta/_journal.json` に `0028_add_page_snapshots` のエントリを追加
- 再実行安全性のため `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` / `duplicate_object` 例外処理を使用

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `node scripts/check-drizzle-migrations.mjs` を実行し、既存ガードが通ることを確認
2. PR マージ後、develop の deploy workflow が migration を適用することを確認
3. Railway `hocuspocus-dev` でページを保存し、`relation "page_snapshots" does not exist` が再発しないことを確認

## チェックリスト

- [x] テストがすべてパスする（migration only / 既存 Drizzle guard 実行）
- [x] Lint エラーがない（pre-commit formatting passed）
- [ ] 必要に応じてドキュメントを更新した（不要）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

該当なし（DB migration のみ）

## 関連 Issue

Related to #823

Made with [Cursor](https://cursor.com)