### PR TITLE
fix: align NoteMeRedirect skeleton with PageGrid layout

### DIFF
--- a/src/components/page/PageGrid.tsx
+++ b/src/components/page/PageGrid.tsx
@@ -74,8 +74,17 @@ function findScrollParent(el: HTMLElement | null): HTMLElement | null {
   return null;
 }
 
-/** スケルトン表示。列数は親の PageGrid で計測した columns を渡す（表示の一貫性のため） */
-const PageGridSkeleton: React.FC<{ columns: 2 | 3 | 4 | 5 | 6 }> = ({ columns }) => (
+/**
+ * スケルトン表示。列数は親の PageGrid で計測した columns を渡す（表示の一貫性のため）。
+ * `NoteMeRedirect` のように PageGrid 本体をマウントせずに先行表示したい箇所からも
+ * 再利用できるよう export している。
+ *
+ * Page grid skeleton. The `columns` prop comes from the parent's
+ * `useContainerColumns` measurement so the skeleton lines up with the eventual
+ * content. Exported so surfaces that resolve a target before mounting the real
+ * `PageGrid` (e.g. `NoteMeRedirect`) can render the same placeholder.
+ */
+export const PageGridSkeleton: React.FC<{ columns: 2 | 3 | 4 | 5 | 6 }> = ({ columns }) => (
   <div className={cn("grid gap-3", gridColsClass[columns])}>
     {skeletonItems.map((index) => (
       <div

--- a/src/pages/NoteMeRedirect.tsx
+++ b/src/pages/NoteMeRedirect.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Navigate, useLocation, useSearchParams } from "react-router-dom";
+import { Skeleton } from "@zedi/ui";
 import Container from "@/components/layout/Container";
 import { PageGridSkeleton } from "@/components/page/PageGrid";
 import { useContainerColumns } from "@/hooks/useContainerColumns";
@@ -72,17 +73,25 @@ const NoteMeRedirect: React.FC = () => {
   }
 
   if (isLoading) {
-    // 旧実装の独自 3 カラムスケルトンは、リダイレクト先 `NoteView` の `PageGrid`
-    // が出すスケルトンと見た目がズレて視覚的なジャンプが発生していたため、
-    // 同じ `PageGridSkeleton` を先行表示してジャンプを抑える。
-    // The previous bespoke 3-column skeleton diverged from the `PageGridSkeleton`
-    // rendered by the destination `NoteView`, causing a visible jump after
-    // redirect. Render the same skeleton here so the transition is seamless.
+    // リダイレクト先 `NoteView` は `Container` 内に「タイトル行 → ページグリッド」の
+    // 縦並びを描画するため、解決中も同じ縦リズム（タイトル相当の高さ + `space-y-4`
+    // による mt-4 相当のギャップ）を確保した上で、`PageGrid` 本体と同じ
+    // `PageGridSkeleton` を表示する。これにより `NoteView` 遷移時にグリッドが
+    // 上下にずれるレイアウトジャンプを抑える（PR #898 gemini-code-assist review）。
+    //
+    // `NoteView` lays out a title row above the page grid inside the same
+    // `Container`, so the skeleton mirrors that rhythm: a title-shaped
+    // `Skeleton` plus `space-y-4` (≈ the `mt-4` gap above the grid) keeps the
+    // skeleton grid aligned with the eventual grid, eliminating the vertical
+    // jump observed after redirect (raised by gemini-code-assist on PR #898).
     return (
       <div className="min-h-0 flex-1 py-6">
         <Container>
-          <div ref={columnsRef}>
-            <PageGridSkeleton columns={columns} />
+          <div className="space-y-4">
+            <Skeleton className="h-8 w-48" />
+            <div ref={columnsRef}>
+              <PageGridSkeleton columns={columns} />
+            </div>
           </div>
         </Container>
       </div>

--- a/src/pages/NoteMeRedirect.tsx
+++ b/src/pages/NoteMeRedirect.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Navigate, useLocation, useSearchParams } from "react-router-dom";
-import { Skeleton } from "@zedi/ui";
 import Container from "@/components/layout/Container";
+import { PageGridSkeleton } from "@/components/page/PageGrid";
+import { useContainerColumns } from "@/hooks/useContainerColumns";
 import { useMyNote } from "@/hooks/useNoteQueries";
 import { useOnboarding } from "@/hooks/useOnboarding";
 import { isClipUrlAllowed } from "@/lib/webClipper";
@@ -54,6 +55,11 @@ const NoteMeRedirect: React.FC = () => {
   const location = useLocation();
   const { needsSetupWizard } = useOnboarding();
   const { data, isLoading, error } = useMyNote({ enabled: !needsSetupWizard });
+  // リダイレクト先の `NoteView` 内 `PageGrid` と同じ列数計測ロジックを使い、
+  // 解決中スケルトンと遷移後の実コンテンツでカード列数を一致させる。
+  // Use the same container-width measurement as the destination `PageGrid` so
+  // the placeholder columns match the eventual rendered grid.
+  const { ref: columnsRef, columns } = useContainerColumns();
 
   // セットアップウィザード未完了のユーザーは先にオンボーディングに送る。
   // useMyNote 側の API は idempotent だがウィザード後にデフォルトノートを
@@ -66,16 +72,17 @@ const NoteMeRedirect: React.FC = () => {
   }
 
   if (isLoading) {
+    // 旧実装の独自 3 カラムスケルトンは、リダイレクト先 `NoteView` の `PageGrid`
+    // が出すスケルトンと見た目がズレて視覚的なジャンプが発生していたため、
+    // 同じ `PageGridSkeleton` を先行表示してジャンプを抑える。
+    // The previous bespoke 3-column skeleton diverged from the `PageGridSkeleton`
+    // rendered by the destination `NoteView`, causing a visible jump after
+    // redirect. Render the same skeleton here so the transition is seamless.
     return (
-      <div className="min-h-0 flex-1 py-10">
+      <div className="min-h-0 flex-1 py-6">
         <Container>
-          <div className="space-y-4">
-            <Skeleton className="h-8 w-48" />
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-              <Skeleton className="h-24 w-full" />
-              <Skeleton className="h-24 w-full" />
-              <Skeleton className="h-24 w-full" />
-            </div>
+          <div ref={columnsRef}>
+            <PageGridSkeleton columns={columns} />
           </div>
         </Container>
       </div>


### PR DESCRIPTION
## 概要

`NoteMeRedirect` で表示されるスケルトンを、リダイレクト先の `NoteView` 内 `PageGrid` と同じレイアウトに統一し、ページ遷移時の視覚的なジャンプを解消します。

## 変更点

- `NoteMeRedirect` で `useContainerColumns` フックを使用し、コンテナ幅に応じた動的な列数計測を実装
- 独自の 3 カラム固定スケルトンを廃止し、`PageGridSkeleton` コンポーネントを再利用
- `PageGridSkeleton` を export して、`PageGrid` 本体をマウントせずに先行表示する箇所から再利用可能に
- スケルトン表示時の padding を `py-10` から `py-6` に調整
- JSDoc コメントを日本語・英語で併記し、再利用の意図を明確化

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)

## テスト方法

1. `NoteMeRedirect` ページにアクセスし、データ読み込み中にスケルトンが表示されることを確認
2. 異なる画面幅（モバイル、タブレット、デスクトップ）でスケルトンの列数が正しく変動することを確認
3. リダイレクト完了後、スケルトンから実コンテンツへの遷移時に視覚的なジャンプが発生しないことを確認
4. `bun run lint` と `bun run format:check` が通ることを確認

## チェックリスト

- [x] Lint エラーがない
- [x] コメント・ドキュメントが日本語・英語で併記されている
- [x] 既存の `PageGridSkeleton` の再利用により、スケルトンと実コンテンツの一貫性を確保

## 関連背景

リダイレクト中に表示される独自の 3 カラムスケルトンが、リダイレクト先 `NoteView` の `PageGrid` が出すスケルトンと見た目がズレており、ページ遷移時に視覚的なジャンプが発生していました。同じ `PageGridSkeleton` コンポーネントを先行表示することで、この問題を解決します。

https://claude.ai/code/session_01Cy87NVCgxJeBvoQmDnXQt6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated visual layout shift during redirects by aligning the loading placeholder with the final grid and improving vertical spacing.

* **Refactor**
  * Made the grid loading skeleton reusable so multiple pages can display a consistent placeholder while content loads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->