### PR TITLE
fix: Add ON DELETE CASCADE to user FKs in invite link tables

### DIFF
--- a/server/api/drizzle/0029_invite_links_user_fk_cascade.sql
+++ b/server/api/drizzle/0029_invite_links_user_fk_cascade.sql
@@ -1,0 +1,42 @@
+-- 0029: Make user FKs on `note_invite_links` / `note_invite_link_redemptions`
+-- explicit `ON DELETE CASCADE` to match the rest of the user FKs in
+-- `server/api/src/schema/notes.ts` (see issue #680, follow-up of #672 / #678).
+--
+-- `created_by_user_id` と `redeemed_by_user_id` は 0013 で
+-- `ON DELETE NO ACTION` のまま登録されていたが、`NOT NULL` と組み合わさると
+-- ユーザー削除が FK 違反でブロックされてしまう。同ファイル内の他の
+-- user FK（`note_members.invited_by_user_id` / `note_invitations.invited_by_user_id`
+-- / `note_domain_access.created_by_user_id`）と同じく `CASCADE` に揃え、
+-- 直接 `DELETE FROM "user"` した場合のオーファン化を防ぐ。
+--
+-- In practice this is a no-op: `note_invite_links.note_id` cascades from
+-- `notes`, which cascades from `user`, so user deletion already wipes
+-- these rows transitively. This migration just closes the edge case where
+-- a user row is deleted without first deleting their notes.
+--
+-- Idempotent / re-run safety: DROP CONSTRAINT IF EXISTS, then re-add inside
+-- a DO block that swallows `duplicate_object` so re-running is safe.
+
+ALTER TABLE "note_invite_links"
+    DROP CONSTRAINT IF EXISTS "note_invite_links_created_by_user_id_user_id_fk";
+--> statement-breakpoint
+DO $$ BEGIN
+    ALTER TABLE "note_invite_links"
+        ADD CONSTRAINT "note_invite_links_created_by_user_id_user_id_fk"
+        FOREIGN KEY ("created_by_user_id") REFERENCES "user"("id")
+        ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "note_invite_link_redemptions"
+    DROP CONSTRAINT IF EXISTS "note_invite_link_redemptions_redeemed_by_user_id_user_id_fk";
+--> statement-breakpoint
+DO $$ BEGIN
+    ALTER TABLE "note_invite_link_redemptions"
+        ADD CONSTRAINT "note_invite_link_redemptions_redeemed_by_user_id_user_id_fk"
+        FOREIGN KEY ("redeemed_by_user_id") REFERENCES "user"("id")
+        ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;

--- a/server/api/drizzle/0029_invite_links_user_fk_cascade.sql
+++ b/server/api/drizzle/0029_invite_links_user_fk_cascade.sql
@@ -40,3 +40,11 @@ DO $$ BEGIN
 EXCEPTION
     WHEN duplicate_object THEN NULL;
 END $$;
+--> statement-breakpoint
+-- `redeemed_by_user_id` 単体のインデックス。
+-- `(link_id, redeemed_by_user_id)` の複合ユニークは先頭列が `link_id` のため
+-- `redeemed_by_user_id` 単独検索には効かず、CASCADE 削除時の seq scan を招く。
+-- Standalone index on `redeemed_by_user_id` so cascade deletes from `user`
+-- can use an index instead of sequential-scanning this table.
+CREATE INDEX IF NOT EXISTS "idx_note_invite_link_redemptions_user"
+    ON "note_invite_link_redemptions" ("redeemed_by_user_id");

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1779062400000,
       "tag": "0028_add_page_snapshots",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1779667200000,
+      "tag": "0029_invite_links_user_fk_cascade",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/src/schema/notes.ts
+++ b/server/api/src/schema/notes.ts
@@ -189,7 +189,7 @@ export const noteInviteLinks = pgTable(
       .default("viewer"),
     createdByUserId: text("created_by_user_id")
       .notNull()
-      .references(() => users.id),
+      .references(() => users.id, { onDelete: "cascade" }),
     /** 有効期限（必須、無期限リンクは作れない） / Expiration (required; no forever links) */
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
     /** 利用上限。null は無制限 / Max redemptions; null means unlimited */
@@ -235,7 +235,7 @@ export const noteInviteLinkRedemptions = pgTable(
       .references(() => noteInviteLinks.id, { onDelete: "cascade" }),
     redeemedByUserId: text("redeemed_by_user_id")
       .notNull()
-      .references(() => users.id),
+      .references(() => users.id, { onDelete: "cascade" }),
     /** 受諾時点のメールアドレス（監査用） / Email at the time of redemption */
     redeemedEmail: text("redeemed_email").notNull(),
     redeemedAt: timestamp("redeemed_at", { withTimezone: true }).defaultNow().notNull(),

--- a/server/api/src/schema/notes.ts
+++ b/server/api/src/schema/notes.ts
@@ -243,6 +243,13 @@ export const noteInviteLinkRedemptions = pgTable(
   (table) => [
     unique("uq_note_invite_link_redemptions_link_user").on(table.linkId, table.redeemedByUserId),
     index("idx_note_invite_link_redemptions_link").on(table.linkId),
+    // `redeemed_by_user_id` 単体のインデックス。`(link_id, redeemed_by_user_id)` の
+    // 複合ユニークでは先頭列でない当列を引けず、`ON DELETE CASCADE` 時の
+    // ユーザー削除でシーケンシャルスキャンになるのを避ける。
+    // Standalone index on `redeemed_by_user_id`; the composite unique above
+    // cannot serve queries that filter only by this column, so cascade
+    // deletes from `user` would otherwise sequential-scan this table.
+    index("idx_note_invite_link_redemptions_user").on(table.redeemedByUserId),
   ],
 );
 


### PR DESCRIPTION
## 概要

`note_invite_links` と `note_invite_link_redemptions` テーブルのユーザー外部キー制約を `ON DELETE CASCADE` に変更し、ユーザー削除時の一貫性を確保します。これにより、ユーザー削除時に FK 違反でブロックされることを防ぎます。

## 変更点

- `note_invite_links.created_by_user_id` の FK を `ON DELETE CASCADE` に変更
- `note_invite_link_redemptions.redeemed_by_user_id` の FK を `ON DELETE CASCADE` に変更
- Drizzle スキーマ定義（`server/api/src/schema/notes.ts`）を更新
- マイグレーション SQL（`0029_invite_links_user_fk_cascade.sql`）を追加
- マイグレーション履歴（`_journal.json`）を更新

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)

## テスト方法

- CI の `drizzle-migration-check` ジョブでスキーマ変更と SQL マイグレーションのペアが検証されます
- マイグレーションは冪等性を持つ設計（`DROP CONSTRAINT IF EXISTS` + `DO` ブロック）のため、再実行時も安全です

## チェックリスト

- [x] Drizzle スキーマと SQL マイグレーションが対応している
- [x] マイグレーション履歴が更新されている
- [x] 冪等性のある SQL 設計

## 関連 Issue

Closes #680 (follow-up of #672 / #678)

## 補足

実装上、`note_invite_links.note_id` が `notes` からカスケード削除され、`notes` が `user` からカスケード削除されるため、ユーザー削除時には既に推移的にこれらの行が削除されます。本マイグレーションは、ユーザー行が直接削除される場合のエッジケースを閉じるものです。

https://claude.ai/code/session_01X3yBBNWdZET7aLj5paCk7H

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Database migration updates to make invite links and redemptions automatically cascade-delete when their users are removed, preventing orphaned records.
* **Performance**
  * Added an index to speed lookups and support efficient cascade deletes on redemption records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->