### PR TITLE
feat: Add tag filter bar to note page list

### DIFF
--- a/server/api/drizzle/0030_add_notes_tag_filter_bar.sql
+++ b/server/api/drizzle/0030_add_notes_tag_filter_bar.sql
@@ -1,0 +1,23 @@
+-- 0030: Add per-note tag filter bar defaults to `notes`.
+--
+-- これらのカラムは `/notes/:noteId` 上部のハッシュタグフィルタバーの「ノート
+-- 既定値」を持つ。ユーザー側はデバイスごとに localStorage で上書きできる
+-- (`zedi-note-filter-preferences`)。選択中タグそのものは URL クエリ
+-- `?tags=` に乗せるためここには保存しない。
+--
+-- Stores the note-side defaults for the tag filter bar shown above the page
+-- list on `/notes/:noteId`. Each device may override `show_tag_filter_bar`
+-- via localStorage. The currently-selected tags live in `?tags=` and are not
+-- persisted here.
+--
+-- `default_filter_tags` は小文字キーで保存し、`__none__` トークンを含めると
+-- 「タグなしページのみ」が既定になる。配列が空のときはオーナーが既定の絞り
+-- 込みを指定していない状態。
+--
+-- `default_filter_tags` stores lower-cased keys. Including the `__none__`
+-- token defaults the filter to "untagged only". An empty array means the
+-- owner has not picked any defaults.
+
+ALTER TABLE "notes" ADD COLUMN IF NOT EXISTS "show_tag_filter_bar" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE "notes" ADD COLUMN IF NOT EXISTS "default_filter_tags" text[] NOT NULL DEFAULT '{}'::text[];

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1779667200000,
       "tag": "0029_invite_links_user_fk_cascade",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1779840000000,
+      "tag": "0030_add_notes_tag_filter_bar",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/src/routes/notes/crud.ts
+++ b/server/api/src/routes/notes/crud.ts
@@ -53,7 +53,7 @@ const ALLOWED_EDIT_PERMISSION = new Set<NoteEditPermission>([
  * validators from clients cannot revive an outdated cached body via 304
  * (Issue #860 Phase 0). Bump this whenever the wire shape changes.
  */
-const NOTE_DETAIL_RESPONSE_VERSION = "v3";
+const NOTE_DETAIL_RESPONSE_VERSION = "v4";
 
 function validateVisibility(value: string | undefined): NoteVisibility {
   if (value === undefined) return "private";
@@ -94,6 +94,74 @@ function parseIsOfficialForUpdate(value: unknown): boolean | undefined {
   if (typeof value === "boolean") return value;
   throw new HTTPException(400, { message: "Invalid is_official" });
 }
+
+/**
+ * ノート更新ボディの `show_tag_filter_bar` を真偽値に正規化する。未指定は
+ * `undefined` を返す（クライアントが触っていない＝既存値を保つ）。
+ *
+ * Normalize `show_tag_filter_bar` from the update body to a boolean, or
+ * `undefined` when the client did not send it (= keep the stored value).
+ */
+function parseShowTagFilterBarForUpdate(value: unknown): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "boolean") return value;
+  throw new HTTPException(400, { message: "Invalid show_tag_filter_bar" });
+}
+
+/**
+ * タグ名フィルタ用の `default_filter_tags` を検証・正規化する。配列要素は
+ * 文字列のみ許容し、トリム＋小文字化後の `__none__` トークンまたは
+ * `TAG_NAME_CHAR_CLASS_STRING` に一致する文字列を期待する。重複は除去し、
+ * 配列長は 0..20 に制限する。
+ *
+ * Validate / normalize `default_filter_tags` on an update body. Tags are
+ * trimmed and lower-cased; each must match the `TAG_NAME_CHAR_CLASS` regex
+ * (or be the special `__none__` token). Duplicates are removed. The array
+ * length is capped at 20 entries. Returns `undefined` when the field was not
+ * sent.
+ */
+function parseDefaultFilterTagsForUpdate(value: unknown): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw new HTTPException(400, { message: "Invalid default_filter_tags" });
+  }
+  if (value.length > 20) {
+    throw new HTTPException(400, { message: "Too many default_filter_tags (max 20)" });
+  }
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      throw new HTTPException(400, { message: "Invalid default_filter_tags entry" });
+    }
+    const normalized = entry.trim().toLowerCase();
+    if (normalized.length === 0 || normalized.length > 100) {
+      throw new HTTPException(400, { message: "Invalid default_filter_tags entry" });
+    }
+    if (normalized !== "__none__" && !VALID_TAG_NAME_REGEX.test(normalized)) {
+      throw new HTTPException(400, { message: "Invalid default_filter_tags entry" });
+    }
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    out.push(normalized);
+  }
+  return out;
+}
+
+/**
+ * `parseDefaultFilterTagsForUpdate` で使うタグ名の文字種パターン。クライアント
+ * 側の `packages/shared/src/tagCharacterClass.ts` および
+ * `services/ydocRenameRewrite.ts` の `TAG_NAME_CHAR_CLASS_STRING` と等価。
+ *
+ * Character-class regex used to validate tag names; mirrors
+ * `TAG_NAME_CHAR_CLASS_STRING` (the source of truth for client/server alike).
+ */
+const TAG_NAME_CHAR_CLASS_STRING = "A-Za-z0-9_\\-぀-ヿ㐀-鿿";
+// `TAG_NAME_CHAR_CLASS_STRING` is a hardcoded constant (never user input).
+// The pattern is a single anchored character class with one quantifier and
+// no nested quantifiers / alternations, so matching is linear in input
+// length. Static-analysis ReDoS warnings on this regex are false positives.
+const VALID_TAG_NAME_REGEX = new RegExp(`^[${TAG_NAME_CHAR_CLASS_STRING}]+$`);
 
 /**
  * `Date | string | null` のいずれで来ても安全に epoch ms に正規化するヘルパー。
@@ -263,6 +331,8 @@ app.put("/:noteId", authRequired, async (c) => {
     visibility?: string;
     edit_permission?: string;
     is_official?: unknown;
+    show_tag_filter_bar?: unknown;
+    default_filter_tags?: unknown;
   }>();
 
   const isOfficial = parseIsOfficialForUpdate(body.is_official);
@@ -279,6 +349,8 @@ app.put("/:noteId", authRequired, async (c) => {
     body.visibility !== undefined ? validateVisibility(body.visibility) : undefined;
   const editPermission =
     body.edit_permission !== undefined ? validateEditPermission(body.edit_permission) : undefined;
+  const showTagFilterBar = parseShowTagFilterBarForUpdate(body.show_tag_filter_bar);
+  const defaultFilterTags = parseDefaultFilterTagsForUpdate(body.default_filter_tags);
 
   const updated = await db
     .update(notes)
@@ -287,6 +359,8 @@ app.put("/:noteId", authRequired, async (c) => {
       visibility,
       editPermission,
       isOfficial: isOfficial !== undefined ? isOfficial : undefined,
+      showTagFilterBar: showTagFilterBar !== undefined ? showTagFilterBar : undefined,
+      defaultFilterTags: defaultFilterTags !== undefined ? defaultFilterTags : undefined,
       updatedAt: new Date(),
     })
     .where(eq(notes.id, noteId))
@@ -298,16 +372,21 @@ app.put("/:noteId", authRequired, async (c) => {
   // Issue #860 Phase 4: visibility / edit_permission の変化は `getNoteRole`
   // の解釈に直結するため、ノート購読者へ sentinel を投げて details / window /
   // members を invalidate させる。title だけの変更でも `noteRowToApi` の値が
-  // 変わるので一律で emit する。
+  // 変わるので一律で emit する。タグフィルタバー設定はアクセス権には影響しない
+  // が、`noteRowToApi` の値は変わるためキャッシュの整合性のために同様に通知する。
   // Issue #860 Phase 4: changes to visibility / edit_permission flip the
   // result of `getNoteRole` for some callers, so notify subscribers to
   // re-evaluate access. Always emit on a successful PUT (even title-only
-  // changes) so the cached note shell does not drift.
+  // changes) so the cached note shell does not drift. Tag-filter-bar fields
+  // don't affect access but still mutate the shell payload, so they
+  // trigger the same notification path for cache freshness.
   if (
     visibility !== undefined ||
     editPermission !== undefined ||
     body.title !== undefined ||
-    isOfficial !== undefined
+    isOfficial !== undefined ||
+    showTagFilterBar !== undefined ||
+    defaultFilterTags !== undefined
   ) {
     publishNoteEvent({ type: "note.permission_changed", note_id: noteId });
   }

--- a/server/api/src/routes/notes/helpers.ts
+++ b/server/api/src/routes/notes/helpers.ts
@@ -26,6 +26,8 @@ export function noteRowToApi(note: Note): NoteApiFields {
     is_official: note.isOfficial,
     is_default: note.isDefault,
     view_count: note.viewCount,
+    show_tag_filter_bar: note.showTagFilterBar,
+    default_filter_tags: note.defaultFilterTags,
     created_at: note.createdAt,
     updated_at: note.updatedAt,
     is_deleted: note.isDeleted,

--- a/server/api/src/routes/notes/index.ts
+++ b/server/api/src/routes/notes/index.ts
@@ -12,6 +12,7 @@ import domainAccessRoutes from "./domainAccess.js";
 import searchRoutes from "./search.js";
 import eventsRoutes from "./events.js";
 import titleIndexRoutes from "./titleIndex.js";
+import tagsRoutes from "./tags.js";
 
 const app = new Hono<AppEnv>();
 
@@ -21,6 +22,7 @@ app.route("/", meRoutes);
 app.route("/", crudRoutes);
 app.route("/", pageRoutes);
 app.route("/", titleIndexRoutes);
+app.route("/", tagsRoutes);
 app.route("/", memberRoutes);
 app.route("/", inviteLinkRoutes);
 app.route("/", domainAccessRoutes);

--- a/server/api/src/routes/notes/pages.ts
+++ b/server/api/src/routes/notes/pages.ts
@@ -169,6 +169,64 @@ function parsePagesInclude(raw: string | undefined): { preview: boolean; thumbna
   };
 }
 
+/**
+ * `/notes/:noteId/pages?tags=...` のタグフィルタに使う最大要素数。クライアント
+ * 側 (`urlTagsCodec.MAX_TAGS`) と整合させる。
+ *
+ * Cap on the number of tags accepted in `?tags=`, matching the client-side
+ * `urlTagsCodec.MAX_TAGS` constant.
+ */
+const MAX_TAGS_FILTER = 20;
+
+/**
+ * `?tags=` URL クエリのパース結果。
+ *
+ * - `null`: パラメータ無し or 空文字 — フィルタを適用しない。
+ * - `{ kind: 'tags' }`: 小文字キーの OR フィルタ。
+ * - `{ kind: 'untagged-only' }`: `__none__` トークン — タグ無しページのみ。
+ *
+ * Parsed `?tags=` value:
+ * - `null` for no filter
+ * - `{ kind: 'tags' }` for a lower-cased OR list
+ * - `{ kind: 'untagged-only' }` for the `__none__` token
+ */
+export type TagsFilter = { kind: "tags"; tags: string[] } | { kind: "untagged-only" } | null;
+
+/**
+ * `?tags=` を {@link TagsFilter} へ正規化する。クライアント側 codec
+ * (`urlTagsCodec.parseTagsParam`) と同じ規則: トリム・小文字化・重複排除・
+ * `MAX_TAGS_FILTER` で切り詰め。`__none__` が混ざれば untagged-only。要素 0
+ * なら `null` を返してフィルタ無し扱い。不正値で 500 になるのを避けるため、
+ * 文字列長や形が外れたものは静かに無視する (URL 経由の壊れた値で 400 を
+ * 出してエラー画面に飛ばしたくないため)。
+ *
+ * Mirror of `urlTagsCodec.parseTagsParam` for server-side use. Lenient: malformed
+ * tokens are silently dropped so a stale or broken URL doesn't 400 the
+ * listing endpoint. Returns `null` to mean "no filter".
+ */
+function parseTagsFilter(raw: string | undefined): TagsFilter {
+  if (raw === undefined || raw === null) return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  const tokens = trimmed
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0 && t.length <= 100);
+  if (tokens.length === 0) return null;
+  if (tokens.some((t) => t === "__none__")) return { kind: "untagged-only" };
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const token of tokens) {
+    const key = token.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(key);
+    if (normalized.length >= MAX_TAGS_FILTER) break;
+  }
+  if (normalized.length === 0) return null;
+  return { kind: "tags", tags: normalized };
+}
+
 const app = new Hono<AppEnv>();
 
 // ── POST /:noteId/pages ─────────────────────────────────────────────────────
