### PR TITLE
Fix page graph sync race condition and wiki link normalization

### DIFF
--- a/server/api/src/middleware/csrfOrigin.ts
+++ b/server/api/src/middleware/csrfOrigin.ts
@@ -31,7 +31,16 @@ export const csrfOriginCheck = createMiddleware<AppEnv>(async (c, next) => {
 
   const path = c.req.path;
   // Only exclude routes that use Bearer/no cookie; /api/ext/authorize-code (cookie) stays protected.
-  const excludedPrefixes = ["/api/webhooks/"];
+  // `/api/internal/` は Hocuspocus からのサーバ間呼び出し用で、Origin/Referer は
+  // 付かない代わりに `x-internal-secret` (BETTER_AUTH_SECRET) で認証する。
+  // CSRF オリジン検証を残すと、本番 (`CORS_ORIGIN` 非ワイルドカード) で全件 403 に
+  // なってしまうため除外する。各エンドポイント側で必ず秘密ヘッダを検証すること。
+  // `/api/internal/` is the Hocuspocus → API service-to-service surface. Those
+  // calls have no Origin/Referer and authenticate via the `x-internal-secret`
+  // shared secret (`BETTER_AUTH_SECRET`). Without this exemption every call
+  // would 403 in production where `CORS_ORIGIN` is not wildcard. Each internal
+  // route is responsible for validating the secret header itself.
+  const excludedPrefixes = ["/api/webhooks/", "/api/internal/"];
   const exactExcluded = ["/api/ext/session", "/api/ext/clip-and-create"];
   if (excludedPrefixes.some((prefix) => path.startsWith(prefix))) return next();
   if (exactExcluded.includes(path)) return next();

--- a/server/api/src/services/pageGraphSyncService.ts
+++ b/server/api/src/services/pageGraphSyncService.ts
@@ -47,7 +47,7 @@
  */
 
 import * as Y from "yjs";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { links, ghostLinks, pages, pageContents } from "../schema/index.js";
 import type { Database } from "../types/index.js";
 import type { LinkType } from "../schema/links.js";
@@ -233,10 +233,18 @@ async function buildResolvedScope(
   sourcePageId: string,
   markedTargetIds: Set<string>,
 ): Promise<ResolvedScope> {
+  // `createdAt` 昇順 + `id` 昇順で読み出し、同一ノート内で同名ページが複数ある
+  // 場合の解決を「作成順（最初勝ち）」で決定的にする。下の `titleToId` 構築は
+  // `if (!titleToId.has(key))` で最初に出てきた行を採用するため、ここで安定した
+  // 順序を与えないと実行ごとに解決先がブレうる。
+  // Order by creation time (with id as deterministic tie-breaker) so duplicate
+  // titles within a note resolve to the same page across runs — `titleToId`
+  // below uses first-write-wins semantics and depends on a stable scan order.
   const scopeRows = await tx
     .select({ id: pages.id, title: pages.title, isDeleted: pages.isDeleted })
     .from(pages)
-    .where(eq(pages.noteId, sourcePageNoteId));
+    .where(eq(pages.noteId, sourcePageNoteId))
+    .orderBy(asc(pages.createdAt), asc(pages.id));
 
   const titleToId = new Map<string, string>();
   const validIds = new Set<string>();
@@ -387,6 +395,102 @@ async function replaceBucket(
 }
 
 /**
+ * 与えられた `tx` 内でリンクグラフ再構築を実行する共通本体。
+ * `sourceNoteId` は呼び出し側がロック取得後に読み出した値を渡すこと。
+ *
+ * Shared core that performs the (source_id, link_type) bucket rewrite inside
+ * an existing transaction. Callers are responsible for first acquiring a
+ * write lock on the source `pages` row and supplying its `noteId`.
+ */
+type TxHandle = ReadHandle & WriteHandle;
+async function rewriteGraphInTx(
+  tx: TxHandle,
+  sourcePageId: string,
+  sourceNoteId: string,
+  doc: Y.Doc,
+): Promise<PageGraphSyncResult> {
+  const refs = extractRefsFromYDoc(doc);
+  const allTargetIds = new Set<string>();
+  for (const ref of refs.wikiRefs) {
+    if (ref.targetId) allTargetIds.add(ref.targetId);
+  }
+  for (const ref of refs.tagRefs) {
+    if (ref.targetId) allTargetIds.add(ref.targetId);
+  }
+  const scope = await buildResolvedScope(tx, sourceNoteId, sourcePageId, allTargetIds);
+
+  const wikiPlan = planBucket(sourcePageId, refs.wikiRefs, scope);
+  const tagPlan = planBucket(sourcePageId, refs.tagRefs, scope);
+
+  const wikiResult = await replaceBucket(
+    tx,
+    sourcePageId,
+    "wiki",
+    wikiPlan.linkTargetIds,
+    wikiPlan.ghostTexts,
+  );
+  const tagResult = await replaceBucket(
+    tx,
+    sourcePageId,
+    "tag",
+    tagPlan.linkTargetIds,
+    tagPlan.ghostTexts,
+  );
+
+  return {
+    wikiLinksInserted: wikiResult.insertedLinks,
+    wikiGhostsInserted: wikiResult.insertedGhosts,
+    tagLinksInserted: tagResult.insertedLinks,
+    tagGhostsInserted: tagResult.insertedGhosts,
+    skippedSourceNotFound: false,
+  };
+}
+
+/**
+ * ソースページ行を `SELECT ... FOR UPDATE` でロックする。
+ * 同一ページに対する並列同期を直列化し、後勝ちで一貫した結果を保証する。
+ *
+ * Acquire a row-level write lock on the source page so that concurrent graph
+ * syncs for the same page serialize. Combined with reading the latest Y.Doc
+ * inside the same transaction, this prevents an older sync from overwriting
+ * a newer one's edges.
+ */
+async function lockSourcePage(
+  tx: TxHandle,
+  sourcePageId: string,
+): Promise<{ noteId: string; isDeleted: boolean } | null> {
+  // drizzle-orm の `select(...).for("update")` で `SELECT ... FOR UPDATE` を発行する。
+  // Issues `SELECT ... FOR UPDATE` so parallel syncs on the same page queue up
+  // instead of racing on `links` / `ghost_links`.
+  const rows = await tx
+    .select({ noteId: pages.noteId, isDeleted: pages.isDeleted })
+    .from(pages)
+    .where(eq(pages.id, sourcePageId))
+    .for("update")
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * `ydocState` カラムの値を `Buffer` に正規化する。
+ * Drizzle / pg ドライバの組み合わせによっては Buffer / Uint8Array / base64 文字列
+ * のいずれかが返るため、`titleRenamePropagationService` と同じ防御策を取る。
+ *
+ * Normalize a `ydoc_state` column value to a `Buffer`. Some driver
+ * configurations hand the bytes back as a base64 string, so handle that
+ * branch explicitly — `Buffer.from(string)` without an encoding would treat
+ * each character as a raw byte and corrupt the payload. Mirrors the helper
+ * in `titleRenamePropagationService.ts`.
+ */
+function toYdocBuffer(ydocState: unknown): Buffer | null {
+  if (ydocState instanceof Buffer) return ydocState;
+  if (ydocState instanceof Uint8Array) return Buffer.from(ydocState);
+  if (typeof ydocState === "string") return Buffer.from(ydocState, "base64");
+  if (ydocState == null) return null;
+  return Buffer.from(ydocState as ArrayBufferLike);
+}
+
+/**
  * `pageId` のソースページについて、Y.Doc の現在内容から
  * `links` / `ghost_links` を `(source_id, link_type)` バケット単位で
  * 再構築する。
@@ -413,56 +517,17 @@ export async function syncPageGraphFromYDoc(
   };
 
   return db.transaction(async (tx) => {
-    // ソースページの note スコープを解決する。削除済み・行欠落は best-effort
-    // としてサイレント no-op（呼び出し側のメイン保存パスは既に終わっている）。
-    // Resolve the source page's note scope. Missing / soft-deleted rows are
-    // treated as a no-op since this service runs in a best-effort context
-    // after the main content save has already succeeded.
-    const sourceRows = await tx
-      .select({ noteId: pages.noteId, isDeleted: pages.isDeleted })
-      .from(pages)
-      .where(eq(pages.id, sourcePageId))
-      .limit(1);
-    const source = sourceRows[0];
+    // ソースページ行を FOR UPDATE でロックし、note スコープを取得する。
+    // 削除済み・行欠落は best-effort としてサイレント no-op
+    // （呼び出し側のメイン保存パスは既に終わっている）。
+    // Lock the source page (FOR UPDATE) and read its note scope. Missing /
+    // soft-deleted rows are treated as a no-op since this service runs in a
+    // best-effort context after the main content save has already succeeded.
+    const source = await lockSourcePage(tx, sourcePageId);
     if (!source || source.isDeleted) {
       return { ...empty, skippedSourceNotFound: true };
     }
-
-    const refs = extractRefsFromYDoc(doc);
-    const allTargetIds = new Set<string>();
-    for (const ref of refs.wikiRefs) {
-      if (ref.targetId) allTargetIds.add(ref.targetId);
-    }
-    for (const ref of refs.tagRefs) {
-      if (ref.targetId) allTargetIds.add(ref.targetId);
-    }
-    const scope = await buildResolvedScope(tx, source.noteId, sourcePageId, allTargetIds);
-
-    const wikiPlan = planBucket(sourcePageId, refs.wikiRefs, scope);
-    const tagPlan = planBucket(sourcePageId, refs.tagRefs, scope);
-
-    const wikiResult = await replaceBucket(
-      tx,
-      sourcePageId,
-      "wiki",
-      wikiPlan.linkTargetIds,
-      wikiPlan.ghostTexts,
-    );
-    const tagResult = await replaceBucket(
-      tx,
-      sourcePageId,
-      "tag",
-      tagPlan.linkTargetIds,
-      tagPlan.ghostTexts,
-    );
-
-    return {
-      wikiLinksInserted: wikiResult.insertedLinks,
-      wikiGhostsInserted: wikiResult.insertedGhosts,
-      tagLinksInserted: tagResult.insertedLinks,
-      tagGhostsInserted: tagResult.insertedGhosts,
-      skippedSourceNotFound: false,
-    };
+    return rewriteGraphInTx(tx, sourcePageId, source.noteId, doc);
   });
 }
 
@@ -471,10 +536,19 @@ export async function syncPageGraphFromYDoc(
  * グラフ同期を実行するラッパー。Hocuspocus 保存後の internal 経路や、API 内
  * の fire-and-forget 呼び出しから使う。
  *
- * Convenience wrapper: read `page_contents.ydoc_state` for `pageId`, hydrate
- * the Y.Doc, and run `syncPageGraphFromYDoc`. Used by the Hocuspocus
- * post-save trigger (via internal HTTP) and by the REST PUT /content path
- * (fire-and-forget).
+ * Convenience wrapper: lock the source page, read the latest
+ * `page_contents.ydoc_state` under that lock, hydrate the Y.Doc, then rewrite
+ * the graph. Used by the Hocuspocus post-save trigger (via internal HTTP)
+ * and by the REST PUT /content path (fire-and-forget).
+ *
+ * 並列保存が連続して走るケース（fire-and-forget で 2 つの同期が ほぼ同時に
+ * 起動する）に備えて、`pages` 行のロック取得後に `page_contents` を読み直す。
+ * これにより「古い Y.Doc を読んでいた古い同期がロック解放後に新しいグラフを
+ * 上書きする」レースを防ぐ。
+ *
+ * Reading `page_contents` inside the transaction (after the `pages` lock) is
+ * what makes the lock useful: it ensures the older of two queued syncs sees
+ * the newer Y.Doc state and never regresses the graph back to an older one.
  *
  * Returns `null` when there is no stored content yet — the caller should
  * treat that as a no-op (graph stays empty).
@@ -483,22 +557,32 @@ export async function syncPageGraphFromStoredYDoc(
   db: Database,
   sourcePageId: string,
 ): Promise<PageGraphSyncResult | null> {
-  const rows = await db
-    .select({ ydocState: pageContents.ydocState })
-    .from(pageContents)
-    .where(eq(pageContents.pageId, sourcePageId))
-    .limit(1);
-  const row = rows[0];
-  if (!row?.ydocState) return null;
+  const empty: PageGraphSyncResult = {
+    wikiLinksInserted: 0,
+    wikiGhostsInserted: 0,
+    tagLinksInserted: 0,
+    tagGhostsInserted: 0,
+    skippedSourceNotFound: false,
+  };
 
-  const buffer =
-    row.ydocState instanceof Buffer
-      ? row.ydocState
-      : Buffer.from(row.ydocState as unknown as ArrayBufferLike);
+  return db.transaction(async (tx) => {
+    const source = await lockSourcePage(tx, sourcePageId);
+    if (!source || source.isDeleted) {
+      return source ? { ...empty, skippedSourceNotFound: true } : null;
+    }
 
-  const doc = new Y.Doc();
-  Y.applyUpdate(doc, new Uint8Array(buffer));
-  return syncPageGraphFromYDoc(db, sourcePageId, doc);
+    const rows = await tx
+      .select({ ydocState: pageContents.ydocState })
+      .from(pageContents)
+      .where(eq(pageContents.pageId, sourcePageId))
+      .limit(1);
+    const buffer = toYdocBuffer(rows[0]?.ydocState);
+    if (!buffer) return null;
+
+    const doc = new Y.Doc();
+    Y.applyUpdate(doc, new Uint8Array(buffer));
+    return rewriteGraphInTx(tx, sourcePageId, source.noteId, doc);
+  });
 }
 
 /**

--- a/src/components/editor/TiptapEditor/useEditorLifecycle.ts
+++ b/src/components/editor/TiptapEditor/useEditorLifecycle.ts
@@ -210,7 +210,13 @@ export function useEditorLifecycle({
       }
     }, 0);
     return () => clearTimeout(timer);
-  }, [editor, isCollabSynced]);
+    // `pageId` を deps に含めることで、エディタインスタンスが使い回されたまま
+    // ページ遷移したケース (上の reset effect が ref を false に戻すケース) でも
+    // この effect が再実行されて正規化が走るようにする。
+    // `pageId` is in deps so that when the editor instance is reused across
+    // page navigation, the reset effect above flips the guard back to false
+    // AND this effect re-runs to perform the normalization on the new page.
+  }, [editor, isCollabSynced, pageId]);
 
   usePasteImageHandler({ editor, handleImageUpload });
 

--- a/src/components/editor/TiptapEditor/useEditorLifecycle.ts
+++ b/src/components/editor/TiptapEditor/useEditorLifecycle.ts
@@ -166,11 +166,21 @@ export function useEditorLifecycle({
   // The `collaborationConfig` object is rebuilt on every parent render; key
   // the effect on the boolean `isSynced` flag so the effect doesn't tear down
   // and re-arm the timer needlessly.
+  // editor インスタンスまたは pageId が切り替わったら、normalization 履歴を
+  // リセットして新しい文書でも一度だけ走るようにする。useRef はマウント中
+  // 値を保持するため、ページ遷移しても明示的に false に戻す必要がある。
+  // Reset the one-shot guard when the editor instance or page changes so a
+  // navigated-to page also runs the normalization once. `useRef` persists
+  // across renders, so without this reset a stale `true` would block the
+  // post-sync pass on the next page.
+  useEffect(() => {
+    wikiLinkNormalizationAppliedRef.current = false;
+  }, [editor, pageId]);
+
   const isCollabSynced = Boolean(collaborationConfig?.isSynced);
   useEffect(() => {
     if (!editor || !isCollabSynced) return;
     if (wikiLinkNormalizationAppliedRef.current) return;
-    wikiLinkNormalizationAppliedRef.current = true;
 
     // editor mount 直後だと PM doc がまだ最終形に落ちていないことがあるため、
     // 1 tick 待ってから走査する。`useContentSanitizer` の初期化フローや、
@@ -178,21 +188,29 @@ export function useEditorLifecycle({
     // Defer one microtask so the editor finishes binding to the synced Y.Doc
     // before we scan it. Matches the deferral pattern used for `initialContent`.
     const timer = setTimeout(() => {
+      // ガードはタイマ起動時ではなく実際に走った時点で flip する。effect
+      // クリーンアップで timer が解除された場合に「未実行なのに guard=true」
+      // 状態を残さないため。
+      // Flip the guard inside the timer (not when scheduling it) so a cleanup
+      // that cancels the timer does not leave the guard armed and silently
+      // skip the real run forever.
+      if (wikiLinkNormalizationAppliedRef.current) return;
+      wikiLinkNormalizationAppliedRef.current = true;
       try {
-        const applied = applyWikiLinkMarksToEditor(editor);
-        if (applied) {
-          // 変更を永続化経路へ流す（collab mode では Y.Doc に伝わるが、
-          // onChange 経由でフロント状態も一致させる）。
-          // Push the JSON downstream so the React-side `content` state matches
-          // the mark transaction's result (Y.Doc already sees it directly).
-          onChange(JSON.stringify(editor.getJSON()));
-        }
+        // `applyWikiLinkMarksToEditor` 内の `editor.view.dispatch(tr)` が
+        // Tiptap の `onUpdate` を発火し、上位 (`useEditorSetup`) で
+        // `onChange(JSON.stringify(editor.getJSON()))` が呼ばれる。
+        // ここで明示的に呼ぶと二重呼び出しになるため呼ばない。
+        // The dispatch inside `applyWikiLinkMarksToEditor` triggers Tiptap's
+        // `onUpdate`, which already invokes `onChange` upstream. Calling it
+        // again here would double-fire the downstream state update.
+        applyWikiLinkMarksToEditor(editor);
       } catch (e) {
         console.error("[WikiLinkNormalize] Failed to normalize post-sync marks", e);
       }
     }, 0);
     return () => clearTimeout(timer);
-  }, [editor, isCollabSynced, onChange]);
+  }, [editor, isCollabSynced]);
 
   usePasteImageHandler({ editor, handleImageUpload });
 

--- a/src/components/editor/extensions/applyWikiLinkMarksToEditor.ts
+++ b/src/components/editor/extensions/applyWikiLinkMarksToEditor.ts
@@ -103,7 +103,14 @@ export function applyWikiLinkMarksToEditor(editor: Editor): boolean {
 
   if (edits.length === 0) return false;
 
-  let tr = editor.state.tr;
+  // この正規化はユーザー操作ではなく初期同期後の機械的処理なので、Undo スタック
+  // に積まない (`addToHistory=false`)。これがないと、最初の Cmd+Z で plain
+  // text `[[Title]]` に戻ってしまい、ユーザーの直前操作 (タイトル入力等) が
+  // 取り消せなくなる。
+  // The normalization is a post-sync, machine-driven cleanup — not a user
+  // edit — so keep it out of the undo stack. Otherwise the first Cmd+Z would
+  // undo the mark promotion instead of the user's most recent change.
+  let tr = editor.state.tr.setMeta("addToHistory", false);
   // `addMark` は文書位置を変えないため、順序に関わらず安全に複数適用できる。
   // `addMark` does not change positions, so the order is irrelevant; iterate
   // in document order for clarity.
@@ -117,11 +124,6 @@ export function applyWikiLinkMarksToEditor(editor: Editor): boolean {
     tr = tr.addMark(edit.from, edit.to, mark);
   }
 
-  // 履歴に残さないことで、ユーザーが「元に戻す」で同期前状態に戻れないようにする
-  // のが望ましいが、Tiptap の history は ProseMirror transaction metadata で扱う。
-  // ここでは標準 dispatch のままにし、必要なら呼び出し側で history を分離する。
-  // We dispatch with default metadata; callers may wrap with `history` meta if
-  // they want to keep the normalization out of the undo stack.
   editor.view.dispatch(tr);
   return true;
 }


### PR DESCRIPTION
## 概要

ページグラフ同期の並列実行時のレース条件を修正し、wiki リンク正規化の一度限りの実行を確実にします。また、CSRF オリジン検証から内部 API を除外します。

## 変更点

### pageGraphSyncService.ts
- **`buildResolvedScope` の安定化**: `createdAt` と `id` でソート順を確定し、同一ノート内の同名ページ解決を決定的にする
- **`lockSourcePage` 関数追加**: `SELECT ... FOR UPDATE` でソースページ行をロックし、並列同期を直列化
- **`rewriteGraphInTx` 関数追加**: グラフ再構築ロジックを共通化し、トランザクション内で実行
- **`toYdocBuffer` ヘルパー追加**: Y.Doc バイナリ状態の正規化（Buffer/Uint8Array/base64 文字列対応）
- **`syncPageGraphFromYDoc` の簡潔化**: ロック取得後に `rewriteGraphInTx` を呼び出す
- **`syncPageGraphFromStoredYDoc` の改善**: トランザクション内でロック→読み込み→再構築を実行し、古い同期が新しいグラフを上書きするレースを防止

### useEditorLifecycle.ts
- **正規化ガード のリセット**: `editor` または `pageId` 変更時に `wikiLinkNormalizationAppliedRef` を `false` にリセット
- **タイマ内でのガード flip**: 効果クリーンアップによるキャンセル時に「未実行なのに guard=true」状態を残さない
- **二重呼び出し排除**: `applyWikiLinkMarksToEditor` の `dispatch` が既に `onChange` を発火するため、明示的な呼び出しを削除

### applyWikiLinkMarksToEditor.ts
- **Undo スタック除外**: `tr.setMeta("addToHistory", false)` で正規化をユーザー操作の履歴から除外

### csrfOrigin.ts
- **内部 API 除外**: `/api/internal/` を CSRF オリジン検証から除外（Hocuspocus サーバ間呼び出し用）

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)

## テスト方法

- 既存の単体テスト・E2E テストが通ることを確認
- 並列保存シナリオ（fire-and-forget で複数の同期が連続実行）でグラフが正しく更新されることを確認
- ページ遷移後に wiki リンク正規化が一度だけ実行されることを確認
- Undo で正規化前の状態に戻らないことを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

https://claude.ai/code/session_01LUjcaQWM8B9xg9QqsMdtPU