### PR TITLE
feat: Add `/health` endpoint with Postgres pool saturation monitoring

### DIFF
--- a/server/hocuspocus/src/health.test.ts
+++ b/server/hocuspocus/src/health.test.ts
@@ -121,6 +121,24 @@ describe("evaluateHealth", () => {
     expect(payload.status).toBe("healthy");
   });
 
+  it("clamps saturation to 1.0 when active exceeds max (burst above pool size)", () => {
+    // `pg.Pool` の一時的なバーストや設定不整合で `active > max` になっても、`saturation`
+    // の公開仕様 (0..1) を逸脱しないこと。`saturated` も当然 true のまま。
+    // Defensive clamp: a burst that pushes `active` above `max` must not leak a
+    // saturation > 1.0 to dashboards, and `saturated` stays true.
+    const payload = evaluateHealth({
+      connections: 0,
+      documents: 0,
+      pool: { totalCount: 12, idleCount: 0, waitingCount: 0 },
+      poolMax: 10,
+      now: NOW,
+    });
+    expect(payload.pool.active).toBe(12);
+    expect(payload.pool.saturation).toBe(1);
+    expect(payload.pool.saturated).toBe(true);
+    expect(payload.status).toBe("degraded");
+  });
+
   it("yields saturation=0 when poolMax is 0 (avoids divide-by-zero)", () => {
     // poolMax を渡し忘れたケースでも例外を投げず、飽和度 0 で degrade させない。
     // A misconfigured poolMax=0 must not throw or trip `degraded`.

--- a/server/hocuspocus/src/health.test.ts
+++ b/server/hocuspocus/src/health.test.ts
@@ -1,0 +1,171 @@
+/**
+ * `evaluateHealth` のユニットテスト。Postgres プールの飽和判定と payload shape を網羅する。
+ *
+ * Unit tests for `evaluateHealth`. Exhaustive coverage of the saturation logic
+ * and the wire shape consumed by Railway / external monitors.
+ */
+import { describe, expect, it } from "vitest";
+import { POOL_SATURATION_THRESHOLD, evaluateHealth } from "./health.js";
+
+const NOW = "2026-05-17T00:00:00.000Z";
+
+/** デフォルトの spacious pool snapshot / Roomy pool snapshot for negative tests. */
+const idlePool = { totalCount: 1, idleCount: 1, waitingCount: 0 };
+
+describe("evaluateHealth", () => {
+  it("returns healthy when pool has plenty of headroom", () => {
+    const payload = evaluateHealth({
+      connections: 3,
+      documents: 2,
+      pool: { totalCount: 2, idleCount: 1, waitingCount: 0 },
+      poolMax: 10,
+      now: NOW,
+    });
+    expect(payload).toEqual({
+      status: "healthy",
+      service: "zedi-hocuspocus",
+      timestamp: NOW,
+      connections: 3,
+      documents: 2,
+      pool: {
+        total: 2,
+        idle: 1,
+        active: 1,
+        waiting: 0,
+        max: 10,
+        saturation: 0.1,
+        saturated: false,
+      },
+    });
+  });
+
+  it("flips to degraded when there is even a single waiter", () => {
+    // waiters > 0 はキュー化が始まったサイン。飽和率に関わらず degraded にする。
+    // Any non-zero waiter means the queue has started; degrade unconditionally.
+    const payload = evaluateHealth({
+      connections: 100,
+      documents: 50,
+      pool: { totalCount: 10, idleCount: 10, waitingCount: 1 },
+      poolMax: 10,
+      now: NOW,
+    });
+    expect(payload.status).toBe("degraded");
+    expect(payload.pool.saturated).toBe(true);
+    expect(payload.pool.waiting).toBe(1);
+  });
+
+  it("flips to degraded once active/max crosses the saturation threshold", () => {
+    // POOL_SATURATION_THRESHOLD = 0.8 → max=10, active=8 で degraded になること。
+    // With max=10 and active=8 we hit the 80% threshold and trip `degraded`.
+    const payload = evaluateHealth({
+      connections: 8,
+      documents: 8,
+      pool: { totalCount: 10, idleCount: 2, waitingCount: 0 },
+      poolMax: 10,
+      now: NOW,
+    });
+    expect(payload.pool.saturation).toBeCloseTo(0.8, 5);
+    expect(payload.pool.saturation).toBeGreaterThanOrEqual(POOL_SATURATION_THRESHOLD);
+    expect(payload.pool.saturated).toBe(true);
+    expect(payload.status).toBe("degraded");
+  });
+
+  it("stays healthy when active/max is just below the threshold", () => {
+    // 7/10 = 0.7 はまだ閾値未満。waiters も 0 なので healthy のまま。
+    // 70% is below the 80% threshold and there are no waiters → healthy.
+    const payload = evaluateHealth({
+      connections: 7,
+      documents: 7,
+      pool: { totalCount: 10, idleCount: 3, waitingCount: 0 },
+      poolMax: 10,
+      now: NOW,
+    });
+    expect(payload.pool.saturation).toBeCloseTo(0.7, 5);
+    expect(payload.pool.saturated).toBe(false);
+    expect(payload.status).toBe("healthy");
+  });
+
+  it("treats a cold pool (totalCount=0) as healthy regardless of max", () => {
+    // 起動直後で接続がまだ無い場合は誤って degraded にしない（active=0, saturation=0）。
+    // A freshly started Hocuspocus that has not yet opened any pg client must
+    // not be reported as degraded just because the pool is empty.
+    const payload = evaluateHealth({
+      connections: 0,
+      documents: 0,
+      pool: { totalCount: 0, idleCount: 0, waitingCount: 0 },
+      poolMax: 10,
+      now: NOW,
+    });
+    expect(payload.status).toBe("healthy");
+    expect(payload.pool.saturated).toBe(false);
+    expect(payload.pool.active).toBe(0);
+    expect(payload.pool.saturation).toBe(0);
+  });
+
+  it("clamps an out-of-range idleCount > totalCount (defensive)", () => {
+    // `pg.Pool` 内部実装が変わって idle > total が観測されても、active が負にならず
+    // saturation も 0..1 の範囲に収まること。
+    // Guard against future `pg.Pool` internals exposing idle > total; active
+    // must never go negative and saturation must stay non-negative.
+    const payload = evaluateHealth({
+      connections: 1,
+      documents: 1,
+      pool: { totalCount: 2, idleCount: 99, waitingCount: 0 },
+      poolMax: 10,
+      now: NOW,
+    });
+    expect(payload.pool.total).toBe(2);
+    expect(payload.pool.idle).toBe(2);
+    expect(payload.pool.active).toBe(0);
+    expect(payload.pool.saturation).toBe(0);
+    expect(payload.status).toBe("healthy");
+  });
+
+  it("yields saturation=0 when poolMax is 0 (avoids divide-by-zero)", () => {
+    // poolMax を渡し忘れたケースでも例外を投げず、飽和度 0 で degrade させない。
+    // A misconfigured poolMax=0 must not throw or trip `degraded`.
+    const payload = evaluateHealth({
+      connections: 1,
+      documents: 1,
+      pool: { totalCount: 1, idleCount: 0, waitingCount: 0 },
+      poolMax: 0,
+      now: NOW,
+    });
+    expect(payload.pool.saturation).toBe(0);
+    expect(payload.pool.saturated).toBe(false);
+    expect(payload.status).toBe("healthy");
+  });
+
+  it("preserves Hocuspocus counters verbatim", () => {
+    // `connections` / `documents` はそのまま透過する。Railway / 外部監視はこれを直接参照する。
+    // `connections` / `documents` must pass through unchanged for external dashboards.
+    const payload = evaluateHealth({
+      connections: 42,
+      documents: 17,
+      pool: idlePool,
+      poolMax: 10,
+      now: NOW,
+    });
+    expect(payload.connections).toBe(42);
+    expect(payload.documents).toBe(17);
+  });
+
+  it("defaults `timestamp` to a parseable ISO string when `now` is omitted", () => {
+    // 引数 `now` を省略すると `new Date().toISOString()` が呼ばれる。具体値は固定せず、
+    // ISO 8601 のフォーマットだけ検証する。
+    // When `now` is omitted, fall back to `new Date().toISOString()`. We only
+    // assert the result parses cleanly, not its literal value.
+    const before = Date.now();
+    const payload = evaluateHealth({
+      connections: 0,
+      documents: 0,
+      pool: idlePool,
+      poolMax: 10,
+    });
+    const after = Date.now();
+    const parsed = Date.parse(payload.timestamp);
+    expect(Number.isNaN(parsed)).toBe(false);
+    expect(parsed).toBeGreaterThanOrEqual(before);
+    expect(parsed).toBeLessThanOrEqual(after);
+  });
+});

--- a/server/hocuspocus/src/health.ts
+++ b/server/hocuspocus/src/health.ts
@@ -138,7 +138,13 @@ export function evaluateHealth(inputs: HealthInputs): HealthPayload {
   // Clamp `idle` to the legal `0..total` window to absorb out-of-range inputs.
   const idleClamped = Math.min(idle, total);
   const active = total - idleClamped;
-  const saturation = max > 0 ? active / max : 0;
+  // `active > max` は pg.Pool の一時的なバーストや設定不整合で起きうるが、saturation の
+  // 公開仕様 (0.0 - 1.0) を逸脱しないように 1.0 で頭打ちにする。`saturated` 判定は
+  // 0.8 閾値で行うのでクランプの影響を受けない。
+  // `active` can temporarily exceed `max` during a `pg.Pool` burst, so clamp
+  // `saturation` to the documented 0..1 range. The `saturated` flag uses the
+  // 0.8 threshold and is unaffected by the clamp.
+  const saturation = max > 0 ? Math.min(1, active / max) : 0;
   const saturated = waiting > 0 || (total > 0 && saturation >= POOL_SATURATION_THRESHOLD);
 
   return {

--- a/server/hocuspocus/src/health.ts
+++ b/server/hocuspocus/src/health.ts
@@ -1,0 +1,160 @@
+/**
+ * Hocuspocus `/health` エンドポイント用のペイロード組み立てロジック。
+ *
+ * Issue #889 Phase 5 で全ページが Hocuspocus を経由するようになり、Hocuspocus が
+ * Zedi の編集機能の単一障害点になった。Railway のオートヘルスチェックが拾える形で
+ * `connections` / `documents` / Postgres プール使用率を集約し、Pg プール枯渇を
+ * `degraded` ステータスとして外部から観測できるようにする。
+ *
+ * 本モジュールは Hocuspocus サーバや `pg.Pool` 本体には依存させず、必要な値だけを
+ * 受け取って結果オブジェクトを返す純関数として保つ。これにより以下が成立する:
+ *   - 単体テストで状態列挙が網羅できる（プール枯渇・空 Hocuspocus 等）。
+ *   - 将来 `/metrics` 形式（Prometheus textfmt 等）への横展開も容易。
+ *
+ * Pure helpers for the Hocuspocus `/health` endpoint introduced as part of
+ * Issue #889 Phase 5. The router caller passes in current counters from the
+ * live Hocuspocus instance and the `pg.Pool` so that this module stays free of
+ * runtime dependencies — making the saturation logic exhaustively testable
+ * (empty pool, saturated pool, callers waiting, etc.).
+ */
+
+/**
+ * `pg.Pool` から拾うフィールドの最小サブセット。実 `Pool` を import せずに使えるよう
+ * 型を直接定義しておく。`max` はコンストラクタオプションから別途渡す。
+ *
+ * Minimal slice of `pg.Pool`'s observable counters. We avoid pulling in `pg`'s
+ * type so this module is unit-testable in isolation. `max` is provided
+ * separately because `pg.Pool` does not expose it as a public property.
+ */
+export interface PgPoolStats {
+  /** 現在プールに保持されているクライアント数 / Total clients currently in the pool. */
+  totalCount: number;
+  /** アイドル状態のクライアント数 / Idle clients available for checkout. */
+  idleCount: number;
+  /** プール解放待ちで滞留している呼び出し数。0 でなければ枯渇のサイン。
+   *  Callers currently waiting for an idle client; non-zero indicates pressure. */
+  waitingCount: number;
+}
+
+/** `/health` JSON のステータス区分 / Status discriminator for the `/health` payload. */
+export type HealthStatus = "healthy" | "degraded";
+
+/**
+ * Postgres プールの状態を `/health` 用に正規化したオブジェクト。
+ * `active` は呼び出し中（acquired-but-not-idle）の概算。
+ *
+ * Normalized snapshot of the Postgres pool exposed by `/health`.
+ * `active` is approximated as `totalCount - idleCount`.
+ */
+export interface PgPoolHealth {
+  total: number;
+  idle: number;
+  /** total - idle 相当。プール上限に対するアクティブ比率の分子。
+   *  Approx active clients (`total - idle`); numerator for saturation. */
+  active: number;
+  /** プール解放待ちの呼び出し数。1 以上なら飽和。Waiters; >=1 means saturation. */
+  waiting: number;
+  /** プールサイズ上限。pg.Pool コンストラクタの `max` と一致させる。 Pool's `max`. */
+  max: number;
+  /**
+   * 飽和度 (0.0 - 1.0)。`active / max`。`max=0` の場合は 0 として返す。
+   * Saturation ratio (`active / max`); 0 when `max <= 0`.
+   */
+  saturation: number;
+  /**
+   * `true` のとき `/health` 全体を `degraded` に倒す根拠になる（waiters > 0 か飽和度
+   * が閾値以上）。具体的な閾値は `evaluateHealth` の実装を参照。
+   *
+   * When `true`, the pool is the root cause of a `degraded` overall status —
+   * either a non-zero waiting queue or saturation at/over the threshold.
+   */
+  saturated: boolean;
+}
+
+/** `evaluateHealth` の入力 / Inputs to {@link evaluateHealth}. */
+export interface HealthInputs {
+  /** Hocuspocus が現在開いている WebSocket 接続数。From `hocuspocus.getConnectionsCount()`. */
+  connections: number;
+  /** Hocuspocus がメモリに常駐させている Y.Doc 数。From `hocuspocus.getDocumentsCount()`. */
+  documents: number;
+  /** Postgres プールのカウンタ。From `pg.Pool` の public フィールド。 */
+  pool: PgPoolStats;
+  /** Pool の `max` 設定値。`pg.Pool` は公開していないので呼び出し側で渡す。
+   *  `max` from the `pg.Pool` constructor; not exposed by `pg`, so passed in. */
+  poolMax: number;
+  /**
+   * `evaluateHealth` がレスポンスに刻む現在時刻。テストで固定したいので関数引数として
+   * 受け取る。省略時はモジュール内で `new Date().toISOString()` を呼ぶ。
+   *
+   * ISO timestamp stamped onto the response. Injected for deterministic tests;
+   * defaults to `new Date().toISOString()` when omitted.
+   */
+  now?: string;
+}
+
+/** `/health` レスポンスの最終形。GET /health の JSON ボディそのもの。
+ *  Shape returned to HTTP callers; serialized as the `/health` JSON body. */
+export interface HealthPayload {
+  status: HealthStatus;
+  service: "zedi-hocuspocus";
+  timestamp: string;
+  connections: number;
+  documents: number;
+  pool: PgPoolHealth;
+}
+
+/**
+ * Postgres プールの飽和判定で使う閾値（0..1）。`active / max` がこれ以上で飽和扱い。
+ *
+ * 80% にしているのは、`pg.Pool` の `max=10`（`server/hocuspocus/src/index.ts:59`）
+ * 前提で `active >= 8` を「予備が 2 接続しか残っていない」と読むため。waiters が
+ * 出る前段（飽和が現実化する直前）で degraded を出してアラート余地を残す。
+ *
+ * Saturation threshold (active/max). 80% leaves a 2-slot headroom on the
+ * default `max=10` pool so `degraded` fires before the queue starts growing.
+ */
+export const POOL_SATURATION_THRESHOLD = 0.8;
+
+/**
+ * `/health` のスナップショットを組み立てる。プール飽和や `waiting > 0` を検知すると
+ * `status: "degraded"` を返し、エンドポイント側は引き続き HTTP 200 を返す（Railway の
+ * ヘルスチェックでは healthy 扱いになるが、外部監視・ログ側で `status` を見て pager を
+ * 飛ばす想定）。Pg プールが完全に空 (totalCount=0) の起動直後は飽和とは見なさない。
+ *
+ * Build the `/health` payload. Flags `status: "degraded"` when the Postgres
+ * pool is saturated or has callers waiting; HTTP status remains 200 so Railway
+ * keeps the container in rotation, but external monitors (Better Uptime,
+ * Grafana, etc.) page on `status !== "healthy"`. A cold pool with
+ * `totalCount=0` is never considered saturated.
+ */
+export function evaluateHealth(inputs: HealthInputs): HealthPayload {
+  const { connections, documents, pool, poolMax, now } = inputs;
+  const total = Math.max(0, pool.totalCount | 0);
+  const idle = Math.max(0, pool.idleCount | 0);
+  const waiting = Math.max(0, pool.waitingCount | 0);
+  const max = Math.max(0, poolMax | 0);
+
+  // `idle` が `total` を超える異常値はクランプして 0..total に収める。
+  // Clamp `idle` to the legal `0..total` window to absorb out-of-range inputs.
+  const idleClamped = Math.min(idle, total);
+  const active = total - idleClamped;
+  const saturation = max > 0 ? active / max : 0;
+  const saturated = waiting > 0 || (total > 0 && saturation >= POOL_SATURATION_THRESHOLD);
+
+  return {
+    status: saturated ? "degraded" : "healthy",
+    service: "zedi-hocuspocus",
+    timestamp: now ?? new Date().toISOString(),
+    connections: Math.max(0, connections | 0),
+    documents: Math.max(0, documents | 0),
+    pool: {
+      total,
+      idle: idleClamped,
+      active,
+      waiting,
+      max,
+      saturation,
+      saturated,
+    },
+  };
+}

--- a/server/hocuspocus/src/index.ts
+++ b/server/hocuspocus/src/index.ts
@@ -9,6 +9,7 @@ import {
   warnDevAuthBypassOnce,
 } from "./dev-auth-bypass.js";
 import { buildContentPreview, extractTextFromYXml } from "./extractPlainTextFromYXml.js";
+import { evaluateHealth } from "./health.js";
 import {
   canEditFromRole,
   resolveNoteRole,
@@ -24,6 +25,19 @@ const REDIS_URL = process.env.REDIS_URL;
 const DATABASE_URL = process.env.DATABASE_URL;
 const API_INTERNAL_URL = process.env.API_INTERNAL_URL;
 const INTERNAL_SECRET = process.env.BETTER_AUTH_SECRET?.trim();
+
+/**
+ * Postgres プールの最大同時接続数。`pg.Pool` は `max` を public フィールドとして
+ * 公開していないため、コンストラクタに渡した値と `/health` で参照する値を本定数で
+ * 共有する。Railway 上の Hocuspocus は単一インスタンス想定なのでここで上限を直接
+ * 表現する。
+ *
+ * Pool size shared between `pg.Pool({ max })` and the `/health` snapshot.
+ * `pg.Pool` does not expose `max` publicly, so we keep the source of truth
+ * here. Hocuspocus runs as a single Railway replica, so this directly caps
+ * total live Postgres clients.
+ */
+const PG_POOL_MAX = 10;
 
 /** Cached env reads for auth paths (avoid repeated `process.env` lookups). / 認証経路用に env を一度だけ読む */
 const NODE_ENV = process.env.NODE_ENV;
@@ -56,7 +70,7 @@ function getPool(): Pool {
   }
   pgPool = new Pool({
     connectionString: DATABASE_URL,
-    max: 10,
+    max: PG_POOL_MAX,
     idleTimeoutMillis: 30000,
   });
   return pgPool;
@@ -647,18 +661,28 @@ hocuspocusServer.httpServer.on("request", (req: IncomingMessage, res: ServerResp
 });
 
 async function handleHttpRequestFallback(requestUrl: URL, res: ServerResponse): Promise<void> {
-  // ヘルスチェックエンドポイント
+  // ヘルスチェックエンドポイント。Issue #889 Phase 5 で `connections` / `documents`
+  // に加えて Postgres プールの飽和度も返すよう拡張した。ステータス自体は
+  // Railway の `restartPolicy` が拾えるよう常に HTTP 200 にし、`status` フィールド
+  // (`healthy` / `degraded`) で外部監視がアラートを上げる想定。
+  //
+  // `/health` returns connection / document counts and Postgres pool
+  // saturation. HTTP status stays 200 so Railway never restarts purely on
+  // pool pressure; external monitors page on `status !== "healthy"`.
   if (requestUrl.pathname === "/health" || requestUrl.pathname === "/") {
+    const pool = pgPool;
+    const payload = evaluateHealth({
+      connections: hocuspocus.getConnectionsCount(),
+      documents: hocuspocus.getDocumentsCount(),
+      pool: {
+        totalCount: pool?.totalCount ?? 0,
+        idleCount: pool?.idleCount ?? 0,
+        waitingCount: pool?.waitingCount ?? 0,
+      },
+      poolMax: PG_POOL_MAX,
+    });
     res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(
-      JSON.stringify({
-        status: "healthy",
-        service: "zedi-hocuspocus",
-        timestamp: new Date().toISOString(),
-        connections: hocuspocus.getConnectionsCount(),
-        documents: hocuspocus.getDocumentsCount(),
-      }),
-    );
+    res.end(JSON.stringify(payload));
     return;
   }
 

--- a/server/mcp/README.md
+++ b/server/mcp/README.md
@@ -203,9 +203,9 @@ Claude Code の `mcpServers` では、HTTP transport 向け設定を使う。`Au
 | `zedi_create_page` | 新規ページを作成 (Y.Doc は空)。                                                                |
 | `zedi_delete_page` | ページをソフトデリートする。                                                                   |
 
-> Issue #889 Phase 5 で MCP は read-only に縮退しました。ページ本文の更新は Zedi クライアント (Hocuspocus 経由のリアルタイム編集) から行ってください。`zedi_update_page_content` は廃止されました。
+> Issue #889 Phase 5 で MCP からはページ本文の更新ツール (`zedi_update_page_content`) のみが廃止されました。ノート作成・メンバー追加など他の書き込み系ツールは引き続き利用可能です。ページ本文の編集は Zedi クライアント (Hocuspocus 経由のリアルタイム編集) から行ってください。
 >
-> _Issue #889 Phase 5 made MCP read-only. To edit a page body, use the Zedi web/desktop client which writes through Hocuspocus. The retired tool was `zedi_update_page_content`._
+> _Issue #889 Phase 5 retired only the page-body update tool (`zedi_update_page_content`) from the MCP surface. Other mutating tools (note creation, membership, etc.) remain available. To edit a page body, use the Zedi web/desktop client which writes through Hocuspocus._
 
 ### ノート
 
@@ -242,7 +242,7 @@ Claude Code の `mcpServers` では、HTTP transport 向け設定を使う。`Au
 | `zedi_search`   | タイトルと本文で全文検索。`scope: own` or `shared`、`limit` を指定可能。 |
 | `zedi_clip_url` | 公開 URL を Readability で整形し、新規ページとして保存。                 |
 
-計 19 ツール。ツール名の一覧は `src/tools/index.ts` の `ALL_TOOL_NAMES` にも定義済み。
+計 20 ツール。ツール名の一覧は `src/tools/index.ts` の `ALL_TOOL_NAMES` にも定義済み。
 
 ---
 

--- a/server/mcp/README.md
+++ b/server/mcp/README.md
@@ -197,12 +197,15 @@ Claude Code の `mcpServers` では、HTTP transport 向け設定を使う。`Au
 
 ### ページ
 
-| ツール名                   | 概要                                                          |
-| -------------------------- | ------------------------------------------------------------- |
-| `zedi_get_page`            | 単一ページの Y.Doc state と `content_text` を取得。           |
-| `zedi_create_page`         | 新規ページを作成 (Y.Doc は空)。                               |
-| `zedi_update_page_content` | ページの Y.Doc state を `expected_version` で楽観ロック更新。 |
-| `zedi_delete_page`         | ページをソフトデリートする。                                  |
+| ツール名           | 概要                                                                                           |
+| ------------------ | ---------------------------------------------------------------------------------------------- |
+| `zedi_get_page`    | 単一ページの本文 (`content_text`) とメタデータを読み取り専用で取得。Y.Doc バイト列は含まない。 |
+| `zedi_create_page` | 新規ページを作成 (Y.Doc は空)。                                                                |
+| `zedi_delete_page` | ページをソフトデリートする。                                                                   |
+
+> Issue #889 Phase 5 で MCP は read-only に縮退しました。ページ本文の更新は Zedi クライアント (Hocuspocus 経由のリアルタイム編集) から行ってください。`zedi_update_page_content` は廃止されました。
+>
+> _Issue #889 Phase 5 made MCP read-only. To edit a page body, use the Zedi web/desktop client which writes through Hocuspocus. The retired tool was `zedi_update_page_content`._
 
 ### ノート
 
@@ -239,7 +242,7 @@ Claude Code の `mcpServers` では、HTTP transport 向け設定を使う。`Au
 | `zedi_search`   | タイトルと本文で全文検索。`scope: own` or `shared`、`limit` を指定可能。 |
 | `zedi_clip_url` | 公開 URL を Readability で整形し、新規ページとして保存。                 |
 
-計 20 ツール。ツール名の一覧は `src/tools/index.ts` の `ALL_TOOL_NAMES` にも定義済み。
+計 19 ツール。ツール名の一覧は `src/tools/index.ts` の `ALL_TOOL_NAMES` にも定義済み。
 
 ---
 
@@ -252,7 +255,7 @@ Claude Code の `mcpServers` では、HTTP transport 向け設定を使う。`Au
 ### ツール呼び出しが 401 / 403 を返す
 
 - トークンの有効期限が切れている (`MCP_JWT_EXP_DAYS` 日で失効)。`zedi-mcp-cli login` でトークンを再発行する。
-- スコープが足りない。書き込み系ツール (`zedi_create_note`, `zedi_update_page_content` など) は `mcp:write` を要求する。`issue-mcp-token.ts` の第 2 引数に `mcp:read,mcp:write` を渡す、もしくは CLI ログイン時に既定の `mcp:read,mcp:write` で発行する。
+- スコープが足りない。書き込み系ツール (`zedi_create_note`, `zedi_add_page_to_note` など) は `mcp:write` を要求する。`issue-mcp-token.ts` の第 2 引数に `mcp:read,mcp:write` を渡す、もしくは CLI ログイン時に既定の `mcp:read,mcp:write` で発行する。なお Issue #889 Phase 5 以降、ページ本文の更新ツールは MCP から削除されている。
 - `ZEDI_API_URL` の指す API サーバーと、トークンを発行した API サーバーが別物 (署名鍵が違う)。同じ環境で発行したトークンを使うこと。
 
 ### HTTP transport に接続できない / Claude Code から見えない
@@ -260,10 +263,6 @@ Claude Code の `mcpServers` では、HTTP transport 向け設定を使う。`Au
 - `curl https://<railway-domain>/health` が `{ "ok": true, ... }` を返すか確認。返らない場合はデプロイが立ち上がっていない。
 - Claude Code の設定で `type: "http"` と `Authorization` ヘッダが両方指定されているか確認。
 - Railway の内部通信を使うとき、`ZEDI_API_URL` は内部 URL (`http://api.railway.internal:3000` 等) を指す必要がある。外向き URL を設定すると自己呼び出しでループする可能性がある。
-
-### ツールが `400` を返し "expected_version mismatch" になる
-
-`zedi_update_page_content` は楽観ロック。直前に `zedi_get_page` で最新の `version` を取得し、そのまま `expected_version` に渡すこと。
 
 ### HTTPS でない stdio 出力でクライアントが壊れる
 

--- a/server/mcp/src/__tests__/client/httpClient.test.ts
+++ b/server/mcp/src/__tests__/client/httpClient.test.ts
@@ -116,17 +116,52 @@ describe("HttpZediClient request shaping", () => {
     expect((init as RequestInit).body).toBe(JSON.stringify({ title: "Hello" }));
   });
 
-  it("updatePageContent sends PUT to /api/pages/:id/content", async () => {
-    fetchMock.mockResolvedValueOnce(makeJsonResponse(200, { version: 7 }));
-    const result = await client.updatePageContent("p1", {
-      ydoc_state: "BASE64STATE",
-      expected_version: 6,
-      content_text: "hi",
+  it("getPageContent sends GET to /api/pages/:id/public-content with Bearer token", async () => {
+    // Issue #889 Phase 5: read-only エンドポイントに乗り換えたため、URL とレスポンス shape を固定する。
+    // Issue #889 Phase 5: locked to the read-only endpoint; URL + shape are part of the public contract.
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse(200, {
+        id: "p1",
+        title: "Hello",
+        content_text: "Hello world",
+        content_preview: "Hello",
+        version: 7,
+        updated_at: "2026-05-16T10:00:00.000Z",
+      }),
+    );
+    const content = await client.getPageContent("p1");
+    expect(content).toEqual({
+      id: "p1",
+      title: "Hello",
+      content_text: "Hello world",
+      content_preview: "Hello",
+      version: 7,
+      updated_at: "2026-05-16T10:00:00.000Z",
     });
-    expect(result.version).toBe(7);
     const [url, init] = callArgs(fetchMock as unknown as Mock);
-    expect(url).toBe(`${BASE}/api/pages/p1/content`);
-    expect((init as RequestInit).method).toBe("PUT");
+    expect(url).toBe(`${BASE}/api/pages/p1/public-content`);
+    expect((init as RequestInit).method).toBe("GET");
+    expect((init as RequestInit).body).toBeUndefined();
+    const headers = new Headers((init as RequestInit).headers);
+    expect(headers.get("Authorization")).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("getPageContent URL-encodes the page id (defense against odd characters)", async () => {
+    // page_id に予期せぬ文字が来ても URL を壊さないこと。
+    // URL encoding must guard against unexpected characters in `page_id`.
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse(200, {
+        id: "p/1?x",
+        title: null,
+        content_text: null,
+        content_preview: null,
+        version: 0,
+        updated_at: "2026-05-16T10:00:00.000Z",
+      }),
+    );
+    await client.getPageContent("p/1?x");
+    const url = callArgs(fetchMock as unknown as Mock)[0] as string;
+    expect(url).toBe(`${BASE}/api/pages/${encodeURIComponent("p/1?x")}/public-content`);
   });
 
   it("deletePage sends DELETE to /api/pages/:id", async () => {

--- a/server/mcp/src/__tests__/e2e/stdio-roundtrip.test.ts
+++ b/server/mcp/src/__tests__/e2e/stdio-roundtrip.test.ts
@@ -41,7 +41,6 @@ interface StoredPage {
   created_at: string;
   updated_at: string;
   is_deleted: boolean;
-  ydoc_state: string;
   content_text: string | null;
   version: number;
 }
@@ -88,13 +87,12 @@ function buildMockApi(): Hono {
       created_at: now,
       updated_at: now,
       is_deleted: false,
-      ydoc_state: "",
       content_text: null,
       version: 0,
     };
     pages.set(id, page);
-    // PageRow の形だけを返す (ydoc_state / version は別エンドポイント) /
-    // Return only the PageRow shape; ydoc_state / version live on the content endpoint.
+    // PageRow の形だけを返す (本文は public-content エンドポイントから取得)。
+    // Return only the PageRow shape; rendered text lives on the public-content endpoint.
     return c.json({
       id: page.id,
       owner_id: page.owner_id,
@@ -109,42 +107,22 @@ function buildMockApi(): Hono {
     });
   });
 
-  app.get("/api/pages/:id/content", (c) => {
+  // Issue #889 Phase 5: MCP は read-only `public-content` エンドポイントから本文を取得する。
+  // Y.Doc バイト列はサーバ側でも意図的に返さない。
+  // Issue #889 Phase 5: MCP reads page bodies via the read-only `public-content`
+  // endpoint. Y.Doc bytes are intentionally omitted server-side as well.
+  app.get("/api/pages/:id/public-content", (c) => {
     const id = c.req.param("id");
     const page = pages.get(id);
     if (!page || page.is_deleted) return c.json({ message: "not found" }, 404);
     return c.json({
-      ydoc_state: page.ydoc_state,
-      version: page.version,
+      id: page.id,
+      title: page.title,
       content_text: page.content_text,
+      content_preview: page.content_preview,
+      version: page.version,
       updated_at: page.updated_at,
     });
-  });
-
-  app.put("/api/pages/:id/content", async (c) => {
-    const id = c.req.param("id");
-    const page = pages.get(id);
-    if (!page || page.is_deleted) return c.json({ message: "not found" }, 404);
-    const body = (await c.req.json().catch(() => ({}))) as {
-      ydoc_state?: unknown;
-      expected_version?: unknown;
-      content_text?: unknown;
-      content_preview?: unknown;
-      title?: unknown;
-    };
-    if (typeof body.ydoc_state !== "string" || typeof body.expected_version !== "number") {
-      return c.json({ message: "invalid body" }, 400);
-    }
-    if (body.expected_version !== page.version) {
-      return c.json({ message: "version conflict" }, 409);
-    }
-    page.ydoc_state = body.ydoc_state;
-    if (typeof body.content_text === "string") page.content_text = body.content_text;
-    if (typeof body.content_preview === "string") page.content_preview = body.content_preview;
-    if (typeof body.title === "string") page.title = body.title;
-    page.version += 1;
-    page.updated_at = new Date().toISOString();
-    return c.json({ version: page.version });
   });
 
   app.delete("/api/pages/:id", (c) => {
@@ -234,7 +212,7 @@ describe("stdio MCP roundtrip", () => {
     expect(parsed.email).toBe("test@example.com");
   });
 
-  it("create -> get -> update -> delete page roundtrip via stdio", async () => {
+  it("create -> get -> delete page roundtrip via stdio (MCP is read-only after #889 Phase 5)", async () => {
     const created = await client.callTool({
       name: "zedi_create_page",
       arguments: { title: "E2E Page", content_preview: "preview" },
@@ -248,47 +226,36 @@ describe("stdio MCP roundtrip", () => {
     const pageId = createdParsed.id;
     expect(pageId).toMatch(/^page-/);
 
+    // Issue #889 Phase 5: 取得は read-only `public-content` 経路。Y.Doc バイト列は
+    // 含まれず、`id / title / content_text / content_preview / version / updated_at`
+    // のみが返る。
+    // Issue #889 Phase 5: reads flow through the read-only `public-content`
+    // endpoint, which never exposes the Y.Doc bytes.
     const got = await client.callTool({
       name: "zedi_get_page",
       arguments: { page_id: pageId },
     });
     expect(got.isError).toBeFalsy();
     const gotParsed = JSON.parse((got.content as Array<{ text?: string }>)[0]?.text ?? "") as {
+      id: string;
+      title: string | null;
+      content_text: string | null;
+      content_preview: string | null;
       version: number;
-      ydoc_state: string;
+      updated_at: string;
     };
+    expect(gotParsed.id).toBe(pageId);
+    expect(gotParsed.title).toBe("E2E Page");
+    expect(gotParsed.content_text).toBeNull();
+    expect(gotParsed.content_preview).toBe("preview");
     expect(gotParsed.version).toBe(0);
-    expect(gotParsed.ydoc_state).toBe("");
+    expect(gotParsed).not.toHaveProperty("ydoc_state");
 
-    const updated = await client.callTool({
-      name: "zedi_update_page_content",
-      arguments: {
-        page_id: pageId,
-        ydoc_state: "BASE64-STATE",
-        expected_version: 0,
-        content_text: "hello world",
-      },
-    });
-    expect(updated.isError).toBeFalsy();
-    const updatedParsed = JSON.parse(
-      (updated.content as Array<{ text?: string }>)[0]?.text ?? "",
-    ) as { version: number };
-    expect(updatedParsed.version).toBe(1);
-
-    // 楽観ロック: 古い expected_version を渡すと 409 → isError として届くこと。
-    // Optimistic locking: stale expected_version surfaces as an isError result.
-    const conflicted = await client.callTool({
-      name: "zedi_update_page_content",
-      arguments: {
-        page_id: pageId,
-        ydoc_state: "BASE64-STATE-2",
-        expected_version: 0,
-        content_text: "stale",
-      },
-    });
-    expect(conflicted.isError).toBe(true);
-    const conflictedText = (conflicted.content as Array<{ text?: string }>)[0]?.text ?? "";
-    expect(conflictedText).toContain("HTTP 409");
+    // Issue #889 Phase 5 で MCP 経由のページ更新ツールは廃止された。
+    // Issue #889 Phase 5 retired the page-update tool from the MCP surface.
+    const tools = await client.listTools();
+    const toolNames = tools.tools.map((t) => t.name);
+    expect(toolNames).not.toContain("zedi_update_page_content");
 
     const deleted = await client.callTool({
       name: "zedi_delete_page",

--- a/server/mcp/src/__tests__/server.test.ts
+++ b/server/mcp/src/__tests__/server.test.ts
@@ -22,7 +22,6 @@ function createMockClient(): ZediClient {
     listPages: vi.fn(),
     getPageContent: vi.fn(),
     createPage: vi.fn(),
-    updatePageContent: vi.fn(),
     deletePage: vi.fn(),
     listNotes: vi.fn(),
     getNote: vi.fn(),
@@ -177,23 +176,37 @@ describe("createMcpServer", () => {
     });
   });
 
-  it("zedi_update_page_content includes expected_version", async () => {
-    vi.mocked(mockClient.updatePageContent).mockResolvedValue({ version: 5 });
+  it("zedi_get_page returns the read-only PageContent shape (no ydoc_state)", async () => {
+    // Issue #889 Phase 5: read-only MCP では Y.Doc バイト列を返さない。`public-content`
+    // と shape を合わせて `id / title / content_text / content_preview / version / updated_at`
+    // を必ず公開し、`ydoc_state` が混入しないことを CI で固定する。
+    // Issue #889 Phase 5: lock the public PageContent shape so a regression
+    // that re-introduces Y.Doc bytes via MCP fails CI.
+    vi.mocked(mockClient.getPageContent).mockResolvedValue({
+      id: "p1",
+      title: "Hello",
+      content_text: "Hello world",
+      content_preview: "Hello",
+      version: 7,
+      updated_at: "2026-05-16T10:00:00.000Z",
+    });
     const result = await mcpClient.callTool({
-      name: "zedi_update_page_content",
-      arguments: {
-        page_id: "p1",
-        ydoc_state: "BASE64",
-        expected_version: 4,
-        content_text: "x",
-      },
+      name: "zedi_get_page",
+      arguments: { page_id: "p1" },
     });
     expect(result.isError).toBeFalsy();
-    expect(mockClient.updatePageContent).toHaveBeenCalledWith("p1", {
-      ydoc_state: "BASE64",
-      expected_version: 4,
-      content_text: "x",
+    expect(mockClient.getPageContent).toHaveBeenCalledWith("p1");
+    const content = result.content as Array<{ type: string; text?: string }>;
+    const parsed = JSON.parse(content[0]?.text ?? "") as Record<string, unknown>;
+    expect(parsed).toEqual({
+      id: "p1",
+      title: "Hello",
+      content_text: "Hello world",
+      content_preview: "Hello",
+      version: 7,
+      updated_at: "2026-05-16T10:00:00.000Z",
     });
+    expect(parsed).not.toHaveProperty("ydoc_state");
   });
 
   it("converts ZediApiError into an isError result", async () => {

--- a/server/mcp/src/__tests__/tools/index.test.ts
+++ b/server/mcp/src/__tests__/tools/index.test.ts
@@ -26,7 +26,6 @@ function createMockClient(): ZediClient {
     listPages: vi.fn(),
     getPageContent: vi.fn(),
     createPage: vi.fn(),
-    updatePageContent: vi.fn(),
     deletePage: vi.fn(),
     listNotes: vi.fn(),
     getNote: vi.fn(),
@@ -95,7 +94,6 @@ describe("ALL_TOOL_NAMES", () => {
       "zedi_list_pages",
       "zedi_get_page",
       "zedi_create_page",
-      "zedi_update_page_content",
       "zedi_delete_page",
       "zedi_list_notes",
       "zedi_get_note",
@@ -115,6 +113,22 @@ describe("ALL_TOOL_NAMES", () => {
     ];
     for (const name of required) {
       expect(ALL_TOOL_NAMES).toContain(name);
+    }
+  });
+
+  it("does not re-introduce retired write tools (read-only contract after #889 Phase 5)", () => {
+    // Issue #889 Phase 5 で MCP は read-only に縮退した。Hocuspocus を経由しない
+    // Y.Doc 書き込み (`zedi_update_page_content`) を将来うっかり戻さないよう、
+    // 仕様として "retired" のリストを CI で固定する。書き込み機能を再導入する場合は
+    // この list から名前を外し、Hocuspocus 経由で安全に書ける形を別 issue で設計する。
+    //
+    // After Issue #889 Phase 5 the MCP surface is read-only. This guard makes a
+    // future regression — silently re-adding `zedi_update_page_content` — fail
+    // CI. Bringing back write access requires both removing the entry here and
+    // a new design that routes through Hocuspocus.
+    const retired = ["zedi_update_page_content"];
+    for (const name of retired) {
+      expect(ALL_TOOL_NAMES).not.toContain(name);
     }
   });
 });

--- a/server/mcp/src/client/ZediClient.ts
+++ b/server/mcp/src/client/ZediClient.ts
@@ -69,21 +69,34 @@ export interface ListPagesParams {
   scope?: "own" | "shared";
 }
 
-/** ページ本文 (Y.Doc) / Page Y.Doc content. */
+/**
+ * ページ本文 (読み取り専用) / Page content (read-only).
+ *
+ * Issue #889 Phase 5 で MCP は Hocuspocus を経由せず、`GET /api/pages/:id/public-content`
+ * から `content_text` のみを取得する。Y.Doc バイト列は意図的に含めず、MCP 側で
+ * 編集セッションを開始できないようにしている。バックエンドの公開エンドポイント
+ * （`server/api/src/routes/pages.ts` の `GET /:id/public-content`）と shape を揃える。
+ *
+ * Issue #889 Phase 5 makes the MCP client read-only. The shape mirrors the
+ * `GET /api/pages/:id/public-content` REST endpoint, which deliberately omits
+ * the Y.Doc bytes so MCP cannot accidentally start an editing session.
+ */
 export interface PageContent {
-  ydoc_state: string;
+  /** ページ ID / Page ID. */
+  id: string;
+  /** ページタイトル。空ページや未設定では `null`。 Page title; `null` when unset. */
+  title: string | null;
+  /** Y.Doc から抽出した本文プレーンテキスト。未保存なら `null`。
+   *  Plain text rendered from the persisted Y.Doc; `null` when never saved. */
+  content_text: string | null;
+  /** ページ一覧プレビュー用の短いテキスト。Short preview text used by list views. */
+  content_preview: string | null;
+  /** 楽観ロック用バージョン。`page_contents` 未作成時は 0。
+   *  Optimistic-lock version; 0 when no `page_contents` row exists yet. */
   version: number;
-  content_text?: string | null;
-  updated_at?: string;
-}
-
-/** ページ本文更新の入力 / Input for updating page content. */
-export interface UpdatePageContentInput {
-  ydoc_state: string;
-  expected_version: number;
-  content_text?: string;
-  content_preview?: string;
-  title?: string;
+  /** 最終更新 (ISO 文字列)。`page_contents` が無ければ `pages.updated_at` を返す。
+   *  Last-modified timestamp (ISO); falls back to `pages.updated_at` when content is missing. */
+  updated_at: string;
 }
 
 // ── Notes ───────────────────────────────────────────────────────────────────
@@ -218,12 +231,18 @@ export interface ZediClient {
    * List the caller's pages — own only or own + shared via notes — ordered by `updated_at DESC`.
    */
   listPages(params?: ListPagesParams): Promise<PageListItem[]>;
-  /** ページ本文 (Y.Doc) を取得する。Get page Y.Doc content. */
+  /**
+   * ページ本文を読み取り専用で取得する。Issue #889 Phase 5 以降、MCP は Y.Doc バイト列を
+   * 受け取らず、`GET /api/pages/:id/public-content` から `content_text` のみを取り出す。
+   * private / restricted ノートに対して role が解決しない呼び出し元には 403 が返る。
+   *
+   * Read-only page accessor. After Issue #889 Phase 5, MCP no longer ferries
+   * Y.Doc bytes; the underlying endpoint serves rendered text only and gates
+   * private/restricted notes via `getNoteRole` (403 when no role resolves).
+   */
   getPageContent(pageId: string): Promise<PageContent>;
   /** 新規ページを作成する。Create a new page. */
   createPage(input: CreatePageInput): Promise<PageRow>;
-  /** ページ本文を更新する (楽観的ロック)。Update page content with optimistic lock. */
-  updatePageContent(pageId: string, input: UpdatePageContentInput): Promise<{ version: number }>;
   /** ページを論理削除する。Soft-delete a page. */
   deletePage(pageId: string): Promise<{ id: string; deleted: boolean }>;
 

--- a/server/mcp/src/client/httpClient.ts
+++ b/server/mcp/src/client/httpClient.ts
@@ -17,7 +17,6 @@ import type {
   PageContent,
   PageListItem,
   ListPagesParams,
-  UpdatePageContentInput,
   CreateNoteInput,
   UpdateNoteInput,
   NoteRow,
@@ -167,21 +166,22 @@ export class HttpZediClient implements ZediClient {
 
   /** {@inheritDoc ZediClient.getPageContent} */
   getPageContent(pageId: string): Promise<PageContent> {
-    return this.request<PageContent>("GET", `/api/pages/${encodeURIComponent(pageId)}/content`);
+    // Issue #889 Phase 5: `GET /api/pages/:id/content` を廃止したので、Y.Doc バイト列を
+    // 返さない `public-content` エンドポイントを叩く。`authOptional` + `getNoteRole`
+    // でサーバ側が認可するため、MCP の Bearer トークンはそのまま付けて構わない。
+    // Issue #889 Phase 5: `GET /api/pages/:id/content` was retired, so we hit
+    // the Y.Doc-free `public-content` endpoint. Server-side `authOptional` +
+    // `getNoteRole` handles authorization, so we can forward the MCP bearer
+    // token unchanged.
+    return this.request<PageContent>(
+      "GET",
+      `/api/pages/${encodeURIComponent(pageId)}/public-content`,
+    );
   }
 
   /** {@inheritDoc ZediClient.createPage} */
   createPage(input: CreatePageInput): Promise<PageRow> {
     return this.request<PageRow>("POST", "/api/pages", input);
-  }
-
-  /** {@inheritDoc ZediClient.updatePageContent} */
-  updatePageContent(pageId: string, input: UpdatePageContentInput): Promise<{ version: number }> {
-    return this.request<{ version: number }>(
-      "PUT",
-      `/api/pages/${encodeURIComponent(pageId)}/content`,
-      input,
-    );
   }
 
   /** {@inheritDoc ZediClient.deletePage} */

--- a/server/mcp/src/tools/index.ts
+++ b/server/mcp/src/tools/index.ts
@@ -61,7 +61,7 @@ export function registerAllTools(server: McpServer, client: ZediClient): void {
     {
       title: "Get page content (read-only)",
       description:
-        "Fetches the rendered plain text (`content_text`) of a single page along with its title, preview, version, and last-modified timestamp. Issue #889 Phase 5 made MCP read-only: this endpoint never returns the Y.Doc bytes, and there is no longer a write counterpart — use the Zedi web/desktop client (Hocuspocus collaborative editor) to mutate pages.",
+        "Fetches the rendered plain text (`content_text`) of a single page along with its title, preview, version, and last-modified timestamp. Issue #889 Phase 5 retired MCP page-body updates: this endpoint never returns Y.Doc bytes and there is no `zedi_update_page_content` counterpart anymore (other mutating MCP tools such as `zedi_create_note` are unaffected). To edit page body content, use the Zedi web/desktop client (Hocuspocus collaborative editor).",
       inputSchema: { page_id: z.string().min(1) },
     },
     async (args) =>

--- a/server/mcp/src/tools/index.ts
+++ b/server/mcp/src/tools/index.ts
@@ -59,9 +59,9 @@ export function registerAllTools(server: McpServer, client: ZediClient): void {
   server.registerTool(
     "zedi_get_page",
     {
-      title: "Get page content",
+      title: "Get page content (read-only)",
       description:
-        "Fetches the Y.Doc state and content_text for a single page. Use this to read a page's body.",
+        "Fetches the rendered plain text (`content_text`) of a single page along with its title, preview, version, and last-modified timestamp. Issue #889 Phase 5 made MCP read-only: this endpoint never returns the Y.Doc bytes, and there is no longer a write counterpart — use the Zedi web/desktop client (Hocuspocus collaborative editor) to mutate pages.",
       inputSchema: { page_id: z.string().min(1) },
     },
     async (args) =>
@@ -88,28 +88,6 @@ export function registerAllTools(server: McpServer, client: ZediClient): void {
       wrapToolHandler(async (input) => {
         const page = await client.createPage(input);
         return jsonResult(page);
-      }, args),
-  );
-
-  server.registerTool(
-    "zedi_update_page_content",
-    {
-      title: "Update page content",
-      description:
-        "Updates a page's Y.Doc state with optimistic locking. `expected_version` must match the current version on the server.",
-      inputSchema: {
-        page_id: z.string().min(1),
-        ydoc_state: z.string().min(1),
-        expected_version: z.number().int().nonnegative(),
-        content_text: z.string().optional(),
-        content_preview: z.string().optional(),
-        title: z.string().optional(),
-      },
-    },
-    async (args) =>
-      wrapToolHandler(async ({ page_id, ...rest }) => {
-        const result = await client.updatePageContent(page_id, rest);
-        return jsonResult(result);
       }, args),
   );
 
@@ -388,7 +366,6 @@ export const ALL_TOOL_NAMES = [
   "zedi_list_pages",
   "zedi_get_page",
   "zedi_create_page",
-  "zedi_update_page_content",
   "zedi_delete_page",
   "zedi_list_notes",
   "zedi_get_note",


### PR DESCRIPTION
## 概要

Issue #889 Phase 5 の一環として、Hocuspocus `/health` エンドポイントを拡張し、Postgres プール飽和度を監視できるようにしました。同時に MCP を read-only に縮退し、ページ本文の更新は Hocuspocus（Zedi クライアント）経由のみに限定しました。

## 変更点

### Hocuspocus `/health` エンドポイント拡張
- **新規モジュール**: `server/hocuspocus/src/health.ts` + `health.test.ts`
  - `evaluateHealth()` 純関数で Postgres プール飽和度を計算
  - `connections` / `documents` / プール統計（`total`, `idle`, `active`, `waiting`, `saturation`）を JSON で返却
  - プール飽和度が 80% 以上、または待機キュー（`waiting > 0`）で `status: "degraded"` を返す
  - 起動直後の空プール（`totalCount=0`）は飽和と見なさない
  - 171 行の包括的なユニットテストで状態遷移を網羅

- **Hocuspocus サーバ統合**: `server/hocuspocus/src/index.ts`
  - `PG_POOL_MAX = 10` 定数を導入し、プール上限を一元管理
  - `/health` エンドポイントで `evaluateHealth()` を呼び出し、プール統計を含めたペイロードを返却
  - HTTP ステータスは常に 200（Railway の自動再起動を避ける）、`status` フィールドで外部監視が判定

### MCP の read-only 化（Issue #889 Phase 5）
- **ページ取得の変更**:
  - `GET /api/pages/:id/content` → `GET /api/pages/:id/public-content` に移行
  - Y.Doc バイト列（`ydoc_state`）を返さず、`content_text` のみを提供
  - `PageContent` インターフェースを再定義（`id`, `title`, `content_text`, `content_preview`, `version`, `updated_at`）

- **ページ更新ツール廃止**:
  - `zedi_update_page_content` MCP ツールを削除
  - `updatePageContent()` クライアントメソッドを削除
  - `PUT /api/pages/:id/content` エンドポイント呼び出しを削除

- **テスト・ドキュメント更新**:
  - E2E テスト（`stdio-roundtrip.test.ts`）を read-only フローに更新
  - HTTP クライアントテスト（`httpClient.test.ts`）で新エンドポイント URL を固定
  - MCP サーバテスト（`server.test.ts`）で `ydoc_state` 非存在を CI で検証
  - ツール定義テスト（`tools/index.test.ts`）で廃止ツール再導入を防ぐガード追加
  - README.md でツール一覧を更新

## 変更の種類

- [x] ✨ 新機能 (New feature) — `/health` エンドポイント拡張
- [x] 💥 破壊的変更 (Breaking change) — MCP から `zedi_update_page_content` 廃止、`PageContent` shape 変更
- [x] 🧪 テスト (Tests) — 171 行の health.test.ts

https://claude.ai/code/session_01E51XL3drU61gMzfUAY4QWQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health endpoint now returns computed PostgreSQL pool health (status, saturation, active/idle/waiting counts), timestamps, connection and document stats.

* **Changes**
  * MCP page tools are read-only: page bodies are served via a public-content endpoint and cannot be updated via MCP tools.
  * Removed the MCP page-update tool from the toolset.

* **Documentation**
  * Updated MCP docs to reflect read-only page body behavior and tooling changes.

* **Tests**
  * Added unit and end-to-end tests covering health evaluation and the read-only MCP behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->