### PR TITLE
feat: implement issue #880 Phase B & C - wiki link graph sync

### DIFF
--- a/server/api/src/__tests__/services/pageGraphSyncService.test.ts
+++ b/server/api/src/__tests__/services/pageGraphSyncService.test.ts
@@ -1,0 +1,289 @@
+/**
+ * `pageGraphSyncService` の pure helper を対象にしたユニットテスト。
+ * Issue #880 Phase C：Y.Doc からの参照抽出と (links/ghosts) プランニング部分を
+ * DB 非依存で検証する。実 DB を介する `syncPageGraphFromYDoc` は別途
+ * 統合テストでカバーする想定。
+ *
+ * Unit tests for the pure helpers of `pageGraphSyncService` (issue #880
+ * Phase C). The DB-touching wrapper `syncPageGraphFromYDoc` is exercised by
+ * separate integration tests; these unit tests guard the extraction/planning
+ * logic in isolation.
+ */
+
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+
+import { __test_only } from "../../services/pageGraphSyncService.js";
+
+const { extractRefsFromYDoc, planBucket } = __test_only;
+
+/**
+ * 最小の Tiptap 風 Y.Doc を作るヘルパー。
+ * Build a Y.Doc with a single paragraph containing the given delta segments.
+ */
+function buildDoc(
+  segments: Array<{ insert: string; attributes?: Record<string, unknown> }>,
+): Y.Doc {
+  const doc = new Y.Doc();
+  const fragment = doc.getXmlFragment("default");
+  const paragraph = new Y.XmlElement("paragraph");
+  fragment.insert(0, [paragraph]);
+  const text = new Y.XmlText();
+  paragraph.insert(0, [text]);
+  for (const seg of segments) {
+    text.insert(text.length, seg.insert, seg.attributes);
+  }
+  return doc;
+}
+
+describe("extractRefsFromYDoc", () => {
+  it("returns empty refs for a doc without wiki/tag marks", () => {
+    const doc = buildDoc([{ insert: "plain text" }]);
+    const refs = extractRefsFromYDoc(doc);
+    expect(refs.wikiRefs).toHaveLength(0);
+    expect(refs.tagRefs).toHaveLength(0);
+  });
+
+  it("extracts a single WikiLink ref", () => {
+    const doc = buildDoc([
+      {
+        insert: "Foo",
+        attributes: { wikiLink: { title: "Foo", exists: false, referenced: false } },
+      },
+    ]);
+    const refs = extractRefsFromYDoc(doc);
+    expect(refs.wikiRefs).toHaveLength(1);
+    expect(refs.wikiRefs[0]).toEqual({
+      normalizedTitle: "foo",
+      displayTitle: "Foo",
+      targetId: null,
+    });
+  });
+
+  it("preserves the user-facing spelling but normalizes the lookup key", () => {
+    // 大小文字・前後空白の差分は正規化キーで吸収しつつ、表示テキストは保持。
+    // The lookup key collapses case + whitespace; the display spelling is
+    // preserved (used for ghost rows).
+    const doc = buildDoc([
+      {
+        insert: "  Foo  ",
+        attributes: { wikiLink: { title: "  FOO  ", exists: false, referenced: false } },
+      },
+    ]);
+    const refs = extractRefsFromYDoc(doc);
+    expect(refs.wikiRefs[0]?.normalizedTitle).toBe("foo");
+    expect(refs.wikiRefs[0]?.displayTitle).toBe("FOO");
+  });
+
+  it("captures targetId when the mark carries one", () => {
+    const doc = buildDoc([
+      {
+        insert: "Foo",
+        attributes: {
+          wikiLink: {
+            title: "Foo",
+            exists: true,
+            referenced: false,
+            targetId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          },
+        },
+      },
+    ]);
+    const refs = extractRefsFromYDoc(doc);
+    expect(refs.wikiRefs[0]?.targetId).toBe("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+  });
+
+  it("collapses duplicate WikiLink references with the same id+title", () => {
+    // 同じタイトル + targetId が複数箇所に現れても 1 件にまとまる。
+    // Repeated `(title, targetId)` collapses to one ref.
+    const doc = buildDoc([
+      {
+        insert: "Foo",
+        attributes: { wikiLink: { title: "Foo", exists: false, referenced: false } },
+      },
+      { insert: " and " },
+      {
+        insert: "foo",
+        attributes: { wikiLink: { title: "foo", exists: false, referenced: false } },
+      },
+    ]);
+    const refs = extractRefsFromYDoc(doc);
+    expect(refs.wikiRefs).toHaveLength(1);
+  });
+
+  it("keeps a same-titled mark with a different targetId as a separate ref", () => {
+    // 同名タイトルでも `targetId` が違えば別マークとして両方残す
+    // (古いコピー mark と新しい title-only mark の共存ケース)。
+    // Distinct `targetId` keeps the entries separate — handles a stale copied
+    // mark with a foreign id coexisting with a fresh title-only mark.
+    const doc = buildDoc([
+      {
+        insert: "Foo",
+        attributes: {
+          wikiLink: { title: "Foo", targetId: "aaaa", exists: true, referenced: false },
+        },
+      },
+      { insert: " " },
+      {
+        insert: "Foo",
+        attributes: { wikiLink: { title: "Foo", exists: false, referenced: false } },
+      },
+    ]);
+    const refs = extractRefsFromYDoc(doc);
+    expect(refs.wikiRefs).toHaveLength(2);
+    const targetIds = refs.wikiRefs.map((r) => r.targetId);
+    expect(targetIds).toContain("aaaa");
+    expect(targetIds).toContain(null);
+  });
+
+  it("extracts tag refs alongside wiki refs without interference", () => {
+    const doc = buildDoc([
+      {
+        insert: "Foo",
+        attributes: { wikiLink: { title: "Foo", exists: false, referenced: false } },
+      },
+      { insert: " " },
+      {
+        insert: "tech",
+        attributes: { tag: { name: "tech", exists: false, referenced: false } },
+      },
+    ]);
+    const refs = extractRefsFromYDoc(doc);
+    expect(refs.wikiRefs).toHaveLength(1);
+    expect(refs.tagRefs).toHaveLength(1);
+    expect(refs.wikiRefs[0]?.normalizedTitle).toBe("foo");
+    expect(refs.tagRefs[0]?.normalizedTitle).toBe("tech");
+  });
+
+  it("ignores segments without a relevant mark attribute", () => {
+    // wikiLink / tag 以外の mark しか持たない区間は無視する。
+    // Segments carrying only bold / italic marks must not pollute extraction.
+    const doc = buildDoc([
+      { insert: "bold text", attributes: { bold: true } },
+      { insert: "italic", attributes: { italic: true } },
+    ]);
+    const refs = extractRefsFromYDoc(doc);
+    expect(refs.wikiRefs).toHaveLength(0);
+    expect(refs.tagRefs).toHaveLength(0);
+  });
+
+  it("ignores wiki marks with empty / non-string titles", () => {
+    const doc = buildDoc([
+      {
+        insert: "  ",
+        attributes: { wikiLink: { title: "   ", exists: false, referenced: false } },
+      },
+      {
+        insert: "X",
+        attributes: { wikiLink: { title: 42, exists: false, referenced: false } },
+      },
+    ]);
+    const refs = extractRefsFromYDoc(doc);
+    expect(refs.wikiRefs).toHaveLength(0);
+  });
+});
+
+describe("planBucket", () => {
+  const SOURCE_ID = "11111111-1111-1111-1111-111111111111";
+  const PAGE_FOO = "22222222-2222-2222-2222-222222222222";
+  const PAGE_BAR = "33333333-3333-3333-3333-333333333333";
+
+  function ref(
+    normalizedTitle: string,
+    displayTitle: string,
+    targetId: string | null = null,
+  ): {
+    normalizedTitle: string;
+    displayTitle: string;
+    targetId: string | null;
+  } {
+    return { normalizedTitle, displayTitle, targetId };
+  }
+
+  function scope(
+    opts: {
+      titleToId?: Record<string, string>;
+      validTargetIds?: string[];
+    } = {},
+  ): { titleToId: Map<string, string>; validTargetIds: Set<string> } {
+    return {
+      titleToId: new Map(Object.entries(opts.titleToId ?? {})),
+      validTargetIds: new Set(opts.validTargetIds ?? []),
+    };
+  }
+
+  it("resolves WikiLink titles to links when the same note has a matching page", () => {
+    const plan = planBucket(
+      SOURCE_ID,
+      [ref("foo", "Foo")],
+      scope({ titleToId: { foo: PAGE_FOO } }),
+    );
+    expect(plan.linkTargetIds.has(PAGE_FOO)).toBe(true);
+    expect(plan.ghostTexts.size).toBe(0);
+  });
+
+  it("falls back to a ghost row when the title does not resolve", () => {
+    const plan = planBucket(SOURCE_ID, [ref("foo", "Foo")], scope());
+    expect(plan.linkTargetIds.size).toBe(0);
+    expect(plan.ghostTexts.get("foo")).toBe("Foo");
+  });
+
+  it("prefers mark.targetId over title resolution (rename in flight)", () => {
+    // mark.targetId が有効なら、タイトルが古い／存在しない場合でも edge を立てる。
+    // A still-valid targetId wins even if the title has not updated yet
+    // (in-flight rename); the edge is preserved and no ghost is added.
+    const plan = planBucket(
+      SOURCE_ID,
+      [ref("foo", "Foo", PAGE_FOO)],
+      scope({ validTargetIds: [PAGE_FOO] }),
+    );
+    expect(plan.linkTargetIds.has(PAGE_FOO)).toBe(true);
+    expect(plan.ghostTexts.has("foo")).toBe(false);
+  });
+
+  it("drops a targetId that points outside the source page's note scope", () => {
+    // 別ノートの id が乗っていた場合は validTargetIds に入ってこないので
+    // ghost に倒される。ノート跨ぎでリンクを成立させない契約。
+    // A `targetId` from a different note is filtered out of `validTargetIds`,
+    // so the ref falls back to title (and if that fails, becomes a ghost).
+    const plan = planBucket(SOURCE_ID, [ref("foo", "Foo", PAGE_FOO)], scope());
+    expect(plan.linkTargetIds.size).toBe(0);
+    expect(plan.ghostTexts.get("foo")).toBe("Foo");
+  });
+
+  it("does not link to the source page itself (self-reference guard)", () => {
+    // タイトル一致で自分自身が出てきた場合は CHECK 制約に弾かれるので、links
+    // にも ghost にも入れない（完全に無視）。
+    // Title-based self-resolution is dropped entirely (CHECK rejects self
+    // links and a same-page ghost is noise).
+    const plan = planBucket(
+      SOURCE_ID,
+      [ref("self", "Self")],
+      scope({ titleToId: { self: SOURCE_ID } }),
+    );
+    expect(plan.linkTargetIds.has(SOURCE_ID)).toBe(false);
+    expect(plan.ghostTexts.size).toBe(0);
+  });
+
+  it("handles a mix of resolved and unresolved refs", () => {
+    const plan = planBucket(
+      SOURCE_ID,
+      [ref("foo", "Foo"), ref("bar", "Bar"), ref("missing", "Missing")],
+      scope({ titleToId: { foo: PAGE_FOO, bar: PAGE_BAR } }),
+    );
+    expect(plan.linkTargetIds.has(PAGE_FOO)).toBe(true);
+    expect(plan.linkTargetIds.has(PAGE_BAR)).toBe(true);
+    expect(plan.linkTargetIds.size).toBe(2);
+    expect(plan.ghostTexts.get("missing")).toBe("Missing");
+    expect(plan.ghostTexts.size).toBe(1);
+  });
+
+  it("does not duplicate ghost rows when the same normalized title appears twice", () => {
+    // 同名 ghost は first-write-wins で 1 行に集約する。
+    // Same normalized title collapses into a single ghost row (first spelling
+    // wins).
+    const plan = planBucket(SOURCE_ID, [ref("foo", "Foo"), ref("foo", "FOO")], scope());
+    expect(plan.ghostTexts.size).toBe(1);
+    expect(plan.ghostTexts.get("foo")).toBe("Foo");
+  });
+});

--- a/server/api/src/app.ts
+++ b/server/api/src/app.ts
@@ -42,6 +42,7 @@ import subscriptionManageRoutes from "./routes/subscriptionManage.js";
 import lintRoutes from "./routes/lint.js";
 import activityRoutes from "./routes/activity.js";
 import onboardingRoutes from "./routes/onboarding.js";
+import internalRoutes from "./routes/internal.js";
 
 /**
  * Creates and configures the Hono API app (routes, CORS, etc.).
@@ -124,6 +125,10 @@ export function createApp(): Hono<AppEnv> {
   // Onboarding wizard completion + status
   // セットアップウィザード完了・状況取得
   app.route("/api/onboarding", onboardingRoutes);
+
+  // Internal-only endpoints for service-to-service calls (Hocuspocus → API).
+  // 内部サービス間専用エンドポイント (Hocuspocus → API)。x-internal-secret 必須。
+  app.route("/api/internal", internalRoutes);
 
   // Pages
   app.route("/api/pages", pageRoutes);

--- a/server/api/src/middleware/csrfOrigin.ts
+++ b/server/api/src/middleware/csrfOrigin.ts
@@ -31,7 +31,16 @@ export const csrfOriginCheck = createMiddleware<AppEnv>(async (c, next) => {
 
   const path = c.req.path;
   // Only exclude routes that use Bearer/no cookie; /api/ext/authorize-code (cookie) stays protected.
-  const excludedPrefixes = ["/api/webhooks/"];
+  // `/api/internal/` は Hocuspocus からのサーバ間呼び出し用で、Origin/Referer は
+  // 付かない代わりに `x-internal-secret` (BETTER_AUTH_SECRET) で認証する。
+  // CSRF オリジン検証を残すと、本番 (`CORS_ORIGIN` 非ワイルドカード) で全件 403 に
+  // なってしまうため除外する。各エンドポイント側で必ず秘密ヘッダを検証すること。
+  // `/api/internal/` is the Hocuspocus → API service-to-service surface. Those
+  // calls have no Origin/Referer and authenticate via the `x-internal-secret`
+  // shared secret (`BETTER_AUTH_SECRET`). Without this exemption every call
+  // would 403 in production where `CORS_ORIGIN` is not wildcard. Each internal
+  // route is responsible for validating the secret header itself.
+  const excludedPrefixes = ["/api/webhooks/", "/api/internal/"];
   const exactExcluded = ["/api/ext/session", "/api/ext/clip-and-create"];
   if (excludedPrefixes.some((prefix) => path.startsWith(prefix))) return next();
   if (exactExcluded.includes(path)) return next();

--- a/server/api/src/routes/internal.ts
+++ b/server/api/src/routes/internal.ts
@@ -1,0 +1,103 @@
+/**
+ * Internal-only API endpoints intended for service-to-service calls
+ * (currently: Hocuspocus → API). All routes require an
+ * `x-internal-secret: $BETTER_AUTH_SECRET` header. No user session is needed
+ * because the caller is a trusted backend service.
+ *
+ * 内部サービス間呼び出し用の API エンドポイント（現状は Hocuspocus → API）。
+ * すべて `x-internal-secret` ヘッダ必須。ユーザーセッションは要求しない。
+ *
+ * 命名規則 / Naming convention:
+ *   - URL は `/api/internal/...` プレフィックスでマウントする。
+ *   - エンドポイントは小さく単目的に保つ（GET なし、副作用のある POST のみ）。
+ *
+ * Naming: every route is mounted under `/api/internal/...` and stays
+ * single-purpose. We only add side-effecting POSTs here; read endpoints stay
+ * on the public API surface.
+ *
+ * 認証 / Auth:
+ *   - 共有秘密 `BETTER_AUTH_SECRET` をヘッダで照合する。Hocuspocus 側の
+ *     `/internal/documents/:id/invalidate` と同じ契約。
+ *   - 秘密が未設定の環境では本サービスから 503 を返してリクエストを弾く。
+ *
+ * Authentication:
+ *   - Symmetric shared-secret comparison against `BETTER_AUTH_SECRET`,
+ *     matching the contract Hocuspocus uses for its own internal endpoint
+ *     (`/internal/documents/:id/invalidate`).
+ *   - When the secret is missing, return 503 so callers fail loudly instead
+ *     of silently allowing unauthenticated calls.
+ */
+
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import type { AppEnv } from "../types/index.js";
+import { syncPageGraphFromStoredYDoc } from "../services/pageGraphSyncService.js";
+
+const app = new Hono<AppEnv>();
+
+/**
+ * 共有秘密ヘッダの検証。マッチしなければ 401 を投げる。
+ * `BETTER_AUTH_SECRET` が未設定なら 503 を返す（本番で誤って公開しないため）。
+ *
+ * Validate the `x-internal-secret` header. Throws 401 on mismatch and 503 on
+ * missing config so callers can distinguish misconfiguration from a wrong
+ * secret.
+ */
+function assertInternalAuth(c: { req: { header: (name: string) => string | undefined } }): void {
+  const expected = process.env.BETTER_AUTH_SECRET?.trim();
+  if (!expected) {
+    // 本番でこの状態になるのは設定漏れ。403/401 だと「秘密が正しくない」と
+    // 誤読されかねないので 503 にして外形監視に拾わせる。
+    // Hitting this branch in prod means missing configuration. We deliberately
+    // return 503 (not 401/403) so external monitoring picks it up as a
+    // service issue rather than masking it as an auth failure.
+    throw new HTTPException(503, { message: "Internal API not configured" });
+  }
+  const provided = c.req.header("x-internal-secret")?.trim();
+  if (!provided || provided !== expected) {
+    throw new HTTPException(401, { message: "Unauthorized" });
+  }
+}
+
+/**
+ * `POST /api/internal/pages/:id/graph-sync`
+ *
+ * Hocuspocus が `onStoreDocument` で `page_contents` を更新したあとに呼ぶ。
+ * 現在 DB に保存されている Y.Doc から `links` / `ghost_links` を再構築する。
+ *
+ * Endpoint Hocuspocus calls after persisting a Y.Doc in `onStoreDocument`.
+ * Rebuilds outgoing edges (`links` / `ghost_links`) from the just-saved
+ * Y.Doc state for that page.
+ *
+ * レスポンス / Response:
+ *   - 200: `\{ ok: true, applied: true|false, ...counters \}`.
+ *     `applied: false` は `page_contents` 行が無い（コンテンツ未保存）か、
+ *     ソースページが論理削除された場合。
+ *   - 401: 認証失敗 / Auth failed.
+ *   - 503: BETTER_AUTH_SECRET 未設定 / Secret unset.
+ */
+app.post("/pages/:id/graph-sync", async (c) => {
+  assertInternalAuth(c);
+  const pageId = c.req.param("id");
+  const db = c.get("db");
+
+  try {
+    const result = await syncPageGraphFromStoredYDoc(db, pageId);
+    if (result === null) {
+      // ydoc_state がまだ無いページ。エラーではなく no-op として返す。
+      // No `page_contents` row yet; return ok with applied=false so callers
+      // can log a metric without treating it as failure.
+      return c.json({ ok: true, applied: false });
+    }
+    return c.json({ ok: true, applied: !result.skippedSourceNotFound, ...result });
+  } catch (error) {
+    // 失敗しても呼び出し元（Hocuspocus）は本文保存自体は完了しているので、
+    // 同期失敗は 5xx で返して呼び出し側のリトライ判断に任せる。
+    // The caller has already persisted the content; surface failure as 5xx
+    // so the caller can decide whether to retry / log.
+    console.error(`[InternalGraphSync] Failed for page ${pageId}:`, error);
+    throw new HTTPException(500, { message: "Graph sync failed" });
+  }
+});
+
+export default app;

--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -25,6 +25,7 @@ import { assertPageViewAccess, assertPageEditAccess } from "../services/pageAcce
 import { propagateTitleRename } from "../services/titleRenamePropagationService.js";
 import { deleteThumbnailObject } from "../services/thumbnailGcService.js";
 import { publishNoteEvent } from "../services/noteEventBroadcaster.js";
+import { syncPageGraphFromStoredYDoc } from "../services/pageGraphSyncService.js";
 import { pageRowToWindowItem } from "./notes/eventHelpers.js";
 
 /**
@@ -69,6 +70,21 @@ function tryPropagateTitleRename(
         `(${oldTitle} → ${newTitle}):`,
       error,
     );
+  });
+}
+
+/**
+ * 本文保存後に、現在の Y.Doc から `links` / `ghost_links` を再構築する
+ * (issue #880 Phase C)。本文保存のレスポンスはブロックしないよう
+ * fire-and-forget。失敗は本文保存とは独立にログに残す。
+ *
+ * Fire-and-forget rebuild of `links` / `ghost_links` from the just-saved
+ * Y.Doc (issue #880 Phase C). Failures are logged but do not block the
+ * content save response.
+ */
+function tryGraphSync(db: Database, pageId: string): void {
+  void syncPageGraphFromStoredYDoc(db, pageId).catch((error) => {
+    console.error(`[PageGraphSync] Background graph sync crashed for page ${pageId}:`, error);
   });
 }
 
@@ -390,6 +406,9 @@ app.put("/:id/content", authRequired, async (c) => {
             firstSave.renamed.newTitle,
           );
         }
+        // Issue #880 Phase C: 本文保存と同じトリガーでリンクグラフを再構築する。
+        // Issue #880 Phase C: rebuild outgoing edges from the saved Y.Doc.
+        tryGraphSync(db, pageId);
         // Issue #860 Phase 4: メタデータが実際に変化したときだけ通知。
         // Issue #860 Phase 4: emit only when metadata really changed.
         emitPageUpdatedIfChanged(firstSave.metadataChanged, firstSave.updatedRow);
@@ -444,6 +463,10 @@ app.put("/:id/content", authRequired, async (c) => {
       tryPropagateTitleRename(db, pageId, renamed.oldTitle, renamed.newTitle);
     }
 
+    // Issue #880 Phase C: 楽観的ロック成功経路でもグラフ再構築を発火する。
+    // Issue #880 Phase C: trigger graph rebuild on the optimistic-lock path.
+    tryGraphSync(db, pageId);
+
     // Issue #860 Phase 4: optimistic-lock 経路のメタデータ変化を通知。
     // Notify subscribers from the optimistic-lock path as well.
     emitPageUpdatedIfChanged(metadataChanged, metadataRow);
@@ -492,6 +515,10 @@ app.put("/:id/content", authRequired, async (c) => {
   if (renamed) {
     tryPropagateTitleRename(db, pageId, renamed.oldTitle, renamed.newTitle);
   }
+
+  // Issue #880 Phase C: UPSERT 経路（楽観的ロック未使用）でも graph 再構築する。
+  // Issue #880 Phase C: trigger graph rebuild on the UPSERT path too.
+  tryGraphSync(db, pageId);
 
   // Issue #860 Phase 4: UPSERT 経路（楽観的ロック未使用）でも emit。
   // Issue #860 Phase 4: emit from the UPSERT path too (no optimistic lock).

--- a/server/api/src/services/pageGraphSyncService.ts
+++ b/server/api/src/services/pageGraphSyncService.ts
@@ -47,7 +47,7 @@
  */
 
 import * as Y from "yjs";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { links, ghostLinks, pages, pageContents } from "../schema/index.js";
 import type { Database } from "../types/index.js";
 import type { LinkType } from "../schema/links.js";
@@ -233,10 +233,18 @@ async function buildResolvedScope(
   sourcePageId: string,
   markedTargetIds: Set<string>,
 ): Promise<ResolvedScope> {
+  // `createdAt` 昇順 + `id` 昇順で読み出し、同一ノート内で同名ページが複数ある
+  // 場合の解決を「作成順（最初勝ち）」で決定的にする。下の `titleToId` 構築は
+  // `if (!titleToId.has(key))` で最初に出てきた行を採用するため、ここで安定した
+  // 順序を与えないと実行ごとに解決先がブレうる。
+  // Order by creation time (with id as deterministic tie-breaker) so duplicate
+  // titles within a note resolve to the same page across runs — `titleToId`
+  // below uses first-write-wins semantics and depends on a stable scan order.
   const scopeRows = await tx
     .select({ id: pages.id, title: pages.title, isDeleted: pages.isDeleted })
     .from(pages)
-    .where(eq(pages.noteId, sourcePageNoteId));
+    .where(eq(pages.noteId, sourcePageNoteId))
+    .orderBy(asc(pages.createdAt), asc(pages.id));
 
   const titleToId = new Map<string, string>();
   const validIds = new Set<string>();
@@ -387,6 +395,102 @@ async function replaceBucket(
 }
 
 /**
+ * 与えられた `tx` 内でリンクグラフ再構築を実行する共通本体。
+ * `sourceNoteId` は呼び出し側がロック取得後に読み出した値を渡すこと。
+ *
+ * Shared core that performs the (source_id, link_type) bucket rewrite inside
+ * an existing transaction. Callers are responsible for first acquiring a
+ * write lock on the source `pages` row and supplying its `noteId`.
+ */
+type TxHandle = ReadHandle & WriteHandle;
+async function rewriteGraphInTx(
+  tx: TxHandle,
+  sourcePageId: string,
+  sourceNoteId: string,
+  doc: Y.Doc,
+): Promise<PageGraphSyncResult> {
+  const refs = extractRefsFromYDoc(doc);
+  const allTargetIds = new Set<string>();
+  for (const ref of refs.wikiRefs) {
+    if (ref.targetId) allTargetIds.add(ref.targetId);
+  }
+  for (const ref of refs.tagRefs) {
+    if (ref.targetId) allTargetIds.add(ref.targetId);
+  }
+  const scope = await buildResolvedScope(tx, sourceNoteId, sourcePageId, allTargetIds);
+
+  const wikiPlan = planBucket(sourcePageId, refs.wikiRefs, scope);
+  const tagPlan = planBucket(sourcePageId, refs.tagRefs, scope);
+
+  const wikiResult = await replaceBucket(
+    tx,
+    sourcePageId,
+    "wiki",
+    wikiPlan.linkTargetIds,
+    wikiPlan.ghostTexts,
+  );
+  const tagResult = await replaceBucket(
+    tx,
+    sourcePageId,
+    "tag",
+    tagPlan.linkTargetIds,
+    tagPlan.ghostTexts,
+  );
+
+  return {
+    wikiLinksInserted: wikiResult.insertedLinks,
+    wikiGhostsInserted: wikiResult.insertedGhosts,
+    tagLinksInserted: tagResult.insertedLinks,
+    tagGhostsInserted: tagResult.insertedGhosts,
+    skippedSourceNotFound: false,
+  };
+}
+
+/**
+ * ソースページ行を `SELECT ... FOR UPDATE` でロックする。
+ * 同一ページに対する並列同期を直列化し、後勝ちで一貫した結果を保証する。
+ *
+ * Acquire a row-level write lock on the source page so that concurrent graph
+ * syncs for the same page serialize. Combined with reading the latest Y.Doc
+ * inside the same transaction, this prevents an older sync from overwriting
+ * a newer one's edges.
+ */
+async function lockSourcePage(
+  tx: TxHandle,
+  sourcePageId: string,
+): Promise<{ noteId: string; isDeleted: boolean } | null> {
+  // drizzle-orm の `select(...).for("update")` で `SELECT ... FOR UPDATE` を発行する。
+  // Issues `SELECT ... FOR UPDATE` so parallel syncs on the same page queue up
+  // instead of racing on `links` / `ghost_links`.
+  const rows = await tx
+    .select({ noteId: pages.noteId, isDeleted: pages.isDeleted })
+    .from(pages)
+    .where(eq(pages.id, sourcePageId))
+    .for("update")
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * `ydocState` カラムの値を `Buffer` に正規化する。
+ * Drizzle / pg ドライバの組み合わせによっては Buffer / Uint8Array / base64 文字列
+ * のいずれかが返るため、`titleRenamePropagationService` と同じ防御策を取る。
+ *
+ * Normalize a `ydoc_state` column value to a `Buffer`. Some driver
+ * configurations hand the bytes back as a base64 string, so handle that
+ * branch explicitly — `Buffer.from(string)` without an encoding would treat
+ * each character as a raw byte and corrupt the payload. Mirrors the helper
+ * in `titleRenamePropagationService.ts`.
+ */
+function toYdocBuffer(ydocState: unknown): Buffer | null {
+  if (ydocState instanceof Buffer) return ydocState;
+  if (ydocState instanceof Uint8Array) return Buffer.from(ydocState);
+  if (typeof ydocState === "string") return Buffer.from(ydocState, "base64");
+  if (ydocState == null) return null;
+  return Buffer.from(ydocState as ArrayBufferLike);
+}
+
+/**
  * `pageId` のソースページについて、Y.Doc の現在内容から
  * `links` / `ghost_links` を `(source_id, link_type)` バケット単位で
  * 再構築する。
@@ -413,56 +517,17 @@ export async function syncPageGraphFromYDoc(
   };
 
   return db.transaction(async (tx) => {
-    // ソースページの note スコープを解決する。削除済み・行欠落は best-effort
-    // としてサイレント no-op（呼び出し側のメイン保存パスは既に終わっている）。
-    // Resolve the source page's note scope. Missing / soft-deleted rows are
-    // treated as a no-op since this service runs in a best-effort context
-    // after the main content save has already succeeded.
-    const sourceRows = await tx
-      .select({ noteId: pages.noteId, isDeleted: pages.isDeleted })
-      .from(pages)
-      .where(eq(pages.id, sourcePageId))
-      .limit(1);
-    const source = sourceRows[0];
+    // ソースページ行を FOR UPDATE でロックし、note スコープを取得する。
+    // 削除済み・行欠落は best-effort としてサイレント no-op
+    // （呼び出し側のメイン保存パスは既に終わっている）。
+    // Lock the source page (FOR UPDATE) and read its note scope. Missing /
+    // soft-deleted rows are treated as a no-op since this service runs in a
+    // best-effort context after the main content save has already succeeded.
+    const source = await lockSourcePage(tx, sourcePageId);
     if (!source || source.isDeleted) {
       return { ...empty, skippedSourceNotFound: true };
     }
-
-    const refs = extractRefsFromYDoc(doc);
-    const allTargetIds = new Set<string>();
-    for (const ref of refs.wikiRefs) {
-      if (ref.targetId) allTargetIds.add(ref.targetId);
-    }
-    for (const ref of refs.tagRefs) {
-      if (ref.targetId) allTargetIds.add(ref.targetId);
-    }
-    const scope = await buildResolvedScope(tx, source.noteId, sourcePageId, allTargetIds);
-
-    const wikiPlan = planBucket(sourcePageId, refs.wikiRefs, scope);
-    const tagPlan = planBucket(sourcePageId, refs.tagRefs, scope);
-
-    const wikiResult = await replaceBucket(
-      tx,
-      sourcePageId,
-      "wiki",
-      wikiPlan.linkTargetIds,
-      wikiPlan.ghostTexts,
-    );
-    const tagResult = await replaceBucket(
-      tx,
-      sourcePageId,
-      "tag",
-      tagPlan.linkTargetIds,
-      tagPlan.ghostTexts,
-    );
-
-    return {
-      wikiLinksInserted: wikiResult.insertedLinks,
-      wikiGhostsInserted: wikiResult.insertedGhosts,
-      tagLinksInserted: tagResult.insertedLinks,
-      tagGhostsInserted: tagResult.insertedGhosts,
-      skippedSourceNotFound: false,
-    };
+    return rewriteGraphInTx(tx, sourcePageId, source.noteId, doc);
   });
 }
 
@@ -471,10 +536,19 @@ export async function syncPageGraphFromYDoc(
  * グラフ同期を実行するラッパー。Hocuspocus 保存後の internal 経路や、API 内
  * の fire-and-forget 呼び出しから使う。
  *
- * Convenience wrapper: read `page_contents.ydoc_state` for `pageId`, hydrate
- * the Y.Doc, and run `syncPageGraphFromYDoc`. Used by the Hocuspocus
- * post-save trigger (via internal HTTP) and by the REST PUT /content path
- * (fire-and-forget).
+ * Convenience wrapper: lock the source page, read the latest
+ * `page_contents.ydoc_state` under that lock, hydrate the Y.Doc, then rewrite
+ * the graph. Used by the Hocuspocus post-save trigger (via internal HTTP)
+ * and by the REST PUT /content path (fire-and-forget).
+ *
+ * 並列保存が連続して走るケース（fire-and-forget で 2 つの同期が ほぼ同時に
+ * 起動する）に備えて、`pages` 行のロック取得後に `page_contents` を読み直す。
+ * これにより「古い Y.Doc を読んでいた古い同期がロック解放後に新しいグラフを
+ * 上書きする」レースを防ぐ。
+ *
+ * Reading `page_contents` inside the transaction (after the `pages` lock) is
+ * what makes the lock useful: it ensures the older of two queued syncs sees
+ * the newer Y.Doc state and never regresses the graph back to an older one.
  *
  * Returns `null` when there is no stored content yet — the caller should
  * treat that as a no-op (graph stays empty).
@@ -483,22 +557,32 @@ export async function syncPageGraphFromStoredYDoc(
   db: Database,
   sourcePageId: string,
 ): Promise<PageGraphSyncResult | null> {
-  const rows = await db
-    .select({ ydocState: pageContents.ydocState })
-    .from(pageContents)
-    .where(eq(pageContents.pageId, sourcePageId))
-    .limit(1);
-  const row = rows[0];
-  if (!row?.ydocState) return null;
+  const empty: PageGraphSyncResult = {
+    wikiLinksInserted: 0,
+    wikiGhostsInserted: 0,
+    tagLinksInserted: 0,
+    tagGhostsInserted: 0,
+    skippedSourceNotFound: false,
+  };
 
-  const buffer =
-    row.ydocState instanceof Buffer
-      ? row.ydocState
-      : Buffer.from(row.ydocState as unknown as ArrayBufferLike);
+  return db.transaction(async (tx) => {
+    const source = await lockSourcePage(tx, sourcePageId);
+    if (!source || source.isDeleted) {
+      return source ? { ...empty, skippedSourceNotFound: true } : null;
+    }
 
-  const doc = new Y.Doc();
-  Y.applyUpdate(doc, new Uint8Array(buffer));
-  return syncPageGraphFromYDoc(db, sourcePageId, doc);
+    const rows = await tx
+      .select({ ydocState: pageContents.ydocState })
+      .from(pageContents)
+      .where(eq(pageContents.pageId, sourcePageId))
+      .limit(1);
+    const buffer = toYdocBuffer(rows[0]?.ydocState);
+    if (!buffer) return null;
+
+    const doc = new Y.Doc();
+    Y.applyUpdate(doc, new Uint8Array(buffer));
+    return rewriteGraphInTx(tx, sourcePageId, source.noteId, doc);
+  });
 }
 
 /**

--- a/server/api/src/services/pageGraphSyncService.ts
+++ b/server/api/src/services/pageGraphSyncService.ts
@@ -1,0 +1,511 @@
+/**
+ * Y.Doc から WikiLink / tag マークを抽出し、`links` / `ghost_links` の
+ * 「ソースページごとに正しいエッジ集合」状態へ同期するサービス
+ * (Issue #880 Phase C)。
+ *
+ * Extract WikiLink and tag references from a server-side Y.Doc and rebuild
+ * the `(source_id, link_type)` slices of `links` / `ghost_links` so they
+ * match the current document contents (issue #880 Phase C).
+ *
+ * 呼び出し元 / Callers:
+ *   - `PUT /api/pages/:id/content` (REST 経路の本文保存後)
+ *   - Hocuspocus 保存経路 (internal HTTP `POST /api/internal/pages/:id/graph-sync`)
+ *
+ * 設計方針 / Design notes:
+ *   - 解決スコープは「ソースページと同じ `pages.note_id`」のページ集合のみ。
+ *     ノートを跨ぐ解決は行わない（個人ページはオーナーのデフォルトノートが
+ *     スコープになる）。
+ *   - mark に `targetId` が埋まっていれば、(a) ソースと同じ `note_id` かつ
+ *     未削除であることを確認した上で `links` に保存する。タイトルが古い／
+ *     リネーム途中でも id 一致で解決できる。
+ *   - `targetId` が無いマークはタイトル文字列を正規化（小文字 + trim）して
+ *     スコープ内ページの正規化タイトルと突き合わせる。`ydocRenameRewrite.ts`
+ *     のフォールバック契約と同じ。
+ *   - 解決失敗（id 不明 / タイトル不一致）は `ghost_links` に記録する。
+ *   - `links` / `ghost_links` の置換は `(source_id, link_type)` 単位の
+ *     DELETE → INSERT。他種別 (`wiki` ↔ `tag`) のエッジには触れない
+ *     (`syncPages.ts` のセマンティクスと一致)。
+ *   - 自己参照（自分のページへのリンク）は CHECK 制約で弾かれるため事前除外。
+ *   - 全体を 1 つの DB トランザクションで実行することで、レースしても
+ *     `(source_id, link_type)` バケットの状態は常に整合する。
+ *
+ *   - Resolution scope: the source page's owning `pages.note_id`. Refs do not
+ *     resolve across notes; for personal pages this means the owner's
+ *     default note.
+ *   - Marks carrying a `targetId` are matched by id when the target is in the
+ *     same scope; this keeps freshly-renamed links resolving even before the
+ *     editor catches up on the title.
+ *   - Marks without `targetId` fall back to normalized-title matching, the
+ *     same contract as `ydocRenameRewrite.ts`.
+ *   - Unresolvable refs are stored in `ghost_links`.
+ *   - Replacement is scoped per `(source_id, link_type)` pair so wiki and tag
+ *     buckets never wipe each other (matches `syncPages.ts`).
+ *   - Self-references are rejected by `links_no_self_ref` (CHECK constraint),
+ *     so we filter them out before INSERT.
+ *   - Everything runs in one DB transaction so concurrent writers cannot
+ *     observe a half-empty bucket.
+ */
+
+import * as Y from "yjs";
+import { and, eq } from "drizzle-orm";
+import { links, ghostLinks, pages, pageContents } from "../schema/index.js";
+import type { Database } from "../types/index.js";
+import type { LinkType } from "../schema/links.js";
+
+/**
+ * 1 つの抽出された参照（WikiLink もしくは tag の 1 つのマーク相当）。
+ * normalizedTitle / displayTitle / 任意の targetId をまとめて保持する。
+ *
+ * One extracted reference (a single WikiLink or tag mark instance). Carries
+ * both the lookup key (`normalizedTitle`) and the user-facing spelling
+ * (`displayTitle`); `targetId` is set when the mark already resolved on the
+ * client side.
+ */
+interface ExtractedRef {
+  /** Lookup key: lowercase + trimmed. */
+  normalizedTitle: string;
+  /** Display value used for ghost rows. */
+  displayTitle: string;
+  /** Client-resolved `targetId`, if any. */
+  targetId: string | null;
+}
+
+/**
+ * Y.Doc から抽出した WikiLink / tag 参照集合。各マークごとに 1 件として保持し、
+ * planBucket でバケット単位の (links, ghost_links) 計算へ流す。
+ *
+ * Extracted references grouped per mark type. Each list keeps one entry per
+ * mark occurrence (deduplicated by `(normalizedTitle, targetId)`) so the
+ * planner can decide id-first vs title-first resolution on a per-mark basis.
+ */
+interface ExtractedRefs {
+  wikiRefs: ExtractedRef[];
+  tagRefs: ExtractedRef[];
+}
+
+/**
+ * `syncPageGraphFromYDoc` の結果カウンタ。運用ログ用。
+ * Counters returned by `syncPageGraphFromYDoc` for logging.
+ */
+export interface PageGraphSyncResult {
+  wikiLinksInserted: number;
+  wikiGhostsInserted: number;
+  tagLinksInserted: number;
+  tagGhostsInserted: number;
+  /** Whether the source page is missing or deleted (no sync performed). */
+  skippedSourceNotFound: boolean;
+}
+
+function normalize(value: string): string {
+  return value.toLowerCase().trim();
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function extractStringAttr(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Y.Doc の `default` XmlFragment を走査し、`Y.XmlText.toDelta()` の
+ * `attributes.wikiLink` / `attributes.tag` から参照を取り出す。
+ *
+ * Walk the Y.Doc's `default` XmlFragment and collect references from
+ * `Y.XmlText.toDelta()` segments carrying `wikiLink` / `tag` mark attributes.
+ */
+/**
+ * 1 セグメントの `attributes` から、`wikiLink` / `tag` どちらか（または両方）の
+ * 参照を抽出して seen Map に追加する。同じ正規化キーが既にあれば first-write-wins。
+ *
+ * Pull `wikiLink` / `tag` references out of a single delta segment's
+ * attributes and accumulate them into the seen maps. Same `normalizedTitle`
+ * plus `targetId` collapses to one entry (first-write-wins).
+ */
+function collectFromAttributes(
+  attributes: Record<string, unknown>,
+  wikiSeen: Map<string, ExtractedRef>,
+  tagSeen: Map<string, ExtractedRef>,
+): void {
+  const wikiAttr = isPlainObject(attributes.wikiLink) ? attributes.wikiLink : null;
+  if (wikiAttr) {
+    const title = extractStringAttr(wikiAttr.title);
+    if (title) {
+      const normalized = normalize(title);
+      const targetId = extractStringAttr(wikiAttr.targetId);
+      const key = `${normalized}\x00${targetId ?? ""}`;
+      if (!wikiSeen.has(key)) {
+        wikiSeen.set(key, { normalizedTitle: normalized, displayTitle: title, targetId });
+      }
+    }
+  }
+
+  const tagAttr = isPlainObject(attributes.tag) ? attributes.tag : null;
+  if (tagAttr) {
+    const name = extractStringAttr(tagAttr.name);
+    if (name) {
+      const normalized = normalize(name);
+      const targetId = extractStringAttr(tagAttr.targetId);
+      const key = `${normalized}\x00${targetId ?? ""}`;
+      if (!tagSeen.has(key)) {
+        tagSeen.set(key, { normalizedTitle: normalized, displayTitle: name, targetId });
+      }
+    }
+  }
+}
+
+function extractRefsFromYDoc(doc: Y.Doc, fragmentName = "default"): ExtractedRefs {
+  // (normalizedTitle, targetId|"") キーで重複排除する。タイトルが同じで
+  // targetId が違う場合は別マーク扱いとし、両方を保持する（例: 別ノートの id
+  // を持ち越したコピー参照が同名の別 mark と共存するケース）。
+  // Dedupe by `(normalizedTitle, targetId|"")` so a same-titled mark with a
+  // different `targetId` is kept distinct — e.g. a stale copied mark carrying
+  // a foreign id alongside a fresh title-only mark.
+  const wikiSeen = new Map<string, ExtractedRef>();
+  const tagSeen = new Map<string, ExtractedRef>();
+
+  function visitDelta(text: Y.XmlText): void {
+    const delta = text.toDelta() as Array<unknown>;
+    for (const raw of delta) {
+      if (!isPlainObject(raw) || typeof raw.insert !== "string") continue;
+      const attributes = isPlainObject(raw.attributes) ? raw.attributes : null;
+      if (!attributes) continue;
+      collectFromAttributes(attributes, wikiSeen, tagSeen);
+    }
+  }
+
+  function walk(node: Y.XmlFragment | Y.XmlElement): void {
+    // `node.get(i)` is O(i); use `toArray()` for a single O(N) pass — same
+    // optimisation as `ydocRenameRewrite.ts`.
+    const children = node.toArray() as Array<Y.XmlElement | Y.XmlText>;
+    for (const child of children) {
+      if (child instanceof Y.XmlText) {
+        visitDelta(child);
+      } else if (child instanceof Y.XmlElement) {
+        walk(child);
+      }
+    }
+  }
+
+  walk(doc.getXmlFragment(fragmentName));
+
+  return {
+    wikiRefs: [...wikiSeen.values()],
+    tagRefs: [...tagSeen.values()],
+  };
+}
+
+/**
+ * 解決結果（タイトル → ページ id の正規化マップ + 有効な targetId 集合）。
+ * Resolution result: title→id map (keyed on normalized title) plus the set
+ * of `targetId` values that survived the in-scope / not-deleted filter.
+ */
+interface ResolvedScope {
+  /** Normalized page title → page id (lookup by mark.title). */
+  titleToId: Map<string, string>;
+  /** `targetId` values that are in scope and not deleted. */
+  validTargetIds: Set<string>;
+}
+
+/**
+ * `sourcePageNoteId` と同じノートに属する有効なページから、解決マップを構築する。
+ * `markedTargetIds` に含まれる id は別途検証して、ノート跨ぎや削除済みを弾く。
+ *
+ * Build a resolution map from the source page's note: normalized page titles
+ * mapped to their ids, plus the subset of mark-supplied `targetId` values
+ * that survive scope + soft-delete checks.
+ *
+ * 型注: drizzle の `tx` 型 (`PgTransaction<...>`) は `Database` (`NodePgDatabase`)
+ * に直接代入できないが、`select` API は共通の親クラスから来ているため
+ * structural な部分型を要求する形にしている。
+ *
+ * Type note: drizzle's `tx` (`PgTransaction<...>`) is not assignable to
+ * `Database` (`NodePgDatabase`) directly, but both expose the same `select`
+ * API. The structural pick keeps the helper callable from either context.
+ */
+type ReadHandle = Pick<Database, "select">;
+async function buildResolvedScope(
+  tx: ReadHandle,
+  sourcePageNoteId: string,
+  sourcePageId: string,
+  markedTargetIds: Set<string>,
+): Promise<ResolvedScope> {
+  const scopeRows = await tx
+    .select({ id: pages.id, title: pages.title, isDeleted: pages.isDeleted })
+    .from(pages)
+    .where(eq(pages.noteId, sourcePageNoteId));
+
+  const titleToId = new Map<string, string>();
+  const validIds = new Set<string>();
+  for (const row of scopeRows) {
+    if (row.isDeleted) continue;
+    validIds.add(row.id);
+    if (row.title) {
+      const key = normalize(row.title);
+      // 同一ノート内で同名ページが複数あった場合は最初に見つかった id を採用
+      // する (作成順)。WikiLink の解決方針として、新しいページが既存の同名
+      // ページを「奪う」のは挙動として混乱しやすいため最初勝ち。
+      // First-write-wins on duplicate titles within a note; later same-name
+      // pages do not steal resolution from older ones (less surprising UX).
+      if (!titleToId.has(key)) {
+        titleToId.set(key, row.id);
+      }
+    }
+  }
+
+  const validTargetIds = new Set<string>();
+  for (const id of markedTargetIds) {
+    // `targetId` がソースページと同じノート内の有効ページなら採用。
+    // ノートを跨いだ id（過去にコピー前の id を保持している場合など）は弾く。
+    // Only keep `targetId` values for in-scope, non-deleted pages so cross-note
+    // ids (e.g. left behind by a copy-to-personal flow) become ghosts.
+    if (validIds.has(id)) validTargetIds.add(id);
+  }
+  // 自己参照は CHECK 制約に弾かれるので事前除外する。
+  // Strip self-references up front to keep the CHECK constraint from rejecting
+  // the whole INSERT batch.
+  validTargetIds.delete(sourcePageId);
+
+  return { titleToId, validTargetIds };
+}
+
+/**
+ * 1 つの link バケット（wiki または tag）について、参照リストと解決マップから
+ * 「保存するべき links 行」と「保存するべき ghost_links 行」を計算する。
+ *
+ * For one link bucket (wiki or tag), turn the extracted refs + scope map into
+ * the (sourceId, targetId) edges and the (linkText, sourceId) ghost rows that
+ * should exist after this sync pass. Each ref is decided independently:
+ *   1. mark.targetId が scope 内で有効なら、その id でリンク化する。
+ *      タイトル fallback は走らない（rename 中でも壊れない）。
+ *   2. そうでなければタイトル一致で解決を試みる。
+ *   3. どちらも解決できない場合だけ ghost に倒す。
+ *
+ * Each ref is processed independently:
+ *   1. If the mark's `targetId` is still valid in scope, link by id (no
+ *      title fallback — protects against in-flight renames).
+ *   2. Otherwise, try title resolution against scope.
+ *   3. Only if neither resolves, write a ghost row.
+ */
+function planBucket(
+  sourcePageId: string,
+  refs: ExtractedRef[],
+  scope: ResolvedScope,
+): { linkTargetIds: Set<string>; ghostTexts: Map<string, string> } {
+  const linkTargetIds = new Set<string>();
+  const ghostTexts = new Map<string, string>();
+
+  for (const ref of refs) {
+    // 1. mark.targetId 経由の解決を最優先。`targetId` がスコープ内で有効なら
+    //    タイトル fallback には進まない（in-flight rename 対策）。
+    // 1. id-based resolution wins; a valid `targetId` short-circuits title
+    //    fallback so an in-flight rename does not regress to a ghost.
+    if (ref.targetId && scope.validTargetIds.has(ref.targetId)) {
+      // `targetId === sourcePageId` の自己参照は buildResolvedScope で除外済み。
+      // Self-references were removed from `validTargetIds` upstream.
+      linkTargetIds.add(ref.targetId);
+      continue;
+    }
+
+    // 2. タイトル一致で解決する。
+    // 2. Title-based resolution.
+    const titleResolvedId = scope.titleToId.get(ref.normalizedTitle);
+    if (titleResolvedId && titleResolvedId !== sourcePageId) {
+      linkTargetIds.add(titleResolvedId);
+      continue;
+    }
+
+    // 3. 解決できなかった refs を ghost に倒す。同一 normalizedTitle が複数
+    //    出てきた場合は first-write-wins で display を保存する。
+    // 3. Unresolved refs become ghosts; first-seen display spelling wins on
+    //    duplicate normalized titles.
+    if (titleResolvedId === sourcePageId) {
+      // タイトル一致で自分自身が出てきた場合は CHECK 制約で弾かれるので
+      // ghost にも入れない（自己参照は完全に無視）。
+      // Title resolved to the source page itself — drop entirely (the CHECK
+      // constraint forbids self-links, and a ghost on your own page is noise).
+      continue;
+    }
+    if (!ghostTexts.has(ref.normalizedTitle)) {
+      ghostTexts.set(ref.normalizedTitle, ref.displayTitle);
+    }
+  }
+
+  return { linkTargetIds, ghostTexts };
+}
+
+/**
+ * `(source_id, link_type)` バケットの links / ghost_links を、与えられた集合へ
+ * 置き換える。`syncPages.ts` の DELETE → INSERT セマンティクスと同じ。
+ *
+ * Replace the `(source_id, link_type)` slice of `links` / `ghost_links` with
+ * the supplied target/ghost sets. Mirrors `syncPages.ts` semantics.
+ */
+type WriteHandle = Pick<Database, "insert" | "delete">;
+async function replaceBucket(
+  tx: WriteHandle,
+  sourcePageId: string,
+  linkType: LinkType,
+  desiredLinkTargetIds: Set<string>,
+  desiredGhostTexts: Map<string, string>,
+): Promise<{ insertedLinks: number; insertedGhosts: number }> {
+  // DELETE existing edges for this (source, link_type).
+  // 既存エッジを (source, link_type) 単位で全削除し、計算済みの新規集合で
+  // 再構成する。`syncPages.ts` と同じ「バケット内 LWW」モデル。
+  await tx.delete(links).where(and(eq(links.sourceId, sourcePageId), eq(links.linkType, linkType)));
+  await tx
+    .delete(ghostLinks)
+    .where(and(eq(ghostLinks.sourcePageId, sourcePageId), eq(ghostLinks.linkType, linkType)));
+
+  let insertedLinks = 0;
+  let insertedGhosts = 0;
+
+  if (desiredLinkTargetIds.size > 0) {
+    const rows = Array.from(desiredLinkTargetIds).map((targetId) => ({
+      sourceId: sourcePageId,
+      targetId,
+      linkType,
+    }));
+    await tx.insert(links).values(rows).onConflictDoNothing();
+    insertedLinks = rows.length;
+  }
+
+  if (desiredGhostTexts.size > 0) {
+    const rows = Array.from(desiredGhostTexts.values()).map((linkText) => ({
+      linkText,
+      sourcePageId,
+      linkType,
+    }));
+    await tx.insert(ghostLinks).values(rows).onConflictDoNothing();
+    insertedGhosts = rows.length;
+  }
+
+  return { insertedLinks, insertedGhosts };
+}
+
+/**
+ * `pageId` のソースページについて、Y.Doc の現在内容から
+ * `links` / `ghost_links` を `(source_id, link_type)` バケット単位で
+ * 再構築する。
+ *
+ * Rebuild the `(source_id, link_type)` slices of `links` / `ghost_links` for
+ * `pageId` from the current Y.Doc contents.
+ *
+ * @param db - Drizzle database handle.
+ * @param sourcePageId - The page whose outgoing edges are being synced.
+ * @param doc - The current Y.Doc for that page (already deserialized).
+ * @returns Counters describing what was rewritten.
+ */
+export async function syncPageGraphFromYDoc(
+  db: Database,
+  sourcePageId: string,
+  doc: Y.Doc,
+): Promise<PageGraphSyncResult> {
+  const empty: PageGraphSyncResult = {
+    wikiLinksInserted: 0,
+    wikiGhostsInserted: 0,
+    tagLinksInserted: 0,
+    tagGhostsInserted: 0,
+    skippedSourceNotFound: false,
+  };
+
+  return db.transaction(async (tx) => {
+    // ソースページの note スコープを解決する。削除済み・行欠落は best-effort
+    // としてサイレント no-op（呼び出し側のメイン保存パスは既に終わっている）。
+    // Resolve the source page's note scope. Missing / soft-deleted rows are
+    // treated as a no-op since this service runs in a best-effort context
+    // after the main content save has already succeeded.
+    const sourceRows = await tx
+      .select({ noteId: pages.noteId, isDeleted: pages.isDeleted })
+      .from(pages)
+      .where(eq(pages.id, sourcePageId))
+      .limit(1);
+    const source = sourceRows[0];
+    if (!source || source.isDeleted) {
+      return { ...empty, skippedSourceNotFound: true };
+    }
+
+    const refs = extractRefsFromYDoc(doc);
+    const allTargetIds = new Set<string>();
+    for (const ref of refs.wikiRefs) {
+      if (ref.targetId) allTargetIds.add(ref.targetId);
+    }
+    for (const ref of refs.tagRefs) {
+      if (ref.targetId) allTargetIds.add(ref.targetId);
+    }
+    const scope = await buildResolvedScope(tx, source.noteId, sourcePageId, allTargetIds);
+
+    const wikiPlan = planBucket(sourcePageId, refs.wikiRefs, scope);
+    const tagPlan = planBucket(sourcePageId, refs.tagRefs, scope);
+
+    const wikiResult = await replaceBucket(
+      tx,
+      sourcePageId,
+      "wiki",
+      wikiPlan.linkTargetIds,
+      wikiPlan.ghostTexts,
+    );
+    const tagResult = await replaceBucket(
+      tx,
+      sourcePageId,
+      "tag",
+      tagPlan.linkTargetIds,
+      tagPlan.ghostTexts,
+    );
+
+    return {
+      wikiLinksInserted: wikiResult.insertedLinks,
+      wikiGhostsInserted: wikiResult.insertedGhosts,
+      tagLinksInserted: tagResult.insertedLinks,
+      tagGhostsInserted: tagResult.insertedGhosts,
+      skippedSourceNotFound: false,
+    };
+  });
+}
+
+/**
+ * `pageId` の現在の `page_contents.ydoc_state` を読み込んで Y.Doc を組み立て、
+ * グラフ同期を実行するラッパー。Hocuspocus 保存後の internal 経路や、API 内
+ * の fire-and-forget 呼び出しから使う。
+ *
+ * Convenience wrapper: read `page_contents.ydoc_state` for `pageId`, hydrate
+ * the Y.Doc, and run `syncPageGraphFromYDoc`. Used by the Hocuspocus
+ * post-save trigger (via internal HTTP) and by the REST PUT /content path
+ * (fire-and-forget).
+ *
+ * Returns `null` when there is no stored content yet — the caller should
+ * treat that as a no-op (graph stays empty).
+ */
+export async function syncPageGraphFromStoredYDoc(
+  db: Database,
+  sourcePageId: string,
+): Promise<PageGraphSyncResult | null> {
+  const rows = await db
+    .select({ ydocState: pageContents.ydocState })
+    .from(pageContents)
+    .where(eq(pageContents.pageId, sourcePageId))
+    .limit(1);
+  const row = rows[0];
+  if (!row?.ydocState) return null;
+
+  const buffer =
+    row.ydocState instanceof Buffer
+      ? row.ydocState
+      : Buffer.from(row.ydocState as unknown as ArrayBufferLike);
+
+  const doc = new Y.Doc();
+  Y.applyUpdate(doc, new Uint8Array(buffer));
+  return syncPageGraphFromYDoc(db, sourcePageId, doc);
+}
+
+/**
+ * テスト用フック。ユニットテストで内部ヘルパーを直接検証するために露出する。
+ * production code が触ることは想定していない。
+ *
+ * Internal helpers exposed solely for tests. Production code should call
+ * `syncPageGraphFromYDoc` / `syncPageGraphFromStoredYDoc`.
+ */
+export const __test_only = { extractRefsFromYDoc, planBucket };

--- a/server/hocuspocus/src/index.ts
+++ b/server/hocuspocus/src/index.ts
@@ -361,6 +361,78 @@ async function saveDocumentToDb(pageId: string, document: Y.Doc): Promise<void> 
   } finally {
     snapshotClient.release();
   }
+
+  // Issue #880 Phase C: 本文保存後に API 経由でリンクグラフ (links / ghost_links)
+  // を再構築する。本処理は内部 HTTP 呼び出しのベストエフォートで、失敗しても
+  // 本文保存の成功には影響させない。
+  // Issue #880 Phase C: rebuild outgoing edges (links / ghost_links) via the
+  // API's internal endpoint after persisting the document. Best-effort — a
+  // failure does not roll back the content save.
+  void triggerGraphSync(pageId).catch((error) => {
+    console.error(`[GraphSync] Failed to trigger graph sync for page ${pageId}:`, error);
+  });
+}
+
+/**
+ * `API_INTERNAL_URL` の末尾スラッシュを取り除いた origin を返す。
+ * Resolves the API origin used for internal calls. Returns `null` when the
+ * variable is unset so the caller can skip silently in dev.
+ */
+function getApiInternalOrigin(): string | null {
+  const raw = process.env.API_INTERNAL_URL?.trim();
+  if (!raw) return null;
+  return raw.replace(/\/+$/, "");
+}
+
+/** HTTP timeout for the API graph-sync call (ms). / API グラフ同期 HTTP のタイムアウト (ms) */
+const API_GRAPH_SYNC_TIMEOUT_MS = 2500;
+
+/**
+ * `POST /api/internal/pages/:id/graph-sync` を呼び出して、保存済み Y.Doc から
+ * リンクグラフを再構築させる。ネットワーク失敗・タイムアウトは握りつぶす
+ * （呼び出し元はベストエフォートで呼ぶ）。
+ *
+ * Call the API's internal graph-sync endpoint so it rebuilds outgoing edges
+ * from the just-persisted Y.Doc. Network failures / timeouts are swallowed
+ * because the caller treats this as best-effort.
+ */
+async function triggerGraphSync(pageId: string): Promise<void> {
+  const baseUrl = getApiInternalOrigin();
+  const secret = INTERNAL_SECRET;
+  if (!baseUrl || !secret) {
+    // dev: ログだけ残してスキップ。production では起動時に API_INTERNAL_URL
+    // が未設定だと起動拒否しているため、ここに来るのは dev か設定ミス。
+    // Dev: log + skip. In production the server already refuses to start
+    // without `API_INTERNAL_URL`, so this branch is dev-only or misconfig.
+    const missing = [baseUrl ? null : "API_INTERNAL_URL", secret ? null : "BETTER_AUTH_SECRET"]
+      .filter((v): v is string => v !== null)
+      .join(", ");
+    console.warn(`[GraphSync] Skipped for page ${pageId}: missing env var(s): ${missing}`);
+    return;
+  }
+
+  const url = `${baseUrl}/api/internal/pages/${encodeURIComponent(pageId)}/graph-sync`;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), API_GRAPH_SYNC_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "x-internal-secret": secret },
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    if (!response.ok) {
+      console.warn(`[GraphSync] HTTP ${response.status} for page ${pageId}`);
+    }
+  } catch (error) {
+    clearTimeout(timeoutId);
+    const name = error instanceof Error ? error.name : "";
+    if (name === "AbortError") {
+      console.warn(`[GraphSync] Timed out for page ${pageId}`);
+      return;
+    }
+    console.warn(`[GraphSync] Request failed for page ${pageId}:`, error);
+  }
 }
 
 function parseRedisOptions(redisUrl: string): Record<string, unknown> {

--- a/src/components/editor/PageEditor/PageEditorContent.tsx
+++ b/src/components/editor/PageEditor/PageEditorContent.tsx
@@ -14,15 +14,31 @@ import type { UseCollaborationReturn } from "@/lib/collaboration/types";
 import type { WikiGeneratorStatus } from "./types";
 import { PageTitleBlock } from "./PageTitleBlock";
 
+/**
+ * `useCollaboration` の戻り値から、Tiptap に渡す collaborationConfig と
+ * 編集可否ゲートに使うフラグを導出する。Issue #880 で初期同期完了
+ * (`isSynced`) を編集可否条件に取り込んだ。
+ *
+ * Derive both the `CollaborationConfig` for Tiptap and the gating flags used
+ * to lock editing during the initial Hocuspocus/IDB merge. Issue #880 added
+ * `isInitialSyncPending` so the body editor stays unmounted while a remote
+ * Y.Doc is still being merged, preventing the user from typing into an empty
+ * doc that will be overwritten by the upcoming sync.
+ */
 function getCollaborationState(collaboration: UseCollaborationReturn | undefined): {
   useCollaborationMode: boolean;
+  isInitialSyncPending: boolean;
   collaborationConfig: CollaborationConfig | undefined;
 } {
   const ready = Boolean(
     collaboration?.ydoc && collaboration?.xmlFragment && collaboration?.collaborationUser,
   );
   if (!ready || !collaboration) {
-    return { useCollaborationMode: false, collaborationConfig: undefined };
+    return {
+      useCollaborationMode: false,
+      isInitialSyncPending: false,
+      collaborationConfig: undefined,
+    };
   }
   const config: CollaborationConfig = {
     ydoc: collaboration.ydoc,
@@ -31,8 +47,13 @@ function getCollaborationState(collaboration: UseCollaborationReturn | undefined
     user: collaboration.collaborationUser,
     updateCursor: collaboration.updateCursor,
     updateSelection: collaboration.updateSelection,
+    isSynced: collaboration.isSynced,
   };
-  return { useCollaborationMode: true, collaborationConfig: config };
+  return {
+    useCollaborationMode: true,
+    isInitialSyncPending: !collaboration.isSynced,
+    collaborationConfig: config,
+  };
 }
 
 interface PageEditorContentProps {
@@ -121,9 +142,23 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
     contentFocusRef.current?.();
   }, []);
 
-  const { useCollaborationMode, collaborationConfig } = getCollaborationState(collaboration);
-  const showCollaborationLoading = Boolean(collaboration && !useCollaborationMode);
-  const showEditor = useCollaborationMode || !collaboration;
+  const { useCollaborationMode, isInitialSyncPending, collaborationConfig } =
+    getCollaborationState(collaboration);
+  // Issue #880: `isSynced` を満たすまで本文 editor を表示しない。`ydoc/xmlFragment`
+  // は HocuspocusProvider の初期同期完了より前に作られるため、ここを編集可能条件に
+  // すると空 Y.Doc に入力できてしまい、その直後に届く remote update と競合する。
+  // タイトル input は `pages.title` 列に独立して保存され Y.Doc とは無関係なため、
+  // 初期同期中も編集可能にしておく（保存レースは発生しない）。
+  //
+  // Issue #880: keep the body editor unmounted until the initial Y.Doc sync
+  // completes. Using `ydoc/xmlFragment` presence alone would let users type
+  // into an empty Y.Doc that is about to be overwritten by the remote sync.
+  // Title input persists into `pages.title` (separate from Y.Doc) so there is
+  // no race and it can remain editable during sync.
+  const showCollaborationLoading = Boolean(
+    collaboration && (!useCollaborationMode || isInitialSyncPending),
+  );
+  const showEditor = (useCollaborationMode && !isInitialSyncPending) || !collaboration;
 
   return (
     <div className="flex-1 pt-6 pb-32">

--- a/src/components/editor/TiptapEditor/types.ts
+++ b/src/components/editor/TiptapEditor/types.ts
@@ -4,6 +4,7 @@ import type { Awareness } from "y-protocols/awareness";
 
 /**
  * リアルタイムコラボレーション用の設定（useCollaboration の戻り値から渡す）
+ * Collaboration configuration forwarded to TiptapEditor.
  */
 export interface CollaborationConfig {
   ydoc: Y.Doc;
@@ -13,6 +14,16 @@ export interface CollaborationConfig {
   user: { name: string; color: string };
   updateCursor: (anchor: number, head: number) => void;
   updateSelection: (from: number, to: number) => void;
+  /**
+   * `useCollaboration` の `isSynced` 状態。初期同期が完了したかを示す。
+   * 編集ロックや、初期同期後の一度きりの正規化（WikiLink mark 化など）に使う。
+   *
+   * Mirrors `useCollaboration().isSynced`. Editors use this to gate input
+   * before initial sync completes and to trigger one-shot post-sync
+   * normalization passes (e.g. promoting plain `[[Title]]` text to wikiLink
+   * marks loaded from Hocuspocus). Issue #880.
+   */
+  isSynced: boolean;
 }
 
 /**

--- a/src/components/editor/TiptapEditor/useEditorLifecycle.ts
+++ b/src/components/editor/TiptapEditor/useEditorLifecycle.ts
@@ -166,11 +166,21 @@ export function useEditorLifecycle({
   // The `collaborationConfig` object is rebuilt on every parent render; key
   // the effect on the boolean `isSynced` flag so the effect doesn't tear down
   // and re-arm the timer needlessly.
+  // editor インスタンスまたは pageId が切り替わったら、normalization 履歴を
+  // リセットして新しい文書でも一度だけ走るようにする。useRef はマウント中
+  // 値を保持するため、ページ遷移しても明示的に false に戻す必要がある。
+  // Reset the one-shot guard when the editor instance or page changes so a
+  // navigated-to page also runs the normalization once. `useRef` persists
+  // across renders, so without this reset a stale `true` would block the
+  // post-sync pass on the next page.
+  useEffect(() => {
+    wikiLinkNormalizationAppliedRef.current = false;
+  }, [editor, pageId]);
+
   const isCollabSynced = Boolean(collaborationConfig?.isSynced);
   useEffect(() => {
     if (!editor || !isCollabSynced) return;
     if (wikiLinkNormalizationAppliedRef.current) return;
-    wikiLinkNormalizationAppliedRef.current = true;
 
     // editor mount 直後だと PM doc がまだ最終形に落ちていないことがあるため、
     // 1 tick 待ってから走査する。`useContentSanitizer` の初期化フローや、
@@ -178,21 +188,35 @@ export function useEditorLifecycle({
     // Defer one microtask so the editor finishes binding to the synced Y.Doc
     // before we scan it. Matches the deferral pattern used for `initialContent`.
     const timer = setTimeout(() => {
+      // ガードはタイマ起動時ではなく実際に走った時点で flip する。effect
+      // クリーンアップで timer が解除された場合に「未実行なのに guard=true」
+      // 状態を残さないため。
+      // Flip the guard inside the timer (not when scheduling it) so a cleanup
+      // that cancels the timer does not leave the guard armed and silently
+      // skip the real run forever.
+      if (wikiLinkNormalizationAppliedRef.current) return;
+      wikiLinkNormalizationAppliedRef.current = true;
       try {
-        const applied = applyWikiLinkMarksToEditor(editor);
-        if (applied) {
-          // 変更を永続化経路へ流す（collab mode では Y.Doc に伝わるが、
-          // onChange 経由でフロント状態も一致させる）。
-          // Push the JSON downstream so the React-side `content` state matches
-          // the mark transaction's result (Y.Doc already sees it directly).
-          onChange(JSON.stringify(editor.getJSON()));
-        }
+        // `applyWikiLinkMarksToEditor` 内の `editor.view.dispatch(tr)` が
+        // Tiptap の `onUpdate` を発火し、上位 (`useEditorSetup`) で
+        // `onChange(JSON.stringify(editor.getJSON()))` が呼ばれる。
+        // ここで明示的に呼ぶと二重呼び出しになるため呼ばない。
+        // The dispatch inside `applyWikiLinkMarksToEditor` triggers Tiptap's
+        // `onUpdate`, which already invokes `onChange` upstream. Calling it
+        // again here would double-fire the downstream state update.
+        applyWikiLinkMarksToEditor(editor);
       } catch (e) {
         console.error("[WikiLinkNormalize] Failed to normalize post-sync marks", e);
       }
     }, 0);
     return () => clearTimeout(timer);
-  }, [editor, isCollabSynced, onChange]);
+    // `pageId` を deps に含めることで、エディタインスタンスが使い回されたまま
+    // ページ遷移したケース (上の reset effect が ref を false に戻すケース) でも
+    // この effect が再実行されて正規化が走るようにする。
+    // `pageId` is in deps so that when the editor instance is reused across
+    // page navigation, the reset effect above flips the guard back to false
+    // AND this effect re-runs to perform the normalization on the new page.
+  }, [editor, isCollabSynced, pageId]);
 
   usePasteImageHandler({ editor, handleImageUpload });
 

--- a/src/components/editor/TiptapEditor/useEditorLifecycle.ts
+++ b/src/components/editor/TiptapEditor/useEditorLifecycle.ts
@@ -5,6 +5,7 @@ import { useContentSanitizer } from "./useContentSanitizer";
 import { useWikiLinkStatusSync } from "./useWikiLinkStatusSync";
 import { useTagStatusSync } from "./useTagStatusSync";
 import { usePasteImageHandler } from "./usePasteImageHandler";
+import { applyWikiLinkMarksToEditor } from "../extensions/applyWikiLinkMarksToEditor";
 
 import { rememberSlashAgentSelection } from "@/lib/agentSlashCommands/slashAgentSelectionCache";
 import type { TiptapEditorProps } from "./types";
@@ -61,6 +62,15 @@ export function useEditorLifecycle({
   pageNoteId,
 }: UseEditorLifecycleOptions) {
   const initialContentAppliedRef = useRef(false);
+  /**
+   * Issue #880 Phase B: 初期同期完了後に `[[Title]]` プレーンテキストを一度だけ
+   * `wikiLink` mark 化したかを記録する。エディタ／ページが変わった場合は
+   * 別効果で false にリセットされる。
+   *
+   * Issue #880 Phase B: tracks whether the post-sync `[[Title]]` → wikiLink
+   * mark normalization already ran on the current editor/page combination.
+   */
+  const wikiLinkNormalizationAppliedRef = useRef(false);
 
   useEffect(() => {
     if (!editor) return;
@@ -137,6 +147,52 @@ export function useEditorLifecycle({
     onWikiContentApplied,
     isEditorInitializedRef,
   ]);
+
+  // Issue #880 Phase B: Hocuspocus からロードされた既存 Y.Doc に含まれる plain
+  // text `[[Title]]` を、初期同期完了直後に一度だけ `wikiLink` mark へ昇格する。
+  // - collaborative mode の場合のみ実行（local mode は paste 時に既に mark 化される）。
+  // - `setContent` を使わず ProseMirror transaction で `addMark` のみ呼ぶことで
+  //   Y.Doc 構造を壊さない。
+  // - `useWikiLinkStatusSync` は mark 後の `exists/referenced/targetId` を更新する。
+  //
+  // Issue #880 Phase B: promote plain `[[Title]]` text inside the
+  // Hocuspocus-loaded Y.Doc to `wikiLink` marks once, immediately after the
+  // initial sync completes. Collaborative mode only — local mode marks links
+  // at paste time via `WikiLinkExtension`. The downstream `useWikiLinkStatusSync`
+  // hook then fills in `exists/referenced/targetId`.
+  // `collaborationConfig` は親側で毎回 new されるが、判定に必要なのは isSynced
+  // フラグだけなのでプリミティブで dep に積む。これで effect の再実行が必要
+  // 以上に走らない。
+  // The `collaborationConfig` object is rebuilt on every parent render; key
+  // the effect on the boolean `isSynced` flag so the effect doesn't tear down
+  // and re-arm the timer needlessly.
+  const isCollabSynced = Boolean(collaborationConfig?.isSynced);
+  useEffect(() => {
+    if (!editor || !isCollabSynced) return;
+    if (wikiLinkNormalizationAppliedRef.current) return;
+    wikiLinkNormalizationAppliedRef.current = true;
+
+    // editor mount 直後だと PM doc がまだ最終形に落ちていないことがあるため、
+    // 1 tick 待ってから走査する。`useContentSanitizer` の初期化フローや、
+    // Hocuspocus からの Y.Doc 反映の最終ステップが完了してから実行したい。
+    // Defer one microtask so the editor finishes binding to the synced Y.Doc
+    // before we scan it. Matches the deferral pattern used for `initialContent`.
+    const timer = setTimeout(() => {
+      try {
+        const applied = applyWikiLinkMarksToEditor(editor);
+        if (applied) {
+          // 変更を永続化経路へ流す（collab mode では Y.Doc に伝わるが、
+          // onChange 経由でフロント状態も一致させる）。
+          // Push the JSON downstream so the React-side `content` state matches
+          // the mark transaction's result (Y.Doc already sees it directly).
+          onChange(JSON.stringify(editor.getJSON()));
+        }
+      } catch (e) {
+        console.error("[WikiLinkNormalize] Failed to normalize post-sync marks", e);
+      }
+    }, 0);
+    return () => clearTimeout(timer);
+  }, [editor, isCollabSynced, onChange]);
 
   usePasteImageHandler({ editor, handleImageUpload });
 

--- a/src/components/editor/extensions/applyWikiLinkMarksToEditor.test.ts
+++ b/src/components/editor/extensions/applyWikiLinkMarksToEditor.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { WikiLink } from "./WikiLinkExtension";
+import { applyWikiLinkMarksToEditor } from "./applyWikiLinkMarksToEditor";
+
+/**
+ * 初期同期後の `[[Title]]` → `wikiLink` mark 一括正規化テスト。
+ * Issue #880 Phase B（Hocuspocus からロードした既存 Y.Doc に対する正規化）。
+ *
+ * Tests cover acceptance criteria for issue #880 Phase B:
+ *   - plain `[[Title]]` text is promoted to a `wikiLink` mark
+ *   - already-marked wiki links are not double-marked
+ *   - code-block / inline-code text stays literal
+ *   - status attributes (`exists` / `referenced` / `targetId`) start unresolved
+ */
+function makeEditor(initialContent: string): Editor {
+  return new Editor({
+    extensions: [StarterKit, WikiLink],
+    content: initialContent,
+  });
+}
+
+/**
+ * Find the first `wikiLink` mark and return its `attrs`.
+ * 最初に見つかった `wikiLink` mark の attrs を取り出すヘルパー。
+ */
+function firstWikiMarkAttrs(editor: Editor): Record<string, unknown> | null {
+  let result: Record<string, unknown> | null = null;
+  editor.state.doc.descendants((node) => {
+    if (!node.isText || result) return;
+    const mark = node.marks.find((m) => m.type.name === "wikiLink");
+    if (mark) {
+      result = mark.attrs as Record<string, unknown>;
+    }
+  });
+  return result;
+}
+
+/**
+ * Count total wikiLink-marked text segments in the document.
+ * 文書内の wikiLink mark 付きセグメント数を数える。
+ */
+function countWikiMarks(editor: Editor): number {
+  let count = 0;
+  editor.state.doc.descendants((node) => {
+    if (!node.isText) return;
+    if (node.marks.some((m) => m.type.name === "wikiLink")) count += 1;
+  });
+  return count;
+}
+
+describe("applyWikiLinkMarksToEditor", () => {
+  it("promotes a plain `[[Title]]` text node to a wikiLink mark", () => {
+    const editor = makeEditor("<p>see [[Foo]] for details</p>");
+    try {
+      const applied = applyWikiLinkMarksToEditor(editor);
+      expect(applied).toBe(true);
+
+      const attrs = firstWikiMarkAttrs(editor);
+      expect(attrs).not.toBeNull();
+      expect(attrs?.title).toBe("Foo");
+      // 初期同期直後の正規化は未解決状態でマークする。`useWikiLinkStatusSync`
+      // が後段で `exists/referenced/targetId` を埋める設計（issue #880 受入条件）。
+      // Issue #880 acceptance criteria: post-sync normalization marks links as
+      // unresolved; `useWikiLinkStatusSync` later fills in status attrs.
+      expect(attrs?.exists).toBe(false);
+      expect(attrs?.referenced).toBe(false);
+      expect(attrs?.targetId).toBeNull();
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  it("does not double-mark an already-marked wikiLink", () => {
+    // 既に WikiLink mark が付いている text node は対象外。
+    // Already-marked wikiLink text must not be re-marked.
+    const editor = makeEditor(
+      '<p><span data-wiki-link data-title="Foo" data-exists="true" data-referenced="false">[[Foo]]</span></p>',
+    );
+    try {
+      const before = countWikiMarks(editor);
+      const applied = applyWikiLinkMarksToEditor(editor);
+      expect(applied).toBe(false);
+      expect(countWikiMarks(editor)).toBe(before);
+
+      // 既存マークの `exists=true` を温存する。再 mark すると `exists=false` に
+      // 巻き戻ってしまうため、これは重要な不変条件。
+      // The mark must keep its existing `exists=true`; a second pass would
+      // regress it back to `false`, which is a regression we explicitly guard
+      // against.
+      const attrs = firstWikiMarkAttrs(editor);
+      expect(attrs?.exists).toBe(true);
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  it("does not mark `[[Title]]` inside an inline code mark", () => {
+    const editor = makeEditor("<p><code>[[Foo]]</code></p>");
+    try {
+      const applied = applyWikiLinkMarksToEditor(editor);
+      expect(applied).toBe(false);
+      expect(countWikiMarks(editor)).toBe(0);
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  it("does not mark `[[Title]]` inside a code block", () => {
+    const editor = makeEditor("<pre><code>[[Foo]]</code></pre>");
+    try {
+      const applied = applyWikiLinkMarksToEditor(editor);
+      expect(applied).toBe(false);
+      expect(countWikiMarks(editor)).toBe(0);
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  it("skips empty title `[[   ]]`", () => {
+    // 空タイトルは `transformWikiLinksInContent` と同じ契約でスキップ。
+    // Empty titles are skipped, matching the paste-time normalizer contract.
+    const editor = makeEditor("<p>[[   ]]</p>");
+    try {
+      const applied = applyWikiLinkMarksToEditor(editor);
+      expect(applied).toBe(false);
+      expect(countWikiMarks(editor)).toBe(0);
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  it("marks multiple `[[Title]]` patterns in the same paragraph", () => {
+    const editor = makeEditor("<p>see [[A]] and [[B]]</p>");
+    try {
+      const applied = applyWikiLinkMarksToEditor(editor);
+      expect(applied).toBe(true);
+      expect(countWikiMarks(editor)).toBe(2);
+
+      const titles: string[] = [];
+      editor.state.doc.descendants((node) => {
+        if (!node.isText) return;
+        const mark = node.marks.find((m) => m.type.name === "wikiLink");
+        if (mark) titles.push(mark.attrs.title as string);
+      });
+      expect(titles).toEqual(["A", "B"]);
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  it("returns false when no `[[Title]]` patterns exist", () => {
+    const editor = makeEditor("<p>just plain text</p>");
+    try {
+      const applied = applyWikiLinkMarksToEditor(editor);
+      expect(applied).toBe(false);
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  it("trims whitespace from the title attribute and marks the full bracket span", () => {
+    // 表示テキストは `[[ Foo Bar ]]` 全体に mark が乗り、attrs.title はトリム後の値。
+    // (Note: ProseMirror's HTML parser collapses consecutive whitespace, so the
+    // input `[[  Foo Bar  ]]` becomes `[[ Foo Bar ]]` once it lands in the doc.
+    // What the helper guarantees is that the mark spans the brackets verbatim
+    // and `attrs.title` holds the trimmed value.)
+    //
+    // Display text retains the bracket form and the mark spans the whole
+    // `[[...]]`; `attrs.title` is the trimmed inner string.
+    const editor = makeEditor("<p>[[ Foo Bar ]]</p>");
+    try {
+      const applied = applyWikiLinkMarksToEditor(editor);
+      expect(applied).toBe(true);
+
+      const attrs = firstWikiMarkAttrs(editor);
+      expect(attrs?.title).toBe("Foo Bar");
+
+      let text = "";
+      editor.state.doc.descendants((node) => {
+        if (node.isText && node.marks.some((m) => m.type.name === "wikiLink")) {
+          text = node.text ?? "";
+        }
+      });
+      expect(text).toBe("[[ Foo Bar ]]");
+    } finally {
+      editor.destroy();
+    }
+  });
+});

--- a/src/components/editor/extensions/applyWikiLinkMarksToEditor.ts
+++ b/src/components/editor/extensions/applyWikiLinkMarksToEditor.ts
@@ -1,0 +1,127 @@
+/**
+ * Hocuspocus からロードされた既存 Y.Doc 上で、まだ `wikiLink` mark になっていない
+ * `[[Title]]` プレーンテキストを wikiLink mark に昇格させる正規化ヘルパー。
+ * Issue #880 の Phase B（初期同期後の mark 化）で導入。
+ *
+ * Post-initial-sync normalizer that promotes plain `[[Title]]` text to
+ * `wikiLink` marks inside a Tiptap editor bound to a Hocuspocus-backed Y.Doc.
+ * Introduced for issue #880 Phase B.
+ *
+ * 設計方針 / Design notes:
+ * - `editor.commands.setContent()` を使わない。collaborative mode では Y.Doc が
+ *   editor の状態源なので、setContent は Y.Doc を捨てて再構築してしまい、初期
+ *   同期で得た既存コンテンツを失う。ここではプレーンテキストをスキャンし、
+ *   ProseMirror transaction で `addMark` のみ呼ぶ（テキスト構造は変えない）。
+ * - 二重 mark 化を防ぐため、既に `wikiLink` mark が付いた text node はスキップ。
+ * - `code` mark や `codeBlock` / `executableCodeBlock` 親の text はスキップする
+ *   (`transformWikiLinksInContent` の契約と同じ)。
+ * - mark 適用は単一トランザクションで一括適用する。`addMark` はテキストの
+ *   位置を変えないため、順序は安全。
+ *
+ * - Avoid `editor.commands.setContent()` — in collaborative mode that would
+ *   wipe the Y.Doc and lose the just-synced content. We mutate marks in place
+ *   via a ProseMirror transaction (`addMark`), which does not change text
+ *   positions.
+ * - Skip text nodes that already carry a `wikiLink` mark (no double-marking).
+ * - Skip code-block / inline-code text, mirroring the contract of
+ *   `transformWikiLinksInContent` (paste-time normalizer).
+ * - All marks are applied in one transaction so subscribers see a single
+ *   update.
+ */
+
+import type { Editor } from "@tiptap/core";
+
+/**
+ * テキスト中の `[[Title]]` パターンを列挙する正規表現（global）。
+ * 共有しないために関数内で都度 `new RegExp` する設計の方が安全だが、ここでは
+ * `matchAll` のみで使うため副作用は出ない。
+ *
+ * Pattern matching `[[Title]]` in plain text. Used only with `matchAll`, so
+ * the global flag's `lastIndex` side effects do not leak.
+ */
+const WIKI_LINK_TEXT_REGEX = /\[\[([^[\]]+)\]\]/g;
+
+/** Tiptap がコードとして扱うブロックノード型集合。 / Tiptap code-container node types. */
+const CODE_CONTAINER_TYPES = new Set<string>(["codeBlock", "code_block", "executableCodeBlock"]);
+
+interface PendingEdit {
+  /** Document position where the match starts. */
+  from: number;
+  /** Document position where the match ends. */
+  to: number;
+  /** Trimmed inner title. */
+  title: string;
+}
+
+/**
+ * `editor` の本文を走査し、未 mark の `[[Title]]` テキストに `wikiLink` mark を
+ * 適用する。返り値は実際に mark を適用したかどうか。`exists` / `referenced` /
+ * `targetId` は未解決状態で書き込み、後続の `useWikiLinkStatusSync` が
+ * `exists/referenced/targetId` を更新する責務を持つ。
+ *
+ * Scan `editor` for unmarked `[[Title]]` literals and apply the `wikiLink`
+ * mark. Returns `true` when at least one mark was added. Status attributes
+ * (`exists` / `referenced` / `targetId`) are written as unresolved so the
+ * downstream `useWikiLinkStatusSync` hook can fill them in.
+ *
+ * @param editor - Tiptap editor instance whose Y.Doc just finished syncing.
+ * @returns Whether any marks were applied.
+ */
+export function applyWikiLinkMarksToEditor(editor: Editor): boolean {
+  const wikiLinkType = editor.schema.marks.wikiLink;
+  if (!wikiLinkType) return false;
+
+  const edits: PendingEdit[] = [];
+  const { doc } = editor.state;
+
+  doc.descendants((node, pos, parent) => {
+    if (!node.isText) return;
+    // 既に wikiLink mark 済みのテキストはスキップ（二重 mark 化防止）。
+    // Skip text that already carries a wikiLink mark (no double-marking).
+    if (node.marks.some((mark) => mark.type.name === "wikiLink")) return;
+    // inline code mark 内はリテラルとして残す。
+    // Inline code marks: keep the text literal.
+    if (node.marks.some((mark) => mark.type.name === "code")) return;
+    // code block / executable code block の中はリテラルとして残す。
+    // Code block / executable code block children stay literal.
+    if (parent && CODE_CONTAINER_TYPES.has(parent.type.name)) return;
+
+    const text = node.text;
+    if (!text || !text.includes("[[")) return;
+
+    for (const match of text.matchAll(WIKI_LINK_TEXT_REGEX)) {
+      const raw = match[1] ?? "";
+      const title = raw.trim();
+      // 空タイトル `[[   ]]` はスキップする（transformWikiLinksInContent と同契約）。
+      // Empty titles `[[   ]]` are skipped (matches the paste-time contract).
+      if (!title) continue;
+      const start = pos + (match.index ?? 0);
+      const end = start + match[0].length;
+      edits.push({ from: start, to: end, title });
+    }
+  });
+
+  if (edits.length === 0) return false;
+
+  let tr = editor.state.tr;
+  // `addMark` は文書位置を変えないため、順序に関わらず安全に複数適用できる。
+  // `addMark` does not change positions, so the order is irrelevant; iterate
+  // in document order for clarity.
+  for (const edit of edits) {
+    const mark = wikiLinkType.create({
+      title: edit.title,
+      exists: false,
+      referenced: false,
+      targetId: null,
+    });
+    tr = tr.addMark(edit.from, edit.to, mark);
+  }
+
+  // 履歴に残さないことで、ユーザーが「元に戻す」で同期前状態に戻れないようにする
+  // のが望ましいが、Tiptap の history は ProseMirror transaction metadata で扱う。
+  // ここでは標準 dispatch のままにし、必要なら呼び出し側で history を分離する。
+  // We dispatch with default metadata; callers may wrap with `history` meta if
+  // they want to keep the normalization out of the undo stack.
+  editor.view.dispatch(tr);
+  return true;
+}

--- a/src/components/editor/extensions/applyWikiLinkMarksToEditor.ts
+++ b/src/components/editor/extensions/applyWikiLinkMarksToEditor.ts
@@ -103,7 +103,14 @@ export function applyWikiLinkMarksToEditor(editor: Editor): boolean {
 
   if (edits.length === 0) return false;
 
-  let tr = editor.state.tr;
+  // この正規化はユーザー操作ではなく初期同期後の機械的処理なので、Undo スタック
+  // に積まない (`addToHistory=false`)。これがないと、最初の Cmd+Z で plain
+  // text `[[Title]]` に戻ってしまい、ユーザーの直前操作 (タイトル入力等) が
+  // 取り消せなくなる。
+  // The normalization is a post-sync, machine-driven cleanup — not a user
+  // edit — so keep it out of the undo stack. Otherwise the first Cmd+Z would
+  // undo the mark promotion instead of the user's most recent change.
+  let tr = editor.state.tr.setMeta("addToHistory", false);
   // `addMark` は文書位置を変えないため、順序に関わらず安全に複数適用できる。
   // `addMark` does not change positions, so the order is irrelevant; iterate
   // in document order for clarity.
@@ -117,11 +124,6 @@ export function applyWikiLinkMarksToEditor(editor: Editor): boolean {
     tr = tr.addMark(edit.from, edit.to, mark);
   }
 
-  // 履歴に残さないことで、ユーザーが「元に戻す」で同期前状態に戻れないようにする
-  // のが望ましいが、Tiptap の history は ProseMirror transaction metadata で扱う。
-  // ここでは標準 dispatch のままにし、必要なら呼び出し側で history を分離する。
-  // We dispatch with default metadata; callers may wrap with `history` meta if
-  // they want to keep the normalization out of the undo stack.
   editor.view.dispatch(tr);
   return true;
 }


### PR DESCRIPTION
## 概要

Issue #880 Phase B & C の実装：Hocuspocus からロードされた既存 Y.Doc に含まれるプレーンテキスト `[[Title]]` を `wikiLink` mark に昇格させ、その後サーバー側で Y.Doc から抽出した WikiLink / tag 参照を `links` / `ghost_links` テーブルに同期する機能を追加します。

## 変更点

### サーバー側（API）

- **`pageGraphSyncService.ts`** (新規)
  - Y.Doc から WikiLink / tag 参照を抽出する `extractRefsFromYDoc()`
  - 参照をスコープ内ページと照合して解決する `buildResolvedScope()`
  - 解決結果から `links` / `ghost_links` の目的状態を計画する `planBucket()`
  - `(source_id, link_type)` バケット単位で `links` / `ghost_links` を置き換える `replaceBucket()`
  - メイン処理 `syncPageGraphFromYDoc()` と、保存済み Y.Doc から同期するラッパー `syncPageGraphFromStoredYDoc()`
  - 設計方針：ノート内スコープのみ解決、`targetId` 優先、タイトル正規化フォールバック、自己参照除外、トランザクション一括実行

- **`pageGraphSyncService.test.ts`** (新規)
  - `extractRefsFromYDoc()` の抽出ロジック（重複排除、正規化、targetId 保持）
  - `planBucket()` の解決ロジック（id 優先、タイトル fallback、ghost 化）
  - 289 行のユニットテスト

- **`internal.ts`** (新規)
  - `POST /api/internal/pages/:id/graph-sync` エンドポイント
  - `x-internal-secret` ヘッダによる認証（Hocuspocus との共有秘密）
  - Hocuspocus の `onStoreDocument` 後に呼ばれる

- **`pages.ts`** (修正)
  - `PUT /api/pages/:id/content` の本文保存後に `syncPageGraphFromStoredYDoc()` を fire-and-forget で呼び出し

- **`app.ts`** (修正)
  - `internalRoutes` をマウント

- **`hocuspocus/src/index.ts`** (修正)
  - `saveDocumentToDb()` 後に `triggerGraphSync()` で API の内部エンドポイントを呼び出し
  - `getApiInternalOrigin()` で `API_INTERNAL_URL` を解決
  - `triggerGraphSync()` で HTTP POST を実行（タイムアウト 2.5s、ベストエフォート）

### クライアント側（エディタ）

- **`applyWikiLinkMarksToEditor.ts`** (新規)
  - Hocuspocus からロードされた Y.Doc 内のプレーンテキスト `[[Title]]` を `wikiLink` mark に昇格
  - 既に mark 済み、code mark / code block 内のテキストはスキップ
  - 空タイトルはスキップ
  - 単一トランザクションで一括適用

- **`applyWikiLinkMarksToEditor.test.ts`** (新規)
  - 191 行のテスト：mark 昇格、二重 mark 防止、code 内スキップ、複数マーク

https://claude.ai/code/session_016ndXtjgjYtDZztMdHfWFob

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic page link-graph synchronization after saving page content (extracts wiki links and tags).
  * Editor auto-converts plain [[Title]] text into wiki-link marks for unresolved links.

* **Improvements**
  * Collaboration sync gating: editor body waits for initial sync before mounting while title remains editable.
  * Duplicate/unresolved link handling improved (collapsed ghosts and stable normalization).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->