### PR TITLE
ci: Add Drizzle schema drift detection across entire repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,33 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: node scripts/check-drizzle-migrations.mjs
 
+  drizzle-schema-drift-check:
+    name: Drizzle Schema Drift Check
+    # `pgTable("name", ...)` で宣言された全テーブルが、checked-in な
+    # `server/api/drizzle/*.sql` の `CREATE TABLE` に対応しているかをリポジトリ
+    # 全体で検査する。`drizzle-migration-check` は同一 PR 内のペア漏れしか
+    # 拾えなかったため、本ジョブは push / PR 双方で実行し、過去から放置されて
+    # いた drift（例: Issue #878 の `page_snapshots`）も検出する。
+    #
+    # Repo-wide audit ensuring every `pgTable("name", ...)` is actually created
+    # by a checked-in migration. `drizzle-migration-check` only covers
+    # within-PR pair omissions, so this job runs on push + PR to also catch
+    # historical drift like the `page_snapshots` regression in Issue #878.
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Unit-test drift extractors (regex + allowlist logic)
+        run: node --test scripts/check-drizzle-schema-drift.test.mjs
+
+      - name: Audit repository schema ↔ migration drift
+        run: node scripts/check-drizzle-schema-drift.mjs
+
   mcp-test:
     name: MCP Server Tests
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft

