### PR TITLE
refactor: unify page-detail toolbar into shared PageEditorHeader

### DIFF
--- a/e2e/page-editor.spec.ts
+++ b/e2e/page-editor.spec.ts
@@ -16,11 +16,15 @@ test.describe("Page Editor", () => {
       await expect(page.getByPlaceholder("タイトル")).toBeVisible();
     });
 
-    test("redirects /pages/new to home (direct /pages/new is not a creation entry)", async ({
+    test("redirects /pages/new to the default note (direct /pages/new is not a creation entry)", async ({
       page,
     }) => {
+      // `/pages/new` 直接アクセスは /notes/me に飛ばし、NoteMeRedirect 経由で
+      // 既定の `/notes/:noteId` に着地する (issue #884)。`/home` 経路は廃止。
+      // `/pages/new` redirects to `/notes/me`, which `NoteMeRedirect` then
+      // resolves into `/notes/:noteId` — the legacy `/home` hop is gone (#884).
       await page.goto("/pages/new");
-      await expect(page).toHaveURL(/\/home/, { timeout: 10000 });
+      await expect(page).toHaveURL(/\/notes\/(me|[^/]+)/, { timeout: 10000 });
     });
   });
 
@@ -163,7 +167,14 @@ test.describe("Page Editor", () => {
   });
 
   test.describe("Navigation", () => {
-    test("should navigate back to home on back button click", async ({ page, helpers }) => {
+    // `/home` は #884 で廃止予定。back ボタン / 失敗時の遷移先は /notes/me に集約され、
+    // `NoteMeRedirect` 経由で `/notes/:noteId` に着地する。
+    // `/home` is being retired in #884: back-button navigation now lands on
+    // `/notes/me` which `NoteMeRedirect` resolves to `/notes/:noteId`.
+    test("should navigate back to the default note on back button click", async ({
+      page,
+      helpers,
+    }) => {
       await helpers.createNewPage(page);
 
       // Enter title to avoid delete warning
@@ -173,8 +184,8 @@ test.describe("Page Editor", () => {
       // Click back button
       await page.locator('button:has(svg[class*="lucide-arrow-left"])').click();
 
-      // Should be on home page
-      await expect(page).toHaveURL("/home");
+      // Should land on the default note (via /notes/me redirect)
+      await expect(page).toHaveURL(/\/notes\/(me|[^/]+)/);
     });
 
     test("should delete page on back if title is empty", async ({ page, helpers }) => {
@@ -187,15 +198,15 @@ test.describe("Page Editor", () => {
       // Click back button
       await page.locator('button:has(svg[class*="lucide-arrow-left"])').click();
 
-      // Should be on home page
-      await expect(page).toHaveURL("/home");
+      // Should land on the default note (via /notes/me redirect)
+      await expect(page).toHaveURL(/\/notes\/(me|[^/]+)/);
 
       // Page should not exist anymore
       await page.goto(pageUrl);
       await page.waitForTimeout(1000);
 
-      // Should redirect to home (page not found)
-      await expect(page).toHaveURL("/home");
+      // Should redirect to the default note (page not found)
+      await expect(page).toHaveURL(/\/notes\/(me|[^/]+)/);
     });
   });
 
@@ -229,13 +240,13 @@ test.describe("Page Editor", () => {
       await page.locator('button:has(svg[class*="lucide-more-horizontal"])').click();
       await page.getByText("削除").click();
 
-      // Should redirect to home
-      await expect(page).toHaveURL("/home");
+      // Should redirect to the default note (via /notes/me)
+      await expect(page).toHaveURL(/\/notes\/(me|[^/]+)/);
 
       // Page should not exist
       await page.goto(pageUrl);
       await page.waitForTimeout(1000);
-      await expect(page).toHaveURL("/home");
+      await expect(page).toHaveURL(/\/notes\/(me|[^/]+)/);
     });
   });
 
@@ -250,8 +261,8 @@ test.describe("Page Editor", () => {
       // Press Cmd+H (or Ctrl+H on Windows/Linux)
       await page.keyboard.press("Meta+h");
 
-      // Should be on home page
-      await expect(page).toHaveURL("/home");
+      // Should land on the default note (via /notes/me redirect)
+      await expect(page).toHaveURL(/\/notes\/(me|[^/]+)/);
     });
   });
 
@@ -329,7 +340,11 @@ test.describe("Page Editor", () => {
       await deletePromise;
 
       await expect(page.getByRole("alertdialog")).not.toBeVisible({ timeout: 5000 });
-      await expect(page).toHaveURL("/home");
+      // /home は /notes/me に redirect され、その後 NoteMeRedirect が /notes/:noteId
+      // に着地させるため、最終 URL は note detail になる (#884)。
+      // The /home hop redirects through /notes/me into /notes/:noteId, so the
+      // final URL after the delete settles on the note detail (#884).
+      await expect(page).toHaveURL(/\/notes\/(me|[^/]+)/);
       await expect(card).toHaveCount(0);
 
       const fab = page.locator('[data-testid="home-fab"]');

--- a/src/components/editor/PageEditor/PageEditorHeader.test.tsx
+++ b/src/components/editor/PageEditor/PageEditorHeader.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { PageEditorHeader } from "./PageEditorHeader";
+import { Copy, Download, History, Trash2 } from "lucide-react";
+import { PageEditorHeader, type PageDetailToolbarAction } from "./PageEditorHeader";
 
 vi.mock("../ConnectionIndicator", () => ({
   ConnectionIndicator: ({ onReconnect }: { onReconnect: () => void }) => (
@@ -25,16 +26,11 @@ vi.mock("@/lib/dateUtils", () => ({
 // actual `editor.savedAt` template behaviour.
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string, opts?: Record<string, unknown>) => {
-      if (key === "editor.savedAt" && opts?.relative !== undefined) {
+    t: (key: string, opts?: Record<string, unknown> | string) => {
+      if (key === "editor.savedAt" && typeof opts === "object" && opts?.relative !== undefined) {
         return `${String(opts.relative)}に保存`;
       }
-      if (key === "editor.pageMenu.exportMarkdown") return "Markdownでエクスポート";
-      if (key === "editor.pageMenu.copyMarkdown") return "Markdownをコピー";
-      if (key === "editor.pageMenu.deletePage") return "削除";
-      if (key === "editor.pageHistory.menuButton") return "変更履歴";
-      if (key === "common.back") return "戻る";
-      if (key === "common.moreActions") return "more";
+      if (typeof opts === "string") return opts;
       return key;
     },
   }),
@@ -45,16 +41,95 @@ vi.mock("@/contexts/GlobalSearchContext", () => ({
   useGlobalSearchContextOptional: () => null,
 }));
 
-const defaultProps = {
-  lastSaved: null as number | null,
-  onBack: vi.fn(),
-  onDelete: vi.fn(),
-  onExportMarkdown: vi.fn(),
-  onCopyMarkdown: vi.fn(),
-};
+/**
+ * `/pages/:id` の既定アクションメニュー項目をテストヘルパーとして組み立てる。
+ * 既存テストが `onDelete` / `onExportMarkdown` などの個別 prop に依存していたため、
+ * 新しい `menuItems` API でも同じ振る舞いを再現できることを示す。
+ *
+ * Build the same default-action menu items `/pages/:id` uses, so the tests
+ * exercise the new `menuItems` API end-to-end while preserving the labels
+ * and callbacks the old per-prop API exposed.
+ */
+function buildPageEditorMenuItems(opts: {
+  onDelete: () => void;
+  onExportMarkdown: () => void;
+  onCopyMarkdown: () => void;
+  onOpenHistory?: () => void;
+}): PageDetailToolbarAction[] {
+  const items: PageDetailToolbarAction[] = [];
+  if (opts.onOpenHistory) {
+    items.push({
+      id: "history",
+      label: "変更履歴",
+      icon: History,
+      onClick: opts.onOpenHistory,
+    });
+  }
+  items.push({
+    id: "export-markdown",
+    label: "Markdownでエクスポート",
+    icon: Download,
+    onClick: opts.onExportMarkdown,
+  });
+  items.push({
+    id: "copy-markdown",
+    label: "Markdownをコピー",
+    icon: Copy,
+    onClick: opts.onCopyMarkdown,
+  });
+  items.push({
+    id: "delete",
+    label: "削除",
+    icon: Trash2,
+    onClick: opts.onDelete,
+    destructive: true,
+    separatorBefore: true,
+  });
+  return items;
+}
 
-function renderHeader(overrides = {}) {
-  return render(<PageEditorHeader {...defaultProps} {...overrides} />);
+interface RenderOverrides {
+  lastSaved?: number | null;
+  onBack?: () => void;
+  onDelete?: () => void;
+  onExportMarkdown?: () => void;
+  onCopyMarkdown?: () => void;
+  onOpenHistory?: () => void;
+  menuItems?: PageDetailToolbarAction[];
+  supplementalRightContent?: React.ReactNode;
+  collaboration?: React.ComponentProps<typeof PageEditorHeader>["collaboration"];
+  includeDefaultMenu?: boolean;
+}
+
+function renderHeader(overrides: RenderOverrides = {}) {
+  const {
+    lastSaved = null,
+    onBack = vi.fn(),
+    onDelete = vi.fn(),
+    onExportMarkdown = vi.fn(),
+    onCopyMarkdown = vi.fn(),
+    onOpenHistory,
+    menuItems,
+    supplementalRightContent,
+    collaboration,
+    includeDefaultMenu = true,
+  } = overrides;
+
+  const resolvedMenuItems =
+    menuItems ??
+    (includeDefaultMenu
+      ? buildPageEditorMenuItems({ onDelete, onExportMarkdown, onCopyMarkdown, onOpenHistory })
+      : undefined);
+
+  return render(
+    <PageEditorHeader
+      lastSaved={lastSaved}
+      onBack={onBack}
+      menuItems={resolvedMenuItems}
+      supplementalRightContent={supplementalRightContent}
+      collaboration={collaboration}
+    />,
+  );
 }
 
 describe("PageEditorHeader", () => {
@@ -96,6 +171,21 @@ describe("PageEditorHeader", () => {
       renderHeader();
       expect(screen.queryByText("未設定")).not.toBeInTheDocument();
       expect(screen.queryByText("接続済み")).not.toBeInTheDocument();
+    });
+
+    it("menuItems が空または未指定のとき、… ボタン自体を表示しない / hides the more-actions button when no menu items", () => {
+      renderHeader({ includeDefaultMenu: false });
+      // back button のみで more-actions のトリガーは存在しないはず
+      // Only the back button is present; the menu trigger should be absent.
+      const buttons = screen.getAllByRole("button");
+      expect(buttons).toHaveLength(1);
+    });
+
+    it("supplementalRightContent を渡すと右側に追加コンテンツを表示する / renders supplemental right content", () => {
+      renderHeader({
+        supplementalRightContent: <span data-testid="extra">閲覧専用</span>,
+      });
+      expect(screen.getByTestId("extra")).toHaveTextContent("閲覧専用");
     });
   });
 
@@ -186,11 +276,49 @@ describe("PageEditorHeader", () => {
       expect(onReconnect).toHaveBeenCalledTimes(1);
     });
 
-    it("スクロールで非表示になったヘッダーはフォーカス対象から外れる", async () => {
+    it("カスタム menuItems が表示され、クリックでハンドラが呼ばれる / renders custom menu items and routes clicks", async () => {
       const user = userEvent.setup();
+      const onCopyToPersonal = vi.fn();
+      renderHeader({
+        menuItems: [
+          {
+            id: "copy-to-personal",
+            label: "個人に取り込み",
+            icon: Download,
+            onClick: onCopyToPersonal,
+          },
+        ],
+      });
+      const buttons = screen.getAllByRole("button");
+      await user.click(buttons[buttons.length - 1]);
+      const item = await screen.findByRole("menuitem", { name: /個人に取り込み/ });
+      await user.click(item);
+      expect(onCopyToPersonal).toHaveBeenCalledTimes(1);
+    });
+
+    it("menuItems の disabled をセットすると DropdownMenuItem の data-disabled が立つ / honours disabled flag", async () => {
+      const user = userEvent.setup();
+      const onClick = vi.fn();
+      renderHeader({
+        menuItems: [
+          {
+            id: "copy-to-personal",
+            label: "個人に取り込み",
+            onClick,
+            disabled: true,
+          },
+        ],
+      });
+      const buttons = screen.getAllByRole("button");
+      await user.click(buttons[buttons.length - 1]);
+      const item = await screen.findByRole("menuitem", { name: /個人に取り込み/ });
+      expect(item).toHaveAttribute("data-disabled");
+    });
+
+    it("スクロールで非表示になったヘッダーはフォーカス対象から外れる", async () => {
       const { container } = render(
         <div style={{ overflowY: "auto" }}>
-          <PageEditorHeader {...defaultProps} />
+          <PageEditorHeader onBack={vi.fn()} />
         </div>,
       );
 

--- a/src/components/editor/PageEditor/PageEditorHeader.tsx
+++ b/src/components/editor/PageEditor/PageEditorHeader.tsx
@@ -87,17 +87,40 @@ function getScrollTop(target: HTMLElement | Window): number {
  * caller decide which actions are exposed in the more-actions menu.
  */
 export interface PageDetailToolbarAction {
-  /** Stable identifier used as the React key and for testing hooks. */
+  /**
+   * 安定した識別子。React の key とテストのフックに使う。
+   * Stable identifier used as the React key and for testing hooks.
+   */
   id: string;
-  /** Visible label / aria label. */
+  /**
+   * 表示ラベル兼アクセシブルネーム。
+   * Visible label / aria label.
+   */
   label: string;
-  /** Optional leading icon component (e.g. `Trash2`, `Download`). */
+  /**
+   * メニュー項目左側に表示するアイコンコンポーネント（例: `Trash2`, `Download`）。
+   * Optional leading icon component (e.g. `Trash2`, `Download`).
+   */
   icon?: React.ComponentType<{ className?: string }>;
+  /**
+   * メニュー項目クリック時のハンドラ。
+   * Handler invoked when the menu item is clicked.
+   */
   onClick: () => void;
+  /**
+   * 真のとき項目を無効化する（mutation pending 中など）。
+   * Disable the item (e.g. while a mutation is pending).
+   */
   disabled?: boolean;
-  /** Apply destructive styling (red text). */
+  /**
+   * 破壊的アクション用のスタイル（赤文字）を適用する。
+   * Apply destructive styling (red text).
+   */
   destructive?: boolean;
-  /** Render a visual separator immediately before this item. */
+  /**
+   * この項目の直前に視覚的な区切り線を入れる。
+   * Render a visual separator immediately before this item.
+   */
   separatorBefore?: boolean;
 }
 

--- a/src/components/editor/PageEditor/PageEditorHeader.tsx
+++ b/src/components/editor/PageEditor/PageEditorHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { ArrowLeft, Trash2, MoreHorizontal, Download, Copy, History } from "lucide-react";
+import { ArrowLeft, MoreHorizontal } from "lucide-react";
 import { Button, cn } from "@zedi/ui";
 import {
   DropdownMenu,
@@ -77,14 +77,57 @@ function getScrollTop(target: HTMLElement | Window): number {
   return target instanceof Window ? window.scrollY : target.scrollTop;
 }
 
+/**
+ * ページ詳細ツールバーのアクションメニュー項目。`/pages/:id` と
+ * `/notes/:noteId/:pageId` で共通の見た目・スクロール挙動を再利用しつつ、
+ * メニュー項目だけは呼び出し側が定義できるようにする。
+ *
+ * Menu item for the shared page-detail toolbar. Lets `/pages/:id` and
+ * `/notes/:noteId/:pageId` share layout / scroll behaviour while letting the
+ * caller decide which actions are exposed in the more-actions menu.
+ */
+export interface PageDetailToolbarAction {
+  /** Stable identifier used as the React key and for testing hooks. */
+  id: string;
+  /** Visible label / aria label. */
+  label: string;
+  /** Optional leading icon component (e.g. `Trash2`, `Download`). */
+  icon?: React.ComponentType<{ className?: string }>;
+  onClick: () => void;
+  disabled?: boolean;
+  /** Apply destructive styling (red text). */
+  destructive?: boolean;
+  /** Render a visual separator immediately before this item. */
+  separatorBefore?: boolean;
+}
+
 interface PageEditorHeaderProps {
-  lastSaved: number | null;
+  /**
+   * 最終保存時刻のタイムスタンプ。指定したときだけ「○○前に保存」を表示する。
+   * 閲覧専用やノート側のように保存時刻を持たないページ詳細では未指定でよい。
+   *
+   * Last-saved timestamp. The savedAt label is only shown when this is set,
+   * so read-only or note-detail callers without a save timestamp can omit it.
+   */
+  lastSaved?: number | null;
   onBack: () => void;
-  onDelete: () => void;
-  onExportMarkdown: () => void;
-  onCopyMarkdown: () => void;
-  /** 変更履歴モーダルを開く / Open version history modal */
-  onOpenHistory?: () => void;
+  /**
+   * ドロップダウンメニューに表示するアクション。空または未指定なら
+   * 「…」ボタン自体を出さない。
+   *
+   * Items in the more-actions dropdown. The trigger button is hidden when
+   * this is empty or undefined, so callers that have no actions get a clean
+   * toolbar with just the back button (plus any supplemental content).
+   */
+  menuItems?: PageDetailToolbarAction[];
+  /**
+   * 戻るボタンと「…」メニューの間に並べる追加コンテンツ。閲覧専用ラベルや
+   * カスタムボタンを差し込むためのスロット。
+   *
+   * Extra content rendered between the back button and the more-actions
+   * menu. Use it for things like the "閲覧専用" badge on note pages.
+   */
+  supplementalRightContent?: React.ReactNode;
   /** リアルタイムコラボレーション状態（有効時のみ渡す） */
   collaboration?: {
     status: ConnectionStatus;
@@ -95,20 +138,20 @@ interface PageEditorHeaderProps {
 }
 
 /**
- * Page-specific toolbar for PageEditor. Shown below the common `Header`
- * (which already provides search / UnifiedMenu), so this toolbar only
- * contains editor-specific actions (back, collaboration status, more menu).
+ * 共通ヘッダー直下に並べるページ詳細用ツールバー。`/pages/:id` と
+ * `/notes/:noteId/:pageId` の両方で同じ sticky / scroll-hide / inert 挙動を
+ * 共有するための薄いコンポーネント。
  *
- * PageEditor のページ固有ツールバー。検索・ユーザーメニューは共通 `Header`
- * 側で提供されるため、ここではエディタ固有の操作（戻る・コラボ・その他メニュー）のみ。
+ * Shared page-detail toolbar shown below the global `Header`. Both
+ * `/pages/:id` and `/notes/:noteId/:pageId` reuse this component so they
+ * share the same sticky / scroll-hide / inert focus behaviour; only the
+ * action menu items and supplemental content differ.
  */
 export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
   lastSaved,
   onBack,
-  onDelete,
-  onExportMarkdown,
-  onCopyMarkdown,
-  onOpenHistory,
+  menuItems,
+  supplementalRightContent,
   collaboration,
 }) => {
   const { t } = useTranslation();
@@ -158,6 +201,8 @@ export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
     }
   }, [hidden]);
 
+  const hasMenu = Boolean(menuItems && menuItems.length > 0);
+
   return (
     <div
       ref={wrapperRef}
@@ -197,42 +242,42 @@ export const PageEditorHeader: React.FC<PageEditorHeaderProps> = ({
             </span>
           )}
 
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label={t("common.moreActions", "More actions")}
-                className="h-12 w-12"
-              >
-                <MoreHorizontal className="h-5 w-5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {onOpenHistory && (
-                <DropdownMenuItem onClick={onOpenHistory}>
-                  <History className="mr-2 h-4 w-4" />
-                  {t("editor.pageHistory.menuButton")}
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuItem onClick={onExportMarkdown}>
-                <Download className="mr-2 h-4 w-4" />
-                {t("editor.pageMenu.exportMarkdown")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={onCopyMarkdown}>
-                <Copy className="mr-2 h-4 w-4" />
-                {t("editor.pageMenu.copyMarkdown")}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onClick={onDelete}
-                className="text-destructive focus:text-destructive"
-              >
-                <Trash2 className="mr-2 h-4 w-4" />
-                {t("editor.pageMenu.deletePage")}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {supplementalRightContent}
+
+          {hasMenu && menuItems && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={t("common.moreActions", "More actions")}
+                  className="h-12 w-12"
+                >
+                  <MoreHorizontal className="h-5 w-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {menuItems.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <React.Fragment key={item.id}>
+                      {item.separatorBefore && <DropdownMenuSeparator />}
+                      <DropdownMenuItem
+                        onClick={item.onClick}
+                        disabled={item.disabled}
+                        className={
+                          item.destructive ? "text-destructive focus:text-destructive" : undefined
+                        }
+                      >
+                        {Icon && <Icon className="mr-2 h-4 w-4" />}
+                        {item.label}
+                      </DropdownMenuItem>
+                    </React.Fragment>
+                  );
+                })}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
       </Container>
     </div>

--- a/src/components/editor/PageEditor/PageEditorLayout.test.tsx
+++ b/src/components/editor/PageEditor/PageEditorLayout.test.tsx
@@ -11,15 +11,27 @@ import type { PageEditorLayoutProps } from "./PageEditorLayout";
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
 vi.mock("./PageEditorHeader", () => ({
-  PageEditorHeader: ({ onOpenHistory }: { onOpenHistory?: () => void }) => (
-    <div data-testid="editor-header">
-      {onOpenHistory && (
-        <button data-testid="open-history-btn" onClick={onOpenHistory}>
-          Open History
-        </button>
-      )}
-    </div>
-  ),
+  PageEditorHeader: ({
+    menuItems,
+  }: {
+    menuItems?: Array<{ id: string; label: string; onClick: () => void }>;
+  }) => {
+    // PageEditorLayout は履歴メニュー項目を `menuItems` 配列で渡すように変更された
+    // ため、テストでも id ベースで該当項目を引いて click をディスパッチする。
+    // PageEditorLayout now passes the history action via the `menuItems` array,
+    // so the mock surfaces buttons keyed by id (matching the production
+    // toolbar item ids) instead of the old per-prop callbacks.
+    const historyItem = menuItems?.find((item) => item.id === "history");
+    return (
+      <div data-testid="editor-header">
+        {historyItem && (
+          <button data-testid="open-history-btn" onClick={historyItem.onClick}>
+            Open History
+          </button>
+        )}
+      </div>
+    );
+  },
 }));
 
 vi.mock("./PageEditorAlerts", () => ({

--- a/src/components/editor/PageEditor/PageEditorLayout.tsx
+++ b/src/components/editor/PageEditor/PageEditorLayout.tsx
@@ -1,5 +1,7 @@
-import React, { useState, useCallback } from "react";
-import { PageEditorHeader } from "./PageEditorHeader";
+import React, { useMemo, useState, useCallback } from "react";
+import { Copy, Download, History, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { PageEditorHeader, type PageDetailToolbarAction } from "./PageEditorHeader";
 import { PageEditorAlerts } from "./PageEditorAlerts";
 import { PageEditorContent } from "./PageEditorContent";
 import { PageEditorDialogs } from "./PageEditorDialogs";
@@ -100,6 +102,7 @@ export const PageEditorLayout: React.FC<PageEditorLayoutProps> = (props) => {
     onWikiContentApplied,
   } = props;
 
+  const { t } = useTranslation();
   const [historyOpen, setHistoryOpen] = useState(false);
 
   const handleOpenHistory = useCallback(() => {
@@ -111,6 +114,42 @@ export const PageEditorLayout: React.FC<PageEditorLayoutProps> = (props) => {
     // Reload the page after restore to reflect the latest state
     window.location.reload();
   }, []);
+
+  // 個人ページ詳細のアクションメニュー項目。共通ツールバー (`PageEditorHeader`)
+  // へ渡せる形にまとめる。並び順は従来の: 履歴 → エクスポート → コピー → 区切り → 削除。
+  // Menu items for the personal page detail toolbar. Order preserves the
+  // previous layout: history → export → copy → separator → delete.
+  const menuItems = useMemo<PageDetailToolbarAction[]>(
+    () => [
+      {
+        id: "history",
+        label: t("editor.pageHistory.menuButton"),
+        icon: History,
+        onClick: handleOpenHistory,
+      },
+      {
+        id: "export-markdown",
+        label: t("editor.pageMenu.exportMarkdown"),
+        icon: Download,
+        onClick: onExportMarkdown,
+      },
+      {
+        id: "copy-markdown",
+        label: t("editor.pageMenu.copyMarkdown"),
+        icon: Copy,
+        onClick: onCopyMarkdown,
+      },
+      {
+        id: "delete",
+        label: t("editor.pageMenu.deletePage"),
+        icon: Trash2,
+        onClick: onDelete,
+        destructive: true,
+        separatorBefore: true,
+      },
+    ],
+    [t, handleOpenHistory, onExportMarkdown, onCopyMarkdown, onDelete],
+  );
 
   // React Compiler が optional chain の依存を保持できないため先に抽出する
   // Extract ydoc to avoid React Compiler memoization issue with optional chaining
@@ -128,10 +167,7 @@ export const PageEditorLayout: React.FC<PageEditorLayoutProps> = (props) => {
         <PageEditorHeader
           lastSaved={displayLastSaved}
           onBack={onBack}
-          onDelete={onDelete}
-          onExportMarkdown={onExportMarkdown}
-          onCopyMarkdown={onCopyMarkdown}
-          onOpenHistory={handleOpenHistory}
+          menuItems={menuItems}
           collaboration={undefined}
         />
 

--- a/src/components/editor/PageEditor/usePageDeletion.test.ts
+++ b/src/components/editor/PageEditor/usePageDeletion.test.ts
@@ -145,7 +145,7 @@ describe("usePageDeletion.handleOpenDuplicatePage", () => {
     expect(result.current.deleteConfirmOpen).toBe(false);
   });
 
-  it("キャンセル後に handleBack を使うと /home へ戻る / pendingNavTarget resets so handleBack goes back to /home", () => {
+  it("キャンセル後に handleBack を使うと /notes/me へ戻る / pendingNavTarget resets so handleBack goes back to /notes/me", () => {
     const { result } = renderHook(() =>
       usePageDeletion({
         currentPageId: "dup-id",
@@ -162,8 +162,8 @@ describe("usePageDeletion.handleOpenDuplicatePage", () => {
     // handleBack は hasContent のため確認ダイアログを開くだけ
     act(() => result.current.handleConfirmDelete());
 
-    // 最終 navigate は /home であるべき
-    expect(mockNavigate).toHaveBeenLastCalledWith("/home");
+    // 最終 navigate は /notes/me であるべき
+    expect(mockNavigate).toHaveBeenLastCalledWith("/notes/me");
   });
 });
 
@@ -292,7 +292,7 @@ describe("usePageDeletion - cancelPendingSave 順序 (issue #768)", () => {
     act(() => result.current.handleDelete());
 
     expect(callOrder).toEqual(["mutate", "cancel"]);
-    expect(mockNavigate).toHaveBeenCalledWith("/home");
+    expect(mockNavigate).toHaveBeenCalledWith("/notes/me");
   });
 
   it("handleDelete: 削除失敗時は cancelPendingSave を呼ばず保留保存を保持する (Codex P2)", () => {

--- a/src/components/editor/PageEditor/usePageDeletion.ts
+++ b/src/components/editor/PageEditor/usePageDeletion.ts
@@ -51,7 +51,7 @@ interface UsePageDeletionReturn {
  * issue #768: 削除を発火する前に呼び出し側 (`useEditorAutoSave`) の
  * `cancelPendingSave` を必ず実行し、保留中の autosave debounce と unmount
  * flush を抑止する。これにより `updatePage` が論理削除を上書きして
- * 「無題のページ」が `/home` に復活するレースを防ぐ。`handleDelete` だけは
+ * 「無題のページ」が `/notes/me` に復活するレースを防ぐ。`handleDelete` だけは
  * `onError` でユーザーがエディタに残るため、保留中の編集を落とさないよう
  * `onSuccess` 内（navigate 直前）でのみキャンセルする。
  *
@@ -64,7 +64,7 @@ interface UsePageDeletionReturn {
  * `cancelPendingSave` (from `useEditorAutoSave`) to clear pending autosave
  * debounces and suppress the unmount flush, preventing the race where
  * `updatePage` overwrites the soft delete and an "untitled" row reappears
- * on `/home`. `handleDelete` is the exception: its `onError` keeps the user
+ * on `/notes/me`. `handleDelete` is the exception: its `onError` keeps the user
  * on the editor, so cancellation is deferred to `onSuccess` (just before
  * `navigate`) to avoid silently dropping queued edits on a failed delete.
  */
@@ -81,16 +81,16 @@ export function usePageDeletion({
 
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [deleteReason, setDeleteReason] = useState<string>("");
-  // 確認ダイアログ確定後の遷移先。デフォルトは /home。
-  // Navigation target to use after the confirmation dialog resolves. Defaults to /home.
-  const [pendingNavTarget, setPendingNavTarget] = useState<string>("/home");
+  // 確認ダイアログ確定後の遷移先。デフォルトは /notes/me。
+  // Navigation target to use after the confirmation dialog resolves. Defaults to /notes/me.
+  const [pendingNavTarget, setPendingNavTarget] = useState<string>("/notes/me");
 
   const handleDelete = useCallback(() => {
     if (currentPageId) {
       // issue #768 + Codex P2: 他のハンドラと違い、`handleDelete` の `onError`
       // ではユーザーがエディタに残るため、削除失敗時に保留中の autosave を
       // 落とすと最近の編集が失われる。そのため `cancelPendingSave` は削除が
-      // 成功して `/home` に遷移する直前（`onSuccess` 内）でのみ呼ぶ。
+      // 成功して `/notes/me` に遷移する直前（`onSuccess` 内）でのみ呼ぶ。
       //
       // issue #768 + Codex P2: unlike the other handlers, `handleDelete`'s
       // `onError` keeps the user on the editor, so cancelling the pending
@@ -103,7 +103,7 @@ export function usePageDeletion({
           toast({
             title: "ページを削除しました",
           });
-          navigate("/home");
+          navigate("/notes/me");
         },
         onError: () => {
           toast({
@@ -134,7 +134,7 @@ export function usePageDeletion({
           setDeleteReason("タイトルが未入力のページ");
         }
         // 戻る経由なので遷移先はホーム
-        setPendingNavTarget("/home");
+        setPendingNavTarget("/notes/me");
         setDeleteConfirmOpen(true);
         return;
       }
@@ -154,7 +154,7 @@ export function usePageDeletion({
         });
       }
     }
-    navigate("/home");
+    navigate("/notes/me");
   }, [
     navigate,
     currentPageId,
@@ -179,7 +179,7 @@ export function usePageDeletion({
     setDeleteConfirmOpen(false);
     navigate(pendingNavTarget);
     // 次回に備えてデフォルトに戻す / reset to default for next invocation
-    setPendingNavTarget("/home");
+    setPendingNavTarget("/notes/me");
   }, [
     currentPageId,
     deletePageMutation,
@@ -192,7 +192,7 @@ export function usePageDeletion({
 
   const handleCancelDelete = useCallback(() => {
     setDeleteConfirmOpen(false);
-    setPendingNavTarget("/home");
+    setPendingNavTarget("/notes/me");
   }, []);
 
   const handleOpenDuplicatePage = useCallback(

--- a/src/components/editor/PageEditor/usePageEditorEffects.test.tsx
+++ b/src/components/editor/PageEditor/usePageEditorEffects.test.tsx
@@ -85,7 +85,7 @@ describe("usePageEditorEffects", () => {
   });
 
   describe("navigation and initialization", () => {
-    it("navigates to /home when isNewPage is true", () => {
+    it("navigates to /notes/me when isNewPage is true", () => {
       renderHook(
         () =>
           usePageEditorEffects(
@@ -104,10 +104,10 @@ describe("usePageEditorEffects", () => {
         { wrapper },
       );
 
-      expect(mockNavigate).toHaveBeenCalledWith("/home", { replace: true });
+      expect(mockNavigate).toHaveBeenCalledWith("/notes/me", { replace: true });
     });
 
-    it("does not redirect to /home when isNewPage is false", () => {
+    it("does not redirect to /notes/me when isNewPage is false", () => {
       renderHook(
         () =>
           usePageEditorEffects(
@@ -121,7 +121,7 @@ describe("usePageEditorEffects", () => {
         { wrapper },
       );
 
-      expect(wasNavigateCalledWithPath(mockNavigate, "/home")).toBe(false);
+      expect(wasNavigateCalledWithPath(mockNavigate, "/notes/me")).toBe(false);
     });
 
     it("calls initialize when page is set and not yet initialized", () => {
@@ -219,7 +219,7 @@ describe("usePageEditorEffects", () => {
       expect(initialize).toHaveBeenCalledWith(page);
     });
 
-    it("redirects to /home when isNewPage flips to true after mount", () => {
+    it("redirects to /notes/me when isNewPage flips to true after mount", () => {
       const { rerender } = renderHook(
         (props: { isNewPage: boolean }) =>
           usePageEditorEffects(
@@ -233,11 +233,11 @@ describe("usePageEditorEffects", () => {
         { wrapper, initialProps: { isNewPage: false } },
       );
 
-      expect(wasNavigateCalledWithPath(mockNavigate, "/home")).toBe(false);
+      expect(wasNavigateCalledWithPath(mockNavigate, "/notes/me")).toBe(false);
 
       rerender({ isNewPage: true });
 
-      expect(mockNavigate).toHaveBeenCalledWith("/home", { replace: true });
+      expect(mockNavigate).toHaveBeenCalledWith("/notes/me", { replace: true });
     });
   });
 

--- a/src/components/editor/PageEditor/usePageEditorEffects.ts
+++ b/src/components/editor/PageEditor/usePageEditorEffects.ts
@@ -76,10 +76,13 @@ export function usePageEditorEffects(options: UsePageEditorEffectsOptions) {
 
   const { setPageContext, contentAppendHandlerRef } = useAIChatContext();
 
-  // /pages/new への直接アクセスはホームへリダイレクト
+  // /pages/new への直接アクセスはデフォルトノート (/notes/me) へリダイレクト。
+  // /home は #884 で廃止予定のため /notes/me に統一する。
+  // Direct visits to /pages/new redirect to the caller's default note
+  // (/notes/me). /home is being retired in #884 so we route to /notes/me.
   useEffect(() => {
     if (isNewPage) {
-      navigate("/home", { replace: true });
+      navigate("/notes/me", { replace: true });
     }
   }, [isNewPage, navigate]);
 

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -8,6 +8,7 @@
   "back": "Back",
   "open": "Open",
   "moreActions": "More actions",
+  "readOnly": "Read only",
   "goToSettings": "Go to settings",
   "loading": "Loading...",
   "error": "Error",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -8,6 +8,7 @@
   "back": "戻る",
   "open": "開く",
   "moreActions": "その他の操作",
+  "readOnly": "閲覧専用",
   "goToSettings": "設定画面へ",
   "loading": "読み込み中...",
   "error": "エラー",

--- a/src/pages/NotePageView.test.tsx
+++ b/src/pages/NotePageView.test.tsx
@@ -12,6 +12,8 @@ import {
 import { useAuth } from "@/hooks/useAuth";
 import { AIChatProvider } from "@/contexts/AIChatContext";
 
+const { mockNavigate } = vi.hoisted(() => ({ mockNavigate: vi.fn() }));
+
 // `vi.hoisted` で共有フック用の `vi.fn()` を巻き上げる。`vi.mock` のファクトリは
 // hoisting されてテストスコープの変数を参照できないので、モジュール境界をまたぐ
 // 共有状態はこの方式にする必要がある。`mockToast` を差し込むことで、`handleCopyToPersonal`
@@ -35,6 +37,7 @@ vi.mock("react-router-dom", async (importOriginal) => {
   return {
     ...actual,
     useParams: vi.fn(),
+    useNavigate: () => mockNavigate,
   };
 });
 
@@ -48,6 +51,11 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, fallback?: string) => fallback ?? key,
   }),
+  initReactI18next: { type: "3rdParty", init: () => undefined },
+  // Translation 関連の他コンシューマー（dateUtils → @/i18n 経由）が
+  // 副作用で import するための最低限のスタブ。
+  // Minimal stub so other consumers that pull in `@/i18n` via dateUtils
+  // (which uses `initReactI18next`) can load without a real i18n boot.
 }));
 
 vi.mock("@/hooks/useNoteQueries", () => ({
@@ -135,22 +143,34 @@ vi.mock("@/components/ai-chat/ContentWithAIChat", () => ({
 }));
 
 vi.mock("@zedi/ui", () => ({
-  Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
-    <button type="button" onClick={onClick}>
-      {children}
-    </button>
-  ),
-  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DropdownMenuItem: ({
+  Button: ({
     children,
     onClick,
+    "aria-label": ariaLabel,
   }: {
     children: React.ReactNode;
     onClick?: () => void;
+    "aria-label"?: string;
   }) => (
-    <button type="button" onClick={onClick}>
+    <button type="button" onClick={onClick} aria-label={ariaLabel}>
+      {children}
+    </button>
+  ),
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuSeparator: () => <hr data-testid="dropdown-separator" />,
+  DropdownMenuItem: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
       {children}
     </button>
   ),
@@ -180,6 +200,7 @@ describe("NotePageView", () => {
     vi.clearAllMocks();
     mockToast.mockReset();
     mockSetPageContext.mockReset();
+    mockNavigate.mockReset();
     mockUpdatePageMutateAsync.mockResolvedValue({ skipped: false });
     mockApi.getPageContent.mockReset();
     mockApi.putPageContent.mockReset();
@@ -231,6 +252,121 @@ describe("NotePageView", () => {
     renderNotePageView();
 
     expect(screen.getByText(/ページが見つからないか、閲覧権限がありません/)).toBeInTheDocument();
+  });
+
+  // ── 共通ツールバー (`PageEditorHeader`) 統合 ─────────────────────
+  // Issue #884: NotePageView は `/pages/:id` と同じツールバーを再利用する。
+  // back ボタンは必ず `/notes/:noteId` に戻り、`/home` への fallback には依存
+  // しない。閲覧専用ラベル / 個人取り込みメニューは引き続き出すが、それぞれ
+  // 共通ツールバーの `supplementalRightContent` / `menuItems` 経由で渡される。
+  //
+  // Issue #884: NotePageView reuses the shared `PageEditorHeader`. Back must
+  // navigate to `/notes/:noteId` (no legacy `/home` fallback). Read-only
+  // badge and the "copy to personal" action still appear, but they now flow
+  // through the toolbar's `supplementalRightContent` / `menuItems` slots.
+  describe("shared toolbar (issue #884)", () => {
+    it("back ボタンは /notes/:noteId に遷移する / clicking back navigates to /notes/:noteId", () => {
+      vi.mocked(useNote).mockReturnValue({
+        note: { id: "note-1" },
+        access: { canView: true, canEdit: true },
+        source: "local",
+        isLoading: false,
+      } as never);
+      vi.mocked(useNotePage).mockReturnValue({
+        data: {
+          id: "page-1",
+          title: "Test Page",
+          content: "{}",
+          ownerUserId: "user-1",
+          noteId: "note-1",
+        },
+        isLoading: false,
+      } as never);
+
+      renderNotePageView();
+
+      // The back button uses aria-label "Back" (from i18n mock fallback).
+      const backButton = screen.getByRole("button", { name: "Back" });
+      fireEvent.click(backButton);
+
+      expect(mockNavigate).toHaveBeenCalledWith("/notes/note-1");
+      expect(mockNavigate).not.toHaveBeenCalledWith("/home");
+    });
+
+    it("閲覧専用ユーザーには `閲覧専用` ラベルが共通ツールバー右側に出る / surfaces the read-only badge for non-editors", () => {
+      vi.mocked(useNote).mockReturnValue({
+        note: { id: "note-1" },
+        access: { canView: true, canEdit: false },
+        source: "local",
+        isLoading: false,
+      } as never);
+      vi.mocked(useNotePage).mockReturnValue({
+        data: {
+          id: "page-1",
+          title: "Read only",
+          content: "{}",
+          ownerUserId: "user-other",
+          noteId: "note-1",
+        },
+        isLoading: false,
+      } as never);
+
+      renderNotePageView();
+
+      expect(screen.getByText("閲覧専用")).toBeInTheDocument();
+    });
+
+    it("編集可能ユーザーには `閲覧専用` ラベルを出さない / hides the badge when canEdit", () => {
+      vi.mocked(useNote).mockReturnValue({
+        note: { id: "note-1" },
+        access: { canView: true, canEdit: true },
+        source: "local",
+        isLoading: false,
+      } as never);
+      vi.mocked(useNotePage).mockReturnValue({
+        data: {
+          id: "page-1",
+          title: "Editable",
+          content: "{}",
+          ownerUserId: "user-1",
+          noteId: "note-1",
+        },
+        isLoading: false,
+      } as never);
+
+      renderNotePageView();
+
+      expect(screen.queryByText("閲覧専用")).not.toBeInTheDocument();
+    });
+
+    it("note 側未実装の削除アクションを共通ツールバーに露出しない / does not surface the personal-page delete action", () => {
+      vi.mocked(useNote).mockReturnValue({
+        note: { id: "note-1" },
+        access: { canView: true, canEdit: true },
+        source: "local",
+        isLoading: false,
+      } as never);
+      vi.mocked(useNotePage).mockReturnValue({
+        data: {
+          id: "page-1",
+          title: "Note-native",
+          content: "{}",
+          ownerUserId: "user-1",
+          noteId: "note-1",
+        },
+        isLoading: false,
+      } as never);
+
+      renderNotePageView();
+
+      // `/pages/:id` のツールバーは削除 / Markdown ボタンを露出するが、note 側はまだ未実装。
+      // The `/pages/:id` toolbar exposes delete / Markdown actions, but note pages
+      // don't implement them yet — verify they stay hidden.
+      expect(screen.queryByText("editor.pageMenu.deletePage")).not.toBeInTheDocument();
+      expect(screen.queryByText("editor.pageMenu.exportMarkdown")).not.toBeInTheDocument();
+      expect(screen.queryByText("editor.pageMenu.copyMarkdown")).not.toBeInTheDocument();
+      expect(screen.queryByText("editor.pageHistory.menuButton")).not.toBeInTheDocument();
+    });
   });
 
   it("renders editor when note and page are loaded with canEdit", () => {

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -418,7 +418,9 @@ const NotePageView: React.FC = () => {
       onBack={handleBack}
       menuItems={menuItems}
       supplementalRightContent={
-        !canEdit ? <span className="text-muted-foreground text-xs">閲覧専用</span> : undefined
+        !canEdit ? (
+          <span className="text-muted-foreground text-xs">{t("common.readOnly", "閲覧専用")}</span>
+        ) : undefined
       }
     />
   );

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -1,18 +1,14 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Download, MoreHorizontal } from "lucide-react";
-import Container from "@/components/layout/Container";
+import { Download } from "lucide-react";
 import { PageLoadingOrDenied } from "@/components/layout/PageLoadingOrDenied";
 import { PageEditorContent } from "@/components/editor/PageEditor/PageEditorContent";
 import {
-  Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  useToast,
-} from "@zedi/ui";
+  PageEditorHeader,
+  type PageDetailToolbarAction,
+} from "@/components/editor/PageEditor/PageEditorHeader";
+import { Button, useToast } from "@zedi/ui";
 import { useTranslation } from "react-i18next";
 import {
   useNote,
@@ -71,6 +67,7 @@ function NotePageEditorEditable({
   collaboration,
   isCollaborationEnabled,
   isTitleEditable,
+  toolbar,
 }: {
   page: Page;
   noteId: string;
@@ -78,6 +75,16 @@ function NotePageEditorEditable({
   isCollaborationEnabled: boolean;
   /** ページ所有者のみタイトル編集可。Only the page owner can edit the title. */
   isTitleEditable: boolean;
+  /**
+   * Sticky toolbar rendered as the first child of the scroll container
+   * (`ContentWithAIChat`), above `NoteWorkspaceToolbar`. Passed in from the
+   * parent so the shared `PageEditorHeader` can hook into the same scroll
+   * area and toggle visibility on scroll.
+   *
+   * 共通ツールバー。`ContentWithAIChat` の生成するスクロールコンテナ直下に
+   * 配置することで、`PageEditorHeader` の sticky / scroll-hide 挙動を維持する。
+   */
+  toolbar?: React.ReactNode;
 }): React.JSX.Element {
   const [editorContent, setEditorContent] = useState(page.content ?? "");
   const [title, setTitle] = useState(page.title);
@@ -244,6 +251,7 @@ function NotePageEditorEditable({
 
   return (
     <ContentWithAIChat>
+      {toolbar}
       <NoteWorkspaceToolbar />
       <PageEditorContent
         content={editorContent}
@@ -294,11 +302,12 @@ const NotePageView: React.FC = () => {
   );
 
   const handleBack = useCallback(() => {
-    if (noteId) {
-      navigate(`/notes/${noteId}`);
-    } else {
-      navigate("/home");
-    }
+    // `/notes/:noteId/:pageId` ルートなので `noteId` は常に存在する。`/home`
+    // への fallback は廃止済み（issue #884）。
+    // The route guarantees `noteId`, so we always navigate back to the
+    // owning note view. The legacy `/home` fallback was removed in #884.
+    if (!noteId) return;
+    navigate(`/notes/${noteId}`);
   }, [navigate, noteId]);
 
   const canEdit = canEditPage(access, userId, page);
@@ -313,10 +322,15 @@ const NotePageView: React.FC = () => {
   });
 
   // ノートネイティブページを自分の個人ページにコピーする (issue #713 Phase 3)。
-  // 元のノートページはノートに残り、コピーのみが呼び出し元の /home に現れる。
-  // 成功時はトーストで新しい個人ページへ誘導する。
-  // Copy this note-native page into the caller's personal pages. Source stays
-  // in the note; only the copy lands on /home. Toast offers to jump to it.
+  // 元のノートページはノートに残り、コピーのみが呼び出し元の個人ページ一覧
+  // (`/notes/me`) に現れる。成功時はトーストで新しい個人ページへ誘導する。
+  //
+  // Copy this note-native page into the caller's personal pages. Source
+  // stays in the note; only the copy lands in the caller's default note
+  // (`/notes/me`). The toast offers a CTA to jump to it. Plain function on
+  // purpose: `useCallback` cannot preserve memoization here (the mutation
+  // object identity flips with state transitions) so we let React Compiler
+  // handle the surrounding memo.
   const handleCopyToPersonal = async () => {
     if (!noteId || !page?.id) return;
     try {
@@ -332,7 +346,8 @@ const NotePageView: React.FC = () => {
       // If the server-side copy succeeded but the IndexedDB write-through did
       // not (`localImported: false`), navigating `/pages/:id` would land on
       // an empty read because the page grid reads IDB. Keep the success toast
-      // but drop the "Open" CTA; the next sync will reconcile `/home`.
+      // but drop the "Open" CTA; the next sync will reconcile the personal
+      // page list.
       toast({
         title: t("notes.pageCopiedToPersonal"),
         action: result.localImported ? (
@@ -349,6 +364,30 @@ const NotePageView: React.FC = () => {
       });
     }
   };
+
+  // 共通ツールバーに渡すアクションメニュー。ノートネイティブページ
+  // (`page.noteId === noteId`) かつサインイン済みのときだけ「個人に取り込み」
+  // を出す。`page.noteId === null` のリンク済み個人ページや未ログイン状態では
+  // サーバー側で copy が拒否されるため UI 側でも非表示にする（Codex P2）。
+  //
+  // Menu items for the shared toolbar. Surface "copy to personal" only for
+  // note-native pages (`page.noteId === noteId`) and signed-in viewers; the
+  // server rejects copy for linked personal pages (`page.noteId === null`)
+  // so we hide the entry instead of showing a guaranteed-fail action.
+  const showCopyToPersonal = Boolean(isSignedIn && page && page.noteId === noteId);
+  const menuItems: PageDetailToolbarAction[] | undefined = showCopyToPersonal
+    ? [
+        {
+          id: "copy-to-personal",
+          label: t("notes.copyToPersonal"),
+          icon: Download,
+          onClick: () => {
+            void handleCopyToPersonal();
+          },
+          disabled: copyToPersonalMutation.isPending,
+        },
+      ]
+    : undefined;
 
   const isLoading = isNoteLoading || isPageLoading;
   const isNotFound = !note || !access?.canView || !page;
@@ -369,75 +408,37 @@ const NotePageView: React.FC = () => {
     );
   }
 
+  // 共通ツールバー本体。canEdit 分岐で配置場所が変わるため JSX を一度だけ生成する。
+  // The shared toolbar is rendered once and placed inside whichever scroll
+  // container is active (`ContentWithAIChat` for editors, `bodyClassName`
+  // for read-only viewers) so `PageEditorHeader` can find a scrollable
+  // ancestor and remain sticky.
+  const toolbar = (
+    <PageEditorHeader
+      onBack={handleBack}
+      menuItems={menuItems}
+      supplementalRightContent={
+        !canEdit ? <span className="text-muted-foreground text-xs">閲覧専用</span> : undefined
+      }
+    />
+  );
+
+  // 編集時は ContentWithAIChat 内のモバイルスクロールラッパー（flex-1 +
+  // overflow-y-auto）に高さを伝搬させるため、ラッパーも flex 列にする。
+  // ブロックレイアウトのままだと子の `flex-1` が効かず、スクロールラッパーが
+  // コンテンツ高さに張り付き overflow-y-auto が発火しない。
+  // 閲覧専用時はここで本文をスクロールさせる。
+  // When editing, this wrapper is a flex column so the bounded height
+  // propagates down to ContentWithAIChat's mobile scroll wrapper (which
+  // relies on flex-1). In read-only mode, this wrapper scrolls the body
+  // itself.
+  const bodyClassName = canEdit
+    ? "flex min-h-0 flex-1 flex-col md:overflow-hidden"
+    : "min-h-0 flex-1 overflow-y-auto md:overflow-hidden";
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      <div className="border-border/60 shrink-0 border-b">
-        <Container className="flex h-10 items-center justify-between">
-          <Button variant="ghost" size="icon" onClick={handleBack}>
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-          <div className="flex items-center gap-2">
-            {!canEdit && <span className="text-muted-foreground text-xs">閲覧専用</span>}
-            {/*
-              「個人に取り込み」はノートネイティブページ (`page.noteId === noteId`) だけに出す。
-              このノートにリンクされているだけの個人ページ (`page.noteId === null`) は、
-              所有者ならすでに /home にあり、他メンバーにはサーバーがコピーを拒否する
-              （`Page does not belong to this note`）ため、メニューに出すと決め打ちで
-              失敗するアクションになる。両方の意味でリンク済みページでは出さない。
-              Issue #713 Phase 3 / Codex P2。
-
-              Gate "copy to personal" to note-native pages (`page.noteId === noteId`).
-              Linked personal pages (`page.noteId === null`) are already on the
-              owner's /home and, for other members, the server rejects the copy
-              (`Page does not belong to this note`). Showing the action for them
-              is a guaranteed-fail path, so hide it. Issue #713 Phase 3 / Codex P2.
-            */}
-            {isSignedIn && page.noteId === noteId && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={t("common.moreActions", "More actions")}
-                  >
-                    <MoreHorizontal className="h-4 w-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem
-                    onClick={handleCopyToPersonal}
-                    disabled={copyToPersonalMutation.isPending}
-                  >
-                    <Download className="mr-2 h-4 w-4" />
-                    {t("notes.copyToPersonal")}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
-          </div>
-        </Container>
-      </div>
-
-      {/* 編集時は `ContentWithAIChat` 側がスクロールを管理するため、このラッパーでは
-          二重スクロールを避ける。閲覧専用時は従来どおりここで本文をスクロールさせる。
-          When editing, `ContentWithAIChat` owns the scroll container, so keep
-          this wrapper non-scrollable to avoid nested scroll regions. In
-          read-only mode, this wrapper still scrolls the page body. */}
-      {/* 編集時は ContentWithAIChat 内のモバイルスクロールラッパー（flex-1 +
-          overflow-y-auto）に高さを伝搬させるため、このラッパーも flex 列にする。
-          ブロックレイアウトのままだと子の `flex-1` が効かず、スクロールラッパーが
-          コンテンツ高さに張り付き overflow-y-auto が発火しない。
-          When editing, this wrapper must be a flex column so the bounded height
-          propagates down to ContentWithAIChat's mobile scroll wrapper (which
-          relies on flex-1). Without `flex flex-col`, the child's `flex-1` is a
-          no-op in block layout and `overflow-y-auto` never engages. */}
-      <div
-        className={
-          canEdit
-            ? "flex min-h-0 flex-1 flex-col md:overflow-hidden"
-            : "min-h-0 flex-1 overflow-y-auto md:overflow-hidden"
-        }
-      >
+      <div className={bodyClassName}>
         <NoteWorkspaceProvider key={note.id} noteId={note.id}>
           {canEdit ? (
             <NotePageEditorEditable
@@ -447,23 +448,27 @@ const NotePageView: React.FC = () => {
               collaboration={collaboration}
               isCollaborationEnabled={isCollaborationEnabled}
               isTitleEditable={isTitleEditable}
+              toolbar={toolbar}
             />
           ) : (
-            <PageEditorContent
-              content={page?.content ?? ""}
-              title={page.title}
-              sourceUrl={page.sourceUrl}
-              currentPageId={page.id}
-              pageId={page.id}
-              isNewPage={false}
-              isWikiGenerating={false}
-              isReadOnly={true}
-              showLinkedPages={false}
-              showToolbar={false}
-              onContentChange={() => undefined}
-              onContentError={() => undefined}
-              pageNoteId={page.noteId ?? null}
-            />
+            <>
+              {toolbar}
+              <PageEditorContent
+                content={page?.content ?? ""}
+                title={page.title}
+                sourceUrl={page.sourceUrl}
+                currentPageId={page.id}
+                pageId={page.id}
+                isNewPage={false}
+                isWikiGenerating={false}
+                isReadOnly={true}
+                showLinkedPages={false}
+                showToolbar={false}
+                onContentChange={() => undefined}
+                onContentError={() => undefined}
+                pageNoteId={page.noteId ?? null}
+              />
+            </>
           )}
         </NoteWorkspaceProvider>
       </div>


### PR DESCRIPTION
## 概要

`PageEditorHeader` を共通ツールバーコンポーネントに再設計し、`/pages/:id`（個人ページ）と `/notes/:noteId/:pageId`（ノートページ）の両方で同じ sticky / scroll-hide 挙動を共有できるようにしました。アクションメニュー項目を呼び出し側が定義できる `menuItems` API に変更し、ツールバーの見た目・スクロール挙動は統一しつつ、各ページタイプで異なるアクションを柔軟に露出できるようにしました。

## 変更点

- **PageEditorHeader の API 刷新**
  - 個別の `onDelete`, `onExportMarkdown`, `onCopyMarkdown`, `onOpenHistory` props を廃止
  - `menuItems?: PageDetailToolbarAction[]` で統一的にアクション定義
  - `supplementalRightContent?: React.ReactNode` で追加コンテンツ（閲覧専用ラベルなど）を挿入可能に
  - `lastSaved` をオプション化（読み取り専用ページでは不要）
  - メニュー項目がない場合は「…」ボタン自体を非表示

- **NotePageView の統合**
  - 従来のヘッダー（戻るボタン + 閲覧専用ラベル + ドロップダウン）を `PageEditorHeader` に統一
  - 「個人に取り込み」アクションを `menuItems` 経由で渡す
  - 閲覧専用ラベルを `supplementalRightContent` 経由で渡す
  - 編集時は `ContentWithAIChat` 内に toolbar を配置、読み取り専用時は別途配置

- **PageEditorLayout の更新**
  - 個人ページ詳細のアクションメニュー（履歴・エクスポート・コピー・削除）を `menuItems` 配列で構築
  - `useMemo` で依存関係を明示的に管理

- **issue #884 対応**
  - `/pages/new` 直接アクセス時の遷移先を `/home` から `/notes/me` に変更
  - NotePageView の back ボタンは常に `/notes/:noteId` に遷移（`/home` fallback を廃止）
  - E2E テストと単体テストを更新

## 変更の種類

- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `bun run test` で単体テストが全てパス
   - `PageEditorHeader.test.tsx`: 新しい `menuItems` API と `supplementalRightContent` をテスト
   - `NotePageView.test.tsx`: back ボタン遷移、閲覧専用ラベル、個人取り込みメニューをテスト
   - `PageEditorLayout.test.tsx`: 個人ページのアクションメニュー構築をテスト
   - `usePageEditorEffects.test.tsx`: `/pages/new` → `/notes/me` リダイレクトをテスト

2. `bun run test:e2e` で E2E テストが全てパス
   - `/pages/new` 直接アクセスが `/notes/me` にリダイレクト
   - back ボタンが `/notes/:noteId` に遷移

https://claude.ai/code/session_01Vr4qaChJy2dqF3Kqjo81Nz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared sticky toolbar rendered consistently; supplemental right-side content supported
  * Read-only badge added for non-editors; new localized labels for it

* **Bug Fixes**
  * Routing updated: retire `/home` in favor of `/notes/me` and `/notes/:noteId`
  * Back-button and delete/navigation flows now land on note detail routes

* **Tests**
  * Updated test expectations to reflect new routing and toolbar behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->