### PR TITLE
feat(#890): align NotePageView toolbar with /pages/:id (history/export/copy/delete)

### DIFF
--- a/src/pages/NotePageView.test.tsx
+++ b/src/pages/NotePageView.test.tsx
@@ -3,12 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useParams } from "react-router-dom";
 import NotePageView from "./NotePageView";
-import {
-  useNote,
-  useNotePage,
-  useCopyNotePageToPersonal,
-  useNoteApi,
-} from "@/hooks/useNoteQueries";
+import { useNote, useNotePage, useNoteApi, useRemovePageFromNote } from "@/hooks/useNoteQueries";
 import { useAuth } from "@/hooks/useAuth";
 import { AIChatProvider } from "@/contexts/AIChatContext";
 
@@ -16,13 +11,18 @@ const { mockNavigate } = vi.hoisted(() => ({ mockNavigate: vi.fn() }));
 
 // `vi.hoisted` で共有フック用の `vi.fn()` を巻き上げる。`vi.mock` のファクトリは
 // hoisting されてテストスコープの変数を参照できないので、モジュール境界をまたぐ
-// 共有状態はこの方式にする必要がある。`mockToast` を差し込むことで、`handleCopyToPersonal`
-// が `toast({...})` に渡した `action` をテストから検査できるようにする。
+// 共有状態はこの方式にする必要がある。
 // Hoist `vi.fn()` refs so the mock factory (which runs before the test body)