--- a/scripts/check-drizzle-schema-drift.mjs
+++ b/scripts/check-drizzle-schema-drift.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+/**
+ * Drizzle スキーマと migration SQL の「既存ドリフト」検出スクリプト。
+ * Detect pre-existing drift between Drizzle TS schema and checked-in migrations.
+ *
+ * 背景 / Background:
+ *   `scripts/check-drizzle-migrations.mjs` は、同じ PR 内で
+ *   `server/api/src/schema/**` を変更したのに `server/api/drizzle/*.sql` を
+ *   追加し忘れた場合を検出する。一方で、過去にすでに schema だけがマージ
+ *   されていて migration がリポジトリに無いままになっているケース（例:
+ *   `page_snapshots` が `server/api/src/schema/pageSnapshots.ts` には
+ *   定義されていたが `server/api/drizzle/*.sql` に CREATE TABLE が無く、
+ *   develop Railway で `relation "page_snapshots" does not exist` が出た）は
+ *   検出できなかった。
+ *
+ *   このスクリプトはリポジトリ全体を見て、`pgTable("table_name", ...)` で
+ *   定義されている全テーブルが少なくとも 1 つの migration SQL の
+ *   `CREATE TABLE` に登場するか（かつ後で `DROP TABLE` されていないか）を
+ *   検査する。
+ *
+ *   `scripts/check-drizzle-migrations.mjs` covers the "edit-without-migrate"
+ *   case inside a single PR. It cannot catch tables whose schema landed on
+ *   `main` long ago without ever shipping a migration — exactly the
+ *   `page_snapshots` failure mode on develop Railway. This script audits the
+ *   repo as a whole: every `pgTable("<name>", ...)` must appear as
+ *   `CREATE TABLE "<name>"` in at least one migration and must not have been
+ *   subsequently `DROP TABLE`d.
+ *
+ * 使い方 / Usage:
+ *   node scripts/check-drizzle-schema-drift.mjs
+ *
+ * 範囲 / Scope:
+ *   - schema 抽出は `pgTable("...", ...)` / `pgTable(\n  "...", ...)` のみ。
+ *     `relations()` / `view` などは対象外。
+ *   - migration 抽出は `CREATE TABLE [IF NOT EXISTS] "..."` と
+ *     `DROP TABLE [IF EXISTS] "..."`。`bytea`, `jsonb` 等の生 SQL や
+ *     `ALTER TABLE` は対象外。
+ *
+ *   The check is intentionally narrow: only `pgTable("name", ...)` calls in
+ *   schema files and `CREATE TABLE` / `DROP TABLE` statements in migration
+ *   SQL. Raw SQL elsewhere (Hocuspocus, API services) is out of scope for the
+ *   first iteration — see Issue #878 for the follow-up.
+ *
+ * 既存ドリフトの allowlist / Pre-existing drift allowlist:
+ *   `note_invitations` のように、本スクリプトを導入した時点ですでに drift
+ *   していたテーブルは `ALLOWLIST` に明示する。allowlist に入れる場合は
+ *   追跡 issue / 修正方針をコメントで残すこと。
+ *
+ *   Tables that are already drifted at the time this guard ships go in
+ *   `ALLOWLIST`. Always leave a tracking issue / remediation note alongside
+ *   each entry.
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = join(__dirname, "..");
+
+/**
+ * Schema TS ファイル群のルート（相対パス）。
+ * Root of the Drizzle TS schema files.
+ */
+export const SCHEMA_DIR = "server/api/src/schema";
+
+/**
+ * Migration SQL ファイル群のルート（相対パス）。
+ * Root of the Drizzle migration SQL files.
+ */
+export const MIGRATION_DIR = "server/api/drizzle";
+
+/**
+ * `pgTable("name", ...)` の抽出パターン。改行や空白を許容する。
+ * Match `pgTable("name", ...)` allowing whitespace and newlines before the
+ * first string argument.
+ */
+const PG_TABLE_PATTERN = /\bpgTable\s*\(\s*["']([a-zA-Z_][a-zA-Z0-9_]*)["']/g;
+
+/**
+ * `CREATE TABLE [IF NOT EXISTS] "name"` の抽出パターン。
+ * Match `CREATE TABLE [IF NOT EXISTS] "name"`.
+ */
+const CREATE_TABLE_PATTERN = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"([^"]+)"/gi;
+
+/**
+ * `DROP TABLE [IF EXISTS] "name"` の抽出パターン。
+ * Match `DROP TABLE [IF EXISTS] "name"`.
+ */
+const DROP_TABLE_PATTERN = /DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?"([^"]+)"/gi;
+
+/**
+ * 既知の既存ドリフト。スクリプト導入時点で schema と migration が乖離していた
+ * テーブルを列挙する。新規 PR で追加する場合は必ず追跡 issue を併記する。
+ *
+ * Known pre-existing drift. Each entry must come with a tracking issue or
+ * remediation plan so the list stays small and reviewable.
+ *
+ * - `note_invitations`: `server/api/src/schema/notes.ts` で定義されているが、
+ *   `server/api/drizzle/*.sql` のどこにも CREATE TABLE が無い。本ガード
+ *   導入と同じ PR で migration を追加するのは scope 外のため、別 issue で
+ *   フォローアップする想定で一時的に許容する。
+ *
+ *   `note_invitations` is referenced by the API (invite flow / member resend)
+ *   but never created by a checked-in migration. Tracked as follow-up to
+ *   Issue #878; remove this allowlist entry once the migration lands.
+ */
+export const ALLOWLIST = new Set(["note_invitations"]);
+
+/**
+ * Schema ファイルの内容から `pgTable("name", ...)` のテーブル名を抽出する。
+ * Extract table names declared via `pgTable("name", ...)` from one schema file.
+ *
+ * @param {string} content - schema TS ファイルのテキスト / schema file text.
+ * @returns {string[]} 抽出されたテーブル名（重複排除済み） / unique table names.
+ */
+export function extractSchemaTables(content) {
+  const found = new Set();
+  for (const match of content.matchAll(PG_TABLE_PATTERN)) {
+    found.add(match[1]);
+  }
+  return [...found];
+}
+
+/**
+ * Migration SQL の `CREATE TABLE [IF NOT EXISTS] "name"` を抽出する。
+ * Extract table names created in one migration SQL file.
+ *
+ * @param {string} content - migration SQL ファイルのテキスト / SQL text.
+ * @returns {string[]} 抽出されたテーブル名（重複排除済み） / unique table names.
+ */
+export function extractMigrationCreatedTables(content) {
+  const found = new Set();
+  for (const match of content.matchAll(CREATE_TABLE_PATTERN)) {
+    found.add(match[1]);
+  }
+  return [...found];
+}
+
+/**
+ * Migration SQL の `DROP TABLE [IF EXISTS] "name"` を抽出する。
+ * Extract table names dropped in one migration SQL file.
+ *
+ * @param {string} content - migration SQL ファイルのテキスト / SQL text.
+ * @returns {string[]} 抽出されたテーブル名（重複排除済み） / unique table names.
+ */
+export function extractMigrationDroppedTables(content) {
+  const found = new Set();
+  for (const match of content.matchAll(DROP_TABLE_PATTERN)) {
+    found.add(match[1]);
+  }
+  return [...found];
+}
+
+/**
+ * Schema にあるが migration に対応する CREATE TABLE が無い（または後で
+ * DROP されている）テーブルを列挙する。allowlist に含まれるテーブルは除外する。
+ *
+ * Compute the set of schema tables that have no live `CREATE TABLE` in the
+ * migration history (never created, or created and later dropped). Entries
+ * in `allowlist` are excluded so pre-existing drift does not break CI.
+ *
+ * @param {object} args
+ * @param {Set<string>} args.schemaTables - schema 由来のテーブル名集合.
+ * @param {Set<string>} args.createdTables - migration の CREATE TABLE 集合.
+ * @param {Set<string>} args.droppedTables - migration の DROP TABLE 集合.
+ * @param {Set<string>} args.allowlist - 既存ドリフトの許容リスト.
+ * @returns {string[]} 修正が必要なテーブル名の昇順配列.
+ */
+export function findMissingTables({ schemaTables, createdTables, droppedTables, allowlist }) {
+  const missing = [];
+  for (const name of schemaTables) {
+    if (allowlist.has(name)) continue;
+    if (!createdTables.has(name)) {
+      missing.push(name);
+      continue;
+    }
+    if (droppedTables.has(name)) {
+      missing.push(name);
+    }
+  }
+  return missing.sort();
+}
+
+/**
+ * ディレクトリを再帰的に走査して、指定拡張子のファイルパス（リポジトリ相対）を返す。
+ * Recursively list files under `dir` with one of the given extensions.
+ *
+ * @param {string} dir - リポジトリルートからの相対パス / repo-relative path.
+ * @param {readonly string[]} extensions - 対象拡張子 / file extensions to keep.
+ * @returns {string[]}
+ */
+function listFiles(dir, extensions) {
+  const absolute = join(REPO_ROOT, dir);
+  const result = [];
+  for (const entry of readdirSync(absolute)) {
+    const fullPath = join(absolute, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      result.push(...listFiles(relative(REPO_ROOT, fullPath), extensions));
+      continue;
+    }
+    if (extensions.some((ext) => entry.endsWith(ext))) {
+      result.push(relative(REPO_ROOT, fullPath));
+    }
+  }
+  return result;
+}
+
+/**
+ * Schema TS ファイルとして扱うかを判定する。テスト・型ファイル・index は除外する。
+ * Filter to "real" schema source files (skip tests, type-only, index, relations).
+ *
+ * @param {string} relativePath
+ */
+function isSchemaSourceFile(relativePath) {
+  if (relativePath.endsWith(".test.ts") || relativePath.endsWith(".spec.ts")) return false;
+  if (relativePath.includes("/__tests__/") || relativePath.includes("/types/")) return false;
+  return relativePath.endsWith(".ts");
+}
+
+/**
+ * Migration SQL として扱うかを判定する。`meta/` 配下のスナップショットは除外する。
+ * Filter to migration SQL files (skip the drizzle `meta/` snapshots directory).
+ *
+ * @param {string} relativePath
+ */
+function isMigrationSqlFile(relativePath) {
+  if (!relativePath.endsWith(".sql")) return false;
+  if (relativePath.includes("/meta/")) return false;
+  return true;
+}
+
+/**
+ * リポジトリの schema + migration を読み込み、不足テーブルがあれば exit 1。
+ * Scan the repo, fail with a readable message when drift is detected.
+ */
+function main() {
+  const schemaFiles = listFiles(SCHEMA_DIR, [".ts"]).filter(isSchemaSourceFile);
+  const migrationFiles = listFiles(MIGRATION_DIR, [".sql"]).filter(isMigrationSqlFile);
+
+  /** @type {Map<string, string[]>} */
+  const tableToSchemaFiles = new Map();
+  for (const file of schemaFiles) {
+    const content = readFileSync(join(REPO_ROOT, file), "utf8");
+    for (const table of extractSchemaTables(content)) {
+      const list = tableToSchemaFiles.get(table) ?? [];
+      list.push(file);
+      tableToSchemaFiles.set(table, list);
+    }
+  }
+
+  const createdTables = new Set();
+  const droppedTables = new Set();
+  for (const file of migrationFiles) {
+    const content = readFileSync(join(REPO_ROOT, file), "utf8");
+    for (const t of extractMigrationCreatedTables(content)) createdTables.add(t);
+    for (const t of extractMigrationDroppedTables(content)) droppedTables.add(t);
+  }
+
+  const schemaTables = new Set(tableToSchemaFiles.keys());
+  const missing = findMissingTables({
+    schemaTables,
+    createdTables,
+    droppedTables,
+    allowlist: ALLOWLIST,
+  });
+
+  if (missing.length === 0) {
+    console.log(
+      `[check-drizzle-schema-drift] OK — ${schemaTables.size} schema tables are covered by ${createdTables.size} CREATE TABLE statements across ${migrationFiles.length} migration(s).`,
+    );
+    if (ALLOWLIST.size > 0) {
+      console.log(
+        `[check-drizzle-schema-drift] (allowlisted pre-existing drift: ${[...ALLOWLIST].join(", ")})`,
+      );
+    }
+    return;
+  }
+
+  console.error("[check-drizzle-schema-drift] FAIL");
+  console.error("");
+  console.error(
+    "Drizzle schema defines table(s) with no live migration. Production / develop will throw",
+  );
+  console.error(`  relation "<table>" does not exist`);
+  console.error("at runtime. Each missing table is listed below with its schema file(s):");
+  for (const table of missing) {
+    const files = tableToSchemaFiles.get(table) ?? [];
+    console.error(`  - ${table}  (declared in: ${files.join(", ") || "?"})`);
+    if (droppedTables.has(table)) {
+      console.error(
+        `      note: this table was CREATEd then later DROPped in a migration. Either re-add the CREATE or remove it from the TS schema.`,
+      );
+    }
+  }
+  console.error("");
+  console.error("How to fix / 修正方法:");
+  console.error("  1. Add a `server/api/drizzle/NNNN_*.sql` migration that runs");
+  console.error('     `CREATE TABLE IF NOT EXISTS "<table>" (...)` (mirror the TS schema).');
+  console.error("  2. Append the matching entry to `server/api/drizzle/meta/_journal.json`.");
+  console.error("  3. (If truly intentional pre-existing drift) add the table name to");
+  console.error("     `ALLOWLIST` in `scripts/check-drizzle-schema-drift.mjs` with a");
+  console.error("     tracking issue link.");
+  process.exit(1);
+}
+
+// CLI entrypoint — node が直接このファイルを起動した場合のみ main() を走らせる。
+// Run main() only when this file is invoked as a CLI, not when imported by tests.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/scripts/check-drizzle-schema-drift.mjs
+++ b/scripts/check-drizzle-schema-drift.mjs
@@ -72,11 +72,14 @@ export const SCHEMA_DIR = "server/api/src/schema";
 export const MIGRATION_DIR = "server/api/drizzle";
 
 /**
- * `pgTable("name", ...)` の抽出パターン。改行や空白を許容する。
+ * `pgTable("name", ...)` の抽出パターン。改行や空白を許容し、Drizzle が許す
+ * 任意のテーブル名文字列（ハイフン・先頭数字なども含む）を捕捉する。
  * Match `pgTable("name", ...)` allowing whitespace and newlines before the
- * first string argument.
+ * first string argument. The capture group accepts any character that is not
+ * a quote or newline so legal-but-non-identifier names (hyphenated, leading
+ * digit) are not silently skipped.
  */