@@ -359,6 +417,7 @@ app.get("/:noteId/pages", authOptional, async (c) => {
   const limit = parsePagesLimit(c.req.query("limit"));
   const cursor = decodePagesCursor(c.req.query("cursor"));
   const include = parsePagesInclude(c.req.query("include"));
+  const tagsFilter = parseTagsFilter(c.req.query("tags"));
 
   // keyset 条件: `(updated_at, id)` を `(c.updatedAt, c.id)` より小さい組に絞る。
   // `ORDER BY updated_at DESC, id DESC` と同じ向きで進めるため、
@@ -375,6 +434,47 @@ app.get("/:noteId/pages", authOptional, async (c) => {
   // gemini-code-assist + codex on PR #865). Fetching `limit + 1` rows lets
   // us emit `next_cursor` without a separate count query.
   const whereClauses = [eq(pages.noteId, noteId), eq(pages.isDeleted, false)];
+
+  // タグフィルタ (`?tags=`) を WHERE 句に AND で足す。`untagged-only` は
+  // `links` / `ghost_links` どちらにも `link_type='tag'` の出辺が無いページに
+  // 絞り込む。通常の OR フィルタは `links → target.title` または
+  // `ghost_links.link_text` のいずれかが選択タグに含まれるページに絞る。
+  // 小文字キーで突合し、`pages.title` 側も `LOWER(...)` で比較する。
+  //
+  // Apply `?tags=` as an additional WHERE predicate on top of the keyset
+  // pagination. `untagged-only` keeps only pages with zero `link_type='tag'`
+  // edges in both tables. The OR list matches pages whose tag edge points at
+  // a page title in the set or whose ghost-link text is in the set, all
+  // compared case-insensitively against the lower-cased tags.
+  if (tagsFilter) {
+    if (tagsFilter.kind === "untagged-only") {
+      whereClauses.push(sql`NOT EXISTS (
+        SELECT 1 FROM links l WHERE l.source_id = ${pages.id} AND l.link_type = 'tag'
+      )`);
+      whereClauses.push(sql`NOT EXISTS (
+        SELECT 1 FROM ghost_links gl WHERE gl.source_page_id = ${pages.id} AND gl.link_type = 'tag'
+      )`);
+    } else {
+      const tagsParam = sql`${tagsFilter.tags}::text[]`;
+      whereClauses.push(sql`(
+        EXISTS (
+          SELECT 1 FROM links l
+          JOIN pages t ON t.id = l.target_id
+          WHERE l.source_id = ${pages.id}
+            AND l.link_type = 'tag'
+            AND t.is_deleted = false
+            AND LOWER(t.title) = ANY(${tagsParam})
+        )
+        OR EXISTS (
+          SELECT 1 FROM ghost_links gl
+          WHERE gl.source_page_id = ${pages.id}
+            AND gl.link_type = 'tag'
+            AND LOWER(gl.link_text) = ANY(${tagsParam})
+        )
+      )`);
+    }
+  }
+
   if (cursor) {
     const cursorTsSql = sql`${cursor.updatedAt}::timestamptz`;
     // drizzle の `or()` は要素が空配列のとき undefined を返す型だが、ここでは

--- a/server/api/src/routes/notes/pages.ts
+++ b/server/api/src/routes/notes/pages.ts
@@ -448,8 +448,21 @@ app.get("/:noteId/pages", authOptional, async (c) => {
   // compared case-insensitively against the lower-cased tags.
   if (tagsFilter) {
     if (tagsFilter.kind === "untagged-only") {
+      // 削除済みタグページへのリンクは untagged 判定で「無い」ものとして扱う。
+      // OR フィルタ側は `t.is_deleted = false` で削除済みを除外しているため、
+      // ここで `t.is_deleted = false` の JOIN を付けないと「削除済みタグページ
+      // のみ参照するページ」が通常タグにも `__none__` にもマッチせず消えて
+      // しまう (PR #897 Codex P2)。
+      //
+      // Ignore links whose target is soft-deleted when deciding "untagged":
+      // the OR-tag path already filters `t.is_deleted = false`, so without
+      // this `JOIN ... t.is_deleted = false` a page that only references
+      // tombstoned tag pages would match neither real tags nor `__none__`
+      // (PR #897 Codex P2).
       whereClauses.push(sql`NOT EXISTS (
-        SELECT 1 FROM links l WHERE l.source_id = ${pages.id} AND l.link_type = 'tag'
+        SELECT 1 FROM links l
+        JOIN pages t ON t.id = l.target_id AND t.is_deleted = false
+        WHERE l.source_id = ${pages.id} AND l.link_type = 'tag'
       )`);
       whereClauses.push(sql`NOT EXISTS (
         SELECT 1 FROM ghost_links gl WHERE gl.source_page_id = ${pages.id} AND gl.link_type = 'tag'

--- a/server/api/src/routes/notes/tags.ts
+++ b/server/api/src/routes/notes/tags.ts
@@ -58,6 +58,22 @@ const TAGS_RESPONSE_VERSION = "v1";
  * `links.MAX(created_at)` / `ghost_links.MAX(created_at)` with their counts
  * makes the ETag shift on any page mutation, tag insert, or tag delete.
  */
+/**
+ * `db.execute` の生戻り値から `rows` 配列を取り出すための薄いヘルパー。
+ * pg ドライバ依存の型 (`QueryResult<Row>` 風) を `Array<Record<string, unknown>>`
+ * に揃え、呼び出し側でローカルに `unknown` キャストを散らばらせない
+ * (PR #897 Gemini medium レビュー)。
+ *
+ * Coerce a `db.execute` result into an `Array<Record<string, unknown>>` so
+ * downstream column reads don't each need their own `unknown` cast
+ * (PR #897 Gemini medium review). Driver-specific row shapes are reduced to a
+ * single boundary cast here.
+ */
+function executeRows(result: unknown): Array<Record<string, unknown>> {
+  const wrapper = result as { rows?: Array<Record<string, unknown>> };
+  return wrapper.rows ?? [];
+}
+
 function makeTagsETag(
   noteId: string,
   role: string,
@@ -105,48 +121,68 @@ app.get("/:noteId/tags", authOptional, async (c) => {
   if (!note) throw new HTTPException(404, { message: "Note not found" });
   if (!role) throw new HTTPException(403, { message: "Forbidden" });
 
-  // ETag 用のシグナル集約。3 テーブル × (MAX + COUNT) = 6 値だが、いずれも
-  // インデックスから安価に取得できる: `idx_pages_note_active_updated_id`,
-  // `idx_links_source_id` + `idx_links_link_type`, `idx_ghost_links_source_page_id`
-  // + `idx_ghost_links_link_type`。1 つの SELECT に scalar subquery で詰める
-  // ことで往復回数を抑える。
+  // ETag 用のシグナル集約 + 「タグなしページ件数」を 1 つの SELECT に詰める。
+  // 3 テーブル × (MAX + COUNT) と `none_count` の合計 7 値すべて、既存
+  // インデックス (`idx_pages_note_active_updated_id`, `idx_links_source_id`
+  // + `idx_links_link_type`, `idx_ghost_links_source_page_id` +
+  // `idx_ghost_links_link_type`) から安価に解決できる。`none_count` の
+  // `NOT EXISTS ... links` には削除済みタグページを除外する `is_deleted = false`
+  // を付け、`pages.ts` の untagged predicate と挙動を揃える (PR #897 Codex P2)。
   //
-  // ETag signal aggregation. Three tables × (MAX + COUNT) = six values, each
-  // resolvable from existing indexes. Folding them into a single SELECT via
-  // scalar subqueries keeps the round-trip count to 1.
-  const signalRows = await db.execute(sql`
-    SELECT
-      (SELECT MAX(updated_at) FROM pages WHERE note_id = ${noteId}::uuid AND is_deleted = false) AS pages_max_updated_at,
-      (SELECT COUNT(*)::int FROM pages WHERE note_id = ${noteId}::uuid AND is_deleted = false) AS pages_count,
-      (SELECT MAX(l.created_at)
-         FROM links l
-         JOIN pages s ON s.id = l.source_id
-         WHERE s.note_id = ${noteId}::uuid AND s.is_deleted = false AND l.link_type = 'tag'
-      ) AS links_max_created_at,
-      (SELECT COUNT(*)::int
-         FROM links l
-         JOIN pages s ON s.id = l.source_id
-         WHERE s.note_id = ${noteId}::uuid AND s.is_deleted = false AND l.link_type = 'tag'
-      ) AS links_count,
-      (SELECT MAX(gl.created_at)
-         FROM ghost_links gl
-         JOIN pages s ON s.id = gl.source_page_id
-         WHERE s.note_id = ${noteId}::uuid AND s.is_deleted = false AND gl.link_type = 'tag'
-      ) AS ghost_max_created_at,
-      (SELECT COUNT(*)::int
-         FROM ghost_links gl
-         JOIN pages s ON s.id = gl.source_page_id
-         WHERE s.note_id = ${noteId}::uuid AND s.is_deleted = false AND gl.link_type = 'tag'
-      ) AS ghost_count
-  `);
-  const signal =
-    (signalRows as unknown as { rows: Array<Record<string, unknown>> }).rows?.[0] ?? {};
+  // Fold the ETag signal aggregation and the `none_count` query into a single
+  // round-trip (PR #897 Gemini medium review). All seven scalars are
+  // resolvable from existing indexes. The `none_count` NOT EXISTS on `links`
+  // joins `pages.is_deleted = false` so pages whose only tag links target
+  // soft-deleted pages still register as "untagged", matching the predicate
+  // in `pages.ts` (PR #897 Codex P2).
+  const signalRows = executeRows(
+    await db.execute(sql`
+      SELECT
+        (SELECT MAX(updated_at) FROM pages WHERE note_id = ${noteId}::uuid AND is_deleted = false) AS pages_max_updated_at,
+        (SELECT COUNT(*)::int FROM pages WHERE note_id = ${noteId}::uuid AND is_deleted = false) AS pages_count,
+        (SELECT MAX(l.created_at)
+           FROM links l
+           JOIN pages s ON s.id = l.source_id
+           WHERE s.note_id = ${noteId}::uuid AND s.is_deleted = false AND l.link_type = 'tag'
+        ) AS links_max_created_at,
+        (SELECT COUNT(*)::int
+           FROM links l
+           JOIN pages s ON s.id = l.source_id
+           WHERE s.note_id = ${noteId}::uuid AND s.is_deleted = false AND l.link_type = 'tag'
+        ) AS links_count,
+        (SELECT MAX(gl.created_at)
+           FROM ghost_links gl
+           JOIN pages s ON s.id = gl.source_page_id
+           WHERE s.note_id = ${noteId}::uuid AND s.is_deleted = false AND gl.link_type = 'tag'
+        ) AS ghost_max_created_at,
+        (SELECT COUNT(*)::int
+           FROM ghost_links gl
+           JOIN pages s ON s.id = gl.source_page_id
+           WHERE s.note_id = ${noteId}::uuid AND s.is_deleted = false AND gl.link_type = 'tag'
+        ) AS ghost_count,
+        (SELECT COUNT(*)::int
+           FROM pages s
+           WHERE s.note_id = ${noteId}::uuid
+             AND s.is_deleted = false
+             AND NOT EXISTS (
+               SELECT 1 FROM links l
+               JOIN pages t ON t.id = l.target_id AND t.is_deleted = false
+               WHERE l.source_id = s.id AND l.link_type = 'tag'
+             )
+             AND NOT EXISTS (
+               SELECT 1 FROM ghost_links gl WHERE gl.source_page_id = s.id AND gl.link_type = 'tag'
+             )
+        ) AS none_count
+    `),
+  );
+  const signal = signalRows[0] ?? {};
   const pagesMaxUpdatedAt = (signal.pages_max_updated_at as Date | string | null) ?? null;
   const pagesCount = Number(signal.pages_count ?? 0);
   const linksMaxCreatedAt = (signal.links_max_created_at as Date | string | null) ?? null;
   const linksCount = Number(signal.links_count ?? 0);
   const ghostMaxCreatedAt = (signal.ghost_max_created_at as Date | string | null) ?? null;
   const ghostCount = Number(signal.ghost_count ?? 0);
+  const noneCount = Number(signal.none_count ?? 0);
 
   const etag = makeTagsETag(
     noteId,
@@ -168,94 +204,71 @@ app.get("/:noteId/tags", authOptional, async (c) => {
   }
 
   // メイン集計: 解決済みタグ (links 経由) と未解決タグ (ghost_links 経由) を
-  // 同じ key (`LOWER(name)`) で UNION し、外側で sum/合成して 1 行 / キーに
-  // まとめる。`resolved` は「すべての出現が links 経由か」のフラグなので、
-  // ghost_count = 0 で判定する。表示名は resolved 側 (links) の `pages.title`
-  // を優先する (`tag_display_name_resolved`)。それも無い場合は ghost 側の
-  // 最初の表記にフォールバック。
+  // 同じ key (`LOWER(name)`) で UNION し、外側で `GROUP BY name_lower` する。
+  // 表示名は resolved 側の表記を優先 (resolved が無いキーは ghost 側の最小
+  // 表記にフォールバック)。同じ `name_lower` に複数の表記が存在しても
+  // `MIN(...) FILTER (...)` で決定的に選ぶ。`resolved` フラグは ghost 側の
+  // 出現が 0 件かどうかで判定する。
   //
   // Main aggregation. Resolved tags (via `links` → tag-page `title`) and
   // unresolved tags (via `ghost_links.link_text`) are unioned on a
-  // case-insensitive key and summed in the outer SELECT. `resolved` is true
-  // only when the ghost contribution is 0. Display name prefers the
-  // resolved-side `pages.title`; falls back to the first ghost spelling.
-  const tagRows = await db.execute(sql`
-    WITH resolved AS (
+  // case-insensitive key and grouped in the outer SELECT. Display name comes
+  // from `MIN(display_name) FILTER (origin = 'resolved')` (or `MIN(display_name)`
+  // when no resolved row exists), avoiding both the per-group correlated
+  // subqueries and the non-deterministic `LIMIT 1` flagged on the previous
+  // revision (PR #897 Gemini medium / CodeRabbit minor reviews). `resolved`
+  // is true only when the ghost contribution is zero.
+  const tagRows = executeRows(
+    await db.execute(sql`
+      WITH resolved AS (
+        SELECT
+          LOWER(t.title) AS name_lower,
+          t.title AS display_name,
+          s.id AS source_id
+        FROM pages s
+        JOIN links l ON l.source_id = s.id AND l.link_type = 'tag'
+        JOIN pages t ON t.id = l.target_id
+        WHERE s.note_id = ${noteId}::uuid
+          AND s.is_deleted = false
+          AND t.is_deleted = false
+          AND t.title IS NOT NULL
+          AND LENGTH(TRIM(t.title)) > 0
+      ),
+      ghost AS (
+        SELECT
+          LOWER(gl.link_text) AS name_lower,
+          gl.link_text AS display_name,
+          s.id AS source_id
+        FROM pages s
+        JOIN ghost_links gl ON gl.source_page_id = s.id AND gl.link_type = 'tag'
+        WHERE s.note_id = ${noteId}::uuid
+          AND s.is_deleted = false
+          AND LENGTH(TRIM(gl.link_text)) > 0
+      ),
+      merged AS (
+        SELECT name_lower, display_name, source_id, 'resolved' AS origin FROM resolved
+        UNION ALL
+        SELECT name_lower, display_name, source_id, 'ghost' AS origin FROM ghost
+      )
       SELECT
-        LOWER(t.title) AS name_lower,
-        t.title AS display_name,
-        s.id AS source_id
-      FROM pages s
-      JOIN links l ON l.source_id = s.id AND l.link_type = 'tag'
-      JOIN pages t ON t.id = l.target_id
-      WHERE s.note_id = ${noteId}::uuid
-        AND s.is_deleted = false
-        AND t.is_deleted = false
-        AND t.title IS NOT NULL
-        AND LENGTH(TRIM(t.title)) > 0
-    ),
-    ghost AS (
-      SELECT
-        LOWER(gl.link_text) AS name_lower,
-        gl.link_text AS display_name,
-        s.id AS source_id
-      FROM pages s
-      JOIN ghost_links gl ON gl.source_page_id = s.id AND gl.link_type = 'tag'
-      WHERE s.note_id = ${noteId}::uuid
-        AND s.is_deleted = false
-        AND LENGTH(TRIM(gl.link_text)) > 0
-    ),
-    merged AS (
-      SELECT name_lower, display_name, source_id, 'resolved' AS origin FROM resolved
-      UNION ALL
-      SELECT name_lower, display_name, source_id, 'ghost' AS origin FROM ghost
-    )
-    SELECT
-      name_lower,
-      COALESCE(
-        (SELECT display_name FROM merged m2
-           WHERE m2.name_lower = merged.name_lower AND m2.origin = 'resolved'
-           LIMIT 1),
-        (SELECT display_name FROM merged m3
-           WHERE m3.name_lower = merged.name_lower
-           LIMIT 1)
-      ) AS display_name,
-      COUNT(DISTINCT source_id)::int AS page_count,
-      bool_and(origin = 'resolved') AS resolved
-    FROM merged
-    GROUP BY name_lower
-    ORDER BY page_count DESC, name_lower ASC
-  `);
-  const items: NoteTagAggregationItem[] = (
-    tagRows as unknown as { rows: Array<Record<string, unknown>> }
-  ).rows.map((r) => ({
+        name_lower,
+        COALESCE(
+          MIN(display_name) FILTER (WHERE origin = 'resolved'),
+          MIN(display_name)
+        ) AS display_name,
+        COUNT(DISTINCT source_id)::int AS page_count,
+        bool_and(origin = 'resolved') AS resolved
+      FROM merged
+      GROUP BY name_lower
+      ORDER BY page_count DESC, name_lower ASC
+    `),
+  );
+  const items: NoteTagAggregationItem[] = tagRows.map((r) => ({
     name: typeof r.display_name === "string" ? r.display_name : String(r.name_lower ?? ""),
     name_lower: String(r.name_lower ?? ""),
     page_count: Number(r.page_count ?? 0),
     resolved: r.resolved === true,
   }));
-
-  // 「タグなし」件数: 同じノートのアクティブページのうち、`links` / `ghost_links`
-  // どちらにも `link_type='tag'` の出辺を持たないものをカウントする。
-  //
-  // "Untagged page" count: active pages in the note with no outgoing
-  // `link_type='tag'` edge in either table.
-  const noneCountRows = await db.execute(sql`
-    SELECT COUNT(*)::int AS none_count
-    FROM pages s
-    WHERE s.note_id = ${noteId}::uuid
-      AND s.is_deleted = false
-      AND NOT EXISTS (
-        SELECT 1 FROM links l WHERE l.source_id = s.id AND l.link_type = 'tag'
-      )
-      AND NOT EXISTS (
-        SELECT 1 FROM ghost_links gl WHERE gl.source_page_id = s.id AND gl.link_type = 'tag'
-      )
-  `);
-  const noneCount = Number(
-    (noneCountRows as unknown as { rows: Array<Record<string, unknown>> }).rows?.[0]?.none_count ??
-      0,
-  );
 
   const response: NoteTagAggregationResponse = {
     items,

--- a/server/api/src/routes/notes/tags.ts
+++ b/server/api/src/routes/notes/tags.ts
@@ -1,0 +1,268 @@
+/**
+ * `/api/notes/:noteId/tags` — ノート配下で使われているタグの集計エンドポイント。
+ *
+ * `/notes/:noteId` 上部のハッシュタグフィルタバーで「使用ページ数の多い順」に
+ * チップを並べるためのデータソース。`links` (`link_type='tag'`) と
+ * `ghost_links` (`link_type='tag'`) の両テーブルを横断し、case-insensitive な
+ * キー (`LOWER(tag_name)`) でマージする。
+ *
+ * `GET /api/notes/:noteId/tags` — note-wide aggregation of hashtags
+ * (`#name`) used as the data source for the tag filter bar on
+ * `/notes/:noteId`. Walks `links` (`link_type='tag'`) and `ghost_links`
+ * (`link_type='tag'`) for pages in the note and merges them on a
+ * case-insensitive key (`LOWER(tag_name)`), ordered by distinct page count
+ * descending.
+ *
+ * 「タグなしページ件数」(`none_count`) と「ノート内アクティブページ総数」
+ * (`total_pages`) も同梱し、UI が「タグなし」チップを出すかの判定と全体件数
+ * 表示に使えるようにする。
+ *
+ * Also returns `none_count` (active pages with no tag edge at all) and
+ * `total_pages` (active pages in the note) so the UI can decide whether to
+ * surface the "untagged" chip and how to label totals.
+ *
+ * Auth: `authOptional` + `getNoteRole` — public / unlisted ノートはゲスト閲覧可。
+ * Auth model: `authOptional` + `getNoteRole`, same as `/pages` and
+ * `/page-titles`; public / unlisted notes are reachable for guests, private
+ * notes 403 for callers without a role.
+ */
+import { createHash } from "node:crypto";
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { sql } from "drizzle-orm";
+import { authOptional } from "../../middleware/auth.js";
+import type { AppEnv } from "../../types/index.js";
+import type { NoteTagAggregationItem, NoteTagAggregationResponse } from "./types.js";
+import { getNoteRole } from "./helpers.js";
+import { ifNoneMatchMatches } from "./crud.js";
+
+/**
+ * `GET /api/notes/:noteId/tags` のレスポンス形状バージョン。ETag に混ぜることで
+ * サーバ側で形状を変えた直後にクライアントが古い `If-None-Match` を送ってきても
+ * 304 で旧 body をキャッシュ再利用させない。
+ *
+ * Response-shape version for `GET /api/notes/:noteId/tags`. Mixed into the
+ * ETag so stale validators cannot revive an outdated body via 304 after a
+ * wire-shape change. Bump whenever the shape changes.
+ */
+const TAGS_RESPONSE_VERSION = "v1";
+
+/**
+ * 集計対象テーブルの最終変更時刻と件数から weak ETag を生成する。`pages` の
+ * `MAX(updated_at)` + count と、`links` / `ghost_links` 双方の `MAX(created_at)`
+ * + count を混ぜることで、ページ追加・タイトル変更・タグ追加削除いずれでも
+ * ETag がずれる。
+ *
+ * Generate a weak ETag from the latest mutation timestamps and counts of the
+ * tables that feed the aggregation. Mixing `pages.MAX(updated_at)` /
+ * `links.MAX(created_at)` / `ghost_links.MAX(created_at)` with their counts
+ * makes the ETag shift on any page mutation, tag insert, or tag delete.
+ */
+function makeTagsETag(
+  noteId: string,
+  role: string,
+  pagesMaxUpdatedAt: Date | string | null,
+  pagesCount: number,
+  linksMaxCreatedAt: Date | string | null,
+  linksCount: number,
+  ghostMaxCreatedAt: Date | string | null,
+  ghostCount: number,
+): string {
+  const epoch = (v: Date | string | null): number => {
+    if (v === null) return 0;
+    const ms = (v instanceof Date ? v : new Date(v)).getTime();
+    return Number.isNaN(ms) ? 0 : ms;
+  };
+  const hash = createHash("sha1")
+    .update(
+      [
+        TAGS_RESPONSE_VERSION,
+        noteId,
+        role,
+        epoch(pagesMaxUpdatedAt),
+        pagesCount,
+        epoch(linksMaxCreatedAt),
+        linksCount,
+        epoch(ghostMaxCreatedAt),
+        ghostCount,
+      ].join(":"),
+    )
+    .digest("base64url")
+    .slice(0, 22);
+  return `W/"${hash}"`;
+}
+
+const app = new Hono<AppEnv>();
+
+// ── GET /:noteId/tags ───────────────────────────────────────────────────────
+app.get("/:noteId/tags", authOptional, async (c) => {
+  const noteId = c.req.param("noteId");
+  const userId = c.get("userId");
+  const userEmail = c.get("userEmail");
+  const db = c.get("db");
+
+  const { role, note } = await getNoteRole(noteId, userId, userEmail, db);
+  if (!note) throw new HTTPException(404, { message: "Note not found" });
+  if (!role) throw new HTTPException(403, { message: "Forbidden" });
+
+  // ETag 用のシグナル集約。3 テーブル × (MAX + COUNT) = 6 値だが、いずれも
+  // インデックスから安価に取得できる: `idx_pages_note_active_updated_id`,
+  // `idx_links_source_id` + `idx_links_link_type`, `idx_ghost_links_source_page_id`
+  // + `idx_ghost_links_link_type`。1 つの SELECT に scalar subquery で詰める
+  // ことで往復回数を抑える。
+  //
+  // ETag signal aggregation. Three tables × (MAX + COUNT) = six values, each
+  // resolvable from existing indexes. Folding them into a single SELECT via
+  // scalar subqueries keeps the round-trip count to 1.
+  const signalRows = await db.execute(sql`
+    SELECT
+      (SELECT MAX(updated_at) FROM pages WHERE note_id = ${noteId}::uuid AND is_deleted = false) AS pages_max_updated_at,
+      (SELECT COUNT(*)::int FROM pages WHERE note_id = ${noteId}::uuid AND is_deleted = false) AS pages_count,
+      (SELECT MAX(l.created_at)
+         FROM links l
+         JOIN pages s ON s.id = l.source_id
+         WHERE s.note_id = ${noteId}::uuid AND s.is_deleted = false AND l.link_type = 'tag'
+      ) AS links_max_created_at,
+      (SELECT COUNT(*)::int
+         FROM links l
+         JOIN pages s ON s.id = l.source_id
+         WHERE s.note_id = ${noteId}::uuid AND s.is_deleted = false AND l.link_type = 'tag'
+      ) AS links_count,
+      (SELECT MAX(gl.created_at)
+         FROM ghost_links gl
+         JOIN pages s ON s.id = gl.source_page_id
+         WHERE s.note_id = ${noteId}::uuid AND s.is_deleted = false AND gl.link_type = 'tag'
+      ) AS ghost_max_created_at,
+      (SELECT COUNT(*)::int
+         FROM ghost_links gl
+         JOIN pages s ON s.id = gl.source_page_id
+         WHERE s.note_id = ${noteId}::uuid AND s.is_deleted = false AND gl.link_type = 'tag'
+      ) AS ghost_count
+  `);
+  const signal =
+    (signalRows as unknown as { rows: Array<Record<string, unknown>> }).rows?.[0] ?? {};
+  const pagesMaxUpdatedAt = (signal.pages_max_updated_at as Date | string | null) ?? null;
+  const pagesCount = Number(signal.pages_count ?? 0);
+  const linksMaxCreatedAt = (signal.links_max_created_at as Date | string | null) ?? null;
+  const linksCount = Number(signal.links_count ?? 0);
+  const ghostMaxCreatedAt = (signal.ghost_max_created_at as Date | string | null) ?? null;
+  const ghostCount = Number(signal.ghost_count ?? 0);
+
+  const etag = makeTagsETag(
+    noteId,
+    role,
+    pagesMaxUpdatedAt,
+    pagesCount,
+    linksMaxCreatedAt,
+    linksCount,
+    ghostMaxCreatedAt,
+    ghostCount,
+  );
+  c.header("ETag", etag);
+  c.header("Cache-Control", "private, must-revalidate");
+  c.header("Vary", "Cookie");
+
+  const ifNoneMatch = c.req.header("If-None-Match");
+  if (ifNoneMatchMatches(ifNoneMatch, etag)) {
+    return c.body(null, 304);
+  }
+
+  // メイン集計: 解決済みタグ (links 経由) と未解決タグ (ghost_links 経由) を
+  // 同じ key (`LOWER(name)`) で UNION し、外側で sum/合成して 1 行 / キーに
+  // まとめる。`resolved` は「すべての出現が links 経由か」のフラグなので、
+  // ghost_count = 0 で判定する。表示名は resolved 側 (links) の `pages.title`
+  // を優先する (`tag_display_name_resolved`)。それも無い場合は ghost 側の
+  // 最初の表記にフォールバック。
+  //
+  // Main aggregation. Resolved tags (via `links` → tag-page `title`) and
+  // unresolved tags (via `ghost_links.link_text`) are unioned on a
+  // case-insensitive key and summed in the outer SELECT. `resolved` is true
+  // only when the ghost contribution is 0. Display name prefers the
+  // resolved-side `pages.title`; falls back to the first ghost spelling.
+  const tagRows = await db.execute(sql`
+    WITH resolved AS (
+      SELECT
+        LOWER(t.title) AS name_lower,
+        t.title AS display_name,
+        s.id AS source_id
+      FROM pages s
+      JOIN links l ON l.source_id = s.id AND l.link_type = 'tag'
+      JOIN pages t ON t.id = l.target_id
+      WHERE s.note_id = ${noteId}::uuid
+        AND s.is_deleted = false
+        AND t.is_deleted = false
+        AND t.title IS NOT NULL
+        AND LENGTH(TRIM(t.title)) > 0
+    ),
+    ghost AS (
+      SELECT
+        LOWER(gl.link_text) AS name_lower,
+        gl.link_text AS display_name,
+        s.id AS source_id
+      FROM pages s
+      JOIN ghost_links gl ON gl.source_page_id = s.id AND gl.link_type = 'tag'
+      WHERE s.note_id = ${noteId}::uuid
+        AND s.is_deleted = false
+        AND LENGTH(TRIM(gl.link_text)) > 0
+    ),
+    merged AS (
+      SELECT name_lower, display_name, source_id, 'resolved' AS origin FROM resolved
+      UNION ALL
+      SELECT name_lower, display_name, source_id, 'ghost' AS origin FROM ghost
+    )
+    SELECT
+      name_lower,
+      COALESCE(
+        (SELECT display_name FROM merged m2
+           WHERE m2.name_lower = merged.name_lower AND m2.origin = 'resolved'
+           LIMIT 1),
+        (SELECT display_name FROM merged m3
+           WHERE m3.name_lower = merged.name_lower
+           LIMIT 1)
+      ) AS display_name,
+      COUNT(DISTINCT source_id)::int AS page_count,
+      bool_and(origin = 'resolved') AS resolved
+    FROM merged
+    GROUP BY name_lower
+    ORDER BY page_count DESC, name_lower ASC
+  `);
+  const items: NoteTagAggregationItem[] = (
+    tagRows as unknown as { rows: Array<Record<string, unknown>> }
+  ).rows.map((r) => ({
+    name: typeof r.display_name === "string" ? r.display_name : String(r.name_lower ?? ""),
+    name_lower: String(r.name_lower ?? ""),
+    page_count: Number(r.page_count ?? 0),
+    resolved: r.resolved === true,
+  }));
+
+  // 「タグなし」件数: 同じノートのアクティブページのうち、`links` / `ghost_links`
+  // どちらにも `link_type='tag'` の出辺を持たないものをカウントする。
+  //
+  // "Untagged page" count: active pages in the note with no outgoing
+  // `link_type='tag'` edge in either table.
+  const noneCountRows = await db.execute(sql`
+    SELECT COUNT(*)::int AS none_count
+    FROM pages s
+    WHERE s.note_id = ${noteId}::uuid
+      AND s.is_deleted = false
+      AND NOT EXISTS (
+        SELECT 1 FROM links l WHERE l.source_id = s.id AND l.link_type = 'tag'
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM ghost_links gl WHERE gl.source_page_id = s.id AND gl.link_type = 'tag'
+      )
+  `);
+  const noneCount = Number(
+    (noneCountRows as unknown as { rows: Array<Record<string, unknown>> }).rows?.[0]?.none_count ??
+      0,
+  );
+
+  const response: NoteTagAggregationResponse = {
+    items,
+    none_count: noneCount,
+    total_pages: pagesCount,
+  };
+  return c.json(response);
+});
+
+export default app;

--- a/server/api/src/routes/notes/types.ts
+++ b/server/api/src/routes/notes/types.ts
@@ -47,6 +47,16 @@ export interface NoteApiFields {
    */
   is_default: boolean;
   view_count: number;
+  /**
+   * `/notes/:noteId` のタグフィルタバーをオーナーが既定で表示するか。
+   * Owner-declared default for the tag filter bar above the page list.
+   */
+  show_tag_filter_bar: boolean;
+  /**
+   * フィルタバーの既定選択タグ (小文字キー、`__none__` トークンを含み得る)。
+   * Default tags selected on first load (lower-cased keys; may contain `__none__`).
+   */
+  default_filter_tags: string[];
   created_at: Date;
   updated_at: Date;
   is_deleted: boolean;
@@ -185,4 +195,44 @@ export interface DiscoverApiItem {
 export interface DiscoverApiResponse {
   official: DiscoverApiItem[];
   notes: DiscoverApiItem[];
+}
+
+/**
+ * `GET /api/notes/:noteId/tags` の `items[]` 1 件分。
+ * Single row from the note tag aggregation endpoint.
+ *
+ * - `name` は表示名 (resolved 側を優先)。
+ * - `name_lower` は大文字小文字無視のキー。
+ * - `page_count` はこのタグが付いているアクティブページの distinct 件数。
+ * - `resolved` はすべての出現が `links` 経由 (同名ページが存在) であれば `true`、
+ *   1 件でも `ghost_links` 経由が混ざれば `false`。
+ *
+ * `name` is the display spelling (resolved-side wins); `name_lower` is the
+ * case-insensitive key; `page_count` is the distinct count of active pages
+ * tagged with this name; `resolved` is `true` only when every occurrence
+ * resolves via `links`.
+ */
+export interface NoteTagAggregationItem {
+  name: string;
+  name_lower: string;
+  page_count: number;
+  resolved: boolean;
+}
+
+/**
+ * `GET /api/notes/:noteId/tags` のレスポンス全体。
+ * Full response shape for the note tag aggregation endpoint.
+ *
+ * `none_count` は「`links` / `ghost_links` どちらにも `link_type='tag'` の
+ * 出辺を持たないアクティブページ」の件数。「タグなし」フィルタの件数表示と、
+ * UI で「タグなし」チップを出すかの判定に使う。
+ *
+ * `none_count` is the number of active pages with no outgoing tag edge in
+ * either `links` or `ghost_links`; the UI uses it for the "untagged" chip
+ * count and visibility.
+ */
+export interface NoteTagAggregationResponse {
+  items: NoteTagAggregationItem[];
+  none_count: number;
+  total_pages: number;
 }

--- a/server/api/src/schema/notes.ts
+++ b/server/api/src/schema/notes.ts
@@ -51,6 +51,29 @@ export const notes = pgTable(
      * per owner; the delete guard lives in the API layer.
      */
     isDefault: boolean("is_default").notNull().default(false),
+    /**
+     * ノートのオーナーが「`/notes/:noteId` のページ一覧上部にタグフィルタバーを
+     * 既定で表示する」と宣言する真偽値。ユーザーは localStorage で個別に上書き
+     * できる (`zedi-note-filter-preferences`)。
+     *
+     * Owner-declared default for showing the tag filter bar above the page
+     * list on `/notes/:noteId`. Individual users can override it via
+     * localStorage (`zedi-note-filter-preferences`).
+     */
+    showTagFilterBar: boolean("show_tag_filter_bar").notNull().default(false),
+    /**
+     * フィルタバーの既定選択タグ (小文字キー)。空配列は「既定では何も選択しない」、
+     * `['__none__']` は「タグなしページのみ」を既定にする。URL の `?tags=` が
+     * 指定されていればそちらが優先される。
+     *
+     * Default tag selection (lower-cased keys) for the filter bar. An empty
+     * array means "select nothing by default"; `['__none__']` defaults to
+     * "untagged pages only". The URL `?tags=` always wins over this default.
+     */
+    defaultFilterTags: text("default_filter_tags")
+      .array()
+      .notNull()
+      .default(sql`'{}'::text[]`),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
     isDeleted: boolean("is_deleted").default(false).notNull(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import MembersSection from "./pages/NoteSettings/sections/MembersSection";
 import LinksSection from "./pages/NoteSettings/sections/LinksSection";
 import DomainsSection from "./pages/NoteSettings/sections/DomainsSection";
 import DangerZoneSection from "./pages/NoteSettings/sections/DangerZoneSection";
+import TagFilterBarSection from "./pages/NoteSettings/sections/TagFilterBarSection";
 import Onboarding from "./pages/Onboarding";
 import AIChatHistory from "./pages/AIChatHistory";
 import AIChatLanding from "./pages/AIChatLanding";
@@ -284,6 +285,7 @@ const App = () => (
                         <Route path="members" element={<MembersSection />} />
                         <Route path="links" element={<LinksSection />} />
                         <Route path="domains" element={<DomainsSection />} />
+                        <Route path="filter-bar" element={<TagFilterBarSection />} />
                         <Route path="danger" element={<DangerZoneSection />} />
                       </Route>
                       <Route path="/notes/:noteId/members" element={<LegacyMembersRedirect />} />

--- a/src/components/note/NoteTitleSwitcher.test.tsx
+++ b/src/components/note/NoteTitleSwitcher.test.tsx
@@ -82,6 +82,8 @@ function makeNote(overrides: Partial<NoteSummary> & { id: string }): NoteSummary
     isOfficial: overrides.isOfficial ?? false,
     isDefault: overrides.isDefault ?? false,
     viewCount: overrides.viewCount ?? 0,
+    showTagFilterBar: overrides.showTagFilterBar ?? false,
+    defaultFilterTags: overrides.defaultFilterTags ?? [],
     createdAt: overrides.createdAt ?? 0,
     updatedAt: overrides.updatedAt ?? 0,
     isDeleted: overrides.isDeleted ?? false,

--- a/src/components/page/PageGrid.tsx
+++ b/src/components/page/PageGrid.tsx
@@ -10,6 +10,7 @@ import EmptyState from "./EmptyState";
 import { cn, Skeleton } from "@zedi/ui";
 import { hasNeverSynced } from "@/lib/sync";
 import type { PageSummary } from "@/types/page";
+import type { SelectedTags } from "@/types/tagFilter";
 
 /**
  * 末尾検知の前倒し量（行数）。virtual range の末尾がリストの末尾から
@@ -136,6 +137,16 @@ interface PageGridProps {
    * server's `canEdit` guard remains the source of truth.
    */
   canDeletePage?: (page: PageSummary) => boolean;
+  /**
+   * ノート文脈時に適用するタグフィルタ。`none-selected` (デフォルト) のときは
+   * フィルタ無し。値が変わると `useInfiniteNotePages` の queryKey も変わるので
+   * ウィンドウキャッシュは混ざらない。`noteId` 未指定時は無視される。
+   *
+   * Tag filter forwarded to `useInfiniteNotePages` when rendering in a note
+   * context. Changing the filter spawns a new infinite query so prior windows
+   * never leak. Ignored when `noteId` is not provided.
+   */
+  tagFilter?: SelectedTags;
 }
 
 /**
@@ -163,6 +174,7 @@ const PageGrid: React.FC<PageGridProps> = ({
   noteId,
   canEdit = true,
   canDeletePage,
+  tagFilter,
 }) => {
   const { ref: containerRef, columns } = useContainerColumns();
   const isNoteContext = Boolean(noteId);
@@ -178,7 +190,10 @@ const PageGrid: React.FC<PageGridProps> = ({
   // In a note context, fetch the page list as a keyset-paginated infinite
   // query (issue #860 Phase 3). The server's `updated_at DESC, id DESC` order
   // is preserved verbatim; no client-side resort.
-  const noteInfinite = useInfiniteNotePages(noteId ?? "", { enabled: isNoteContext });
+  const noteInfinite = useInfiniteNotePages(noteId ?? "", {
+    enabled: isNoteContext,
+    tagFilter,
+  });
   // Issue #860 Phase 4: ノート画面を開いている間だけ SSE を張り、ページ追加・
   // 更新・削除・権限変更イベントを React Query infinite cache に差分適用する。
   // 結果として `useAddPageToNote` / `useRemovePageFromNote` の onSuccess

--- a/src/components/tagFilterBar/TagChip.tsx
+++ b/src/components/tagFilterBar/TagChip.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { cn } from "@zedi/ui";
+
+/**
+ * {@link TagChip} のバリアント。`tag` は通常の解決済みタグ、`ghost` は同名
+ * ページがまだ存在しない (未解決) タグ、`untagged` は「タグなし」専用チップ。
+ * バリアントによってボーダー / 文字色を少し変えるが、レイアウト自体は同じ。
+ *
+ * Visual variant: `tag` (resolved), `ghost` (no matching page yet), or
+ * `untagged` (the dedicated "no tags" chip). Variants share the same layout
+ * but tweak border / text color so users can tell them apart.
+ */
+export type TagChipVariant = "tag" | "ghost" | "untagged";
+
+/**
+ * 単一のフィルタチップ。`selected` を真にすると塗りつぶし、偽だとアウトライン。
+ * クリックで `onToggle` を呼ぶ。バリアントは `tag` / `ghost` / `untagged`。
+ *
+ * Single filter chip. `selected = true` fills the chip; `false` is outlined.
+ * Click invokes `onToggle`. Variants change subtle border / color cues.
+ */
+export interface TagChipProps {
+  /** チップに表示する名前 (`#` プレフィックスはここでは付けない)。 */
+  label: string;
+  /** 使用ページ数。`undefined` のときは件数バッジを描画しない。 */
+  count?: number;
+  /** 選択中か否か / Whether the chip is currently selected. */
+  selected: boolean;
+  variant: TagChipVariant;
+  /** 全体を無効化する (排他選択時に他チップを操作不能にする等)。 */
+  disabled?: boolean;
+  onToggle: () => void;
+}
+
+const variantStyles: Record<TagChipVariant, { selected: string; idle: string }> = {
+  tag: {
+    selected: "bg-primary text-primary-foreground border-primary hover:bg-primary/90",
+    idle: "bg-background text-foreground border-border hover:bg-muted",
+  },
+  ghost: {
+    selected: "bg-primary text-primary-foreground border-primary hover:bg-primary/90",
+    idle: "bg-background text-muted-foreground border-dashed border-border hover:bg-muted hover:text-foreground",
+  },
+  untagged: {
+    selected: "bg-secondary text-secondary-foreground border-secondary hover:bg-secondary/80",
+    idle: "bg-background text-muted-foreground border-dashed border-border italic hover:bg-muted hover:text-foreground",
+  },
+};
+
+/**
+ * 単一のフィルタチップ。{@link TagChipProps} 参照。
+ * Single filter chip; see {@link TagChipProps}.
+ */
+export const TagChip: React.FC<TagChipProps> = ({
+  label,
+  count,
+  selected,
+  variant,
+  disabled,
+  onToggle,
+}) => {
+  const style = selected ? variantStyles[variant].selected : variantStyles[variant].idle;
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={selected}
+      disabled={disabled}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+        "focus-visible:ring-ring focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        style,
+      )}
+    >
+      <span className="max-w-[14ch] truncate" title={label}>
+        {variant === "untagged" ? label : `#${label}`}
+      </span>
+      {count !== undefined && (
+        <span
+          className={cn(
+            "rounded-full px-1.5 text-[10px] tabular-nums",
+            selected ? "bg-background/20" : "bg-muted/50",
+          )}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+};
+
+export default TagChip;

--- a/src/components/tagFilterBar/TagFilterBar.tsx
+++ b/src/components/tagFilterBar/TagFilterBar.tsx
@@ -112,8 +112,16 @@ export const TagFilterBar: React.FC<TagFilterBarProps> = ({
     );
   }
 
-  // タグも「タグなし」もゼロなら何も描画しない (バーは隠す)。
-  if (items.length === 0 && noneCount === 0) return null;
+  // タグも「タグなし」もゼロなら原則バーを隠すが、URL 由来でフィルタが
+  // 既に効いている場合は「クリア」ボタンを残すために描画を続ける (PR #897
+  // CodeRabbit minor)。これがないと選択タグが (削除・rename 等で) 集計から
+  // 消えた瞬間にフィルタを解除する手段が無くなる。
+  //
+  // Hide the bar when there are no chips to render — unless a URL-driven
+  // filter is still active. Keeping the bar mounted in that case preserves
+  // the clear button so users can always recover from an active filter
+  // whose tag no longer appears in the aggregation (PR #897 CodeRabbit minor).
+  if (items.length === 0 && noneCount === 0 && !hasActiveFilter) return null;
 
   return (
     <div

--- a/src/components/tagFilterBar/TagFilterBar.tsx
+++ b/src/components/tagFilterBar/TagFilterBar.tsx
@@ -1,0 +1,160 @@
+import React, { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Button, Skeleton, cn } from "@zedi/ui";
+import { X } from "lucide-react";
+import type { SelectedTags, TagAggregationItem } from "@/types/tagFilter";
+import { TagChip } from "./TagChip";
+
+/**
+ * {@link TagFilterBar} のプロパティ。
+ * Props for {@link TagFilterBar}.
+ */
+export interface TagFilterBarProps {
+  /**
+   * `useNoteTagAggregation` から取得したタグ集計。サーバ順 (page_count DESC)
+   * をそのまま表示する。
+   * Tag aggregation from `useNoteTagAggregation`, already ordered by count.
+   */
+  items: TagAggregationItem[];
+  /**
+   * 「タグなし」ページ数。`> 0` のときに「タグなし」チップを表示する。
+   * Untagged page count; the chip is rendered only when this is `> 0`.
+   */
+  noneCount: number;
+  /** 現在のフィルタ状態 / Current filter selection. */
+  selected: SelectedTags;
+  /** 選択変更コールバック / Called when the user changes the selection. */
+  onChange: (next: SelectedTags) => void;
+  /** ローディング中フラグ。`true` のときはスケルトンを表示する。 */
+  isLoading?: boolean;
+  /** 追加クラス名 / Optional className for the outer container. */
+  className?: string;
+}
+
+const SKELETON_COUNT = 6;
+
+/**
+ * `/notes/:noteId` のページ一覧上部に並ぶタグチップ列。
+ *
+ * - クリックで OR 追加 / 解除。
+ * - 「タグなし」チップは他タグと排他選択 (どちらか一方のみ)。
+ * - 1 件以上選択中のときは「すべてクリア」ボタンを表示する。
+ *
+ * Filter bar above the page list. Clicking a chip toggles the tag in the
+ * OR list; the "untagged" chip is mutually exclusive with normal tags.
+ * A clear-all button appears when any filter is active.
+ */
+export const TagFilterBar: React.FC<TagFilterBarProps> = ({
+  items,
+  noneCount,
+  selected,
+  onChange,
+  isLoading,
+  className,
+}) => {
+  const { t } = useTranslation();
+
+  // 現在選択されているタグキーの Set を派生。チップ側の `selected` 判定で使う。
+  // Derive a Set of currently-selected tag keys for fast per-chip lookup.
+  const selectedSet = useMemo<Set<string>>(() => {
+    if (selected.kind === "tags") return new Set(selected.tags);
+    return new Set();
+  }, [selected]);
+
+  const isUntaggedSelected = selected.kind === "untagged-only";
+  const hasActiveFilter = selected.kind !== "none-selected";
+
+  const handleToggleTag = useCallback(
+    (key: string) => {
+      // 「タグなし」が選択されているときに通常タグをクリックしたら、untagged を
+      // 解除して通常タグだけが選ばれている状態に切り替える (`__none__` は排他)。
+      // Clicking a normal tag while "untagged-only" is active drops the
+      // untagged filter and starts a fresh tag selection (`__none__` is
+      // exclusive).
+      if (isUntaggedSelected) {
+        onChange({ kind: "tags", tags: [key] });
+        return;
+      }
+      if (selectedSet.has(key)) {
+        const next = Array.from(selectedSet).filter((t) => t !== key);
+        onChange(next.length === 0 ? { kind: "none-selected" } : { kind: "tags", tags: next });
+      } else {
+        onChange({ kind: "tags", tags: [...selectedSet, key] });
+      }
+    },
+    [isUntaggedSelected, onChange, selectedSet],
+  );
+
+  const handleToggleUntagged = useCallback(() => {
+    if (isUntaggedSelected) {
+      onChange({ kind: "none-selected" });
+    } else {
+      onChange({ kind: "untagged-only" });
+    }
+  }, [isUntaggedSelected, onChange]);
+
+  const handleClear = useCallback(() => {
+    onChange({ kind: "none-selected" });
+  }, [onChange]);
+
+  // 読み込み中はスケルトン
+  if (isLoading) {
+    return (
+      <div
+        className={cn("flex flex-wrap items-center gap-2", className)}
+        aria-label={t("notes.filterBar.ariaLabel")}
+        role="region"
+      >
+        {Array.from({ length: SKELETON_COUNT }, (_, i) => (
+          <Skeleton key={`tag-skel-${i}`} className="h-7 w-20 rounded-full" />
+        ))}
+      </div>
+    );
+  }
+
+  // タグも「タグなし」もゼロなら何も描画しない (バーは隠す)。
+  if (items.length === 0 && noneCount === 0) return null;
+
+  return (
+    <div
+      className={cn("flex flex-wrap items-center gap-2", className)}
+      aria-label={t("notes.filterBar.ariaLabel")}
+      role="region"
+    >
+      {items.map((item) => (
+        <TagChip
+          key={item.nameLower}
+          label={item.name}
+          count={item.pageCount}
+          variant={item.resolved ? "tag" : "ghost"}
+          selected={selectedSet.has(item.nameLower)}
+          onToggle={() => handleToggleTag(item.nameLower)}
+        />
+      ))}
+      {noneCount > 0 && (
+        <TagChip
+          label={t("notes.filterBar.untaggedChip")}
+          count={noneCount}
+          variant="untagged"
+          selected={isUntaggedSelected}
+          onToggle={handleToggleUntagged}
+        />
+      )}
+      {hasActiveFilter && (
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={handleClear}
+          className="ml-1 h-7 gap-1 px-2 text-xs"
+          aria-label={t("notes.filterBar.clearAriaLabel")}
+        >
+          <X className="h-3.5 w-3.5" aria-hidden />
+          {t("notes.filterBar.clear")}
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default TagFilterBar;

--- a/src/components/tagFilterBar/index.ts
+++ b/src/components/tagFilterBar/index.ts
@@ -1,0 +1,2 @@
+export { TagFilterBar, type TagFilterBarProps } from "./TagFilterBar";
+export { TagChip, type TagChipProps, type TagChipVariant } from "./TagChip";

--- a/src/hooks/useInfiniteNotePages.test.tsx
+++ b/src/hooks/useInfiniteNotePages.test.tsx
@@ -179,4 +179,49 @@ describe("useInfiniteNotePages", () => {
 
     expect(mockGetNotePages).not.toHaveBeenCalled();
   });
+
+  it("forwards a non-default tagFilter on every windowed fetch (PR #897)", async () => {
+    mockGetNotePages
+      .mockResolvedValueOnce({
+        items: [makeItem("p1", "2026-05-13T10:00:00.000000Z")],
+        next_cursor: "cursor-abc",
+      })
+      .mockResolvedValueOnce({
+        items: [makeItem("p2", "2026-05-13T09:00:00.000000Z")],
+        next_cursor: null,
+      });
+
+    const tagFilter = { kind: "tags" as const, tags: ["typescript", "react"] };
+    const { result } = renderHook(
+      () =>
+        useInfiniteNotePages("note-1", {
+          pageSize: 25,
+          include: ["preview"],
+          tagFilter,
+        }),
+      { wrapper: wrapperWithClient(makeQueryClient()) },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetNotePages).toHaveBeenLastCalledWith("note-1", {
+      cursor: null,
+      limit: 25,
+      include: ["preview"],
+      tags: tagFilter,
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(result.current.isFetchingNextPage).toBe(false));
+    expect(mockGetNotePages).toHaveBeenCalledTimes(2);
+    expect(mockGetNotePages).toHaveBeenLastCalledWith("note-1", {
+      cursor: "cursor-abc",
+      limit: 25,
+      include: ["preview"],
+      tags: tagFilter,
+    });
+    expect(result.current.pages.map((p) => p.id)).toEqual(["p1", "p2"]);
+  });
 });

--- a/src/hooks/useInfiniteNotePages.test.tsx
+++ b/src/hooks/useInfiniteNotePages.test.tsx
@@ -106,6 +106,7 @@ describe("useInfiniteNotePages", () => {
       cursor: null,
       limit: 50,
       include: ["preview", "thumbnail"],
+      tags: { kind: "none-selected" },
     });
     expect(result.current.pages).toHaveLength(1);
     expect(result.current.pages[0]?.id).toBe("p1");
@@ -135,6 +136,7 @@ describe("useInfiniteNotePages", () => {
       cursor: null,
       limit: 25,
       include: ["preview"],
+      tags: { kind: "none-selected" },
     });
 
     await act(async () => {
@@ -147,6 +149,7 @@ describe("useInfiniteNotePages", () => {
       cursor: "cursor-abc",
       limit: 25,
       include: ["preview"],
+      tags: { kind: "none-selected" },
     });
     expect(result.current.pages.map((p) => p.id)).toEqual(["p1", "p2"]);
     expect(result.current.hasNextPage).toBe(false);

--- a/src/hooks/useNoteQueries.ts
+++ b/src/hooks/useNoteQueries.ts
@@ -21,6 +21,8 @@ import type {
 } from "@/lib/api/types";
 import type { Note, NoteAccess, NoteMember, NoteMemberRole } from "@/types/note";
 import type { Page, PageSummary } from "@/types/page";
+import type { SelectedTags } from "@/types/tagFilter";
+import { serializeTagsParam } from "@/lib/noteTagFilterBar/urlTagsCodec";
 import { pageKeys, useRepository } from "@/hooks/usePageQueries";
 
 /** Page in a note with who added it (for canDeletePage). */
@@ -105,6 +107,7 @@ export const noteKeys = {
     userEmail: string | undefined,
     include: ReadonlyArray<NotePageWindowInclude>,
     pageSize: number,
+    tagFilter: SelectedTags = { kind: "none-selected" },
   ) =>
     [
       ...noteKeys.pages(),
@@ -114,6 +117,12 @@ export const noteKeys = {
       userEmail ?? "",
       [...include].sort().join(","),
       pageSize,
+      // タグフィルタの正規化文字列を queryKey に混ぜることで、フィルタが変わると
+      // React Query が別 query 扱いし、既存 InfiniteData と混ざらない。
+      // Folding the serialized filter into the key forces React Query to treat
+      // each filter as a distinct query, preventing stale `InfiniteData`
+      // windows from polluting the next filter state.
+      serializeTagsParam(tagFilter) ?? "",
     ] as const,
   /**
    * `noteId` 配下のすべての window エントリ（任意の include / pageSize / 認証
@@ -170,6 +179,8 @@ function apiNoteToNote(item: {
   is_official?: boolean;
   is_default?: boolean;
   view_count?: number;
+  show_tag_filter_bar?: boolean;
+  default_filter_tags?: string[];
   created_at: string;
   updated_at: string;
   is_deleted: boolean;
@@ -183,6 +194,8 @@ function apiNoteToNote(item: {
     isOfficial: item.is_official ?? false,
     isDefault: item.is_default ?? false,
     viewCount: item.view_count ?? 0,
+    showTagFilterBar: item.show_tag_filter_bar ?? false,
+    defaultFilterTags: Array.isArray(item.default_filter_tags) ? [...item.default_filter_tags] : [],
     createdAt: parseTs(item.created_at),
     updatedAt: parseTs(item.updated_at),
     isDeleted: item.is_deleted,
@@ -708,6 +721,16 @@ export interface UseInfiniteNotePagesOptions {
    * before the caller has confirmed view permission.
    */
   enabled?: boolean;
+  /**
+   * タグフィルタバー由来の `?tags=` フィルタ。`none-selected` を渡したときは
+   * パラメータを付けずに全件取得する。値を変えると React Query は別 query
+   * 扱いし、既存 InfiniteData は破棄される。
+   *
+   * Tag filter bar selection. `none-selected` fetches everything (no param);
+   * changing the filter spawns a new React Query so prior `InfiniteData` is
+   * not reused.
+   */
+  tagFilter?: SelectedTags;
 }
 
 /**
@@ -769,6 +792,7 @@ export function useInfiniteNotePages(noteId: string, options: UseInfiniteNotePag
   const { api, userId, userEmail, isLoaded } = useNoteApi();
   const include = options.include ?? DEFAULT_INFINITE_NOTE_PAGES_INCLUDE;
   const pageSize = options.pageSize ?? DEFAULT_INFINITE_NOTE_PAGES_SIZE;
+  const tagFilter: SelectedTags = options.tagFilter ?? { kind: "none-selected" };
   const enabled = (options.enabled ?? true) && isLoaded && !!noteId;
 
   const query = useInfiniteQuery<
@@ -778,13 +802,14 @@ export function useInfiniteNotePages(noteId: string, options: UseInfiniteNotePag
     readonly unknown[],
     string | null
   >({
-    queryKey: noteKeys.pagesWindow(noteId, userId, userEmail, include, pageSize),
+    queryKey: noteKeys.pagesWindow(noteId, userId, userEmail, include, pageSize, tagFilter),
     queryFn: async (ctx): Promise<NotePageWindowResponse> => {
       const cursor = ctx.pageParam ?? null;
       return api.getNotePages(noteId, {
         cursor,
         limit: pageSize,
         include,
+        tags: tagFilter,
       });
     },
     enabled,
@@ -939,8 +964,15 @@ export function useCreateNote() {
 }
 
 /**
- * ノートの title / visibility / editPermission を更新するミューテーションフック。
- * Mutation hook for updating a note's title / visibility / editPermission.
+ * ノートの title / visibility / editPermission およびタグフィルタバー設定を
+ * 更新するミューテーションフック。`showTagFilterBar` / `defaultFilterTags` は
+ * オーナーが既定値を管理するためのフィールドで、ユーザーは localStorage で
+ * 上書きできる（フックは扱わない）。
+ *
+ * Mutation hook for updating note attributes, including the owner-side
+ * defaults for the tag filter bar (`showTagFilterBar` / `defaultFilterTags`).
+ * Per-user filter-bar overrides live in localStorage and are not touched
+ * here.
  */
 export function useUpdateNote() {
   const { api } = useNoteApi();
@@ -952,12 +984,19 @@ export function useUpdateNote() {
       updates,
     }: {
       noteId: string;
-      updates: Partial<Pick<Note, "title" | "visibility" | "editPermission">>;
+      updates: Partial<
+        Pick<
+          Note,
+          "title" | "visibility" | "editPermission" | "showTagFilterBar" | "defaultFilterTags"
+        >
+      >;
     }) => {
       await api.updateNote(noteId, {
         title: updates.title,
         visibility: updates.visibility,
         edit_permission: updates.editPermission,
+        show_tag_filter_bar: updates.showTagFilterBar,
+        default_filter_tags: updates.defaultFilterTags,
       });
       return { noteId, updates };
     },

--- a/src/hooks/useNoteTagAggregation.ts
+++ b/src/hooks/useNoteTagAggregation.ts
@@ -1,0 +1,86 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useNoteApi } from "@/hooks/useNoteQueries";
+import type { NoteTagAggregationItem, NoteTagAggregationResponse } from "@/lib/api/types";
+import type { TagAggregationItem } from "@/types/tagFilter";
+
+/**
+ * フックの戻り値。`source` は表示しているデータがリモート集計 (`remote`) か、
+ * フェッチ前 / オフライン時のデフォルト (`empty`) かを示す。
+ *
+ * Hook result. `source` reports whether the data came from the remote
+ * aggregation endpoint or the empty pre-fetch / offline fallback.
+ */
+export interface UseNoteTagAggregationResult {
+  items: TagAggregationItem[];
+  noneCount: number;
+  totalPages: number;
+  isLoading: boolean;
+  isError: boolean;
+  source: "remote" | "empty";
+}
+
+const EMPTY_RESULT: Omit<UseNoteTagAggregationResult, "isLoading" | "isError" | "source"> = {
+  items: [],
+  noneCount: 0,
+  totalPages: 0,
+};
+
+/**
+ * `GET /api/notes/:noteId/tags` を呼んで使用ページ数順のタグ一覧を取得するフック。
+ *
+ * Fetches the note-wide tag aggregation. Tags arrive already ordered by
+ * `page_count DESC, name_lower ASC`, so consumers can iterate verbatim.
+ *
+ * `enabled: false` を渡すと React Query は走らず、空状態を返す。フィルタバーが
+ * 非表示のときに無駄なリクエストを抑止するために使う。
+ *
+ * Pass `enabled: false` to skip the query (e.g. while the filter bar is
+ * hidden) and receive an empty result.
+ */
+export function useNoteTagAggregation(
+  noteId: string,
+  options: { enabled?: boolean } = {},
+): UseNoteTagAggregationResult {
+  const { api, userId, userEmail, isLoaded } = useNoteApi();
+  const enabled = (options.enabled ?? true) && isLoaded && !!noteId;
+
+  const query = useQuery<NoteTagAggregationResponse, Error>({
+    queryKey: ["note-tag-aggregation", noteId, userId, userEmail ?? ""],
+    queryFn: () => api.getNoteTags(noteId),
+    enabled,
+    // タグエッジ追加・ページ追加でサーバ ETag が変わるため、stale はやや長めで
+    // 十分。30 秒間は再フェッチを抑止し、フィルタ操作のたびに往復しないようにする。
+    // 30 s staleness is fine: server ETag bumps on tag / page mutations
+    // anyway, and this avoids re-fetching on every chip click.
+    staleTime: 30 * 1000,
+  });
+
+  return useMemo<UseNoteTagAggregationResult>(() => {
+    if (!query.data) {
+      return {
+        ...EMPTY_RESULT,
+        isLoading: query.isLoading,
+        isError: query.isError,
+        source: "empty",
+      };
+    }
+    return {
+      items: query.data.items.map(apiItemToTagAggregation),
+      noneCount: query.data.none_count,
+      totalPages: query.data.total_pages,
+      isLoading: query.isLoading,
+      isError: query.isError,
+      source: "remote",
+    };
+  }, [query.data, query.isLoading, query.isError]);
+}
+
+function apiItemToTagAggregation(item: NoteTagAggregationItem): TagAggregationItem {
+  return {
+    name: item.name,
+    nameLower: item.name_lower,
+    pageCount: item.page_count,
+    resolved: item.resolved,
+  };
+}

--- a/src/hooks/useTagFilterBarPreference.ts
+++ b/src/hooks/useTagFilterBarPreference.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNote } from "@/hooks/useNoteQueries";
+import {
+  getShowTagFilterBarOverride,
+  setShowTagFilterBarOverride,
+} from "@/lib/noteTagFilterBar/preferenceStorage";
+import { resolveShowFilterBar } from "@/lib/noteTagFilterBar/resolvePreference";
+
+/**
+ * `/notes/:noteId` のタグフィルタバーを表示するかを解決するフック。
+ *
+ * - 既定: ノートの DB 設定 (`note.showTagFilterBar`)
+ * - 上書き: ユーザーの localStorage (`zedi-note-filter-preferences`)
+ *
+ * Resolve whether the tag filter bar should render on `/notes/:noteId`,
+ * combining the note's DB default with the user's localStorage override.
+ *
+ * `setOverride(undefined)` を呼ぶと localStorage の上書きを削除して「ノート
+ * 既定に従う」状態に戻る。3 状態セレクタ (`note default / always show /
+ * always hide`) を実装する UI から呼び出すことを想定している。
+ *
+ * `setOverride(undefined)` clears the user override and reverts to "follow
+ * the note default". Designed for the 3-state selector in the filter bar
+ * settings menu.
+ */
+export function useTagFilterBarPreference(noteId: string): {
+  /** バーを表示するか / Whether the bar should render. */
+  enabled: boolean;
+  /** ノート側既定値 / The note's DB default. */
+  noteDefault: boolean;
+  /** localStorage 上書き値。`undefined` は未設定。/ The user override; `undefined` when unset. */
+  userOverride: boolean | undefined;
+  /**
+   * 上書き値を設定 / 解除する。`undefined` を渡すとノート既定に従う。
+   * Set or clear the override; `undefined` reverts to the note default.
+   */
+  setOverride: (value: boolean | undefined) => void;
+} {
+  const { note } = useNote(noteId, { allowRemote: true });
+  const noteDefault = note?.showTagFilterBar ?? false;
+
+  const [userOverride, setUserOverride] = useState<boolean | undefined>(() =>
+    getShowTagFilterBarOverride(noteId),
+  );
+
+  // ノート切替時に override を読み直す。同じ noteId のままなら state を維持する。
+  // Re-read the override whenever the noteId changes; keep state otherwise so
+  // the same tab does not flicker between renders.
+  useEffect(() => {
+    setUserOverride(getShowTagFilterBarOverride(noteId));
+  }, [noteId]);
+
+  const setOverride = useCallback(
+    (value: boolean | undefined) => {
+      setShowTagFilterBarOverride(noteId, value);
+      setUserOverride(value);
+    },
+    [noteId],
+  );
+
+  return {
+    enabled: resolveShowFilterBar(noteDefault, userOverride),
+    noteDefault,
+    userOverride,
+    setOverride,
+  };
+}

--- a/src/hooks/useURLTagFilter.ts
+++ b/src/hooks/useURLTagFilter.ts
@@ -1,0 +1,65 @@
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+import type { SelectedTags } from "@/types/tagFilter";
+import { parseTagsParam, serializeTagsParam } from "@/lib/noteTagFilterBar/urlTagsCodec";
+
+/**
+ * URL クエリ `?tags=` をフィルタ状態として読み書きするフック。
+ * Hook that exposes `?tags=` as a {@link SelectedTags} state.
+ *
+ * - 読み込み: `useSearchParams` から `?tags=` を取り出し、`parseTagsParam` で
+ *   {@link SelectedTags} に正規化する。
+ *   Reads `?tags=` via `useSearchParams` and normalizes it through
+ *   {@link parseTagsParam}.
+ * - 書き込み: `serializeTagsParam` の結果が `null` ならパラメータを削除し、
+ *   それ以外は上書きする。`replace: true` でブラウザ履歴を汚さない。
+ *   Writes via `setSearchParams({ replace: true })`; a `null` from
+ *   {@link serializeTagsParam} removes the param entirely.
+ *
+ * URL を単一の真実のソースにするため、選択中タグは localStorage に複製
+ * しない（リロード後の再現は URL に乗せる側に任せる）。
+ *
+ * Selected tags are deliberately not duplicated to localStorage — the URL
+ * is the single source of truth so reloads / shares restore the same view.
+ */
+export function useURLTagFilter(): {
+  /** 現在のフィルタ状態 / Current filter state. */
+  selected: SelectedTags;
+  /** フィルタを差し替える。`{ replace: true }` で履歴を汚さない。 */
+  setSelected: (next: SelectedTags) => void;
+  /**
+   * 全てのタグ選択を解除して `?tags=` をクリアする。`setSelected({ kind: 'none-selected' })`
+   * の糖衣構文。
+   */
+  clear: () => void;
+} {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const raw = searchParams.get("tags");
+
+  const selected = useMemo<SelectedTags>(() => parseTagsParam(raw), [raw]);
+
+  const setSelected = useCallback(
+    (next: SelectedTags) => {
+      setSearchParams(
+        (prev) => {
+          const updated = new URLSearchParams(prev);
+          const serialized = serializeTagsParam(next);
+          if (serialized === null) {
+            updated.delete("tags");
+          } else {
+            updated.set("tags", serialized);
+          }
+          return updated;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const clear = useCallback(() => {
+    setSelected({ kind: "none-selected" });
+  }, [setSelected]);
+
+  return { selected, setSelected, clear };
+}

--- a/src/i18n/locales/en/notes.json
+++ b/src/i18n/locales/en/notes.json
@@ -48,6 +48,7 @@
     "members": "Members",
     "links": "Share links",
     "domains": "Domains",
+    "filterBar": "Tag filter",
     "danger": "Delete"
   },
   "generalSectionDescription": "Update the note title shown across the app.",
@@ -233,6 +234,8 @@
     "description": "Show a hashtag filter bar above the page list.",
     "showByDefault": "Show by default",
     "showByDefaultHelp": "When off, members can opt-in individually.",
-    "userOverrideHint": "Your visibility preference is saved per device."
+    "userOverrideHint": "Your visibility preference is saved per device.",
+    "userOverrideOn": "On this device, the bar is set to always show.",
+    "userOverrideOff": "On this device, the bar is set to always hide."
   }
 }

--- a/src/i18n/locales/en/notes.json
+++ b/src/i18n/locales/en/notes.json
@@ -221,5 +221,18 @@
   "domainTabCreateFailedInvalid": "The domain format is invalid.",
   "domainTabCreateFailedEmpty": "Enter a domain.",
   "domainTabRemoved": "Domain rule removed",
-  "domainTabRemoveFailed": "Failed to remove domain rule"
+  "domainTabRemoveFailed": "Failed to remove domain rule",
+  "filterBar": {
+    "ariaLabel": "Filter pages by tag",
+    "untaggedChip": "Untagged",
+    "clear": "Clear",
+    "clearAriaLabel": "Clear tag filter"
+  },
+  "filterBarSettings": {
+    "title": "Tag filter bar",
+    "description": "Show a hashtag filter bar above the page list.",
+    "showByDefault": "Show by default",
+    "showByDefaultHelp": "When off, members can opt-in individually.",
+    "userOverrideHint": "Your visibility preference is saved per device."
+  }
 }

--- a/src/i18n/locales/ja/notes.json
+++ b/src/i18n/locales/ja/notes.json
@@ -48,6 +48,7 @@
     "members": "メンバー",
     "links": "招待リンク",
     "domains": "ドメイン招待",
+    "filterBar": "タグフィルタ",
     "danger": "削除"
   },
   "generalSectionDescription": "ノートのタイトルを変更します。",
@@ -233,6 +234,8 @@
     "description": "ページ一覧の上部にハッシュタグの絞り込みバーを表示します。",
     "showByDefault": "既定で表示する",
     "showByDefaultHelp": "オフのときは、各メンバーが個別に表示を有効化できます。",
-    "userOverrideHint": "あなたの表示設定は端末ごとに保存されます。"
+    "userOverrideHint": "あなたの表示設定は端末ごとに保存されます。",
+    "userOverrideOn": "この端末では「常に表示」が設定されています。",
+    "userOverrideOff": "この端末では「常に非表示」が設定されています。"
   }
 }

--- a/src/i18n/locales/ja/notes.json
+++ b/src/i18n/locales/ja/notes.json
@@ -221,5 +221,18 @@
   "domainTabCreateFailedInvalid": "ドメインの形式が正しくありません。",
   "domainTabCreateFailedEmpty": "ドメインを入力してください。",
   "domainTabRemoved": "ドメインルールを削除しました",
-  "domainTabRemoveFailed": "ドメインルールの削除に失敗しました"
+  "domainTabRemoveFailed": "ドメインルールの削除に失敗しました",
+  "filterBar": {
+    "ariaLabel": "タグでページを絞り込む",
+    "untaggedChip": "タグなし",
+    "clear": "クリア",
+    "clearAriaLabel": "タグフィルタを解除する"
+  },
+  "filterBarSettings": {
+    "title": "タグフィルタバー",
+    "description": "ページ一覧の上部にハッシュタグの絞り込みバーを表示します。",
+    "showByDefault": "既定で表示する",
+    "showByDefaultHelp": "オフのときは、各メンバーが個別に表示を有効化できます。",
+    "userOverrideHint": "あなたの表示設定は端末ごとに保存されます。"
+  }
 }

--- a/src/lib/api/apiClient.ts
+++ b/src/lib/api/apiClient.ts
@@ -36,7 +36,10 @@ import type {
   NotePageWindowInclude,
   NotePageWindowResponse,
   NotePageTitleIndexResponse,
+  NoteTagAggregationResponse,
 } from "./types";
+import type { SelectedTags } from "@/types/tagFilter";
+import { serializeTagsParam } from "@/lib/noteTagFilterBar/urlTagsCodec";
 
 export type { NoteListItem };
 
@@ -479,6 +482,7 @@ export function createApiClient(options?: Partial<ApiClientOptions>) {
         cursor?: string | null;
         limit?: number;
         include?: ReadonlyArray<NotePageWindowInclude>;
+        tags?: SelectedTags;
       } = {},
     ): Promise<NotePageWindowResponse> {
       const query: Record<string, string> = {};
@@ -492,10 +496,32 @@ export function createApiClient(options?: Partial<ApiClientOptions>) {
         const tokens = Array.from(new Set(params.include));
         query.include = tokens.join(",");
       }
+      if (params.tags) {
+        // `serializeTagsParam` は none-selected で null を返すので param 自体を
+        // 省略する。`__none__` や `tags=a,b` の URL 形は codec が決める。
+        // Skip the param when the filter is `none-selected`; the codec
+        // encodes `__none__` / `tags=a,b` consistently with the front-end URL.
+        const serialized = serializeTagsParam(params.tags);
+        if (serialized) query.tags = serialized;
+      }
       return reqOptionalAuth<NotePageWindowResponse>(
         "GET",
         `/api/notes/${encodeURIComponent(noteId)}/pages`,
         { query },
+      );
+    },
+
+    /**
+     * `GET /api/notes/:noteId/tags` — タグフィルタバー用の集計を取得する。
+     * `authOptional` なので公開 / unlisted ノートは未ログインでも呼べる。
+     *
+     * Fetch the tag aggregation for the filter bar. `authOptional`, so
+     * public / unlisted notes are reachable without sign-in.
+     */
+    async getNoteTags(noteId: string): Promise<NoteTagAggregationResponse> {
+      return reqOptionalAuth<NoteTagAggregationResponse>(
+        "GET",
+        `/api/notes/${encodeURIComponent(noteId)}/tags`,
       );
     },
 
@@ -541,7 +567,22 @@ export function createApiClient(options?: Partial<ApiClientOptions>) {
     /** PUT /api/notes/:id — update note (owner only). */
     async updateNote(
       noteId: string,
-      body: { title?: string; visibility?: string; edit_permission?: string },
+      body: {
+        title?: string;
+        visibility?: string;
+        edit_permission?: string;
+        /**
+         * オーナーが既定でタグフィルタバーを表示するか。ユーザー側は localStorage
+         * で個別に上書き可能。
+         * Owner-side default for showing the filter bar; users can override locally.
+         */
+        show_tag_filter_bar?: boolean;
+        /**
+         * フィルタバーの既定選択タグ（小文字キー、`__none__` を含み得る）。
+         * Default tags selected on first load (lower-cased; may include `__none__`).
+         */
+        default_filter_tags?: string[];
+      },
     ): Promise<NoteListItem> {
       return req<NoteListItem>("PUT", `/api/notes/${encodeURIComponent(noteId)}`, { body });
     },

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -329,6 +329,19 @@ export interface NoteListItem {
    */
   is_default?: boolean;
   view_count?: number;
+  /**
+   * オーナーが「`/notes/:noteId` のページ一覧上部にタグフィルタバーを既定表示」
+   * と宣言したかどうか。ユーザー側は localStorage で個別に上書き可能。
+   *
+   * Owner-declared default for showing the tag filter bar on `/notes/:noteId`.
+   * Each user can override via localStorage.
+   */
+  show_tag_filter_bar?: boolean;
+  /**
+   * フィルタバーの既定選択タグ (小文字キー、`__none__` トークンを含み得る)。
+   * Default tags selected on first load (lower-cased keys; may include `__none__`).
+   */
+  default_filter_tags?: string[];
   created_at: string;
   updated_at: string;
   is_deleted: boolean;
@@ -389,10 +402,35 @@ export interface GetNoteResponse {
    */
   is_default?: boolean;
   view_count?: number;
+  /** {@link NoteListItem.show_tag_filter_bar} と同じ。/ See {@link NoteListItem.show_tag_filter_bar}. */
+  show_tag_filter_bar?: boolean;
+  /** {@link NoteListItem.default_filter_tags} と同じ。/ See {@link NoteListItem.default_filter_tags}. */
+  default_filter_tags?: string[];
   created_at: string;
   updated_at: string;
   is_deleted: boolean;
   current_user_role: "owner" | "editor" | "viewer" | "guest";
+}
+
+/**
+ * `GET /api/notes/:noteId/tags` の 1 件分。
+ * Single row from the note tag aggregation endpoint.
+ */
+export interface NoteTagAggregationItem {
+  name: string;
+  name_lower: string;
+  page_count: number;
+  resolved: boolean;
+}
+
+/**
+ * `GET /api/notes/:noteId/tags` のレスポンス全体。
+ * Full response for the note tag aggregation endpoint.
+ */
+export interface NoteTagAggregationResponse {
+  items: NoteTagAggregationItem[];
+  none_count: number;
+  total_pages: number;
 }
 
 /**

--- a/src/lib/noteTagFilterBar/preferenceStorage.test.ts
+++ b/src/lib/noteTagFilterBar/preferenceStorage.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  NOTE_FILTER_PREFERENCES_STORAGE_KEY,
+  getShowTagFilterBarOverride,
+  loadNoteFilterPreferences,
+  saveNoteFilterPreferences,
+  setShowTagFilterBarOverride,
+} from "./preferenceStorage";
+
+describe("preferenceStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("loadNoteFilterPreferences", () => {
+    it("returns empty when storage is empty", () => {
+      expect(loadNoteFilterPreferences()).toEqual({});
+    });
+
+    it("returns empty when JSON is invalid", () => {
+      localStorage.setItem(NOTE_FILTER_PREFERENCES_STORAGE_KEY, "{ not json");
+      expect(loadNoteFilterPreferences()).toEqual({});
+    });
+
+    it("returns empty when stored value is not an object", () => {
+      localStorage.setItem(NOTE_FILTER_PREFERENCES_STORAGE_KEY, JSON.stringify([1, 2]));
+      expect(loadNoteFilterPreferences()).toEqual({});
+    });
+
+    it("loads valid entries and drops malformed ones", () => {
+      localStorage.setItem(
+        NOTE_FILTER_PREFERENCES_STORAGE_KEY,
+        JSON.stringify({
+          "note-a": { showTagFilterBar: true },
+          "note-b": { showTagFilterBar: false },
+          "note-c": { showTagFilterBar: "not-a-bool" },
+          "note-d": null,
+          "": { showTagFilterBar: true },
+        }),
+      );
+      expect(loadNoteFilterPreferences()).toEqual({
+        "note-a": { showTagFilterBar: true },
+        "note-b": { showTagFilterBar: false },
+      });
+    });
+  });
+
+  describe("saveNoteFilterPreferences", () => {
+    it("writes valid entries to storage", () => {
+      saveNoteFilterPreferences({
+        "note-a": { showTagFilterBar: true },
+      });
+      const raw = localStorage.getItem(NOTE_FILTER_PREFERENCES_STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      expect(raw && JSON.parse(raw)).toEqual({ "note-a": { showTagFilterBar: true } });
+    });
+
+    it("drops entries that compact to empty objects", () => {
+      saveNoteFilterPreferences({
+        "note-a": { showTagFilterBar: true },
+        "note-b": {},
+      });
+      const raw = localStorage.getItem(NOTE_FILTER_PREFERENCES_STORAGE_KEY);
+      expect(raw && JSON.parse(raw)).toEqual({ "note-a": { showTagFilterBar: true } });
+    });
+
+    it("roundtrips via load", () => {
+      const written = {
+        "note-x": { showTagFilterBar: false },
+        "note-y": { showTagFilterBar: true },
+      };
+      saveNoteFilterPreferences(written);
+      expect(loadNoteFilterPreferences()).toEqual(written);
+    });
+  });
+
+  describe("setShowTagFilterBarOverride", () => {
+    it("sets a new override and persists it", () => {
+      const after = setShowTagFilterBarOverride("note-1", true);
+      expect(after["note-1"]).toEqual({ showTagFilterBar: true });
+      expect(loadNoteFilterPreferences()).toEqual({
+        "note-1": { showTagFilterBar: true },
+      });
+    });
+
+    it("updates an existing override", () => {
+      setShowTagFilterBarOverride("note-1", true);
+      setShowTagFilterBarOverride("note-1", false);
+      expect(getShowTagFilterBarOverride("note-1")).toBe(false);
+    });
+
+    it("removes the override entirely when value is undefined", () => {
+      setShowTagFilterBarOverride("note-1", true);
+      const after = setShowTagFilterBarOverride("note-1", undefined);
+      expect(after["note-1"]).toBeUndefined();
+      expect(loadNoteFilterPreferences()).toEqual({});
+    });
+
+    it("does not affect other notes when clearing one", () => {
+      setShowTagFilterBarOverride("note-1", true);
+      setShowTagFilterBarOverride("note-2", false);
+      setShowTagFilterBarOverride("note-1", undefined);
+      expect(loadNoteFilterPreferences()).toEqual({
+        "note-2": { showTagFilterBar: false },
+      });
+    });
+
+    it("ignores empty noteId", () => {
+      const before = loadNoteFilterPreferences();
+      const after = setShowTagFilterBarOverride("", true);
+      expect(after).toEqual(before);
+    });
+  });
+
+  describe("getShowTagFilterBarOverride", () => {
+    it("returns undefined when no override is set", () => {
+      expect(getShowTagFilterBarOverride("note-x")).toBeUndefined();
+    });
+
+    it("returns the stored boolean value", () => {
+      setShowTagFilterBarOverride("note-x", false);
+      expect(getShowTagFilterBarOverride("note-x")).toBe(false);
+    });
+
+    it("returns undefined for empty noteId", () => {
+      setShowTagFilterBarOverride("note-x", true);
+      expect(getShowTagFilterBarOverride("")).toBeUndefined();
+    });
+  });
+});

--- a/src/lib/noteTagFilterBar/preferenceStorage.ts
+++ b/src/lib/noteTagFilterBar/preferenceStorage.ts
@@ -1,0 +1,128 @@
+import type { NoteFilterPreference, NoteFilterPreferencesMap } from "@/types/noteFilterPreferences";
+
+/**
+ * ノートごとのフィルタバー表示上書きを localStorage に保存・読み出すヘルパー。
+ * Helpers for persisting per-note filter-bar visibility overrides to localStorage.
+ *
+ * 保存形は `{ [noteId]: { showTagFilterBar?: boolean } }` の JSON。`undefined`
+ * フィールドは削除キーとして扱い、空オブジェクトになったエントリ自体を取り除く。
+ * 選択中タグ自体は **URL に永続化** するため、ここでは扱わない (真実のソースを
+ * 一本化するため)。
+ *
+ * Stored as `{ [noteId]: { showTagFilterBar?: boolean } }` JSON. `undefined`
+ * removes the field; an entry whose object becomes empty is removed entirely.
+ * The selected tags themselves live in the URL — never duplicated here.
+ */
+
+/**
+ * localStorage キー。`zedi-` プレフィックスは既存のキー (`zedi-general-settings`
+ * 等) と整合させる。 / localStorage key, matching the `zedi-` prefix used by
+ * the rest of the app.
+ */
+export const NOTE_FILTER_PREFERENCES_STORAGE_KEY = "zedi-note-filter-preferences";
+
+/**
+ * 全ノート分のフィルタ上書きを読み込む。パース失敗・未保存は空マップ。
+ * Load every per-note override; corrupt or absent storage yields an empty map.
+ */
+export function loadNoteFilterPreferences(): NoteFilterPreferencesMap {
+  try {
+    const stored = readStorage(NOTE_FILTER_PREFERENCES_STORAGE_KEY);
+    if (!stored) return {};
+    const parsed = JSON.parse(stored) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+
+    const out: NoteFilterPreferencesMap = {};
+    for (const [noteId, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!noteId) continue;
+      if (!value || typeof value !== "object") continue;
+      const candidate = value as { showTagFilterBar?: unknown };
+      const sanitized: NoteFilterPreference = {};
+      if (typeof candidate.showTagFilterBar === "boolean") {
+        sanitized.showTagFilterBar = candidate.showTagFilterBar;
+      }
+      if (Object.keys(sanitized).length > 0) out[noteId] = sanitized;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * 全ノート分のフィルタ上書きを保存する。空オブジェクトを持つエントリは削除する。
+ * Persist every per-note override; entries whose object is empty are dropped.
+ */
+export function saveNoteFilterPreferences(prefs: NoteFilterPreferencesMap): void {
+  try {
+    const compacted: NoteFilterPreferencesMap = {};
+    for (const [noteId, value] of Object.entries(prefs)) {
+      if (!value) continue;
+      const sanitized: NoteFilterPreference = {};
+      if (typeof value.showTagFilterBar === "boolean") {
+        sanitized.showTagFilterBar = value.showTagFilterBar;
+      }
+      if (Object.keys(sanitized).length > 0) compacted[noteId] = sanitized;
+    }
+    writeStorage(NOTE_FILTER_PREFERENCES_STORAGE_KEY, JSON.stringify(compacted));
+  } catch (error) {
+    console.error("Failed to save note filter preferences:", error);
+  }
+}
+
+/**
+ * 指定ノートの「フィルタバーを表示する」上書きを設定または解除する。
+ * `value === undefined` のときは上書きを削除して「ノート既定に従う」に戻す。
+ *
+ * Set or clear the per-note "show filter bar" override. Passing `undefined`
+ * deletes the override, reverting to the note's DB default.
+ *
+ * @returns 更新後の全ノート分プレファレンスマップ (呼び出し元での参照用)。
+ *   The updated preferences map after the change.
+ */
+export function setShowTagFilterBarOverride(
+  noteId: string,
+  value: boolean | undefined,
+): NoteFilterPreferencesMap {
+  if (!noteId) return loadNoteFilterPreferences();
+  const current = loadNoteFilterPreferences();
+  const next: NoteFilterPreferencesMap = { ...current };
+  if (value === undefined) {
+    const existing = next[noteId];
+    if (existing) {
+      const { showTagFilterBar: _omit, ...rest } = existing;
+      void _omit;
+      if (Object.keys(rest).length === 0) {
+        const { [noteId]: _removed, ...remaining } = next;
+        void _removed;
+        saveNoteFilterPreferences(remaining);
+        return remaining;
+      }
+      next[noteId] = rest;
+    }
+  } else {
+    next[noteId] = { ...next[noteId], showTagFilterBar: value };
+  }
+  saveNoteFilterPreferences(next);
+  return next;
+}
+
+/**
+ * 指定ノートの上書き値を 1 件取り出す (キー欠如時は `undefined`)。
+ * Read a single note's override, or `undefined` when missing.
+ */
+export function getShowTagFilterBarOverride(noteId: string): boolean | undefined {
+  if (!noteId) return undefined;
+  const map = loadNoteFilterPreferences();
+  return map[noteId]?.showTagFilterBar;
+}
+
+function readStorage(key: string): string | null {
+  if (typeof localStorage === "undefined") return null;
+  return localStorage.getItem(key);
+}
+
+function writeStorage(key: string, value: string): void {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(key, value);
+}

--- a/src/lib/noteTagFilterBar/resolvePreference.test.ts
+++ b/src/lib/noteTagFilterBar/resolvePreference.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { resolveShowFilterBar, resolveInitialSelectedTags } from "./resolvePreference";
+
+describe("resolveShowFilterBar", () => {
+  it("returns the note default when there is no user override", () => {
+    expect(resolveShowFilterBar(true, undefined)).toBe(true);
+    expect(resolveShowFilterBar(false, undefined)).toBe(false);
+  });
+
+  it("uses the user override when present (true overrides false)", () => {
+    expect(resolveShowFilterBar(false, true)).toBe(true);
+  });
+
+  it("uses the user override when present (false overrides true)", () => {
+    expect(resolveShowFilterBar(true, false)).toBe(false);
+  });
+
+  it("matches the override exactly even when it equals the default", () => {
+    expect(resolveShowFilterBar(true, true)).toBe(true);
+    expect(resolveShowFilterBar(false, false)).toBe(false);
+  });
+});
+
+describe("resolveInitialSelectedTags", () => {
+  it("prefers URL over note default when URL has tags", () => {
+    expect(resolveInitialSelectedTags("foo,bar", ["baz"])).toEqual({
+      kind: "tags",
+      tags: ["foo", "bar"],
+    });
+  });
+
+  it("prefers URL even when URL is __none__", () => {
+    expect(resolveInitialSelectedTags("__none__", ["baz"])).toEqual({
+      kind: "untagged-only",
+    });
+  });
+
+  it("falls back to note default when URL is null", () => {
+    expect(resolveInitialSelectedTags(null, ["TypeScript", "React"])).toEqual({
+      kind: "tags",
+      tags: ["typescript", "react"],
+    });
+  });
+
+  it("falls back to note default when URL is an empty string", () => {
+    expect(resolveInitialSelectedTags("", ["foo"])).toEqual({
+      kind: "tags",
+      tags: ["foo"],
+    });
+  });
+
+  it("supports __none__ as a note default", () => {
+    expect(resolveInitialSelectedTags(null, ["__none__"])).toEqual({
+      kind: "untagged-only",
+    });
+  });
+
+  it("returns none-selected when both URL and note default are empty", () => {
+    expect(resolveInitialSelectedTags(null, null)).toEqual({ kind: "none-selected" });
+    expect(resolveInitialSelectedTags(null, [])).toEqual({ kind: "none-selected" });
+    expect(resolveInitialSelectedTags("", [])).toEqual({ kind: "none-selected" });
+  });
+});

--- a/src/lib/noteTagFilterBar/resolvePreference.ts
+++ b/src/lib/noteTagFilterBar/resolvePreference.ts
@@ -1,0 +1,54 @@
+import type { SelectedTags } from "@/types/tagFilter";
+import { parseTagsParam } from "./urlTagsCodec";
+
+/**
+ * ノート既定値とユーザー上書きをマージするための純関数群。
+ * Pure resolvers that merge note-side defaults with client-side overrides.
+ *
+ * - {@link resolveShowFilterBar}: フィルタバーの表示 ON/OFF
+ *   (DB の `show_tag_filter_bar` ＋ ユーザーの localStorage 上書き)。
+ * - {@link resolveInitialSelectedTags}: 初期選択タグ
+ *   (URL \> ノート `default_filter_tags` \> 何もない)。
+ */
+
+/**
+ * ユーザー上書きを優先し、なければノート既定値を返す。
+ * Returns the user override when set, otherwise the note default.
+ *
+ * @param noteDefault - notes.show_tag_filter_bar / Note's DB default.
+ * @param userOverride - localStorage の上書き (`undefined` = 既定に従う)。
+ *   The client-side override; `undefined` means "follow the note default".
+ */
+export function resolveShowFilterBar(
+  noteDefault: boolean,
+  userOverride: boolean | undefined,
+): boolean {
+  return userOverride ?? noteDefault;
+}
+
+/**
+ * 初期選択タグの解決。URL に値があればそれを最優先で採用し、無ければノートの
+ * `default_filter_tags` を {@link parseTagsParam} 互換にパースして使う。どちらも
+ * 無ければ `none-selected`。
+ *
+ * Resolve the initial selected tags by precedence: URL \> note default \>
+ * none-selected. The note default array is run through {@link parseTagsParam}
+ * so the same normalization (lower-casing, dedupe, `__none__` exclusivity)
+ * applies to both sources.
+ *
+ * @param urlRaw - `?tags=` クエリの raw 値 / Raw `?tags=` query value.
+ * @param noteDefaultTags - notes.default_filter_tags (text[])。`__none__` も
+ *   含み得る。 / `notes.default_filter_tags`; may include `__none__`.
+ * @returns 解決済みフィルタ状態 / Resolved filter state.
+ */
+export function resolveInitialSelectedTags(
+  urlRaw: string | null | undefined,
+  noteDefaultTags: readonly string[] | null | undefined,
+): SelectedTags {
+  const fromUrl = parseTagsParam(urlRaw);
+  if (fromUrl.kind !== "none-selected") return fromUrl;
+  if (!noteDefaultTags || noteDefaultTags.length === 0) {
+    return { kind: "none-selected" };
+  }
+  return parseTagsParam(noteDefaultTags.join(","));
+}

--- a/src/lib/noteTagFilterBar/urlTagsCodec.test.ts
+++ b/src/lib/noteTagFilterBar/urlTagsCodec.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { MAX_TAGS, MAX_TAG_LENGTH, parseTagsParam, serializeTagsParam } from "./urlTagsCodec";
+import { UNTAGGED_FILTER_TOKEN } from "@/types/tagFilter";
+
+describe("parseTagsParam", () => {
+  it("returns none-selected for null/undefined/empty", () => {
+    expect(parseTagsParam(null)).toEqual({ kind: "none-selected" });
+    expect(parseTagsParam(undefined)).toEqual({ kind: "none-selected" });
+    expect(parseTagsParam("")).toEqual({ kind: "none-selected" });
+  });
+
+  it("returns none-selected when only separators are present", () => {
+    expect(parseTagsParam(",,,")).toEqual({ kind: "none-selected" });
+    expect(parseTagsParam(" , ,  ,")).toEqual({ kind: "none-selected" });
+  });
+
+  it("parses a single tag", () => {
+    expect(parseTagsParam("typescript")).toEqual({
+      kind: "tags",
+      tags: ["typescript"],
+    });
+  });
+
+  it("parses multiple tags as OR list", () => {
+    expect(parseTagsParam("typescript,react,vite")).toEqual({
+      kind: "tags",
+      tags: ["typescript", "react", "vite"],
+    });
+  });
+
+  it("lower-cases tag names", () => {
+    expect(parseTagsParam("TypeScript,React")).toEqual({
+      kind: "tags",
+      tags: ["typescript", "react"],
+    });
+  });
+
+  it("trims whitespace around each token", () => {
+    expect(parseTagsParam("  foo , bar  ")).toEqual({
+      kind: "tags",
+      tags: ["foo", "bar"],
+    });
+  });
+
+  it("de-duplicates case-insensitively while preserving first-seen order", () => {
+    expect(parseTagsParam("foo,Foo,FOO,bar,foo")).toEqual({
+      kind: "tags",
+      tags: ["foo", "bar"],
+    });
+  });
+
+  it("returns untagged-only for the __none__ token alone", () => {
+    expect(parseTagsParam(UNTAGGED_FILTER_TOKEN)).toEqual({
+      kind: "untagged-only",
+    });
+  });
+
+  it("collapses any mix of __none__ + tags to untagged-only (token is exclusive)", () => {
+    expect(parseTagsParam("foo,__none__,bar")).toEqual({
+      kind: "untagged-only",
+    });
+    expect(parseTagsParam("__none__,foo")).toEqual({
+      kind: "untagged-only",
+    });
+  });
+
+  it("truncates at MAX_TAGS distinct tokens", () => {
+    const many = Array.from({ length: MAX_TAGS + 5 }, (_, i) => `tag${i}`).join(",");
+    const parsed = parseTagsParam(many);
+    expect(parsed.kind).toBe("tags");
+    if (parsed.kind === "tags") {
+      expect(parsed.tags).toHaveLength(MAX_TAGS);
+      expect(parsed.tags[0]).toBe("tag0");
+    }
+  });
+
+  it("drops tokens that exceed MAX_TAG_LENGTH", () => {
+    const tooLong = "a".repeat(MAX_TAG_LENGTH + 1);
+    expect(parseTagsParam(`${tooLong},ok`)).toEqual({
+      kind: "tags",
+      tags: ["ok"],
+    });
+  });
+
+  it("supports non-ASCII tag names verbatim (after lowercasing)", () => {
+    expect(parseTagsParam("日本語,テスト")).toEqual({
+      kind: "tags",
+      tags: ["日本語", "テスト"],
+    });
+  });
+});
+
+describe("serializeTagsParam", () => {
+  it("returns null for none-selected so the caller can drop the param", () => {
+    expect(serializeTagsParam({ kind: "none-selected" })).toBeNull();
+  });
+
+  it("serializes untagged-only as the __none__ token", () => {
+    expect(serializeTagsParam({ kind: "untagged-only" })).toBe(UNTAGGED_FILTER_TOKEN);
+  });
+
+  it("serializes a tags list as comma-joined lower-case", () => {
+    expect(serializeTagsParam({ kind: "tags", tags: ["typescript", "react"] })).toBe(
+      "typescript,react",
+    );
+  });
+
+  it("normalizes tags during serialize (lower-case, trim, dedupe)", () => {
+    expect(
+      serializeTagsParam({
+        kind: "tags",
+        tags: [" TypeScript ", "react", "REACT"],
+      }),
+    ).toBe("typescript,react");
+  });
+
+  it("returns null when tags list normalizes to empty", () => {
+    expect(serializeTagsParam({ kind: "tags", tags: ["", "   "] })).toBeNull();
+  });
+
+  it("truncates to MAX_TAGS during serialize", () => {
+    const many = Array.from({ length: MAX_TAGS + 3 }, (_, i) => `tag${i}`);
+    const out = serializeTagsParam({ kind: "tags", tags: many });
+    expect(out).not.toBeNull();
+    expect((out ?? "").split(",")).toHaveLength(MAX_TAGS);
+  });
+});
+
+describe("roundtrip", () => {
+  it("normalizes mixed-case input then survives serialize → parse identically", () => {
+    const parsed = parseTagsParam("TypeScript,React,react,VITE");
+    const serialized = serializeTagsParam(parsed);
+    expect(serialized).toBe("typescript,react,vite");
+    const reparsed = parseTagsParam(serialized);
+    expect(reparsed).toEqual(parsed);
+  });
+
+  it("roundtrips untagged-only", () => {
+    const parsed = parseTagsParam(UNTAGGED_FILTER_TOKEN);
+    const serialized = serializeTagsParam(parsed);
+    expect(serialized).toBe(UNTAGGED_FILTER_TOKEN);
+    expect(parseTagsParam(serialized)).toEqual(parsed);
+  });
+
+  it("roundtrips none-selected via null", () => {
+    const parsed = parseTagsParam(null);
+    expect(serializeTagsParam(parsed)).toBeNull();
+  });
+});

--- a/src/lib/noteTagFilterBar/urlTagsCodec.test.ts
+++ b/src/lib/noteTagFilterBar/urlTagsCodec.test.ts
@@ -64,6 +64,11 @@ describe("parseTagsParam", () => {
     });
   });
 
+  it("recognises __none__ case-insensitively (manual URL edits)", () => {
+    expect(parseTagsParam("__NONE__")).toEqual({ kind: "untagged-only" });
+    expect(parseTagsParam("__None__,foo")).toEqual({ kind: "untagged-only" });
+  });
+
   it("truncates at MAX_TAGS distinct tokens", () => {
     const many = Array.from({ length: MAX_TAGS + 5 }, (_, i) => `tag${i}`).join(",");
     const parsed = parseTagsParam(many);

--- a/src/lib/noteTagFilterBar/urlTagsCodec.ts
+++ b/src/lib/noteTagFilterBar/urlTagsCodec.ts
@@ -1,0 +1,112 @@
+import { type SelectedTags, UNTAGGED_FILTER_TOKEN } from "@/types/tagFilter";
+
+/**
+ * `?tags=` URL クエリと {@link SelectedTags} の相互変換を行う純関数群。
+ * Pure codec between the `?tags=` URL query and {@link SelectedTags}.
+ *
+ * 設計原則 / Design contract:
+ * - 入力は寛容に正規化する: トリム、空要素除去、大文字小文字を小文字キーに統一、
+ *   重複排除、{@link MAX_TAGS} 件まで切り詰め。
+ *   Input is normalized leniently: trim, drop empties, lower-case, dedupe,
+ *   truncate to {@link MAX_TAGS}.
+ * - `__none__` トークンが 1 つでも含まれていれば `untagged-only` を優先返却
+ *   (混在は `untagged-only` 単独として扱う)。
+ *   The `__none__` token wins: any mix collapses to `untagged-only`.
+ * - 正規化の結果 0 件になった場合は `none-selected` を返す。
+ *   When normalization yields 0 entries, return `none-selected`.
+ * - シリアライズは roundtrip 後に同じ正規化結果が得られることを保証する。
+ *   Serialization is roundtrip-stable after normalization.
+ */
+
+/**
+ * URL クエリに乗せられるタグの最大件数。サーバ側 (`parseTagsFilter`) も同じ
+ * 上限を強制する。
+ * Maximum tags accepted from the URL; the server enforces the same cap.
+ */
+export const MAX_TAGS = 20;
+
+/**
+ * 1 タグ名の最大文字数。サーバ側のバリデーションと一致させる。
+ * Maximum tag-name length, matched on the server.
+ */
+export const MAX_TAG_LENGTH = 100;
+
+/**
+ * `?tags=` の raw 文字列 (`URLSearchParams.get()` の戻り値) を
+ * {@link SelectedTags} にパースする。
+ *
+ * Parse the raw `?tags=` query value (as returned by `URLSearchParams.get()`)
+ * into a {@link SelectedTags}.
+ *
+ * @param raw - `URLSearchParams.get('tags')` の戻り値。`null` / `undefined` は
+ *   未指定として扱う。 / Raw query value; `null` / `undefined` means "no param".
+ * @returns 正規化済みフィルタ状態 / Normalized filter state.
+ */
+export function parseTagsParam(raw: string | null | undefined): SelectedTags {
+  if (raw == null) return { kind: "none-selected" };
+
+  const tokens = raw
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0 && t.length <= MAX_TAG_LENGTH);
+
+  if (tokens.length === 0) return { kind: "none-selected" };
+
+  // `__none__` is exclusive — any occurrence forces untagged-only mode so
+  // mixed URLs like `?tags=__none__,foo` collapse predictably.
+  if (tokens.some((t) => t === UNTAGGED_FILTER_TOKEN)) {
+    return { kind: "untagged-only" };
+  }
+
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const token of tokens) {
+    const key = token.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(key);
+    if (normalized.length >= MAX_TAGS) break;
+  }
+
+  if (normalized.length === 0) return { kind: "none-selected" };
+  return { kind: "tags", tags: normalized };
+}
+
+/**
+ * {@link SelectedTags} を `?tags=` の raw 文字列にシリアライズする。
+ * `none-selected` は `null` を返し、呼び出し元が `URLSearchParams.delete('tags')`
+ * を選べるようにする。
+ *
+ * Serialize a {@link SelectedTags} back to the raw query value.
+ * Returns `null` for `none-selected` so callers can drop the param entirely.
+ *
+ * @param selected - シリアライズ対象 / Value to serialize.
+ * @returns `?tags=` に格納する文字列、または `null` (パラメータ削除)。
+ *   String to set as `?tags=`, or `null` to remove the param.
+ */
+export function serializeTagsParam(selected: SelectedTags): string | null {
+  switch (selected.kind) {
+    case "none-selected":
+      return null;
+    case "untagged-only":
+      return UNTAGGED_FILTER_TOKEN;
+    case "tags": {
+      const cleaned = dedupLower(selected.tags).slice(0, MAX_TAGS);
+      if (cleaned.length === 0) return null;
+      return cleaned.join(",");
+    }
+  }
+}
+
+function dedupLower(tags: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const tag of tags) {
+    const key = tag.trim().toLowerCase();
+    if (!key || key.length > MAX_TAG_LENGTH) continue;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(key);
+  }
+  return out;
+}

--- a/src/lib/noteTagFilterBar/urlTagsCodec.ts
+++ b/src/lib/noteTagFilterBar/urlTagsCodec.ts
@@ -53,8 +53,10 @@ export function parseTagsParam(raw: string | null | undefined): SelectedTags {
   if (tokens.length === 0) return { kind: "none-selected" };
 
   // `__none__` is exclusive — any occurrence forces untagged-only mode so
-  // mixed URLs like `?tags=__none__,foo` collapse predictably.
-  if (tokens.some((t) => t === UNTAGGED_FILTER_TOKEN)) {
+  // mixed URLs like `?tags=__none__,foo` collapse predictably. The comparison
+  // is case-insensitive so `?tags=__NONE__` (manual edits / typo'd casing)
+  // is still recognised (PR #897 CodeRabbit minor).
+  if (tokens.some((t) => t.toLowerCase() === UNTAGGED_FILTER_TOKEN)) {
     return { kind: "untagged-only" };
   }
 

--- a/src/pages/NoteSettings/NoteSettings.test.tsx
+++ b/src/pages/NoteSettings/NoteSettings.test.tsx
@@ -62,6 +62,8 @@ const baseNote: Note = {
   isOfficial: false,
   isDefault: false,
   viewCount: 0,
+  showTagFilterBar: false,
+  defaultFilterTags: [],
   createdAt: 0,
   updatedAt: 0,
   isDeleted: false,

--- a/src/pages/NoteSettings/NoteSettingsSidebar.tsx
+++ b/src/pages/NoteSettings/NoteSettingsSidebar.tsx
@@ -2,7 +2,15 @@ import React from "react";
 import { NavLink } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { cn } from "@zedi/ui";
-import { AtSign, Globe, Link2, Settings as SettingsIcon, Trash2, UsersRound } from "lucide-react";
+import {
+  AtSign,
+  Filter,
+  Globe,
+  Link2,
+  Settings as SettingsIcon,
+  Trash2,
+  UsersRound,
+} from "lucide-react";
 
 /**
  * 設定画面サイドナビの 1 項目。アイコン / ラベル i18n キー / サブルートパスを持つ。
@@ -12,7 +20,7 @@ import { AtSign, Globe, Link2, Settings as SettingsIcon, Trash2, UsersRound } fr
  */
 export interface NoteSettingsNavItem {
   /** サブパス。`/notes/:noteId/settings/<key>` の `<key>` 部分。 */
-  key: "general" | "visibility" | "members" | "links" | "domains" | "danger";
+  key: "general" | "visibility" | "members" | "links" | "domains" | "filter-bar" | "danger";
   /** i18n キー（`notes.settingsNav.<key>` ベース）。 */
   labelI18nKey: string;
   /** 行頭アイコン（lucide-react）。 */
@@ -64,6 +72,12 @@ const NAV_ITEMS: NavItemSpec[] = [
     labelI18nKey: "notes.settingsNav.domains",
     Icon: AtSign,
     visibleFor: ["owner", "editor"],
+  },
+  {
+    key: "filter-bar",
+    labelI18nKey: "notes.settingsNav.filterBar",
+    Icon: Filter,
+    visibleFor: ["owner"],
   },
   {
     key: "danger",

--- a/src/pages/NoteSettings/sections/DangerZoneSection.test.tsx
+++ b/src/pages/NoteSettings/sections/DangerZoneSection.test.tsx
@@ -48,6 +48,8 @@ const baseNote: Note = {
   isOfficial: false,
   isDefault: false,
   viewCount: 0,
+  showTagFilterBar: false,
+  defaultFilterTags: [],
   createdAt: 0,
   updatedAt: 0,
   isDeleted: false,

--- a/src/pages/NoteSettings/sections/GeneralSection.test.tsx
+++ b/src/pages/NoteSettings/sections/GeneralSection.test.tsx
@@ -43,6 +43,8 @@ const baseNote: Note = {
   isOfficial: false,
   isDefault: false,
   viewCount: 0,
+  showTagFilterBar: false,
+  defaultFilterTags: [],
   createdAt: 0,
   updatedAt: 0,
   isDeleted: false,

--- a/src/pages/NoteSettings/sections/LinksSection.test.tsx
+++ b/src/pages/NoteSettings/sections/LinksSection.test.tsx
@@ -30,6 +30,8 @@ const baseNote: Note = {
   isOfficial: false,
   isDefault: false,
   viewCount: 0,
+  showTagFilterBar: false,
+  defaultFilterTags: [],
   createdAt: 0,
   updatedAt: 0,
   isDeleted: false,

--- a/src/pages/NoteSettings/sections/MembersSection.test.tsx
+++ b/src/pages/NoteSettings/sections/MembersSection.test.tsx
@@ -47,6 +47,8 @@ const baseNote: Note = {
   isOfficial: false,
   isDefault: false,
   viewCount: 0,
+  showTagFilterBar: false,
+  defaultFilterTags: [],
   createdAt: 0,
   updatedAt: 0,
   isDeleted: false,

--- a/src/pages/NoteSettings/sections/TagFilterBarSection.tsx
+++ b/src/pages/NoteSettings/sections/TagFilterBarSection.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button, Label, Switch, useToast } from "@zedi/ui";
+import { useUpdateNote } from "@/hooks/useNoteQueries";
+import { useNoteSettingsContext } from "../NoteSettingsContext";
+import { useTagFilterBarPreference } from "@/hooks/useTagFilterBarPreference";
+
+/**
+ * `/notes/:noteId/settings/filter-bar` — オーナー向け「タグフィルタバー」設定。
+ *
+ * - DB 側の `showTagFilterBar` (既定で表示するか) を切り替える。
+ * - 補足としてユーザー側の上書き状態を表示する (read-only)。
+ *
+ * `default_filter_tags` の編集 UI は将来の拡張に譲り、本セクションではバーの
+ * ON/OFF 既定のみを扱う (MVP)。
+ *
+ * Owner-only section for the tag filter bar settings on
+ * `/notes/:noteId/settings/filter-bar`. Toggles the DB-side
+ * `showTagFilterBar` flag and surfaces the per-user override read-only.
+ * Default-tag editing is deferred to a follow-up.
+ */
+const TagFilterBarSection: React.FC = () => {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  const { note, canManage } = useNoteSettingsContext();
+  const updateNoteMutation = useUpdateNote();
+  const { userOverride } = useTagFilterBarPreference(note.id);
+
+  const [showByDefault, setShowByDefault] = useState(note.showTagFilterBar);
+
+  useEffect(() => {
+    // ノートが再取得されたらフォームを同期する（保存後の refetch で値が変わった
+    // 場合などに整合させる）。
+    // Sync the form when the note refetches; matches `GeneralSection.tsx`.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot init from loaded note
+    setShowByDefault(note.showTagFilterBar);
+  }, [note.showTagFilterBar]);
+
+  const isDirty = showByDefault !== note.showTagFilterBar;
+
+  const userOverrideLabel = useMemo(() => {
+    if (userOverride === undefined) return t("notes.filterBarSettings.userOverrideHint");
+    return userOverride
+      ? t("notes.filterBarSettings.userOverrideOn")
+      : t("notes.filterBarSettings.userOverrideOff");
+  }, [t, userOverride]);
+
+  const handleSave = async () => {
+    if (!isDirty) return;
+    try {
+      await updateNoteMutation.mutateAsync({
+        noteId: note.id,
+        updates: { showTagFilterBar: showByDefault },
+      });
+      toast({ title: t("notes.noteUpdated") });
+    } catch (error) {
+      console.error("Failed to update tag filter bar setting:", error);
+      toast({ title: t("notes.noteUpdateFailed"), variant: "destructive" });
+    }
+  };
+
+  return (
+    <section className="border-border/60 rounded-lg border p-4">
+      <header className="mb-4 space-y-1">
+        <h2 className="text-base font-semibold">{t("notes.filterBarSettings.title")}</h2>
+        <p className="text-muted-foreground text-xs">{t("notes.filterBarSettings.description")}</p>
+      </header>
+
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <Label htmlFor="tag-filter-bar-show-default" className="text-sm font-medium">
+            {t("notes.filterBarSettings.showByDefault")}
+          </Label>
+          <p className="text-muted-foreground text-xs">
+            {t("notes.filterBarSettings.showByDefaultHelp")}
+          </p>
+        </div>
+        <Switch
+          id="tag-filter-bar-show-default"
+          checked={showByDefault}
+          onCheckedChange={setShowByDefault}
+          disabled={!canManage}
+        />
+      </div>
+
+      <p className="text-muted-foreground mt-3 text-xs" role="note">
+        {userOverrideLabel}
+      </p>
+
+      {canManage ? (
+        <div className="mt-4 flex justify-end">
+          <Button onClick={handleSave} disabled={updateNoteMutation.isPending || !isDirty}>
+            {updateNoteMutation.isPending ? t("common.saving") : t("common.save")}
+          </Button>
+        </div>
+      ) : (
+        <p className="text-muted-foreground mt-3 text-xs" role="note">
+          {t("notes.shareReadOnlyNotice")}
+        </p>
+      )}
+    </section>
+  );
+};
+
+export default TagFilterBarSection;

--- a/src/pages/NoteSettings/sections/VisibilitySection.test.tsx
+++ b/src/pages/NoteSettings/sections/VisibilitySection.test.tsx
@@ -55,6 +55,8 @@ const baseNote: Note = {
   isOfficial: false,
   isDefault: false,
   viewCount: 0,
+  showTagFilterBar: false,
+  defaultFilterTags: [],
   createdAt: 0,
   updatedAt: 0,
   isDeleted: false,

--- a/src/pages/NoteSettings/useNoteSettingsSaveWithPublicConfirm.test.ts
+++ b/src/pages/NoteSettings/useNoteSettingsSaveWithPublicConfirm.test.ts
@@ -38,6 +38,8 @@ const baseDefaultNote: Note = {
   isOfficial: false,
   isDefault: true,
   viewCount: 0,
+  showTagFilterBar: false,
+  defaultFilterTags: [],
   createdAt: 0,
   updatedAt: 0,
   isDeleted: false,

--- a/src/pages/NoteView/NoteView.test.tsx
+++ b/src/pages/NoteView/NoteView.test.tsx
@@ -24,6 +24,13 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("@/hooks/useNoteQueries", () => ({
   useNote: vi.fn(),
+  useNoteApi: () => ({
+    api: { getNoteTags: vi.fn().mockResolvedValue({ items: [], none_count: 0, total_pages: 0 }) },
+    userId: "user-1",
+    userEmail: "user@example.com",
+    isSignedIn: true,
+    isLoaded: true,
+  }),
   useAddPageToNote: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useCopyPersonalPageToNote: () => ({
     mutateAsync: vi.fn().mockResolvedValue({ created: true, page_id: "pg", sort_order: 1 }),
@@ -34,6 +41,32 @@ vi.mock("@/hooks/useNoteQueries", () => ({
   // title-dedup warning. Stub it so the test does not error on
   // undefined-as-function.
   useNoteTitleIndex: () => ({ data: [], isLoading: false }),
+}));
+
+// `useNoteTagAggregation` calls `useNoteApi` internally; we already stub the
+// API there so the hook resolves with an empty aggregation. Mock it directly
+// to keep the test independent of React Query setup.
+vi.mock("@/hooks/useNoteTagAggregation", () => ({
+  useNoteTagAggregation: () => ({
+    items: [],
+    noneCount: 0,
+    totalPages: 0,
+    isLoading: false,
+    isError: false,
+    source: "empty" as const,
+  }),
+}));
+
+// `useTagFilterBarPreference` resolves to disabled by default so the bar does
+// not render in the existing NoteView test fixtures (the note shell does not
+// declare `showTagFilterBar: true`).
+vi.mock("@/hooks/useTagFilterBarPreference", () => ({
+  useTagFilterBarPreference: () => ({
+    enabled: false,
+    noteDefault: false,
+    userOverride: undefined,
+    setOverride: vi.fn(),
+  }),
 }));
 
 vi.mock("@/hooks/usePageQueries", () => ({

--- a/src/pages/NoteView/NoteViewHeaderActions.test.tsx
+++ b/src/pages/NoteView/NoteViewHeaderActions.test.tsx
@@ -39,6 +39,8 @@ const baseNote: Note = {
   isOfficial: false,
   isDefault: false,
   viewCount: 0,
+  showTagFilterBar: false,
+  defaultFilterTags: [],
   createdAt: 0,
   updatedAt: 0,
   isDeleted: false,

--- a/src/pages/NoteView/index.tsx
+++ b/src/pages/NoteView/index.tsx
@@ -14,6 +14,10 @@ import { getNoteViewPermissions } from "./noteViewHelpers";
 import { PageLoadingOrDenied } from "@/components/layout/PageLoadingOrDenied";
 import { NoteViewHeaderActions } from "./NoteViewHeaderActions";
 import PageGrid from "@/components/page/PageGrid";
+import { TagFilterBar } from "@/components/tagFilterBar";
+import { useNoteTagAggregation } from "@/hooks/useNoteTagAggregation";
+import { useTagFilterBarPreference } from "@/hooks/useTagFilterBarPreference";
+import { useURLTagFilter } from "@/hooks/useURLTagFilter";
 import type { PageSummary } from "@/types/page";
 import { isClipUrlAllowed } from "@/lib/webClipper";
 
@@ -166,9 +170,15 @@ const NoteView: React.FC = () => {
               userRole={access?.role ?? "none"}
             />
           </div>
-          <div className="mt-4">
-            <PageGrid noteId={note.id} canEdit={canEdit} canDeletePage={canDeletePageInGrid} />
-          </div>
+          <NoteViewPageList
+            noteId={note.id}
+            canEdit={canEdit}
+            canDeletePageInGrid={canDeletePageInGrid}
+          />
+          {/* PageGrid 描画は NoteViewPageList 内に閉じ込めて、`useURLTagFilter`
+              の `selected` を `TagFilterBar` と `PageGrid` の両方に同期する。
+              The page list and filter bar live together so the URL-driven
+              selection drives both surfaces in lock-step. */}
         </Container>
       </div>
       {canShowAddPage && (
@@ -180,6 +190,51 @@ const NoteView: React.FC = () => {
         />
       )}
     </ContentWithAIChat>
+  );
+};
+
+/**
+ * ノート文脈のページ一覧 + 上部のタグフィルタバーをまとめたサブコンポーネント。
+ * `useURLTagFilter` で `?tags=` を読み書きし、`TagFilterBar` と `PageGrid` の
+ * 両方に同じ `selected` 状態を流し込む。`useTagFilterBarPreference` で
+ * バーの表示可否を解決し、ノート既定 + ユーザー上書きが両方 false のときは
+ * バー自体をマウントしない（タグ集計 API も呼ばない）。
+ *
+ * Pairs the tag filter bar with the page grid so the URL-driven selection
+ * drives both. The bar is only mounted when {@link useTagFilterBarPreference}
+ * resolves to enabled, which also gates the aggregation fetch.
+ */
+const NoteViewPageList: React.FC<{
+  noteId: string;
+  canEdit: boolean;
+  canDeletePageInGrid: (page: PageSummary) => boolean;
+}> = ({ noteId, canEdit, canDeletePageInGrid }) => {
+  const { enabled: showFilterBar } = useTagFilterBarPreference(noteId);
+  const { selected, setSelected } = useURLTagFilter();
+  const aggregation = useNoteTagAggregation(noteId, { enabled: showFilterBar });
+
+  return (
+    <>
+      {showFilterBar && (
+        <div className="mb-3">
+          <TagFilterBar
+            items={aggregation.items}
+            noneCount={aggregation.noneCount}
+            selected={selected}
+            onChange={setSelected}
+            isLoading={aggregation.isLoading}
+          />
+        </div>
+      )}
+      <div className="mt-4">
+        <PageGrid
+          noteId={noteId}
+          canEdit={canEdit}
+          canDeletePage={canDeletePageInGrid}
+          tagFilter={selected}
+        />
+      </div>
+    </>
   );
 };
 

--- a/src/pages/NoteView/index.tsx
+++ b/src/pages/NoteView/index.tsx
@@ -213,6 +213,21 @@ const NoteViewPageList: React.FC<{
   const { selected, setSelected } = useURLTagFilter();
   const aggregation = useNoteTagAggregation(noteId, { enabled: showFilterBar });
 
+  // バーが非表示のとき、URL に残った `?tags=foo` をそのまま PageGrid に流すと
+  // 「絞り込みが効いているのに UI から解除できない」幽霊フィルタ状態になる
+  // (ノート切替で URL が引き継がれた場合など、PR #897 Codex P1)。バーが
+  // 出ていないときは強制的に `none-selected` 扱いにして、フィルタは UI が
+  // 復活したときだけ機能するように倒す。URL は触らずに残しておくので、
+  // バーを再表示すれば前回の選択が復元される。
+  //
+  // Forwarding the URL-derived selection while the bar is hidden produces a
+  // phantom filter — the page list is constrained but there's no UI control
+  // to clear it (PR #897 Codex P1, e.g. when navigating from another note
+  // that left `?tags=` behind). Treat the filter as `none-selected` whenever
+  // the bar is hidden; we keep the URL untouched so the selection comes back
+  // if the user re-enables the bar.
+  const effectiveTagFilter = showFilterBar ? selected : { kind: "none-selected" as const };
+
   return (
     <>
       {showFilterBar && (
@@ -231,7 +246,7 @@ const NoteViewPageList: React.FC<{
           noteId={noteId}
           canEdit={canEdit}
           canDeletePage={canDeletePageInGrid}
-          tagFilter={selected}
+          tagFilter={effectiveTagFilter}
         />
       </div>
     </>

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -38,6 +38,19 @@ export interface Note {
    */
   isDefault: boolean;
   viewCount: number;
+  /**
+   * オーナーが「`/notes/:noteId` のページ一覧上部にタグフィルタバーを既定で
+   * 表示する」と宣言したか。ユーザーは localStorage で個別に上書き可能。
+   *
+   * Owner-declared default for showing the tag filter bar above the page
+   * list on `/notes/:noteId`. Per-user overrides live in localStorage.
+   */
+  showTagFilterBar: boolean;
+  /**
+   * フィルタバーの既定選択タグ（小文字キー、`__none__` トークンを含み得る）。
+   * Default tags selected on first load (lower-cased keys; may include `__none__`).
+   */
+  defaultFilterTags: string[];
   createdAt: number;
   updatedAt: number;
   isDeleted: boolean;

--- a/src/types/noteFilterPreferences.ts
+++ b/src/types/noteFilterPreferences.ts
@@ -1,0 +1,26 @@
+/**
+ * ノートごとのユーザー側フィルタバー上書き設定の型。
+ * Per-note client-side preferences that override a note's DB defaults.
+ *
+ * フィルタバーの「表示する／隠す／ノート既定に従う」の 3 状態セレクタの
+ * 永続化フォーマット。`showTagFilterBar: undefined` (= キー欠如) はノート
+ * 既定値に従う、`true` / `false` は明示的なユーザー上書き。
+ *
+ * Persistence shape for the 3-state filter-bar selector
+ * ("note default / always show / always hide"). `undefined` (omitted key)
+ * defers to the note's DB default; `true` / `false` is an explicit override.
+ */
+export interface NoteFilterPreference {
+  /**
+   * フィルタバー表示の上書き。`undefined` = ノート既定に従う、`true` / `false`
+   * はユーザー強制。
+   * Filter bar visibility override; `undefined` defers to the note default.
+   */
+  showTagFilterBar?: boolean;
+}
+
+/**
+ * localStorage に保存する全ノート分のフィルタ上書きマップ。
+ * Map of `noteId → preference` persisted to localStorage.
+ */
+export type NoteFilterPreferencesMap = Record<string, NoteFilterPreference>;

--- a/src/types/tagFilter.ts
+++ b/src/types/tagFilter.ts
@@ -1,0 +1,77 @@
+/**
+ * `/notes/:noteId` のタグフィルタ機能の型定義。
+ * Type definitions for the `/notes/:noteId` tag filter feature.
+ *
+ * `?tags=` URL クエリの状態とサーバ集計レスポンスの単一型をここに集約する。
+ * `SelectedTags` は判別共用型で `none-selected` / `tags` / `untagged-only`
+ * の 3 状態を表す。
+ *
+ * Houses the discriminated union for the `?tags=` URL state plus the row shape
+ * returned by `GET /api/notes/:noteId/tags`. Keeping them next to each other
+ * keeps the front-end filter and the aggregation endpoint in sync.
+ */
+
+/**
+ * URL クエリ `?tags=` から導出されるフィルタ状態。
+ * Filter state derived from the `?tags=` URL query.
+ *
+ * - `kind: 'none-selected'` — フィルタ未指定。ページ一覧は全件表示。
+ *   No filter applied; the page list shows everything.
+ * - `kind: 'tags'` — 1 件以上のタグが選択されている (OR フィルタ)。
+ *   `tags` は小文字キー (`nameLower`) で正規化済み・重複なし。
+ *   One or more tags selected; tag names are lower-cased keys with no duplicates.
+ * - `kind: 'untagged-only'` — `__none__` トークン: タグが 1 つも付いていない
+ *   ページのみ表示。`tags` との併用は不可。
+ *   The `__none__` token: only untagged pages. Cannot coexist with `tags`.
+ */
+export type SelectedTags =
+  | { kind: "none-selected" }
+  | { kind: "tags"; tags: string[] }
+  | { kind: "untagged-only" };
+
+/**
+ * `GET /api/notes/:noteId/tags` の `items[]` 1 件分。
+ * Single row from the note tag aggregation endpoint.
+ */
+export interface TagAggregationItem {
+  /**
+   * 表示用の表記。同じ大文字小文字無視キーに複数の表記がある場合は
+   * resolved (= 同名ページが存在) 側の表記を優先する。
+   * Display name, preferring the spelling from the resolved-page side when
+   * multiple casings share a key.
+   */
+  name: string;
+  /**
+   * 大文字小文字無視のキー (`name.toLowerCase().trim()`)。URL クエリと
+   * サーバ照合に使う。
+   * Lower-cased, trimmed key used for URL queries and server-side matching.
+   */
+  nameLower: string;
+  /** このタグが付いているページ件数 / Number of pages tagged with this name. */
+  pageCount: number;
+  /**
+   * すべての出現が同名ページ (links 経由) に解決されているか。1 件でも
+   * ghost_links 経由が混ざれば `false`。
+   * Whether every occurrence resolves via `links` (true) or includes at least
+   * one ghost_links row (false).
+   */
+  resolved: boolean;
+}
+
+/**
+ * `GET /api/notes/:noteId/tags` レスポンス全体。
+ * Full response shape for the note tag aggregation endpoint.
+ */
+export interface NoteTagAggregationResponse {
+  items: TagAggregationItem[];
+  /** タグが 1 つも付いていないアクティブページ数 / Active pages without any tag. */
+  noneCount: number;
+  /** ノート配下のアクティブページ総数 / Total active pages in the note. */
+  totalPages: number;
+}
+
+/**
+ * 「タグなし」フィルタを表す URL クエリトークン。
+ * URL token used to request the "untagged only" filter (`?tags=__none__`).
+ */
+export const UNTAGGED_FILTER_TOKEN = "__none__" as const;


### PR DESCRIPTION
## 概要

ノートのページ一覧上部にタグフィルタバーを追加し、ユーザーがハッシュタグで動的にページをフィルタリングできるようにしました。サーバー側の集計エンドポイント、クライアント側のフィルタUI、ノート設定での表示制御を実装しています。

## 変更点

### サーバー側 (API)
- **新規エンドポイント**: `GET /api/notes/:noteId/tags` — ノート内で使用されているタグを集計し、ページ数順に返す
  - `links` と `ghost_links` テーブルを横断し、case-insensitive キーでマージ
  - ETag キャッシング対応（`TAGS_RESPONSE_VERSION` で形状変更を追跡）
  - 「タグなしページ件数」と「ノート内アクティブページ総数」も同梱
- **DB スキーマ追加**: `notes` テーブルに `show_tag_filter_bar` (既定表示フラグ) と `default_filter_tags` (既定選択タグ) カラムを追加
- **ページ一覧フィルタ**: `GET /api/notes/:noteId/pages?tags=...` で `?tags=` クエリをサポート
  - OR フィルタ（複数タグ選択）と `__none__` トークン（タグなしページのみ）に対応
  - クライアント側 `urlTagsCodec` と同じ正規化ルール

### クライアント側 (React)
- **新規コンポーネント**: `TagFilterBar` — タグチップを並べるフィルタバー
  - `TagChip` — 単一タグチップ（resolved / ghost / untagged バリアント）
  - クリックで OR 追加・解除、「タグなし」チップは排他選択
- **新規フック**:
  - `useNoteTagAggregation` — サーバー集計を取得
  - `useURLTagFilter` — `?tags=` URL クエリを読み書き
  - `useTagFilterBarPreference` — ユーザーの localStorage 上書き設定を管理
- **URL コーデック**: `urlTagsCodec.ts` — `?tags=` パラメータと `SelectedTags` の相互変換
  - トリム・小文字化・重複排除・`MAX_TAGS=20` 制限を適用
  - `__none__` トークンは排他的に処理
- **設定UI**: `TagFilterBarSection` — ノートオーナー向けの表示制御設定
- **ページ一覧統合**: `NoteView` に `TagFilterBar` を組み込み、`PageGrid` にフィルタを連携

### 型定義・ユーティリティ
- `types/tagFilter.ts` — `SelectedTags` 判別共用型、`TagAggregationItem` インターフェース
- `types/noteFilterPreferences.ts` — localStorage 永続化形式
- `lib/noteTagFilterBar/preferenceStorage.ts` — localStorage 読み書きヘルパー
- `lib/noteTagFilterBar/resolvePreference.ts` — ノート既定値とユーザー上書きのマージ

### テスト
- `urlTagsCodec.test.ts` — URL パラメータ正規化のテスト
- `preferenceStorage.test.ts` — localStorage 永続化のテスト
- `resolvePreference.test.

https://claude.ai/code/session_01TDgwwZzhwiYLLn1UEvR1Ng

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tag filtering for note pages with a chip-based filter bar and clear action
  * Note-wide tag aggregation (per-tag counts + untagged count) with caching-aware responses
  * Settings to control default tag-filter bar visibility and per-device overrides
  * URL-driven filter state via ?tags= (including an "untagged only" token)
  * Notes now persist default selected tags and filter-bar visibility configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->