-// can see them. Required because `vi.mock` hoists above normal `const`s. The
-// shared `mockToast` lets tests inspect what `toast({...})` was called with
-// — in particular whether the `action` (toast CTA) was supplied.
-const { mockToast, mockUpdatePageMutateAsync, mockApi, mockSetPageContext } = vi.hoisted(() => ({
+// can see them. Required because `vi.mock` hoists above normal `const`s.
+const {
+  mockToast,
+  mockUpdatePageMutateAsync,
+  mockApi,
+  mockSetPageContext,
+  mockExportMarkdown,
+  mockCopyMarkdown,
+  mockRemoveFromNoteMutate,
+} = vi.hoisted(() => ({
   mockToast: vi.fn(),
   mockUpdatePageMutateAsync: vi.fn().mockResolvedValue({ skipped: false }),
   mockApi: {
@@ -30,6 +30,9 @@ const { mockToast, mockUpdatePageMutateAsync, mockApi, mockSetPageContext } = vi
     putPageContent: vi.fn(),
   },
   mockSetPageContext: vi.fn(),
+  mockExportMarkdown: vi.fn(),
+  mockCopyMarkdown: vi.fn().mockResolvedValue(undefined),
+  mockRemoveFromNoteMutate: vi.fn(),
 }));
 
 vi.mock("react-router-dom", async (importOriginal) => {
@@ -49,7 +52,16 @@ vi.mock("react-router-dom", async (importOriginal) => {
 // real locale data. (CodeRabbit.)
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string, fallback?: string) => fallback ?? key,
+    t: (key: string, fallback?: string) => {
+      // `t(key, { title })` のようなオプション引数は無視して生キーを返す。
+      // 既存テストはどれもキー文字列での DOM 引きを前提にしているため、補間後
+      // の文字列を期待しているテストはない。文字列フォールバックはそのまま返す。
+      // Ignore option objects (e.g. `{ title }`) and return the raw key; the
+      // existing assertions consistently match on the i18n key. A second-arg
+      // string fallback (`t(key, "default")`) is passed through verbatim.
+      if (typeof fallback === "string") return fallback;
+      return key;
+    },
   }),
   initReactI18next: { type: "3rdParty", init: () => undefined },
   // Translation 関連の他コンシューマー（dateUtils → @/i18n 経由）が
@@ -68,10 +80,8 @@ vi.mock("@/hooks/useNoteQueries", () => ({
     isSignedIn: true,
     isLoaded: true,
   })),
-  useCopyNotePageToPersonal: vi.fn(() => ({
-    mutateAsync: vi
-      .fn()
-      .mockResolvedValue({ created: true, page_id: "pg-copy", localImported: true }),
+  useRemovePageFromNote: vi.fn(() => ({
+    mutate: mockRemoveFromNoteMutate,
     isPending: false,
   })),
   noteKeys: {
@@ -107,6 +117,29 @@ vi.mock("@/contexts/AIChatContext", () => ({
 
 vi.mock("@/hooks/useCollaboration", () => ({
   useCollaboration: vi.fn(() => ({})),
+}));
+
+vi.mock("@/components/editor/PageEditor/useMarkdownExport", () => ({
+  useMarkdownExport: vi.fn(() => ({
+    handleExportMarkdown: mockExportMarkdown,
+    handleCopyMarkdown: mockCopyMarkdown,
+  })),
+}));
+
+// `PageHistoryModal` は重い依存（yjs / snapshot queries）を引き込むので、テスト
+// 用に「open のときだけ存在を示す要素を出す」軽量モックに差し替える。`pageId`
+// は data-attr で読めるようにして履歴がどのページに対して開いたかを検証できる
+// ようにする。
+// Mock `PageHistoryModal` to avoid pulling in yjs + snapshot queries during
+// this test. The mock renders a marker only while `open` is true and exposes
+// `pageId` so tests can assert the history opened for the correct page.
+vi.mock("@/components/editor/pageHistory/PageHistoryModal", () => ({
+  PageHistoryModal: ({ open, pageId }: { open: boolean; pageId: string }) =>
+    open ? (
+      <div data-testid="page-history-modal" data-page-id={pageId}>
+        history
+      </div>
+    ) : null,
 }));
 
 vi.mock("@/components/layout/Header", () => ({
@@ -174,6 +207,53 @@ vi.mock("@zedi/ui", () => ({
       {children}
     </button>
   ),
+  // ── AlertDialog: `open` のときだけ children を描画する最小モック ──
+  // 削除確認ダイアログのテストで `Action` を直接クリックして mutation を発火
+  // する想定。`onClick` の `preventDefault` も呼ばれるが、ここでは Radix の
+  // 自動 close をシミュレートしないので、production と同じく `onSuccess` /
+  // `onError` 経由でしか閉じない動線を維持できる。
+  //
+  // Minimal AlertDialog mock: render children only while `open`. Tests click
+  // `AlertDialogAction` directly to fire the mutation; we don't simulate Radix
+  // auto-close so the close-on-success / close-on-error contract is exercised.
+  AlertDialog: ({ open, children }: { open?: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="delete-confirm-dialog">{children}</div> : null,
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  AlertDialogCancel: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled} data-testid="confirm-cancel">
+      {children}
+    </button>
+  ),
+  AlertDialogAction: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: (e: React.MouseEvent) => void;
+    disabled?: boolean;
+  }) => (
+    <button
+      type="button"
+      onClick={(e) => onClick?.(e)}
+      disabled={disabled}
+      data-testid="confirm-delete"
+    >
+      {children}
+    </button>
+  ),
   useToast: () => ({ toast: mockToast }),
 }));
 
@@ -204,6 +284,13 @@ describe("NotePageView", () => {
     mockUpdatePageMutateAsync.mockResolvedValue({ skipped: false });
     mockApi.getPageContent.mockReset();
     mockApi.putPageContent.mockReset();
+    mockExportMarkdown.mockReset();
+    mockCopyMarkdown.mockReset().mockResolvedValue(undefined);
+    mockRemoveFromNoteMutate.mockReset();
+    vi.mocked(useRemovePageFromNote).mockReturnValue({
+      mutate: mockRemoveFromNoteMutate,
+      isPending: false,
+    } as never);
     vi.mocked(useParams).mockReturnValue({ noteId: "note-1", pageId: "page-1" });
     vi.mocked(useAuth).mockReturnValue({ isSignedIn: true, userId: "user-1" } as never);
     vi.mocked(useNoteApi).mockReturnValue({
@@ -256,15 +343,11 @@ describe("NotePageView", () => {
 
   // ── 共通ツールバー (`PageEditorHeader`) 統合 ─────────────────────
   // Issue #884: NotePageView は `/pages/:id` と同じツールバーを再利用する。
-  // back ボタンは必ず `/notes/:noteId` に戻り、`/home` への fallback には依存
-  // しない。閲覧専用ラベル / 個人取り込みメニューは引き続き出すが、それぞれ
-  // 共通ツールバーの `supplementalRightContent` / `menuItems` 経由で渡される。
+  // back ボタンは必ず `/notes/:noteId` に戻り、`/home` への fallback には依存しない。
   //
   // Issue #884: NotePageView reuses the shared `PageEditorHeader`. Back must
-  // navigate to `/notes/:noteId` (no legacy `/home` fallback). Read-only
-  // badge and the "copy to personal" action still appear, but they now flow
-  // through the toolbar's `supplementalRightContent` / `menuItems` slots.
-  describe("shared toolbar (issue #884)", () => {
+  // navigate to `/notes/:noteId` (no legacy `/home` fallback).
+  describe("shared toolbar (issue #884 / #890)", () => {
     it("back ボタンは /notes/:noteId に遷移する / clicking back navigates to /notes/:noteId", () => {
       vi.mocked(useNote).mockReturnValue({
         note: { id: "note-1" },
@@ -285,7 +368,6 @@ describe("NotePageView", () => {
 
       renderNotePageView();
 
-      // The back button uses aria-label "Back" (from i18n mock fallback).
       const backButton = screen.getByRole("button", { name: "Back" });
       fireEvent.click(backButton);
 
@@ -339,7 +421,9 @@ describe("NotePageView", () => {
       expect(screen.queryByText("閲覧専用")).not.toBeInTheDocument();
     });
 
-    it("note 側未実装の削除アクションを共通ツールバーに露出しない / does not surface the personal-page delete action", () => {
+    // Issue #890: アクションメニューを `/pages/:id` と同じ4項目に揃える。
+    // Issue #890: align the action menu with `/pages/:id` (4 items).
+    it("編集可能時、共通ツールバーに `/pages/:id` と同じ4項目を出す / surfaces the four `/pages/:id` actions when editable", () => {
       vi.mocked(useNote).mockReturnValue({
         note: { id: "note-1" },
         access: { canView: true, canEdit: true },
@@ -359,13 +443,178 @@ describe("NotePageView", () => {
 
       renderNotePageView();
 
-      // `/pages/:id` のツールバーは削除 / Markdown ボタンを露出するが、note 側はまだ未実装。
-      // The `/pages/:id` toolbar exposes delete / Markdown actions, but note pages
-      // don't implement them yet — verify they stay hidden.
+      expect(screen.getByText("editor.pageHistory.menuButton")).toBeInTheDocument();
+      expect(screen.getByText("editor.pageMenu.exportMarkdown")).toBeInTheDocument();
+      expect(screen.getByText("editor.pageMenu.copyMarkdown")).toBeInTheDocument();
+      expect(screen.getByText("editor.pageMenu.deletePage")).toBeInTheDocument();
+      // 旧「個人に取り込み」項目は削除されていることを明示的に検証する。
+      // Explicitly verify the removed "copy to personal" entry is gone.
+      expect(screen.queryByText("notes.copyToPersonal")).not.toBeInTheDocument();
+    });
+
+    it("read-only 時、削除以外の3項目だけを出す / shows history/export/copy but hides delete in read-only mode", () => {
+      vi.mocked(useNote).mockReturnValue({
+        note: { id: "note-1" },
+        access: { canView: true, canEdit: false },
+        source: "local",
+        isLoading: false,
+      } as never);
+      vi.mocked(useNotePage).mockReturnValue({
+        data: {
+          id: "page-1",
+          title: "Read only",
+          content: "{}",
+          ownerUserId: "user-other",
+          noteId: "note-1",
+        },
+        isLoading: false,
+      } as never);
+
+      renderNotePageView();
+
+      expect(screen.getByText("editor.pageHistory.menuButton")).toBeInTheDocument();
+      expect(screen.getByText("editor.pageMenu.exportMarkdown")).toBeInTheDocument();
+      expect(screen.getByText("editor.pageMenu.copyMarkdown")).toBeInTheDocument();
+      // read-only では削除は出さない（権限がないため）。
+      // Delete is hidden in read-only mode (no permission).
       expect(screen.queryByText("editor.pageMenu.deletePage")).not.toBeInTheDocument();
-      expect(screen.queryByText("editor.pageMenu.exportMarkdown")).not.toBeInTheDocument();
-      expect(screen.queryByText("editor.pageMenu.copyMarkdown")).not.toBeInTheDocument();
-      expect(screen.queryByText("editor.pageHistory.menuButton")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("menu actions (issue #890)", () => {
+    function setupEditableRender(overrides?: { canEdit?: boolean; noteId?: string | null }) {
+      const canEdit = overrides?.canEdit ?? true;
+      const noteIdValue = overrides?.noteId ?? "note-1";
+      vi.mocked(useNote).mockReturnValue({
+        note: { id: "note-1" },
+        access: { canView: true, canEdit },
+        source: "local",
+        isLoading: false,
+      } as never);
+      vi.mocked(useNotePage).mockReturnValue({
+        data: {
+          id: "page-1",
+          title: "Note title",
+          content: "Note body",
+          ownerUserId: canEdit ? "user-1" : "user-other",
+          noteId: noteIdValue,
+        },
+        isLoading: false,
+      } as never);
+    }
+
+    it("`変更履歴` をクリックすると `PageHistoryModal` を開く / opens PageHistoryModal on history click", () => {
+      setupEditableRender();
+      renderNotePageView();
+
+      // 開く前は modal 非表示 / modal hidden initially
+      expect(screen.queryByTestId("page-history-modal")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("editor.pageHistory.menuButton"));
+
+      const modal = screen.getByTestId("page-history-modal");
+      expect(modal).toBeInTheDocument();
+      expect(modal).toHaveAttribute("data-page-id", "page-1");
+    });
+
+    it("`Markdownでエクスポート` で `handleExportMarkdown` を呼ぶ / invokes handleExportMarkdown on export click", () => {
+      setupEditableRender();
+      renderNotePageView();
+
+      fireEvent.click(screen.getByText("editor.pageMenu.exportMarkdown"));
+
+      expect(mockExportMarkdown).toHaveBeenCalledTimes(1);
+    });
+
+    it("`Markdownをコピー` で `handleCopyMarkdown` を呼ぶ / invokes handleCopyMarkdown on copy click", () => {
+      setupEditableRender();
+      renderNotePageView();
+
+      fireEvent.click(screen.getByText("editor.pageMenu.copyMarkdown"));
+
+      expect(mockCopyMarkdown).toHaveBeenCalledTimes(1);
+    });
+
+    it("`削除` で確認ダイアログを開くがミューテーションは確認後に走る / opens confirm dialog without firing mutation until confirmed", () => {
+      setupEditableRender();
+      renderNotePageView();
+
+      // ダイアログは最初閉じている / dialog starts closed
+      expect(screen.queryByTestId("delete-confirm-dialog")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("editor.pageMenu.deletePage"));
+
+      expect(screen.getByTestId("delete-confirm-dialog")).toBeInTheDocument();
+      // 確認前は mutation 未発火 / mutation must not fire pre-confirmation
+      expect(mockRemoveFromNoteMutate).not.toHaveBeenCalled();
+    });
+
+    it("削除成功時に `/notes/:noteId` へ遷移して toast を出す / navigates to /notes/:noteId and toasts on success", () => {
+      setupEditableRender();
+      mockRemoveFromNoteMutate.mockImplementation((_args, options) => {
+        options?.onSuccess?.();
+      });
+      renderNotePageView();
+
+      fireEvent.click(screen.getByText("editor.pageMenu.deletePage"));
+      fireEvent.click(screen.getByTestId("confirm-delete"));
+
+      expect(mockRemoveFromNoteMutate).toHaveBeenCalledWith(
+        { noteId: "note-1", pageId: "page-1" },
+        expect.any(Object),
+      );
+      expect(mockNavigate).toHaveBeenCalledWith("/notes/note-1");
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "common.page.pageDeleted" }),
+      );
+      // 成功後はダイアログを閉じる / dialog closes after success
+      expect(screen.queryByTestId("delete-confirm-dialog")).not.toBeInTheDocument();
+    });
+
+    it("削除失敗時はナビゲートせず destructive toast を出す / does not navigate and surfaces destructive toast on failure", async () => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      setupEditableRender();
+      mockRemoveFromNoteMutate.mockImplementation((_args, options) => {
+        options?.onError?.(new Error("server error"));
+      });
+      renderNotePageView();
+
+      fireEvent.click(screen.getByText("editor.pageMenu.deletePage"));
+      fireEvent.click(screen.getByTestId("confirm-delete"));
+
+      expect(mockRemoveFromNoteMutate).toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalledWith("/notes/note-1");
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "common.error",
+          variant: "destructive",
+        }),
+      );
+      consoleError.mockRestore();
+    });
+
+    it("削除キャンセル時はダイアログを閉じて mutation を呼ばない / closes dialog and skips mutation on cancel", () => {
+      setupEditableRender();
+      renderNotePageView();
+
+      fireEvent.click(screen.getByText("editor.pageMenu.deletePage"));
+      expect(screen.getByTestId("delete-confirm-dialog")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId("confirm-cancel"));
+
+      expect(screen.queryByTestId("delete-confirm-dialog")).not.toBeInTheDocument();
+      expect(mockRemoveFromNoteMutate).not.toHaveBeenCalled();
+    });
+
+    it("read-only でも `変更履歴` から `PageHistoryModal` を開ける / read-only viewer can still open history", () => {
+      setupEditableRender({ canEdit: false });
+      renderNotePageView();
+
+      fireEvent.click(screen.getByText("editor.pageHistory.menuButton"));
+
+      const modal = screen.getByTestId("page-history-modal");
+      expect(modal).toBeInTheDocument();
+      expect(modal).toHaveAttribute("data-page-id", "page-1");
     });
   });
 
@@ -587,143 +836,5 @@ describe("NotePageView", () => {
         noteId: undefined,
       }),
     );
-  });
-
-  it("shows copy-to-personal action for note-native pages (issue #713 Phase 3)", () => {
-    // `page.noteId === noteId` → ノートネイティブ。サインイン済みなら「個人に取り込み」
-    // を出す。i18n モックは `t(key)` が生キーを返す実装なので、キー文字列で DOM を引く。
-    // A note-native page (`page.noteId === noteId`) surfaces the menu item for
-    // signed-in viewers. `useTranslation` is mocked to echo the key, so we
-    // assert on the raw key string. Issue #713 Phase 3.
-    vi.mocked(useNote).mockReturnValue({
-      note: { id: "note-1" },
-      access: { canView: true, canEdit: false },
-      source: "local",
-      isLoading: false,
-    } as never);
-    vi.mocked(useNotePage).mockReturnValue({
-      data: {
-        id: "page-1",
-        title: "Note-native",
-        content: "{}",
-        ownerUserId: "user-other",
-        noteId: "note-1", // note-native: scope matches current note
-      },
-      isLoading: false,
-    } as never);
-
-    renderNotePageView();
-
-    expect(screen.getByText("notes.copyToPersonal")).toBeInTheDocument();
-  });
-
-  it("hides copy-to-personal action for linked personal pages (Codex P2)", () => {
-    // `page.noteId === null` はノートにリンクされている個人ページ。サーバーは
-    // copy-to-personal を 400 で弾くため、UI からは出さない。
-    // A linked personal page (`page.noteId === null`) would be rejected by the
-    // server (`Page does not belong to this note`), so hide the UI entry to
-    // avoid a guaranteed-fail click. Codex P2.
-    vi.mocked(useNote).mockReturnValue({
-      note: { id: "note-1" },
-      access: { canView: true, canEdit: false },
-      source: "local",
-      isLoading: false,
-    } as never);
-    vi.mocked(useNotePage).mockReturnValue({
-      data: {
-        id: "page-1",
-        title: "Linked personal",
-        content: "{}",
-        ownerUserId: "user-1",
-        noteId: null, // linked personal page
-      },
-      isLoading: false,
-    } as never);
-
-    renderNotePageView();
-
-    expect(screen.queryByText("notes.copyToPersonal")).not.toBeInTheDocument();
-  });
-
-  // ── localImported 分岐: トースト CTA の UX 契約を固定する ──
-  // 「コピーに成功」というサーバー側結果は `localImported` の真偽に関わらず
-  // トーストで出す（ユーザーにとっては成功）。ただし「開く」CTA は IDB に
-  // 新ページが載っている場合（`localImported: true`）にだけ出す — 載っていない
-  // ときに遷移させると `/pages/:id` が次回 sync まで空のローカルを読んで着地に
-  // 失敗するため。ここで両分岐をピン止めし、将来の回帰を検知する。
-  // Pin the toast-CTA UX contract: the success toast fires either way (the
-  // server-side copy did happen), but the "Open" CTA should only appear when
-  // the new page is already in IDB (`localImported: true`). Otherwise
-  // `/pages/:id` would land on a stale-empty local read until the next sync.
-  // These two tests lock down the branch behind `result.localImported`.
-  describe("copy-to-personal toast CTA (issue #713 Phase 3 / CodeRabbit)", () => {
-    function setupNoteNativeRender(mutateResult: {
-      created: boolean;
-      page_id: string;
-      localImported: boolean;
-    }) {
-      vi.mocked(useNote).mockReturnValue({
-        note: { id: "note-1" },
-        access: { canView: true, canEdit: false },
-        source: "local",
-        isLoading: false,
-      } as never);
-      vi.mocked(useNotePage).mockReturnValue({
-        data: {
-          id: "page-1",
-          title: "Note-native",
-          content: "{}",
-          ownerUserId: "user-other",
-          noteId: "note-1",
-        },
-        isLoading: false,
-      } as never);
-      const mutateAsync = vi.fn().mockResolvedValue(mutateResult);
-      vi.mocked(useCopyNotePageToPersonal).mockReturnValue({
-        mutateAsync,
-        isPending: false,
-      } as never);
-      return { mutateAsync };
-    }
-
-    async function clickCopyMenuItem() {
-      const trigger = screen.getByText("notes.copyToPersonal");
-      fireEvent.click(trigger);
-      // handleCopyToPersonal は mutateAsync(...)/toast(...) を連続して呼ぶ
-      // async 関数なので、microtask を 1 周回して resolve を消化させる。
-      // `handleCopyToPersonal` is an async function that awaits mutateAsync
-      // then calls toast(...). Flush a microtask so the toast call lands
-      // before we inspect `mockToast`.
-      await Promise.resolve();
-      await Promise.resolve();
-    }
-
-    it("includes the Open CTA when localImported is true", async () => {
-      setupNoteNativeRender({ created: true, page_id: "pg-copy", localImported: true });
-      renderNotePageView();
-
-      await clickCopyMenuItem();
-
-      expect(mockToast).toHaveBeenCalledTimes(1);
-      const arg = mockToast.mock.calls[0][0] as { title: unknown; action?: unknown };
-      expect(arg.title).toBe("notes.pageCopiedToPersonal");
-      // `localImported: true` のときだけ「開く」CTA 用の React 要素が渡される。
-      // The "Open" CTA element is supplied only when `localImported` is true.
-      expect(arg.action).toBeTruthy();
-    });
-
-    it("omits the Open CTA when localImported is false (IDB write-through skipped)", async () => {
-      setupNoteNativeRender({ created: true, page_id: "pg-copy", localImported: false });
-      renderNotePageView();
-
-      await clickCopyMenuItem();
-
-      expect(mockToast).toHaveBeenCalledTimes(1);
-      const arg = mockToast.mock.calls[0][0] as { title: unknown; action?: unknown };
-      expect(arg.title).toBe("notes.pageCopiedToPersonal");
-      // 書き戻し失敗/スキップ時は CTA なし。次回 sync で `/home` に反映される。
-      // No CTA when the write-through missed; the next sync will reconcile.
-      expect(arg.action).toBeUndefined();
-    });
   });
 });

--- a/src/pages/NotePageView.test.tsx
+++ b/src/pages/NotePageView.test.tsx
@@ -479,6 +479,37 @@ describe("NotePageView", () => {
       // Delete is hidden in read-only mode (no permission).
       expect(screen.queryByText("editor.pageMenu.deletePage")).not.toBeInTheDocument();
     });
+
+    // Codex P2 review on PR #891: `/api/pages/:id/snapshots` requires auth, so
+    // unauthenticated guests viewing a public / unlisted note page must not see
+    // the history entry (it would 401 inside `PageHistoryModal`). Export / copy
+    // remain available since they read `page.content` client-side.
+    it("未ログインの read-only viewer には履歴項目を出さず、エクスポート/コピーは残す / hides history but keeps export/copy for unauthenticated read-only viewers", () => {
+      vi.mocked(useAuth).mockReturnValue({ isSignedIn: false, userId: undefined } as never);
+      vi.mocked(useNote).mockReturnValue({
+        note: { id: "note-1" },
+        access: { canView: true, canEdit: false },
+        source: "remote",
+        isLoading: false,
+      } as never);
+      vi.mocked(useNotePage).mockReturnValue({
+        data: {
+          id: "page-1",
+          title: "Guest viewable",
+          content: "Body",
+          ownerUserId: "user-other",
+          noteId: "note-1",
+        },
+        isLoading: false,
+      } as never);
+
+      renderNotePageView();
+
+      expect(screen.queryByText("editor.pageHistory.menuButton")).not.toBeInTheDocument();
+      expect(screen.getByText("editor.pageMenu.exportMarkdown")).toBeInTheDocument();
+      expect(screen.getByText("editor.pageMenu.copyMarkdown")).toBeInTheDocument();
+      expect(screen.queryByText("editor.pageMenu.deletePage")).not.toBeInTheDocument();
+    });
   });
 
   describe("menu actions (issue #890)", () => {
@@ -615,6 +646,76 @@ describe("NotePageView", () => {
       const modal = screen.getByTestId("page-history-modal");
       expect(modal).toBeInTheDocument();
       expect(modal).toHaveAttribute("data-page-id", "page-1");
+    });
+
+    // Codex P2 review on PR #891: 削除成功直後の navigate でアンマウント flush が
+    // 走ると、保留中のタイトル保存が「もう存在しないページ」に対する
+    // `putPageContent` を撃ってしまい spurious な failed-toast が出る。
+    // `change-title` で debounce 中のタイトルを作った状態で削除を成功させ、
+    // `mockApi.putPageContent` が呼ばれていないことで cancel hook の効果を検証する。
+    //
+    // Pin the cancel-pending-title-save behavior added for Codex P2. We prime
+    // a pending debounced title change, then confirm a successful delete; the
+    // editable child's unmount flush must be neutered before navigation so
+    // `putPageContent` is never invoked against the just-removed page.
+    it("削除成功時に保留中のタイトル保存をキャンセルする / cancels pending title save before delete-success navigation", async () => {
+      setupEditableRender();
+      // 漏れた unmount-flush が `putPageContent` まで到達できるよう、
+      // `getPageContent` も成功させておく。
+      // Make `getPageContent` succeed so a leaked unmount-flush would reach
+      // `putPageContent` — the assertions below check both entry points.
+      mockApi.getPageContent.mockResolvedValue({
+        ydoc_state: "AQ==",
+        version: 3,
+        content_text: "body",
+      });
+      mockApi.putPageContent.mockResolvedValue({ version: 4 });
+      mockRemoveFromNoteMutate.mockImplementation((_args, options) => {
+        options?.onSuccess?.();
+      });
+      // `useNavigate` はモック化済みなので、本番の "navigate → route unmount"
+      // を再現するには明示的に `unmount()` する必要がある。`render()` の戻り値を
+      // 取って後で呼ぶ。
+      // `useNavigate` is mocked in this suite, so navigation never actually
+      // unmounts the route's children. Capture `unmount` from `render()` and
+      // invoke it explicitly to reproduce the production sequence
+      // (delete onSuccess → navigate → react-router unmounts `NotePageView`).
+      const { unmount } = renderNotePageView();
+
+      // 編集中のタイトル変更で debounce タイマーを設置する。timer は flush 前に
+      // キャンセルされる前提なので `advanceTimersByTime` は呼ばない。
+      // Stage a debounced title change without flushing it; the delete flow
+      // must cancel the timer before unmount runs.
+      fireEvent.click(screen.getByText("change-title"));
+
+      fireEvent.click(screen.getByText("editor.pageMenu.deletePage"));
+      fireEvent.click(screen.getByTestId("confirm-delete"));
+
+      expect(mockNavigate).toHaveBeenCalledWith("/notes/note-1");
+
+      // ここで navigate 相当のアンマウントを実行する。cancel hook が onSuccess
+      // 内で走っているはずなので、unmount cleanup の `flushPendingTitleRef.current()`
+      // は pending == null で即 return すべき。
+      // Simulate the post-navigate unmount. The cancel hook should have run
+      // inside `onSuccess`, so the unmount cleanup's
+      // `flushPendingTitleRef.current()` must short-circuit on a null pending.
+      unmount();
+      vi.useRealTimers();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // タイトル保存経路の最初のサーバ呼び出しが getPageContent。これが呼ばれて
+      // いなければ pendingTitleRef は確実に null 化されている。
+      // `getPageContent` is the first server call in the title-save flush
+      // path; asserting it never fires guarantees the cancel hook neutered
+      // the pending state before unmount.
+      expect(mockApi.getPageContent).not.toHaveBeenCalled();
+      expect(mockApi.putPageContent).not.toHaveBeenCalled();
+      // unmount-flush が走らなければ `errors.titleSaveFailedTitle` の
+      // destructive トーストも当然出ない。
+      // No spurious title-save-failed toast either.
+      expect(mockToast).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "errors.titleSaveFailedTitle" }),
+      );
     });
   });
 

--- a/src/pages/NotePageView.test.tsx
+++ b/src/pages/NotePageView.test.tsx
@@ -717,6 +717,109 @@ describe("NotePageView", () => {
         expect.objectContaining({ title: "errors.titleSaveFailedTitle" }),
       );
     });
+
+    // CodeRabbit major review on PR #891: debounce が既に発火して
+    // `persistTitleRef.current()` が `getPageContent`/`putPageContent` を await
+    // している最中に削除が成功すると、後から in-flight save が「ページが既に
+    // 存在しない」エラーを返し、削除成功の直後に `errors.titleSaveFailedTitle`
+    // の destructive トーストが出てしまう。`suppressTitleSaveEffectsRef` が
+    // この経路で toast を出さないことを検証する。
+    //
+    // Regression test for the in-flight title-save suppression. When the
+    // debounce has already fired and the save is mid-await, the cancel hook
+    // raises a suppress flag so the rejected `putPageContent` does not toast
+    // `errors.titleSaveFailedTitle` after the delete has navigated away.
+    it("削除成功時に進行中のタイトル保存失敗のトーストを抑止する / suppresses in-flight title-save failure toast after delete success", async () => {
+      setupEditableRender();
+      mockApi.getPageContent.mockResolvedValue({
+        ydoc_state: "AQ==",
+        version: 3,
+        content_text: "body",
+      });
+      // `putPageContent` を保留にしておき、削除確定後にエラーで決着させる。
+      // Defer `putPageContent` and reject it post-delete to simulate
+      // "page no longer exists" returning after the navigation completes.
+      let rejectPut: (err: Error) => void = () => undefined;
+      mockApi.putPageContent.mockReturnValue(
+        new Promise((_, reject) => {
+          rejectPut = reject;
+        }),
+      );
+      mockRemoveFromNoteMutate.mockImplementation((_args, options) => {
+        options?.onSuccess?.();
+      });
+
+      const { unmount } = renderNotePageView();
+
+      // タイトルを編集して debounce timer を仕掛け、500ms 経過させて save を発火。
+      // `getPageContent` は解決済み、`putPageContent` は保留 = in-flight save。
+      // Stage a title change, flush the debounce so the save enters its
+      // awaiting state — `getPageContent` resolves, `putPageContent` is left
+      // pending so the save is genuinely mid-flight.
+      fireEvent.click(screen.getByText("change-title"));
+      await vi.advanceTimersByTimeAsync(500);
+
+      // この時点で in-flight。削除を発火する。
+      // Trigger delete while the save is still awaiting `putPageContent`.
+      fireEvent.click(screen.getByText("editor.pageMenu.deletePage"));
+      fireEvent.click(screen.getByTestId("confirm-delete"));
+
+      // navigate 後のアンマウントを再現。
+      // Simulate the post-navigate unmount.
+      unmount();
+
+      // 削除済みページ側の `putPageContent` を 404 相当で決着させる。
+      // Resolve the deferred `putPageContent` with the "deleted" error.
+      vi.useRealTimers();
+      rejectPut(new Error("page not found"));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // 抑止フラグが立っているので失敗 toast は出ないはず。
+      // Suppress flag should be set, so the destructive toast must not fire.
+      expect(mockToast).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "errors.titleSaveFailedTitle" }),
+      );
+    });
+
+    // CodeRabbit major review on PR #891: `AlertDialogAction` の `disabled` は
+    // 次回コミットまで反映されないため、同一フレームの二重クリックで
+    // `mutate` が二回走ってしまう。`isPending` を同期ガードに使うことで
+    // 二回目を弾く動作をピン止めする。
+    //
+    // Same-frame double-click guard: the AlertDialog's `disabled` prop doesn't
+    // update until next render, so a synchronous `isPending` bail-out is the
+    // only thing keeping `mutate` from firing twice. Force the mutation into
+    // a pending state and verify a second confirm click is a no-op.
+    it("削除確定が同期的に二回呼ばれても mutate は一回しか走らない / guards handleConfirmDelete against same-frame double submit", () => {
+      setupEditableRender();
+      // 1 回目で `isPending: true` に切り替えてから 2 回目をシミュレートする。
+      // Flip the mutation hook into pending after the first call so the
+      // second synchronous click hits the `isPending` guard.
+      let pending = false;
+      vi.mocked(useRemovePageFromNote).mockImplementation(
+        () =>
+          ({
+            mutate: (...args: unknown[]) => {
+              pending = true;
+              mockRemoveFromNoteMutate(...args);
+            },
+            get isPending() {
+              return pending;
+            },
+          }) as never,
+      );
+      renderNotePageView();
+
+      fireEvent.click(screen.getByText("editor.pageMenu.deletePage"));
+      // Confirm button is rendered inside the dialog; click it twice in the
+      // same task. The second click must not reach `mutate`.
+      const confirmButton = screen.getByTestId("confirm-delete");
+      fireEvent.click(confirmButton);
+      fireEvent.click(confirmButton);
+
+      expect(mockRemoveFromNoteMutate).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("renders editor when note and page are loaded with canEdit", () => {

--- a/src/pages/NotePageView.test.tsx
+++ b/src/pages/NotePageView.test.tsx
@@ -486,6 +486,21 @@ describe("NotePageView", () => {
     // remain available since they read `page.content` client-side.
     it("未ログインの read-only viewer には履歴項目を出さず、エクスポート/コピーは残す / hides history but keeps export/copy for unauthenticated read-only viewers", () => {
       vi.mocked(useAuth).mockReturnValue({ isSignedIn: false, userId: undefined } as never);
+      // `useAuth` を未ログインに切り替えるなら、同じく `isSignedIn` を持つ
+      // `useNoteApi` も整合させておく（CodeRabbit）。現状の実装は `useAuth`
+      // 側だけを読んでいるが、将来 `useNoteApi.isSignedIn` を参照しても
+      // テストが silently pass しないよう fixture をそろえる。
+      // Keep the auth fixtures coherent: if `useAuth.isSignedIn` is false, the
+      // sibling `useNoteApi.isSignedIn` should match. The component currently
+      // only reads from `useAuth`, but aligning the fixture prevents a future
+      // refactor from silently passing this test.
+      vi.mocked(useNoteApi).mockReturnValue({
+        api: mockApi,
+        userId: "",
+        userEmail: undefined,
+        isSignedIn: false,
+        isLoaded: true,
+      } as never);
       vi.mocked(useNote).mockReturnValue({
         note: { id: "note-1" },
         access: { canView: true, canEdit: false },
@@ -736,14 +751,21 @@ describe("NotePageView", () => {
         version: 3,
         content_text: "body",
       });
-      // `putPageContent` を保留にしておき、削除確定後にエラーで決着させる。
-      // Defer `putPageContent` and reject it post-delete to simulate
-      // "page no longer exists" returning after the navigation completes.
+      // `putPageContent` 呼び出し時に毎回 fresh な保留 promise を返すよう
+      // `mockImplementation` を使う。`mockReturnValue` で一度作る方式だと
+      // `rejectPut` の捕捉が呼び出しタイミングと無関係に進んで「テストが本当に
+      // in-flight 経路を踏んだか」を保証しにくい (CodeRabbit major)。
+      //
+      // Use `mockImplementation` so each call creates a fresh deferred and
+      // captures its `reject` at invocation time. Stubbing once up-front with
+      // `mockReturnValue` makes it harder to prove the test actually reached
+      // the in-flight path before we reject. CodeRabbit major review.
       let rejectPut: (err: Error) => void = () => undefined;
-      mockApi.putPageContent.mockReturnValue(
-        new Promise((_, reject) => {
-          rejectPut = reject;
-        }),
+      mockApi.putPageContent.mockImplementation(
+        () =>
+          new Promise((_, reject) => {
+            rejectPut = reject;
+          }),
       );
       mockRemoveFromNoteMutate.mockImplementation((_args, options) => {
         options?.onSuccess?.();
@@ -759,6 +781,20 @@ describe("NotePageView", () => {
       fireEvent.click(screen.getByText("change-title"));
       await vi.advanceTimersByTimeAsync(500);
 
+      // save が `putPageContent` まで進んでいることを明示的に確認する。ここを
+      // 通らない限り `rejectPut(...)` は no-op になり、最終アサートが理由で
+      // 通ったように見えてしまう (CodeRabbit major)。`vi.waitFor` は実時間で
+      // ポーリングするので real timers に切り替えてから呼ぶ。
+      // Pin that the save actually entered the in-flight path before we
+      // trigger delete; otherwise `rejectPut(...)` is a no-op and the final
+      // assertion passes for the wrong reason. `vi.waitFor` polls in real
+      // time so flip to real timers first.
+      vi.useRealTimers();
+      await vi.waitFor(() => {
+        expect(mockApi.getPageContent).toHaveBeenCalledTimes(1);
+        expect(mockApi.putPageContent).toHaveBeenCalledTimes(1);
+      });
+
       // この時点で in-flight。削除を発火する。
       // Trigger delete while the save is still awaiting `putPageContent`.
       fireEvent.click(screen.getByText("editor.pageMenu.deletePage"));
@@ -770,7 +806,6 @@ describe("NotePageView", () => {
 
       // 削除済みページ側の `putPageContent` を 404 相当で決着させる。
       // Resolve the deferred `putPageContent` with the "deleted" error.
-      vi.useRealTimers();
       rejectPut(new Error("page not found"));
       await new Promise((resolve) => setTimeout(resolve, 0));
       await new Promise((resolve) => setTimeout(resolve, 0));

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -238,12 +238,27 @@ function NotePageEditorEditable({
   // object on every state transition (idle → pending → success), so referencing
   // the mutation directly in a `useCallback` dep array would cause the unmount
   // flush effect's cleanup to fire mid-typing and flush the debounce early.
+  // 削除フローが進行中の save をキャンセルしたいと宣言したら立てるフラグ。
+  // debounce 済みで既に in-flight な `persistTitleRef.current()` は単純な
+  // timer cancel では止められないため、await 後に毎回このフラグを見て
+  // 早期 return する。Cache invalidation / setTitle ロールバック / toast /
+  // throw のすべてを抑止する。CodeRabbit major (PR #891)。
+  //
+  // Set by the cancel hook when the delete path wants in-flight saves to be
+  // dropped. Clearing the debounce timer alone cannot stop a save that
+  // already entered `persistTitleRef.current()` and is awaiting the
+  // network, so this flag is re-checked after each await — when set, the
+  // save returns without invalidating caches, rolling back the title,
+  // toasting, or re-throwing. CodeRabbit major review on PR #891.
+  const suppressTitleSaveEffectsRef = useRef(false);
+
   const persistTitleRef = useRef<(nextTitle: string) => Promise<void>>(async () => {});
   persistTitleRef.current = async (nextTitle: string) => {
     const previousTitle = lastSavedTitleRef.current;
     try {
       if (page.noteId !== null) {
         const current = await api.getPageContent(page.id);
+        if (suppressTitleSaveEffectsRef.current) return;
         await api.putPageContent(page.id, {
           ydoc_state: current.ydoc_state,
           content_text: current.content_text ?? undefined,
@@ -256,6 +271,10 @@ function NotePageEditorEditable({
           updates: { title: nextTitle },
         });
       }
+      // 削除完了後はキャッシュ無効化も lastSaved 更新もスキップする。
+      // After cancel (delete path), skip cache invalidation and lastSaved update —
+      // `useRemovePageFromNote` has already invalidated note caches.
+      if (suppressTitleSaveEffectsRef.current) return;
       lastSavedTitleRef.current = nextTitle;
       // `useUpdatePage` updates `pageKeys.*` caches, but the note page list and
       // detail are held under `noteKeys.*`. Invalidate those so the new title
@@ -266,6 +285,11 @@ function NotePageEditorEditable({
       queryClient.invalidateQueries({ queryKey: noteKeys.page(noteId, page.id) });
       queryClient.invalidateQueries({ queryKey: noteKeys.detailsByNoteId(noteId) });
     } catch (error) {
+      // 削除済みページに対する失敗は予期されたもの。toast / rollback を抑止する。
+      // Expected failure path when the page was just deleted out from under us;
+      // suppress toast + rollback + rethrow so we don't surface
+      // `errors.titleSaveFailedTitle` right after a successful delete.
+      if (suppressTitleSaveEffectsRef.current) return;
       if (pendingTitleRef.current === null) {
         setTitle(previousTitle);
       }
@@ -334,17 +358,23 @@ function NotePageEditorEditable({
   }, []);
 
   // 削除フローから「保留中タイトル保存をキャンセルしてアンマウント flush を
-  // 抑止する」関数を呼べるよう、親から渡された ref に書き込む。timer と
-  // `pendingTitleRef` を両方 null 化すれば、アンマウント時の
-  // `flushPendingTitleRef.current()` は pending null で即 return する。
+  // 抑止する」関数を呼べるよう、親から渡された ref に書き込む。
+  // 1) debounce timer をクリア → 未着火の save を抑止
+  // 2) `pendingTitleRef` を null 化 → アンマウント flush は pending null で即 return
+  // 3) `suppressTitleSaveEffectsRef` を立てる → 既に in-flight な save が
+  //    完了/失敗してもキャッシュ更新・toast・throw を全部スキップする
   //
   // Expose a cancel function to the parent via ref so the delete-success path
-  // can drop the pending title save before unmount. Clearing both the timer
-  // and `pendingTitleRef.current` makes the unmount-flush a no-op (the flush
-  // bails when `pending === null`). Codex P2 review on PR #891.
+  // can drop the pending title save before unmount. Three guards combined:
+  // 1) clear the debounce timer (kills not-yet-fired saves);
+  // 2) null `pendingTitleRef.current` (makes the unmount flush a no-op);
+  // 3) raise `suppressTitleSaveEffectsRef` so any save that's already mid-await
+  //    no longer triggers cache invalidation / toast / rollback / rethrow.
+  // Codex P2 + CodeRabbit major reviews on PR #891.
   useEffect(() => {
     if (!cancelPendingTitleSaveRef) return;
     cancelPendingTitleSaveRef.current = () => {
+      suppressTitleSaveEffectsRef.current = true;
       if (titleSaveTimerRef.current) {
         clearTimeout(titleSaveTimerRef.current);
         titleSaveTimerRef.current = null;
@@ -700,6 +730,18 @@ const NotePageView: React.FC = () => {
 
   const handleConfirmDelete = useCallback(() => {
     if (!noteId || !page?.id) return;
+    // `removeFromNoteMutation.isPending` は次の React コミットまで true に
+    // ならないため、`AlertDialogAction` の `disabled` だけでは同一フレームの
+    // 二重クリックを防げない（CodeRabbit major）。同期的に `isPending` を
+    // 見て早期 return することで、`mutate` の二重発火と二重 toast / 二重
+    // navigate を確実に抑止する。
+    //
+    // `removeFromNoteMutation.isPending` only flips on the next render commit,
+    // so the `disabled` prop on `AlertDialogAction` cannot stop same-frame
+    // double-clicks. Bail synchronously on `isPending` to keep `mutate` from
+    // firing twice (which would surface duplicate toasts + navigations).
+    // CodeRabbit major review on PR #891.
+    if (removeFromNoteMutation.isPending) return;
     const displayTitle = page.title || t("common.untitledPage");
     removeFromNoteMutation.mutate(
       { noteId, pageId: page.id },

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -1,21 +1,31 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
-import { Download } from "lucide-react";
+import { Copy, Download, History, Trash2 } from "lucide-react";
 import { PageLoadingOrDenied } from "@/components/layout/PageLoadingOrDenied";
 import { PageEditorContent } from "@/components/editor/PageEditor/PageEditorContent";
 import {
   PageEditorHeader,
   type PageDetailToolbarAction,
 } from "@/components/editor/PageEditor/PageEditorHeader";
-import { Button, useToast } from "@zedi/ui";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  useToast,
+} from "@zedi/ui";
 import { useTranslation } from "react-i18next";
 import {
   useNote,
   useNotePage,
   noteKeys,
-  useCopyNotePageToPersonal,
   useNoteApi,
+  useRemovePageFromNote,
 } from "@/hooks/useNoteQueries";
 import { useUpdatePage } from "@/hooks/usePageQueries";
 import { useAuth } from "@/hooks/useAuth";
@@ -24,6 +34,8 @@ import { ContentWithAIChat } from "@/components/ai-chat/ContentWithAIChat";
 import { NoteWorkspaceProvider, useNoteWorkspaceOptional } from "@/contexts/NoteWorkspaceContext";
 import { useAIChatContext } from "@/contexts/AIChatContext";
 import { NoteWorkspaceToolbar } from "@/components/note/NoteWorkspaceToolbar";
+import { useMarkdownExport } from "@/components/editor/PageEditor/useMarkdownExport";
+import { PageHistoryModal } from "@/components/editor/pageHistory/PageHistoryModal";
 import { convertMarkdownToTiptapContent } from "@/lib/markdownToTiptap";
 import type { UseCollaborationReturn } from "@/lib/collaboration/types";
 import type { Page } from "@/types/page";
@@ -58,6 +70,50 @@ function canEditTitle(
 }
 
 /**
+ * `/pages/:id` 側 (`PageEditorLayout`) と揃えた共通メニュー項目のうち、
+ * 「変更履歴」「Markdown でエクスポート」「Markdown をコピー」までを構築する。
+ * 削除は別 i18n キーと destructive スタイル、`separatorBefore` を伴うため
+ * 呼び出し側で `delete` 項目を末尾に追加する想定。
+ *
+ * Build the shared menu items (history / export markdown / copy markdown)
+ * that match the `/pages/:id` toolbar (`PageEditorLayout`). Callers append a
+ * destructive `delete` entry with `separatorBefore` separately, since the
+ * read-only path does not surface deletion.
+ */
+function buildSharedMenuItems({
+  t,
+  onOpenHistory,
+  onExportMarkdown,
+  onCopyMarkdown,
+}: {
+  t: (key: string) => string;
+  onOpenHistory: () => void;
+  onExportMarkdown: () => void;
+  onCopyMarkdown: () => void;
+}): PageDetailToolbarAction[] {
+  return [
+    {
+      id: "history",
+      label: t("editor.pageHistory.menuButton"),
+      icon: History,
+      onClick: onOpenHistory,
+    },
+    {
+      id: "export-markdown",
+      label: t("editor.pageMenu.exportMarkdown"),
+      icon: Download,
+      onClick: onExportMarkdown,
+    },
+    {
+      id: "copy-markdown",
+      label: t("editor.pageMenu.copyMarkdown"),
+      icon: Copy,
+      onClick: onCopyMarkdown,
+    },
+  ];
+}
+
+/**
  * Uses `key` on the parent so page switches reset local editor state.
  * `editorContent` の初期値は `page.content` から。
  */
@@ -67,7 +123,10 @@ function NotePageEditorEditable({
   collaboration,
   isCollaborationEnabled,
   isTitleEditable,
-  toolbar,
+  onBack,
+  onRequestDelete,
+  isDeletePending,
+  supplementalRightContent,
 }: {
   page: Page;
   noteId: string;
@@ -75,16 +134,21 @@ function NotePageEditorEditable({
   isCollaborationEnabled: boolean;
   /** ページ所有者のみタイトル編集可。Only the page owner can edit the title. */
   isTitleEditable: boolean;
+  /** ヘッダーの戻るボタン。Toolbar back button. */
+  onBack: () => void;
   /**
-   * Sticky toolbar rendered as the first child of the scroll container
-   * (`ContentWithAIChat`), above `NoteWorkspaceToolbar`. Passed in from the
-   * parent so the shared `PageEditorHeader` can hook into the same scroll
-   * area and toggle visibility on scroll.
+   * 削除メニュー押下時に呼ぶ。確認ダイアログとミューテーションは親 (`NotePageView`)
+   * が所有しており、ナビゲーション・toast との整合性を一箇所で扱う。
    *
-   * 共通ツールバー。`ContentWithAIChat` の生成するスクロールコンテナ直下に
-   * 配置することで、`PageEditorHeader` の sticky / scroll-hide 挙動を維持する。
+   * Invoked when the delete menu item is selected. The confirmation dialog
+   * and the mutation live on the parent (`NotePageView`) so navigation +
+   * toast handling stay in one place.
    */
-  toolbar?: React.ReactNode;
+  onRequestDelete: () => void;
+  /** 削除実行中はメニューを抑止する。Disable delete while the mutation is pending. */
+  isDeletePending: boolean;
+  /** ツールバー右側の追加スロット。Supplemental right-side toolbar slot. */
+  supplementalRightContent?: React.ReactNode;
 }): React.JSX.Element {
   const [editorContent, setEditorContent] = useState(page.content ?? "");
   const [title, setTitle] = useState(page.title);
@@ -101,6 +165,12 @@ function NotePageEditorEditable({
   const pendingTitleRef = useRef<string | null>(null);
   const isSavingTitleRef = useRef(false);
   const lastSavedTitleRef = useRef(page.title);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const { handleExportMarkdown, handleCopyMarkdown } = useMarkdownExport(
+    title,
+    editorContent,
+    page.sourceUrl,
+  );
 
   useEffect(() => {
     setPageContext({
@@ -249,29 +319,243 @@ function NotePageEditorEditable({
     };
   }, []);
 
+  const handleOpenHistory = useCallback(() => {
+    setHistoryOpen(true);
+  }, []);
+
+  const handleRestored = useCallback(() => {
+    // 復元後にページをリロードして最新状態を反映する。`/pages/:id` 側の
+    // `PageEditorLayout.handleRestored` と同じ方針。
+    // Reload after restore to mirror the `/pages/:id` flow.
+    window.location.reload();
+  }, []);
+
+  // `/pages/:id` と同じ4項目（履歴 → エクスポート → コピー → 区切り → 削除）を
+  // 構築する。Markdown 操作のソースは編集中の `title` / `editorContent` を使う
+  // ので、編集中の変更も即時反映される。削除は親 (`NotePageView`) が確認ダイアログ
+  // とミューテーションを所有しており、ここではトリガーだけを呼び出す。
+  //
+  // Build the same four menu items as `/pages/:id` (history → export → copy →
+  // separator → delete). Markdown actions read live `title` / `editorContent`,
+  // so in-flight edits are surfaced. Deletion is owned by the parent
+  // (`NotePageView`) — this just fires the request to open the confirmation.
+  const menuItems = useMemo<PageDetailToolbarAction[]>(
+    () => [
+      ...buildSharedMenuItems({
+        t,
+        onOpenHistory: handleOpenHistory,
+        onExportMarkdown: handleExportMarkdown,
+        onCopyMarkdown: handleCopyMarkdown,
+      }),
+      {
+        id: "delete",
+        label: t("editor.pageMenu.deletePage"),
+        icon: Trash2,
+        onClick: onRequestDelete,
+        destructive: true,
+        separatorBefore: true,
+        disabled: isDeletePending,
+      },
+    ],
+    [
+      t,
+      handleOpenHistory,
+      handleExportMarkdown,
+      handleCopyMarkdown,
+      onRequestDelete,
+      isDeletePending,
+    ],
+  );
+
+  // React Compiler が optional chain の依存を保持できないため先に抽出する。
+  // Extract ydoc to avoid React Compiler memoization issue with optional chaining.
+  const ydoc = isCollaborationEnabled ? (collaboration.ydoc ?? null) : null;
+
   return (
-    <ContentWithAIChat>
-      {toolbar}
-      <NoteWorkspaceToolbar />
+    <>
+      <ContentWithAIChat>
+        <PageEditorHeader
+          onBack={onBack}
+          menuItems={menuItems}
+          supplementalRightContent={supplementalRightContent}
+        />
+        <NoteWorkspaceToolbar />
+        <PageEditorContent
+          content={editorContent}
+          title={title}
+          sourceUrl={page.sourceUrl}
+          currentPageId={page.id}
+          pageId={page.id}
+          isNewPage={false}
+          isWikiGenerating={false}
+          isReadOnly={false}
+          showLinkedPages={false}
+          showToolbar
+          onContentChange={setEditorContent}
+          onContentError={() => undefined}
+          onTitleChange={isTitleEditable ? handleTitleChange : undefined}
+          collaboration={isCollaborationEnabled ? collaboration : undefined}
+          insertAtCursorRef={editorInsertRef}
+          pageNoteId={page.noteId ?? null}
+        />
+      </ContentWithAIChat>
+      {historyOpen && (
+        <PageHistoryModal
+          open={historyOpen}
+          onOpenChange={setHistoryOpen}
+          pageId={page.id}
+          currentYdoc={ydoc}
+          onRestored={handleRestored}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * 閲覧専用モードのノートページ本文。共通ツールバーには「変更履歴」「Markdown
+ * でエクスポート」「Markdown をコピー」を出すが、削除は出さない。Markdown の
+ * ソースは `page.title` / `page.content` をそのまま使う。
+ *
+ * Read-only note page body. Surfaces the shared toolbar with history /
+ * export / copy actions but omits delete. Markdown export and copy read the
+ * saved `page.title` / `page.content` directly.
+ */
+function NotePageReadOnly({
+  page,
+  onBack,
+  supplementalRightContent,
+}: {
+  page: Page;
+  onBack: () => void;
+  supplementalRightContent?: React.ReactNode;
+}): React.JSX.Element {
+  const { t } = useTranslation();
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const { handleExportMarkdown, handleCopyMarkdown } = useMarkdownExport(
+    page.title,
+    page.content ?? "",
+    page.sourceUrl,
+  );
+
+  const handleOpenHistory = useCallback(() => {
+    setHistoryOpen(true);
+  }, []);
+
+  const handleRestored = useCallback(() => {
+    window.location.reload();
+  }, []);
+
+  const menuItems = useMemo<PageDetailToolbarAction[]>(
+    () =>
+      buildSharedMenuItems({
+        t,
+        onOpenHistory: handleOpenHistory,
+        onExportMarkdown: handleExportMarkdown,
+        onCopyMarkdown: handleCopyMarkdown,
+      }),
+    [t, handleOpenHistory, handleExportMarkdown, handleCopyMarkdown],
+  );
+
+  return (
+    <>
+      <PageEditorHeader
+        onBack={onBack}
+        menuItems={menuItems}
+        supplementalRightContent={supplementalRightContent}
+      />
       <PageEditorContent
-        content={editorContent}
-        title={title}
+        content={page.content ?? ""}
+        title={page.title}
         sourceUrl={page.sourceUrl}
         currentPageId={page.id}
         pageId={page.id}
         isNewPage={false}
         isWikiGenerating={false}
-        isReadOnly={false}
+        isReadOnly={true}
         showLinkedPages={false}
-        showToolbar
-        onContentChange={setEditorContent}
+        showToolbar={false}
+        onContentChange={() => undefined}
         onContentError={() => undefined}
-        onTitleChange={isTitleEditable ? handleTitleChange : undefined}
-        collaboration={isCollaborationEnabled ? collaboration : undefined}
-        insertAtCursorRef={editorInsertRef}
         pageNoteId={page.noteId ?? null}
       />
-    </ContentWithAIChat>
+      {historyOpen && (
+        <PageHistoryModal
+          open={historyOpen}
+          onOpenChange={setHistoryOpen}
+          pageId={page.id}
+          currentYdoc={null}
+          onRestored={handleRestored}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * ノートからページを削除する確認ダイアログ。`/pages/:id` の削除フローと同じ
+ * UX (`AlertDialog` + destructive Action) を踏襲しつつ、ミューテーション中は
+ * 閉じる操作を抑止する。
+ *
+ * Confirmation dialog for removing a page from a note. Mirrors the
+ * `/pages/:id` delete UX (`AlertDialog` + destructive action) and suppresses
+ * close interactions while the mutation is pending.
+ */
+function NotePageDeleteConfirmDialog({
+  open,
+  onOpenChange,
+  isPending,
+  pageTitle,
+  onCancel,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isPending: boolean;
+  pageTitle: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}): React.JSX.Element {
+  const { t } = useTranslation();
+  return (
+    <AlertDialog
+      open={open}
+      // ミューテーション実行中は閉じる操作（Action / Cancel / Esc / overlay）を
+      // 無視し、`onSuccess` / `onError` で明示的に閉じる動線に揃える。
+      //
+      // Suppress overlay/Esc dismissal while the mutation is in flight so the
+      // dialog only closes through the explicit success / error paths.
+      onOpenChange={(nextOpen) => {
+        if (isPending && !nextOpen) return;
+        onOpenChange(nextOpen);
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("common.page.deleteConfirm")}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("common.page.deleteBody", { title: pageTitle })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel} disabled={isPending}>
+            {t("common.cancel")}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              // Radix の自動 close を抑止し、ミューテーション完了まで pending UI を保つ。
+              // Suppress Radix auto-close so the pending UI stays until the mutation settles.
+              e.preventDefault();
+              onConfirm();
+            }}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={isPending}
+          >
+            {isPending ? t("common.page.deleting") : t("common.page.delete")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 
@@ -285,7 +569,7 @@ const NotePageView: React.FC = () => {
   const { isSignedIn, userId } = useAuth();
   const { t } = useTranslation();
   const { toast } = useToast();
-  const copyToPersonalMutation = useCopyNotePageToPersonal();
+  const removeFromNoteMutation = useRemovePageFromNote();
 
   const {
     note,
@@ -300,6 +584,8 @@ const NotePageView: React.FC = () => {
     source,
     Boolean(access?.canView),
   );
+
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
   const handleBack = useCallback(() => {
     // `/notes/:noteId/:pageId` ルートなので `noteId` は常に存在する。`/home`
@@ -321,73 +607,44 @@ const NotePageView: React.FC = () => {
     mode: "collaborative",
   });
 
-  // ノートネイティブページを自分の個人ページにコピーする (issue #713 Phase 3)。
-  // 元のノートページはノートに残り、コピーのみが呼び出し元の個人ページ一覧
-  // (`/notes/me`) に現れる。成功時はトーストで新しい個人ページへ誘導する。
-  //
-  // Copy this note-native page into the caller's personal pages. Source
-  // stays in the note; only the copy lands in the caller's default note
-  // (`/notes/me`). The toast offers a CTA to jump to it. Plain function on
-  // purpose: `useCallback` cannot preserve memoization here (the mutation
-  // object identity flips with state transitions) so we let React Compiler
-  // handle the surrounding memo.
-  const handleCopyToPersonal = async () => {
-    if (!noteId || !page?.id) return;
-    try {
-      const result = await copyToPersonalMutation.mutateAsync({
-        noteId,
-        sourcePageId: page.id,
-      });
-      // サーバーへのコピーは成功だが、ローカル IDB への書き戻しが失敗/スキップ
-      // された場合は `localImported: false`。その状態で「開く」CTA を押すと
-      // `/pages/:id` は IDB を読むので空に着地してしまうため、成功トースト自体
-      // は出すが CTA は外して次回 sync まで待つ。
-      //
-      // If the server-side copy succeeded but the IndexedDB write-through did
-      // not (`localImported: false`), navigating `/pages/:id` would land on
-      // an empty read because the page grid reads IDB. Keep the success toast
-      // but drop the "Open" CTA; the next sync will reconcile the personal
-      // page list.
-      toast({
-        title: t("notes.pageCopiedToPersonal"),
-        action: result.localImported ? (
-          <Button size="sm" variant="ghost" onClick={() => navigate(`/pages/${result.page_id}`)}>
-            {t("common.open")}
-          </Button>
-        ) : undefined,
-      });
-    } catch (error) {
-      console.error("Failed to copy note page to personal:", error);
-      toast({
-        title: t("notes.pageCopyToPersonalFailed"),
-        variant: "destructive",
-      });
-    }
-  };
+  const handleRequestDelete = useCallback(() => {
+    setDeleteConfirmOpen(true);
+  }, []);
 
-  // 共通ツールバーに渡すアクションメニュー。ノートネイティブページ
-  // (`page.noteId === noteId`) かつサインイン済みのときだけ「個人に取り込み」
-  // を出す。`page.noteId === null` のリンク済み個人ページや未ログイン状態では
-  // サーバー側で copy が拒否されるため UI 側でも非表示にする（Codex P2）。
-  //
-  // Menu items for the shared toolbar. Surface "copy to personal" only for
-  // note-native pages (`page.noteId === noteId`) and signed-in viewers; the
-  // server rejects copy for linked personal pages (`page.noteId === null`)
-  // so we hide the entry instead of showing a guaranteed-fail action.
-  const showCopyToPersonal = Boolean(isSignedIn && page && page.noteId === noteId);
-  const menuItems: PageDetailToolbarAction[] | undefined = showCopyToPersonal
-    ? [
-        {
-          id: "copy-to-personal",
-          label: t("notes.copyToPersonal"),
-          icon: Download,
-          onClick: () => {
-            void handleCopyToPersonal();
-          },
-          disabled: copyToPersonalMutation.isPending,
+  const handleCancelDelete = useCallback(() => {
+    if (removeFromNoteMutation.isPending) return;
+    setDeleteConfirmOpen(false);
+  }, [removeFromNoteMutation.isPending]);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (!noteId || !page?.id) return;
+    const displayTitle = page.title || t("common.untitledPage");
+    removeFromNoteMutation.mutate(
+      { noteId, pageId: page.id },
+      {
+        onSuccess: () => {
+          toast({
+            title: t("common.page.pageDeleted"),
+            description: t("common.page.deletedWithTitle", { title: displayTitle }),
+          });
+          // `useRemovePageFromNote` 側で note 系キャッシュは無効化済み。
+          // `useRemovePageFromNote` already invalidates the note detail and
+          // window caches; nothing extra to do here.
+          setDeleteConfirmOpen(false);
+          navigate(`/notes/${noteId}`);
         },
-      ]
-    : undefined;
+        onError: (error) => {
+          console.error("Failed to remove page from note:", error);
+          toast({
+            title: t("common.error"),
+            description: t("common.page.deleteFailed"),
+            variant: "destructive",
+          });
+          setDeleteConfirmOpen(false);
+        },
+      },
+    );
+  }, [noteId, page, removeFromNoteMutation, toast, t, navigate]);
 
   const isLoading = isNoteLoading || isPageLoading;
   const isNotFound = !note || !access?.canView || !page;
@@ -408,22 +665,9 @@ const NotePageView: React.FC = () => {
     );
   }
 
-  // 共通ツールバー本体。canEdit 分岐で配置場所が変わるため JSX を一度だけ生成する。
-  // The shared toolbar is rendered once and placed inside whichever scroll
-  // container is active (`ContentWithAIChat` for editors, `bodyClassName`
-  // for read-only viewers) so `PageEditorHeader` can find a scrollable
-  // ancestor and remain sticky.
-  const toolbar = (
-    <PageEditorHeader
-      onBack={handleBack}
-      menuItems={menuItems}
-      supplementalRightContent={
-        !canEdit ? (
-          <span className="text-muted-foreground text-xs">{t("common.readOnly", "閲覧専用")}</span>
-        ) : undefined
-      }
-    />
-  );
+  const supplementalRightContent = !canEdit ? (
+    <span className="text-muted-foreground text-xs">{t("common.readOnly", "閲覧専用")}</span>
+  ) : undefined;
 
   // 編集時は ContentWithAIChat 内のモバイルスクロールラッパー（flex-1 +
   // overflow-y-auto）に高さを伝搬させるため、ラッパーも flex 列にする。
@@ -438,6 +682,9 @@ const NotePageView: React.FC = () => {
     ? "flex min-h-0 flex-1 flex-col md:overflow-hidden"
     : "min-h-0 flex-1 overflow-y-auto md:overflow-hidden";
 
+  const displayTitle = page.title || t("common.untitledPage");
+  const isDeletePending = removeFromNoteMutation.isPending;
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className={bodyClassName}>
@@ -450,30 +697,28 @@ const NotePageView: React.FC = () => {
               collaboration={collaboration}
               isCollaborationEnabled={isCollaborationEnabled}
               isTitleEditable={isTitleEditable}
-              toolbar={toolbar}
+              onBack={handleBack}
+              onRequestDelete={handleRequestDelete}
+              isDeletePending={isDeletePending}
+              supplementalRightContent={supplementalRightContent}
             />
           ) : (
-            <>
-              {toolbar}
-              <PageEditorContent
-                content={page?.content ?? ""}
-                title={page.title}
-                sourceUrl={page.sourceUrl}
-                currentPageId={page.id}
-                pageId={page.id}
-                isNewPage={false}
-                isWikiGenerating={false}
-                isReadOnly={true}
-                showLinkedPages={false}
-                showToolbar={false}
-                onContentChange={() => undefined}
-                onContentError={() => undefined}
-                pageNoteId={page.noteId ?? null}
-              />
-            </>
+            <NotePageReadOnly
+              page={page}
+              onBack={handleBack}
+              supplementalRightContent={supplementalRightContent}
+            />
           )}
         </NoteWorkspaceProvider>
       </div>
+      <NotePageDeleteConfirmDialog
+        open={deleteConfirmOpen}
+        onOpenChange={setDeleteConfirmOpen}
+        isPending={isDeletePending}
+        pageTitle={displayTitle}
+        onCancel={handleCancelDelete}
+        onConfirm={handleConfirmDelete}
+      />
     </div>
   );
 };

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -127,6 +127,7 @@ function NotePageEditorEditable({
   onRequestDelete,
   isDeletePending,
   supplementalRightContent,
+  cancelPendingTitleSaveRef,
 }: {
   page: Page;
   noteId: string;
@@ -149,6 +150,19 @@ function NotePageEditorEditable({
   isDeletePending: boolean;
   /** ツールバー右側の追加スロット。Supplemental right-side toolbar slot. */
   supplementalRightContent?: React.ReactNode;
+  /**
+   * 親が削除成功時に呼ぶ「保留中タイトル保存のキャンセル」を流す ref。
+   * 削除直後の navigate で `NotePageEditorEditable` がアンマウントされる際、
+   * 既存の cleanup が pending title を flush して既に消したページに対して
+   * `putPageContent` を発火する競合 (Codex P2) を抑止する。
+   *
+   * Mutable ref the parent calls in the delete-success path to cancel any
+   * debounced title save before navigation. Without this, the unmount
+   * cleanup in this component flushes the pending title against the
+   * just-deleted page and surfaces a spurious title-save-failed toast
+   * (Codex P2 review on PR #891).
+   */
+  cancelPendingTitleSaveRef?: React.MutableRefObject<(() => void) | null>;
 }): React.JSX.Element {
   const [editorContent, setEditorContent] = useState(page.content ?? "");
   const [title, setTitle] = useState(page.title);
@@ -319,6 +333,29 @@ function NotePageEditorEditable({
     };
   }, []);
 
+  // 削除フローから「保留中タイトル保存をキャンセルしてアンマウント flush を
+  // 抑止する」関数を呼べるよう、親から渡された ref に書き込む。timer と
+  // `pendingTitleRef` を両方 null 化すれば、アンマウント時の
+  // `flushPendingTitleRef.current()` は pending null で即 return する。
+  //
+  // Expose a cancel function to the parent via ref so the delete-success path
+  // can drop the pending title save before unmount. Clearing both the timer
+  // and `pendingTitleRef.current` makes the unmount-flush a no-op (the flush
+  // bails when `pending === null`). Codex P2 review on PR #891.
+  useEffect(() => {
+    if (!cancelPendingTitleSaveRef) return;
+    cancelPendingTitleSaveRef.current = () => {
+      if (titleSaveTimerRef.current) {
+        clearTimeout(titleSaveTimerRef.current);
+        titleSaveTimerRef.current = null;
+      }
+      pendingTitleRef.current = null;
+    };
+    return () => {
+      cancelPendingTitleSaveRef.current = null;
+    };
+  }, [cancelPendingTitleSaveRef]);
+
   const handleOpenHistory = useCallback(() => {
     setHistoryOpen(true);
   }, []);
@@ -425,10 +462,25 @@ function NotePageReadOnly({
   page,
   onBack,
   supplementalRightContent,
+  canViewHistory,
 }: {
   page: Page;
   onBack: () => void;
   supplementalRightContent?: React.ReactNode;
+  /**
+   * 履歴メニューを出してよいかどうか。サーバの `/api/pages/:id/snapshots` は
+   * `authRequired` のため、未ログインの guest が公開・unlisted ノートを
+   * 閲覧している場合に履歴を出すと 401 で必ず失敗する (Codex P2)。呼び出し側で
+   * `isSignedIn` を渡し、未認証時は履歴項目自体を出さない。
+   *
+   * Whether the history menu item should be exposed. The server's
+   * `/api/pages/:id/snapshots` route is `authRequired`, so showing the
+   * history entry to unauthenticated guests viewing a public / unlisted
+   * note page would guarantee a 401 inside `PageHistoryModal`. The parent
+   * passes `isSignedIn` so we hide the entry instead of exposing a broken
+   * flow (Codex P2 review on PR #891).
+   */
+  canViewHistory: boolean;
 }): React.JSX.Element {
   const { t } = useTranslation();
   const [historyOpen, setHistoryOpen] = useState(false);
@@ -446,16 +498,32 @@ function NotePageReadOnly({
     window.location.reload();
   }, []);
 
-  const menuItems = useMemo<PageDetailToolbarAction[]>(
-    () =>
-      buildSharedMenuItems({
-        t,
-        onOpenHistory: handleOpenHistory,
-        onExportMarkdown: handleExportMarkdown,
-        onCopyMarkdown: handleCopyMarkdown,
-      }),
-    [t, handleOpenHistory, handleExportMarkdown, handleCopyMarkdown],
-  );
+  const menuItems = useMemo<PageDetailToolbarAction[]>(() => {
+    const items: PageDetailToolbarAction[] = [];
+    if (canViewHistory) {
+      items.push({
+        id: "history",
+        label: t("editor.pageHistory.menuButton"),
+        icon: History,
+        onClick: handleOpenHistory,
+      });
+    }
+    items.push(
+      {
+        id: "export-markdown",
+        label: t("editor.pageMenu.exportMarkdown"),
+        icon: Download,
+        onClick: handleExportMarkdown,
+      },
+      {
+        id: "copy-markdown",
+        label: t("editor.pageMenu.copyMarkdown"),
+        icon: Copy,
+        onClick: handleCopyMarkdown,
+      },
+    );
+    return items;
+  }, [t, canViewHistory, handleOpenHistory, handleExportMarkdown, handleCopyMarkdown]);
 
   return (
     <>
@@ -587,6 +655,20 @@ const NotePageView: React.FC = () => {
 
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
+  // 削除成功時に編集中の保留タイトル保存を flush せずに捨てるためのフック。
+  // `NotePageEditorEditable` がマウント中、自分自身のキャンセル関数をここに
+  // 書き込む（mount 時に set、unmount 時に null）。削除直後の navigate で
+  // child が unmount される前に呼び出すことで、もう存在しないページに
+  // タイトル保存リクエストが飛ぶのを防ぐ (Codex P2 review on PR #891)。
+  //
+  // Mutable handle used to cancel any debounced title save before the
+  // delete-success navigation. The editable child writes its own cancel
+  // function into this ref while mounted (cleared on unmount); the parent
+  // invokes it inside `onSuccess` so the about-to-unmount cleanup no longer
+  // fires a `putPageContent` against the page we just removed. Codex P2
+  // review on PR #891.
+  const cancelPendingTitleSaveRef = useRef<(() => void) | null>(null);
+
   const handleBack = useCallback(() => {
     // `/notes/:noteId/:pageId` ルートなので `noteId` は常に存在する。`/home`
     // への fallback は廃止済み（issue #884）。
@@ -631,6 +713,14 @@ const NotePageView: React.FC = () => {
           // `useRemovePageFromNote` already invalidates the note detail and
           // window caches; nothing extra to do here.
           setDeleteConfirmOpen(false);
+          // navigate でアンマウントされる前に、編集中の保留タイトル保存を破棄する。
+          // 既存の cleanup が pending を flush すると、消したばかりのページに
+          // `putPageContent` が飛んで保存失敗トーストが出てしまう (Codex P2)。
+          //
+          // Cancel any debounced title save before navigation so the editable
+          // child's unmount cleanup does not flush against the just-removed
+          // page. Codex P2 review on PR #891.
+          cancelPendingTitleSaveRef.current?.();
           navigate(`/notes/${noteId}`);
         },
         onError: (error) => {
@@ -701,12 +791,14 @@ const NotePageView: React.FC = () => {
               onRequestDelete={handleRequestDelete}
               isDeletePending={isDeletePending}
               supplementalRightContent={supplementalRightContent}
+              cancelPendingTitleSaveRef={cancelPendingTitleSaveRef}
             />
           ) : (
             <NotePageReadOnly
               page={page}
               onBack={handleBack}
               supplementalRightContent={supplementalRightContent}
+              canViewHistory={isSignedIn}
             />
           )}
         </NoteWorkspaceProvider>


### PR DESCRIPTION
## 概要

ノートページビュー (`NotePageView`) のツールバーを `/pages/:id` と同じ4項目（変更履歴・Markdown エクスポート・Markdown コピー・削除）に統一し、UI の一貫性を向上させます。従来の「個人に取り込み」メニューは削除されます。

## 変更点

- **ツールバーメニューの統一**: `NotePageEditorEditable` と `NotePageReadOnly` に共通メニュー項目を追加
  - 変更履歴（`PageHistoryModal` 統合）
  - Markdown でエクスポート
  - Markdown をコピー
  - ページ削除（編集可能時のみ）

- **削除機能の実装**: 
  - `useRemovePageFromNote` フックを使用してノートからページを削除
  - `NotePageDeleteConfirmDialog` で確認ダイアログを表示
  - 削除成功時に `/notes/:noteId` へ遷移

- **コンポーネント分割**:
  - `NotePageReadOnly` を独立した関数コンポーネントに抽出（read-only 表示ロジック）
  - `buildSharedMenuItems()` ヘルパー関数で `/pages/:id` と共通のメニュー構築ロジックを統一

- **Markdown 操作の統合**:
  - `useMarkdownExport` フックで export / copy 機能を共有
  - 編集中の内容をリアルタイムで反映（編集可能時）

- **テスト更新**:
  - 旧「個人に取り込み」テストを削除
  - 新しいメニュー項目（履歴・エクスポート・コピー・削除）のテストを追加
  - 削除確認ダイアログの UX テストを追加

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)

## テスト方法

1. ノートページを編集可能な状態で開き、ツールバーメニューに「変更履歴」「Markdown でエクスポート」「Markdown をコピー」「削除」の4項目が表示されることを確認
2. 各メニュー項目をクリックして動作を確認：
   - 「変更履歴」: `PageHistoryModal` が開く
   - 「Markdown でエクスポート」: ファイルダウンロードが実行される
   - 「Markdown をコピー」: クリップボードにコピーされる
   - 「削除」: 確認ダイアログが表示される
3. 削除確認ダイアログで「キャンセル」をクリックしてダイアログが閉じることを確認
4. 削除確認ダイアログで「削除」をクリックしてページが削除され、ノート詳細ページへ遷移することを確認
5. read-only モードでは削除メニューが表示されず、他の3項目は表示されることを確認
6. `bun run test` でテストがすべてパスすることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない

https://claude.ai/code/session_01Dx4Pq4EaBQz92LMoaDB2fU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized toolbar actions (history, export/copy, delete) with clearer read-only vs editable behavior
  * Delete confirmation dialog that blocks accidental dismissal while deletion is pending
  * Cancellation of pending title-save side effects when a deletion completes

* **Bug Fixes**
  * Prevents spurious save notifications after successful deletion
  * Guards against duplicate delete requests and ensures correct navigation/order on delete success
  * Ensures in-flight/pending saves are cancelled or suppressed during deletion flows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->