-const PG_TABLE_PATTERN = /\bpgTable\s*\(\s*["']([a-zA-Z_][a-zA-Z0-9_]*)["']/g;
+const PG_TABLE_PATTERN = /\bpgTable\s*\(\s*["']([^"'\n]+)["']/g;
 
 /**
  * `CREATE TABLE [IF NOT EXISTS] "name"` の抽出パターン。
@@ -154,31 +157,63 @@ export function extractMigrationDroppedTables(content) {
 }
 
 /**
- * Schema にあるが migration に対応する CREATE TABLE が無い（または後で
- * DROP されている）テーブルを列挙する。allowlist に含まれるテーブルは除外する。
+ * Migration を chronological 順に再生して、最終的に存在するテーブル集合を返す。
  *
- * Compute the set of schema tables that have no live `CREATE TABLE` in the
- * migration history (never created, or created and later dropped). Entries
- * in `allowlist` are excluded so pre-existing drift does not break CI.
+ * `CREATE TABLE` と `DROP TABLE` をファイル名順 → ファイル内位置順で再生し、
+ * 各テーブルの最後の操作が CREATE のものだけを「live」として返す。これに
+ * より、`CREATE → DROP → CREATE` のような正規のテーブルリサイクルを drift
+ * と誤検出しない。呼び出し側は `migrations` をファイル名昇順で渡す責務を持つ。
+ *
+ * Replay every `CREATE TABLE` / `DROP TABLE` in chronological order (by file,
+ * then by in-file position) and return the set of tables whose last operation
+ * is a CREATE. Lets the checker accept a legitimate
+ * `create → drop → recreate` sequence as live. The caller must pass
+ * `migrations` already sorted by filename.
+ *
+ * @param {ReadonlyArray<{ file: string, content: string }>} migrations
+ * @returns {Set<string>} 最終的に存在するテーブル名 / live table names.
+ */
+export function computeLiveTables(migrations) {
+  /** @type {Map<string, "created" | "dropped">} */
+  const state = new Map();
+  for (const { content } of migrations) {
+    /** @type {Array<{ pos: number, table: string, op: "created" | "dropped" }>} */
+    const transitions = [];
+    for (const m of content.matchAll(CREATE_TABLE_PATTERN)) {
+      transitions.push({ pos: m.index ?? 0, table: m[1], op: "created" });
+    }
+    for (const m of content.matchAll(DROP_TABLE_PATTERN)) {
+      transitions.push({ pos: m.index ?? 0, table: m[1], op: "dropped" });
+    }
+    transitions.sort((a, b) => a.pos - b.pos);
+    for (const t of transitions) state.set(t.table, t.op);
+  }
+  const live = new Set();
+  for (const [table, op] of state) {
+    if (op === "created") live.add(table);
+  }
+  return live;
+}
+
+/**
+ * Schema にあるが migration の最終状態で存在しないテーブルを列挙する。
+ * allowlist に含まれるテーブルは既存ドリフトとして除外する。
+ *
+ * Compute the set of schema tables that are not live after replaying every
+ * migration. Entries in `allowlist` are excluded so pre-existing drift does
+ * not break CI.
  *
  * @param {object} args
  * @param {Set<string>} args.schemaTables - schema 由来のテーブル名集合.
- * @param {Set<string>} args.createdTables - migration の CREATE TABLE 集合.
- * @param {Set<string>} args.droppedTables - migration の DROP TABLE 集合.
+ * @param {Set<string>} args.liveTables - migration 再生後の live テーブル集合.
  * @param {Set<string>} args.allowlist - 既存ドリフトの許容リスト.
  * @returns {string[]} 修正が必要なテーブル名の昇順配列.
  */
-export function findMissingTables({ schemaTables, createdTables, droppedTables, allowlist }) {
+export function findMissingTables({ schemaTables, liveTables, allowlist }) {
   const missing = [];
   for (const name of schemaTables) {
     if (allowlist.has(name)) continue;
-    if (!createdTables.has(name)) {
-      missing.push(name);
-      continue;
-    }
-    if (droppedTables.has(name)) {
-      missing.push(name);
-    }
+    if (!liveTables.has(name)) missing.push(name);
   }
   return missing.sort();
 }
@@ -238,7 +273,11 @@ function isMigrationSqlFile(relativePath) {
  */
 function main() {
   const schemaFiles = listFiles(SCHEMA_DIR, [".ts"]).filter(isSchemaSourceFile);
-  const migrationFiles = listFiles(MIGRATION_DIR, [".sql"]).filter(isMigrationSqlFile);
+  // Migration ファイルは chronological 順（`0000_`, `0001_`, ...）に処理する
+  // 必要があるため、`readdirSync` の順序に頼らず明示的にソートする。
+  // Explicitly sort migration files so `computeLiveTables` sees them in the
+  // chronological order encoded by the `NNNN_` prefix.
+  const migrationFiles = listFiles(MIGRATION_DIR, [".sql"]).filter(isMigrationSqlFile).sort();
 
   /** @type {Map<string, string[]>} */
   const tableToSchemaFiles = new Map();
@@ -251,25 +290,22 @@ function main() {
     }
   }
 
-  const createdTables = new Set();
-  const droppedTables = new Set();
-  for (const file of migrationFiles) {
-    const content = readFileSync(join(REPO_ROOT, file), "utf8");
-    for (const t of extractMigrationCreatedTables(content)) createdTables.add(t);
-    for (const t of extractMigrationDroppedTables(content)) droppedTables.add(t);
-  }
+  const migrations = migrationFiles.map((file) => ({
+    file,
+    content: readFileSync(join(REPO_ROOT, file), "utf8"),
+  }));
+  const liveTables = computeLiveTables(migrations);
 
   const schemaTables = new Set(tableToSchemaFiles.keys());
   const missing = findMissingTables({
     schemaTables,
-    createdTables,
-    droppedTables,
+    liveTables,
     allowlist: ALLOWLIST,
   });
 
   if (missing.length === 0) {
     console.log(
-      `[check-drizzle-schema-drift] OK — ${schemaTables.size} schema tables are covered by ${createdTables.size} CREATE TABLE statements across ${migrationFiles.length} migration(s).`,
+      `[check-drizzle-schema-drift] OK — ${schemaTables.size} schema tables are covered by ${liveTables.size} live table(s) across ${migrationFiles.length} migration(s).`,
     );
     if (ALLOWLIST.size > 0) {
       console.log(
@@ -277,6 +313,17 @@ function main() {
       );
     }
     return;
+  }
+
+  // Drift と判定された各テーブルが「過去に存在したことがあるか」を表示するために、
+  // 「CREATE TABLE が一度でも出現したか」を別途集計する（live 集合だけでは
+  //  create→drop の区別がつかないため）。
+  // Build an "ever created" set separately so the FAIL output can flag the
+  // create-then-drop subcase (live alone cannot distinguish "never created"
+  // from "created then dropped").
+  const everCreated = new Set();
+  for (const m of migrations) {
+    for (const t of extractMigrationCreatedTables(m.content)) everCreated.add(t);
   }
 
   console.error("[check-drizzle-schema-drift] FAIL");
@@ -289,7 +336,7 @@ function main() {
   for (const table of missing) {
     const files = tableToSchemaFiles.get(table) ?? [];
     console.error(`  - ${table}  (declared in: ${files.join(", ") || "?"})`);
-    if (droppedTables.has(table)) {
+    if (everCreated.has(table)) {
       console.error(
         `      note: this table was CREATEd then later DROPped in a migration. Either re-add the CREATE or remove it from the TS schema.`,
       );

--- a/scripts/check-drizzle-schema-drift.test.mjs
+++ b/scripts/check-drizzle-schema-drift.test.mjs
@@ -1,0 +1,189 @@
+/**
+ * `check-drizzle-schema-drift.mjs` のユニットテスト。
+ * Unit tests for `check-drizzle-schema-drift.mjs`.
+ *
+ * 目的 / Purpose:
+ *   - schema TS / migration SQL からのテーブル名抽出が、Zedi の実際の書き方
+ *     （`pgTable("name", ...)`、`pgTable(\n  "name",\n  ...`、
+ *     `CREATE TABLE [IF NOT EXISTS] "name"`、`DROP TABLE [IF EXISTS] "name"`）
+ *     を網羅できているかを保証する。
+ *   - `pageSnapshots` のように schema にはあるが migration が無いケースが
+ *     drift として検出できることをユニットテストで再現する。
+ *
+ *   Guarantee that the extraction regexes cover the patterns Zedi actually
+ *   writes in this repo and that the missing-table detection reproduces the
+ *   `page_snapshots` regression we hit on the develop Railway environment.
+ *
+ * 実行 / Run:
+ *   node --test scripts/check-drizzle-schema-drift.test.mjs
+ */
+
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+
+import {
+  extractSchemaTables,
+  extractMigrationCreatedTables,
+  extractMigrationDroppedTables,
+  findMissingTables,
+} from "./check-drizzle-schema-drift.mjs";
+
+describe("extractSchemaTables", () => {
+  it("extracts a table name from a single-line pgTable() call", () => {
+    const src = `export const pageContents = pgTable("page_contents", { id: uuid("id") });`;
+    assert.deepEqual(extractSchemaTables(src), ["page_contents"]);
+  });
+
+  it("extracts a table name from a multi-line pgTable() call", () => {
+    const src = [
+      "export const pageSnapshots = pgTable(",
+      '  "page_snapshots",',
+      '  { id: uuid("id") },',
+      ");",
+    ].join("\n");
+    assert.deepEqual(extractSchemaTables(src), ["page_snapshots"]);
+  });
+
+  it("extracts multiple tables defined in the same file", () => {
+    const src = [
+      'export const a = pgTable("a", {});',
+      "export const b = pgTable(",
+      '  "b",',
+      "  {},",
+      ");",
+      'export const c = pgTable("c", {});',
+    ].join("\n");
+    assert.deepEqual(extractSchemaTables(src).sort(), ["a", "b", "c"]);
+  });
+
+  it("ignores unrelated string literals", () => {
+    const src = [
+      'const note = "note_invitations"; // not a pgTable call',
+      'someOther("not_a_table", {});',
+      'export const x = pgTable("real_table", {});',
+    ].join("\n");
+    assert.deepEqual(extractSchemaTables(src), ["real_table"]);
+  });
+
+  it("deduplicates if the same pgTable name appears twice in one file", () => {
+    const src = [
+      'export const a = pgTable("dup", {});',
+      'export const b = pgTable("dup", {});',
+    ].join("\n");
+    assert.deepEqual(extractSchemaTables(src), ["dup"]);
+  });
+});
+
+describe("extractMigrationCreatedTables", () => {
+  it("extracts a plain CREATE TABLE", () => {
+    const sql = `CREATE TABLE "pages" ("id" uuid PRIMARY KEY NOT NULL);`;
+    assert.deepEqual(extractMigrationCreatedTables(sql), ["pages"]);
+  });
+
+  it("extracts CREATE TABLE IF NOT EXISTS", () => {
+    const sql = `CREATE TABLE IF NOT EXISTS "page_snapshots" ("id" uuid);`;
+    assert.deepEqual(extractMigrationCreatedTables(sql), ["page_snapshots"]);
+  });
+
+  it("ignores DROP TABLE / CREATE INDEX statements", () => {
+    const sql = [
+      'CREATE TABLE "kept" ("id" uuid);',
+      'DROP TABLE IF EXISTS "old";',
+      'CREATE INDEX "idx_kept_id" ON "kept" ("id");',
+    ].join("\n");
+    assert.deepEqual(extractMigrationCreatedTables(sql), ["kept"]);
+  });
+
+  it("collects multiple CREATE TABLE statements", () => {
+    const sql = [
+      'CREATE TABLE "a" ("id" uuid);',
+      'CREATE TABLE IF NOT EXISTS "b" ("id" uuid);',
+      'CREATE TABLE "c" ("id" uuid);',
+    ].join("\n");
+    assert.deepEqual(extractMigrationCreatedTables(sql).sort(), ["a", "b", "c"]);
+  });
+});
+
+describe("extractMigrationDroppedTables", () => {
+  it("extracts DROP TABLE IF EXISTS", () => {
+    const sql = `DROP TABLE IF EXISTS "note_pages";`;
+    assert.deepEqual(extractMigrationDroppedTables(sql), ["note_pages"]);
+  });
+
+  it("extracts plain DROP TABLE", () => {
+    const sql = `DROP TABLE "obsolete";`;
+    assert.deepEqual(extractMigrationDroppedTables(sql), ["obsolete"]);
+  });
+
+  it("does not match CREATE TABLE statements", () => {
+    const sql = `CREATE TABLE "kept" ("id" uuid);`;
+    assert.deepEqual(extractMigrationDroppedTables(sql), []);
+  });
+});
+
+describe("findMissingTables", () => {
+  it("returns nothing when every schema table has a CREATE TABLE", () => {
+    const result = findMissingTables({
+      schemaTables: new Set(["pages", "notes"]),
+      createdTables: new Set(["pages", "notes", "user"]),
+      droppedTables: new Set(),
+      allowlist: new Set(),
+    });
+    assert.deepEqual(result, []);
+  });
+
+  it("flags a schema table that has no CREATE TABLE — page_snapshots regression", () => {
+    // Reproduces the develop Railway failure:
+    //   `relation "page_snapshots" does not exist`
+    // The schema referenced `page_snapshots` but no migration CREATEd it.
+    const result = findMissingTables({
+      schemaTables: new Set(["pages", "page_snapshots"]),
+      createdTables: new Set(["pages"]),
+      droppedTables: new Set(),
+      allowlist: new Set(),
+    });
+    assert.deepEqual(result, ["page_snapshots"]);
+  });
+
+  it("flags a schema table that was CREATEd but later DROPped", () => {
+    // PR #823 dropped note_pages; if the schema still referenced it, that
+    // would be a drift even though a historical CREATE TABLE exists.
+    const result = findMissingTables({
+      schemaTables: new Set(["note_pages"]),
+      createdTables: new Set(["note_pages"]),
+      droppedTables: new Set(["note_pages"]),
+      allowlist: new Set(),
+    });
+    assert.deepEqual(result, ["note_pages"]);
+  });
+
+  it("does not flag a table that was DROPped and is no longer in the schema", () => {
+    const result = findMissingTables({
+      schemaTables: new Set(["pages"]),
+      createdTables: new Set(["pages", "note_pages"]),
+      droppedTables: new Set(["note_pages"]),
+      allowlist: new Set(),
+    });
+    assert.deepEqual(result, []);
+  });
+
+  it("respects the allowlist for pre-existing drift", () => {
+    const result = findMissingTables({
+      schemaTables: new Set(["note_invitations"]),
+      createdTables: new Set(),
+      droppedTables: new Set(),
+      allowlist: new Set(["note_invitations"]),
+    });
+    assert.deepEqual(result, []);
+  });
+
+  it("returns missing tables in deterministic sorted order", () => {
+    const result = findMissingTables({
+      schemaTables: new Set(["z_table", "a_table", "m_table"]),
+      createdTables: new Set(),
+      droppedTables: new Set(),
+      allowlist: new Set(),
+    });
+    assert.deepEqual(result, ["a_table", "m_table", "z_table"]);
+  });
+});

--- a/scripts/check-drizzle-schema-drift.test.mjs
+++ b/scripts/check-drizzle-schema-drift.test.mjs
@@ -9,10 +9,14 @@
  *     を網羅できているかを保証する。
  *   - `pageSnapshots` のように schema にはあるが migration が無いケースが
  *     drift として検出できることをユニットテストで再現する。
+ *   - `CREATE → DROP → CREATE` のような正規のライフサイクルを drift と
+ *     誤検出しない（migration を chronological 順で評価する）。
  *
  *   Guarantee that the extraction regexes cover the patterns Zedi actually
- *   writes in this repo and that the missing-table detection reproduces the
- *   `page_snapshots` regression we hit on the develop Railway environment.
+ *   writes in this repo, that the missing-table detection reproduces the
+ *   `page_snapshots` regression we hit on the develop Railway environment,
+ *   and that legitimate `create → drop → recreate` sequences are not
+ *   misclassified as drift.
  *
  * 実行 / Run:
  *   node --test scripts/check-drizzle-schema-drift.test.mjs
@@ -25,6 +29,7 @@ import {
   extractSchemaTables,
   extractMigrationCreatedTables,
   extractMigrationDroppedTables,
+  computeLiveTables,
   findMissingTables,
 } from "./check-drizzle-schema-drift.mjs";
 
@@ -71,6 +76,18 @@ describe("extractSchemaTables", () => {
       'export const b = pgTable("dup", {});',
     ].join("\n");
     assert.deepEqual(extractSchemaTables(src), ["dup"]);
+  });
+
+  it("accepts non-identifier characters that are legal Postgres identifiers (hyphen, leading digit)", () => {
+    // Drizzle の pgTable は文字列であって JS 識別子ではないため、
+    // ハイフンや先頭数字を含む名前を抽出できる必要がある。
+    // pgTable accepts arbitrary strings, so the extractor must tolerate
+    // non-identifier characters like hyphens or leading digits.
+    const src = [
+      'export const a = pgTable("kebab-case", {});',
+      'export const b = pgTable("2024_archive", {});',
+    ].join("\n");
+    assert.deepEqual(extractSchemaTables(src).sort(), ["2024_archive", "kebab-case"]);
   });
 });
 
@@ -121,12 +138,70 @@ describe("extractMigrationDroppedTables", () => {
   });
 });
 
+describe("computeLiveTables", () => {
+  // computeLiveTables walks migrations in chronological order and returns the
+  // set of tables that exist after replaying every CREATE/DROP. The caller is
+  // responsible for passing migrations sorted by filename.
+  //
+  // chronological 順に CREATE/DROP を再生し、最終的に存在するテーブル集合を
+  // 返す。呼び出し側はファイル名順にソート済みの配列を渡す責務を持つ。
+
+  it("treats a single CREATE TABLE as live", () => {
+    const live = computeLiveTables([
+      { file: "0000_init.sql", content: 'CREATE TABLE "pages" ();' },
+    ]);
+    assert.deepEqual([...live].sort(), ["pages"]);
+  });
+
+  it("treats CREATE then DROP across files as not-live", () => {
+    const live = computeLiveTables([
+      { file: "0000_init.sql", content: 'CREATE TABLE "note_pages" ();' },
+      { file: "0023_drop.sql", content: 'DROP TABLE IF EXISTS "note_pages";' },
+    ]);
+    assert.deepEqual([...live], []);
+  });
+
+  it("treats CREATE → DROP → CREATE across files as live (recreated)", () => {
+    // Codex / Gemini レビューで指摘された誤検出の再発防止。
+    // Regression guard for the recreate case flagged by Codex / Gemini.
+    const live = computeLiveTables([
+      { file: "0000_init.sql", content: 'CREATE TABLE "audit_logs" ();' },
+      { file: "0010_drop.sql", content: 'DROP TABLE "audit_logs";' },
+      { file: "0020_recreate.sql", content: 'CREATE TABLE IF NOT EXISTS "audit_logs" ();' },
+    ]);
+    assert.deepEqual([...live].sort(), ["audit_logs"]);
+  });
+
+  it("uses the order of statements inside one file (DROP then CREATE → live)", () => {
+    // 同一ファイル内で DROP の後に CREATE がある場合、最終的にはテーブルが
+    // 存在する。statement の位置順で評価する。
+    // When a single migration drops then recreates a table, the final state
+    // is "exists"; honour the in-file statement order.
+    const live = computeLiveTables([
+      {
+        file: "0007_swap.sql",
+        content: 'DROP TABLE IF EXISTS "tmp";\nCREATE TABLE "tmp" ();',
+      },
+    ]);
+    assert.deepEqual([...live].sort(), ["tmp"]);
+  });
+
+  it("uses the order of statements inside one file (CREATE then DROP → not live)", () => {
+    const live = computeLiveTables([
+      {
+        file: "0007_swap.sql",
+        content: 'CREATE TABLE "tmp" ();\nDROP TABLE "tmp";',
+      },
+    ]);
+    assert.deepEqual([...live], []);
+  });
+});
+
 describe("findMissingTables", () => {
-  it("returns nothing when every schema table has a CREATE TABLE", () => {
+  it("returns nothing when every schema table is live", () => {
     const result = findMissingTables({
       schemaTables: new Set(["pages", "notes"]),
-      createdTables: new Set(["pages", "notes", "user"]),
-      droppedTables: new Set(),
+      liveTables: new Set(["pages", "notes", "user"]),
       allowlist: new Set(),
     });
     assert.deepEqual(result, []);
@@ -138,8 +213,7 @@ describe("findMissingTables", () => {
     // The schema referenced `page_snapshots` but no migration CREATEd it.
     const result = findMissingTables({
       schemaTables: new Set(["pages", "page_snapshots"]),
-      createdTables: new Set(["pages"]),
-      droppedTables: new Set(),
+      liveTables: new Set(["pages"]),
       allowlist: new Set(),
     });
     assert.deepEqual(result, ["page_snapshots"]);
@@ -150,8 +224,7 @@ describe("findMissingTables", () => {
     // would be a drift even though a historical CREATE TABLE exists.
     const result = findMissingTables({
       schemaTables: new Set(["note_pages"]),
-      createdTables: new Set(["note_pages"]),
-      droppedTables: new Set(["note_pages"]),
+      liveTables: new Set(), // create-then-drop ⇒ not live
       allowlist: new Set(),
     });
     assert.deepEqual(result, ["note_pages"]);
@@ -160,8 +233,7 @@ describe("findMissingTables", () => {
   it("does not flag a table that was DROPped and is no longer in the schema", () => {
     const result = findMissingTables({
       schemaTables: new Set(["pages"]),
-      createdTables: new Set(["pages", "note_pages"]),
-      droppedTables: new Set(["note_pages"]),
+      liveTables: new Set(["pages"]), // note_pages was created then dropped ⇒ not live, and not in schema
       allowlist: new Set(),
     });
     assert.deepEqual(result, []);
@@ -170,8 +242,7 @@ describe("findMissingTables", () => {
   it("respects the allowlist for pre-existing drift", () => {
     const result = findMissingTables({
       schemaTables: new Set(["note_invitations"]),
-      createdTables: new Set(),
-      droppedTables: new Set(),
+      liveTables: new Set(),
       allowlist: new Set(["note_invitations"]),
     });
     assert.deepEqual(result, []);
@@ -180,8 +251,7 @@ describe("findMissingTables", () => {
   it("returns missing tables in deterministic sorted order", () => {
     const result = findMissingTables({
       schemaTables: new Set(["z_table", "a_table", "m_table"]),
-      createdTables: new Set(),
-      droppedTables: new Set(),
+      liveTables: new Set(),
       allowlist: new Set(),
     });
     assert.deepEqual(result, ["a_table", "m_table", "z_table"]);


### PR DESCRIPTION
## 概要

Drizzle スキーマ（TS）と migration SQL の乖離を検出する新しい CI ガード `check-drizzle-schema-drift.mjs` を追加します。これにより、過去にスキーマだけがマージされて migration が無いままになっているケース（Issue #878 の `page_snapshots` など）を検出できるようになります。

## 変更点

- **`scripts/check-drizzle-schema-drift.mjs`**: リポジトリ全体をスキャンして、`pgTable("name", ...)` で定義されたすべてのテーブルが少なくとも 1 つの migration SQL の `CREATE TABLE` に登場し、後で `DROP TABLE` されていないことを検査するスクリプト
  - `extractSchemaTables()`: TS スキーマファイルから `pgTable("name", ...)` のテーブル名を抽出
  - `extractMigrationCreatedTables()`: migration SQL から `CREATE TABLE [IF NOT EXISTS] "name"` を抽出
  - `extractMigrationDroppedTables()`: migration SQL から `DROP TABLE [IF EXISTS] "name"` を抽出
  - `findMissingTables()`: スキーマにあるが migration に対応する CREATE TABLE が無い（または後で DROP されている）テーブルを検出
  - `ALLOWLIST`: 既存ドリフト（`note_invitations` など）を許容するための allowlist

- **`scripts/check-drizzle-schema-drift.test.mjs`**: 抽出ロジックと allowlist 機能をカバーするユニットテスト
  - `page_snapshots` 回帰テスト（スキーマにあるが migration が無いケース）
  - `note_pages` テスト（CREATE されたが後で DROP されたケース）
  - 複数行の `pgTable()` 呼び出しや `IF NOT EXISTS` / `IF EXISTS` 句の処理を検証

- **`.github/workflows/ci.yml`**: 新しい `drizzle-schema-drift-check` ジョブを追加
  - push と PR の両方で実行（draft PR は除外）
  - ユニットテスト実行 → リポジトリ全体の drift 監査の 2 段階構成

## 変更の種類

- [x] 🔧 ビルド/CI (Build/CI)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `node --test scripts/check-drizzle-schema-drift.test.mjs` でユニットテストが全て通ることを確認
2. `node scripts/check-drizzle-schema-drift.mjs` でリポジトリ全体の drift チェックが成功することを確認
3. CI ワークフロー `drizzle-schema-drift-check` が正常に実行されることを確認

## チェックリスト

- [x] テストがすべてパスする（ユニットテスト + CI）
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #878（`page_snapshots` 回帰の根本原因に対する予防策）

https://claude.ai/code/session_01NTZmQe2dLLNnZ9GqNSo8dP