### PR TITLE
feat: Add read-only share settings access for editors and viewers

### DIFF
--- a/src/i18n/locales/en/notes.json
+++ b/src/i18n/locales/en/notes.json
@@ -39,6 +39,7 @@
   "untitledNote": "Untitled note",
   "noPermissionToEdit": "You don't have permission to change settings.",
   "openSettings": "Open settings",
+  "openShareSettingsReadOnly": "View share settings",
   "copyShareUrlAria": "Copy share URL",
   "settingsNav": {
     "ariaLabel": "Note settings sections",

--- a/src/i18n/locales/ja/notes.json
+++ b/src/i18n/locales/ja/notes.json
@@ -39,6 +39,7 @@
   "untitledNote": "無題のノート",
   "noPermissionToEdit": "設定を変更する権限がありません。",
   "openSettings": "設定を開く",
+  "openShareSettingsReadOnly": "共有設定を確認",
   "copyShareUrlAria": "共有 URL をコピー",
   "settingsNav": {
     "ariaLabel": "ノート設定セクション",

--- a/src/pages/NoteView/NoteViewHeaderActions.test.tsx
+++ b/src/pages/NoteView/NoteViewHeaderActions.test.tsx
@@ -1,10 +1,20 @@
 /**
  * NoteViewHeaderActions: ノート画面のヘッダー右上アクション。
  *
- * 旧仕様（共有モーダル + 設定リンクの 2 系統）から「歯車アイコン 1 個」に
- * 簡素化済み。テストの観点 / Coverage:
- *   - Owner: 設定ページ (`/notes/:id/settings`) へ遷移する歯車リンクを表示
- *   - Editor / Viewer / Guest: 何もレンダリングしない（共有モーダル廃止）
+ * 共有モーダル廃止後は `/notes/:id/settings/*` へのエントリポイントとして
+ * 機能する。Issue #675 の精神 (editor / viewer にもアクセス透明性を) を
+ * 満たすため、ロール別に異なるアイコン / リンク先を提示する。
+ *
+ * テストの観点 / Coverage:
+ *   - Owner: 歯車アイコン → `/notes/:id/settings`
+ *   - Editor: 共有閲覧アイコン → `/notes/:id/settings/members` (read-only)
+ *   - Viewer (canView=true): 共有閲覧アイコン → `/notes/:id/settings/visibility`
+ *   - Guest / canView=false: 何もレンダリングしない
+ *
+ * Header-right actions on the note page. Renders a role-aware entry point
+ * into `/notes/:id/settings/*`. Owners get a gear icon to general settings,
+ * editors and viewers get a read-only "view share settings" icon landing on
+ * the most relevant section for their role.
  */
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
@@ -38,6 +48,7 @@ function renderActions(props: Partial<React.ComponentProps<typeof NoteViewHeader
   const merged = {
     note: baseNote,
     canManageMembers: false,
+    canView: false,
     userRole: "none" as NoteAccessRole,
     ...props,
   };
@@ -50,23 +61,40 @@ function renderActions(props: Partial<React.ComponentProps<typeof NoteViewHeader
 
 describe("NoteViewHeaderActions", () => {
   it("owner には設定ページへ遷移する歯車アイコンを表示する", () => {
-    renderActions({ canManageMembers: true, userRole: "owner" });
+    renderActions({ canManageMembers: true, canView: true, userRole: "owner" });
     const link = screen.getByRole("link", { name: "notes.openSettings" });
     expect(link).toHaveAttribute("href", "/notes/note-1/settings");
   });
 
-  it("editor には何もレンダリングしない（設定画面の編集権限を持たないため）", () => {
-    const { container } = renderActions({ canManageMembers: false, userRole: "editor" });
+  it("editor には共有閲覧アイコンを表示し、members セクションへリンクする", () => {
+    renderActions({ canManageMembers: false, canView: true, userRole: "editor" });
+    const link = screen.getByRole("link", { name: "notes.openShareSettingsReadOnly" });
+    expect(link).toHaveAttribute("href", "/notes/note-1/settings/members");
+    // owner 向けの歯車アイコンは出ない
+    expect(screen.queryByRole("link", { name: "notes.openSettings" })).not.toBeInTheDocument();
+  });
+
+  it("viewer には共有閲覧アイコンを表示し、visibility セクションへリンクする", () => {
+    renderActions({ canManageMembers: false, canView: true, userRole: "viewer" });
+    const link = screen.getByRole("link", { name: "notes.openShareSettingsReadOnly" });
+    expect(link).toHaveAttribute("href", "/notes/note-1/settings/visibility");
+  });
+
+  it("canView=false の guest には何もレンダリングしない", () => {
+    const { container } = renderActions({
+      canManageMembers: false,
+      canView: false,
+      userRole: "guest",
+    });
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("viewer には何もレンダリングしない", () => {
-    const { container } = renderActions({ canManageMembers: false, userRole: "viewer" });
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it("guest (canManageMembers=false) でも何もレンダリングしない", () => {
-    const { container } = renderActions({ canManageMembers: false, userRole: "guest" });
+  it("canView=false の none (未ログイン) には何もレンダリングしない", () => {
+    const { container } = renderActions({
+      canManageMembers: false,
+      canView: false,
+      userRole: "none",
+    });
     expect(container).toBeEmptyDOMElement();
   });
 });

--- a/src/pages/NoteView/NoteViewHeaderActions.tsx
+++ b/src/pages/NoteView/NoteViewHeaderActions.tsx
@@ -1,51 +1,104 @@
 import { Link } from "react-router-dom";
-import { Settings } from "lucide-react";
+import { Settings, Users } from "lucide-react";
 import { Button } from "@zedi/ui";
 import { useTranslation } from "react-i18next";
 import type { Note, NoteAccessRole } from "@/types/note";
 
 /**
- * Props for the simplified note header actions.
- * 簡素化されたノートヘッダーアクションの Props。
+ * Props for the note header actions.
+ * ノートヘッダーアクションの Props。
  */
 export interface NoteViewHeaderActionsProps {
   note: Note;
-  /** owner 判定（管理可能か）。owner のときだけ歯車を出す。 */
+  /**
+   * owner 相当（管理操作可能）か。owner のときは歯車を出して
+   * `/notes/:id/settings` に遷移する。
+   * Owner-equivalent: shows the gear icon linking to `/notes/:id/settings`.
+   */
   canManageMembers: boolean;
   /**
-   * ロール情報。現状は描画分岐に直接使わないが、将来 editor 向け read-only
-   * 設定リンクを出したくなったときの拡張点として props に残す（呼び出し側を
-   * 二度変えなくて済むようにするための予防的シグネチャ維持）。
-   * Kept on the props so a future read-only entry point for editors does not
-   * require touching every caller.
+   * このユーザーがノートを閲覧できるか。editor / viewer が共有設定を
+   * read-only で確認するためのエントリポイント表示判定に使う。
+   * Whether the current user can view the note. Drives the read-only
+   * "View share settings" entry point for editor / viewer.
+   */
+  canView: boolean;
+  /**
+   * ノート上の現在ユーザーのロール。editor / viewer に対するリンク先
+   * (`/settings/members` vs `/settings/visibility`) の分岐に使う。
+   * The caller's role on the note. Determines which settings subroute the
+   * read-only entry point links to.
    */
   userRole: NoteAccessRole;
 }
 
 /**
- * ノート詳細ページ上部の操作アイコン。owner のみ「設定ページへ」遷移する
- * 歯車アイコンリンクを表示する。共有モーダルは廃止し、共有 URL コピーは
- * `NoteShareUrlCopyButton`（タイトル横、public/unlisted のとき）に分離した。
+ * ノート詳細ページ上部の操作アイコン。ロールに応じて 1 個のリンクボタンを描画する。
  *
- * Top-right note actions. Owners get a single gear icon linking to
- * `/notes/:id/settings`. The legacy share modal was retired; the quick-copy
- * URL action now lives next to the title as `NoteShareUrlCopyButton`.
+ * - owner: 歯車 (`Settings`) → `/notes/:id/settings`（フル編集）
+ * - editor (canView=true): 共有閲覧 (`Users`) → `/notes/:id/settings/members`
+ *   （read-only でメンバー / リンク / ドメイン / 公開設定を閲覧）
+ * - viewer (canView=true): 共有閲覧 (`Users`) → `/notes/:id/settings/visibility`
+ *   （viewer は visibility セクションのみ閲覧可）
+ * - guest / canView=false: 非表示
+ *
+ * Issue #675 (#661 follow-up): editor / viewer にもアクセス透明性のための
+ * read-only エントリを提供する。共有モーダル自体は #846 で廃止され、
+ * settings 側がすでに read-only 表示を持っているため、本コンポーネントは
+ * 純粋に動線（リンク 1 つ）に集中する。
+ *
+ * Top-right note actions. The legacy share modal was removed in #846; this
+ * component just exposes a role-aware link into `/notes/:id/settings/*`,
+ * where the read-only behavior is already enforced section by section.
  */
-export function NoteViewHeaderActions({ note, canManageMembers }: NoteViewHeaderActionsProps) {
+export function NoteViewHeaderActions({
+  note,
+  canManageMembers,
+  canView,
+  userRole,
+}: NoteViewHeaderActionsProps) {
   const { t } = useTranslation();
 
-  if (!canManageMembers) return null;
+  if (canManageMembers) {
+    return (
+      <Button
+        asChild
+        variant="ghost"
+        size="icon"
+        aria-label={t("notes.openSettings")}
+        title={t("notes.openSettings")}
+      >
+        <Link to={`/notes/${note.id}/settings`}>
+          <Settings className="h-4 w-4" aria-hidden />
+        </Link>
+      </Button>
+    );
+  }
+
+  // editor / viewer 向け read-only エントリ。canView=false の guest / none は
+  // 何も出さない。editor は members、viewer は visibility をランディングに
+  // 使う（サイドナビで他セクションへ移動可）。
+  // Read-only entry for editor / viewer. Guests with no view access see
+  // nothing. Editors land on members (richest read-only view); viewers land
+  // on visibility (the only section they can see).
+  if (!canView) return null;
+  if (userRole !== "editor" && userRole !== "viewer") return null;
+
+  const target =
+    userRole === "editor"
+      ? `/notes/${note.id}/settings/members`
+      : `/notes/${note.id}/settings/visibility`;
 
   return (
     <Button
       asChild
       variant="ghost"
       size="icon"
-      aria-label={t("notes.openSettings")}
-      title={t("notes.openSettings")}
+      aria-label={t("notes.openShareSettingsReadOnly")}
+      title={t("notes.openShareSettingsReadOnly")}
     >
-      <Link to={`/notes/${note.id}/settings`}>
-        <Settings className="h-4 w-4" aria-hidden />
+      <Link to={target}>
+        <Users className="h-4 w-4" aria-hidden />
       </Link>
     </Button>
   );

--- a/src/pages/NoteView/index.tsx
+++ b/src/pages/NoteView/index.tsx
@@ -49,7 +49,10 @@ const NoteView: React.FC = () => {
   } = useNote(noteId ?? "", { allowRemote: true });
 
   const noteSource = source === "remote" ? "remote" : "local";
-  const { canEdit, canShowAddPage, canManageMembers } = getNoteViewPermissions(access, noteSource);
+  const { canView, canEdit, canShowAddPage, canManageMembers } = getNoteViewPermissions(
+    access,
+    noteSource,
+  );
   const isLoading = isNoteLoading;
   const isNotFound = !note || !access?.canView;
 
@@ -159,6 +162,7 @@ const NoteView: React.FC = () => {
             <NoteViewHeaderActions
               note={note}
               canManageMembers={canManageMembers}
+              canView={canView}
               userRole={access?.role ?? "none"}
             />
           </div>

--- a/src/pages/NoteView/noteViewHelpers.test.ts
+++ b/src/pages/NoteView/noteViewHelpers.test.ts
@@ -42,6 +42,15 @@ describe("getNoteViewPermissions", () => {
     });
   });
 
+  describe("canView", () => {
+    it("returns true when access.canView is true regardless of noteSource", () => {
+      expect(getNoteViewPermissions({ canView: true }, "local").canView).toBe(true);
+      expect(getNoteViewPermissions({ canView: true }, "remote").canView).toBe(true);
+      expect(getNoteViewPermissions({ canView: false }, "local").canView).toBe(false);
+      expect(getNoteViewPermissions(undefined, "local").canView).toBe(false);
+    });
+  });
+
   describe("canManageMembers", () => {
     it("returns true only when access.canManageMembers and noteSource is local", () => {
       expect(getNoteViewPermissions({ canManageMembers: true }, "local").canManageMembers).toBe(

--- a/src/pages/NoteView/noteViewHelpers.ts
+++ b/src/pages/NoteView/noteViewHelpers.ts
@@ -11,6 +11,7 @@ export type { NotePageSummary } from "@/hooks/useNoteQueries";
 export function getNoteViewPermissions(
   access:
     | {
+        canView?: boolean;
         canEdit?: boolean;
         canAddPage?: boolean;
         canManageMembers?: boolean;
@@ -18,9 +19,10 @@ export function getNoteViewPermissions(
     | undefined,
   noteSource: string,
 ) {
+  const canView = Boolean(access?.canView);
   const canEdit = Boolean(access?.canEdit && noteSource === "local");
   const canAddPage = Boolean(access?.canAddPage);
   const canShowAddPage = canEdit || canAddPage;
   const canManageMembers = Boolean(access?.canManageMembers && noteSource === "local");
-  return { canEdit, canAddPage, canShowAddPage, canManageMembers };
+  return { canView, canEdit, canAddPage, canShowAddPage, canManageMembers };
 }


### PR DESCRIPTION
## 概要

Issue #675 の follow-up として、editor / viewer ロールに対して `/notes/:id/settings/*` への read-only なアクセスエントリポイントを提供します。共有モーダル廃止後（#846）、settings 側がすでに read-only 表示を持っているため、本コンポーネントは純粋に動線（ロール別リンク）に集中します。

## 変更点

- **NoteViewHeaderActions**: ロール別に異なるアイコン・リンク先を表示
  - Owner: 歯車アイコン → `/notes/:id/settings`（フル編集）
  - Editor (canView=true): 共有閲覧アイコン → `/notes/:id/settings/members`（read-only）
  - Viewer (canView=true): 共有閲覧アイコン → `/notes/:id/settings/visibility`（read-only）
  - Guest / canView=false: 非表示

- **Props 拡張**: `canView` と `userRole` を活用した条件分岐を実装
  - `canView`: ユーザーがノートを閲覧できるかを判定
  - `userRole`: editor / viewer に対するリンク先の分岐に使用

- **noteViewHelpers**: `getNoteViewPermissions()` が `canView` を返すように拡張

- **i18n**: 新しい翻訳キー `openShareSettingsReadOnly` を追加
  - 日本語: "共有設定を確認"
  - 英語: "View share settings"

- **テスト**: 4 つのロール別シナリオをカバー
  - Owner: 設定ページへの歯車リンク
  - Editor: members セクションへの共有閲覧リンク
  - Viewer: visibility セクションへの共有閲覧リンク
  - Guest / canView=false: 何もレンダリングしない

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `bun run test` で全テストが通ることを確認
   - `NoteViewHeaderActions.test.tsx`: 4 つのロール別テストケースがすべてパス
   - `noteViewHelpers.test.ts`: `canView` の判定ロジックがパス

2. `bun run lint` と `bun run format:check` が通ることを確認

3. 手動確認（オプション）
   - Owner ロール: ノート詳細ページ右上に歯車アイコンが表示され、クリックで `/notes/:id/settings` に遷移
   - Editor ロール: 共有閲覧アイコンが表示され、クリックで `/notes/:id/settings/members` に遷移（read-only）
   - Viewer ロール: 共有閲覧アイコンが表示され、クリックで `/notes/:id/settings/visibility` に遷移（read-only）
   - Guest / canView=false: アイコンが表示されない

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメント（JSDoc / コメント）を更新した
- [x] i18n キーを追加した

## 関連 Issue

Closes #675

https://claude.ai/code/session_01CtroSNPYA2aDhFyEtsE4jQ