### PR TITLE
feat(editor): replace collaboration loading spinner with skeleton UI

### DIFF
--- a/src/components/note/EditorSkeleton.test.tsx
+++ b/src/components/note/EditorSkeleton.test.tsx
@@ -41,11 +41,8 @@ describe("EditorSkeleton", () => {
   });
 
   it("段落構造のスケルトン行を 9 本描画する / renders 9 paragraph-shaped skeleton lines", () => {
-    const { container } = renderWithI18n(<EditorSkeleton />);
-    // Skeleton の実装は `bg-muted animate-pulse rounded-md` を持つ div。
-    // The Skeleton component renders a div with `bg-muted animate-pulse rounded-md`.
-    const lines = container.querySelectorAll("div.animate-pulse");
-    expect(lines).toHaveLength(9);
+    renderWithI18n(<EditorSkeleton />);
+    expect(screen.getAllByTestId("editor-skeleton-line")).toHaveLength(9);
   });
 
   it("旧テキスト「リアルタイム編集を準備中」を含まない / does not render the legacy text", () => {

--- a/src/components/note/EditorSkeleton.test.tsx
+++ b/src/components/note/EditorSkeleton.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { I18nextProvider } from "react-i18next";
+import i18n from "@/i18n";
+import { EditorSkeleton } from "./EditorSkeleton";
+
+/**
+ * Render helper that wires up i18n the same way as `PageTitleBlock.test.tsx`.
+ * `PageTitleBlock.test.tsx` と同じ手順で i18n を組み込むレンダーヘルパー。
+ */
+function renderWithI18n(ui: React.ReactElement) {
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>);
+}
+
+describe("EditorSkeleton", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("ja");
+  });
+
+  it("role=status の要素を描画する / renders an element with role=status", () => {
+    renderWithI18n(<EditorSkeleton />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("aria-busy と aria-live が設定されている / sets aria-busy and aria-live", () => {
+    renderWithI18n(<EditorSkeleton />);
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(status).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("日本語ロケールで aria-label に「エディタを読み込み中」が入る / sets Japanese aria-label", () => {
+    renderWithI18n(<EditorSkeleton />);
+    expect(screen.getByRole("status")).toHaveAttribute("aria-label", "エディタを読み込み中");
+  });
+
+  it("data-testid=editor-skeleton を持つ / has data-testid=editor-skeleton", () => {
+    renderWithI18n(<EditorSkeleton />);
+    expect(screen.getByTestId("editor-skeleton")).toBeInTheDocument();
+  });
+
+  it("段落構造のスケルトン行を 9 本描画する / renders 9 paragraph-shaped skeleton lines", () => {
+    const { container } = renderWithI18n(<EditorSkeleton />);
+    // Skeleton の実装は `bg-muted animate-pulse rounded-md` を持つ div。
+    // The Skeleton component renders a div with `bg-muted animate-pulse rounded-md`.
+    const lines = container.querySelectorAll("div.animate-pulse");
+    expect(lines).toHaveLength(9);
+  });
+
+  it("旧テキスト「リアルタイム編集を準備中」を含まない / does not render the legacy text", () => {
+    renderWithI18n(<EditorSkeleton />);
+    expect(screen.queryByText(/リアルタイム編集を準備中/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/note/EditorSkeleton.tsx
+++ b/src/components/note/EditorSkeleton.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { useTranslation } from "react-i18next";
 import { Skeleton } from "@zedi/ui";
 
@@ -18,7 +19,7 @@ const PARAGRAPH_GROUPS: readonly (readonly string[])[] = [
  * コラボレーティブエディタの初期化中に表示するプレースホルダー。実エディタと同じ最小高さを
  * 確保し、コンテンツ表示への切替時にレイアウトシフトが起きないようにする。
  */
-export function EditorSkeleton() {
+export function EditorSkeleton(): React.ReactElement {
   const { t } = useTranslation();
 
   return (
@@ -33,7 +34,11 @@ export function EditorSkeleton() {
       {PARAGRAPH_GROUPS.map((lines, groupIndex) => (
         <div key={`paragraph-${groupIndex}`} className="space-y-3">
           {lines.map((widthClass, lineIndex) => (
-            <Skeleton key={`line-${groupIndex}-${lineIndex}`} className={`h-4 ${widthClass}`} />
+            <Skeleton
+              key={`line-${groupIndex}-${lineIndex}`}
+              data-testid="editor-skeleton-line"
+              className={`h-4 ${widthClass}`}
+            />
           ))}
         </div>
       ))}

--- a/src/components/note/EditorSkeleton.tsx
+++ b/src/components/note/EditorSkeleton.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from "react-i18next";
+import { Skeleton } from "@zedi/ui";
+
+/**
+ * Per-paragraph line widths designed to mimic natural prose: each inner array represents a
+ * paragraph, and its entries are Tailwind width classes for the lines within that paragraph.
+ * 段落ごとの行幅。内側の配列が 1 段落を表し、その要素が段落内の各行の幅クラスに対応する。
+ */
+const PARAGRAPH_GROUPS: readonly (readonly string[])[] = [
+  ["w-[92%]", "w-[88%]", "w-[60%]"],
+  ["w-[95%]", "w-[78%]"],
+  ["w-[90%]", "w-[85%]", "w-[70%]", "w-[40%]"],
+] as const;
+
+/**
+ * Placeholder UI shown while the collaborative editor is initialising. Mirrors the real
+ * editor's minimum height so the swap to live content does not cause layout shift.
+ * コラボレーティブエディタの初期化中に表示するプレースホルダー。実エディタと同じ最小高さを
+ * 確保し、コンテンツ表示への切替時にレイアウトシフトが起きないようにする。
+ */
+export function EditorSkeleton() {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      aria-label={t("editor.collaborationLoading")}
+      data-testid="editor-skeleton"
+      className="min-h-[calc(100vh-200px)] space-y-6 py-4"
+    >
+      {PARAGRAPH_GROUPS.map((lines, groupIndex) => (
+        <div key={`paragraph-${groupIndex}`} className="space-y-3">
+          {lines.map((widthClass, lineIndex) => (
+            <Skeleton key={`line-${groupIndex}-${lineIndex}`} className={`h-4 ${widthClass}`} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/note/PageEditorContent.tsx
+++ b/src/components/note/PageEditorContent.tsx
@@ -1,6 +1,5 @@
 import React, { useRef, useCallback, useMemo } from "react";
 import type { MutableRefObject } from "react";
-import { Loader2 } from "lucide-react";
 import TiptapEditor from "@/components/editor/TiptapEditor";
 import type { ContentError } from "@/components/editor/TiptapEditor/useContentSanitizer";
 import type { CollaborationConfig } from "@/components/editor/TiptapEditor/types";
@@ -13,6 +12,7 @@ import { isContentNotEmpty } from "@/lib/contentUtils";
 import type { UseCollaborationReturn } from "@/lib/collaboration/types";
 import type { WikiGeneratorStatus } from "@/hooks/useWikiGenerator";
 import { PageTitleBlock } from "./PageTitleBlock";
+import { EditorSkeleton } from "./EditorSkeleton";
 
 /**
  * `useCollaboration` の戻り値から、Tiptap に渡す collaborationConfig と
@@ -191,12 +191,7 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
 
         {/* エディター（生成中はオーバーレイを表示） */}
         <div className="relative">
-          {showCollaborationLoading && (
-            <div className="text-muted-foreground flex min-h-[200px] items-center justify-center">
-              <Loader2 className="h-8 w-8 animate-spin" />
-              <span className="ml-2">リアルタイム編集を準備中...</span>
-            </div>
-          )}
+          {showCollaborationLoading && <EditorSkeleton />}
           {showEditor && (
             <>
               <TiptapEditor

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -3,6 +3,7 @@
   "savedAt": "Saved {{relative}}",
   "startWritingPlaceholder": "Start writing your thoughts...",
   "titlePlaceholder": "Title",
+  "collaborationLoading": "Loading editor",
   "pageMenu": {
     "exportMarkdown": "Export Markdown",
     "copyMarkdown": "Copy Markdown",

--- a/src/i18n/locales/ja/editor.json
+++ b/src/i18n/locales/ja/editor.json
@@ -3,6 +3,7 @@
   "savedAt": "{{relative}}に保存",
   "startWritingPlaceholder": "思考を書き始める...",
   "titlePlaceholder": "タイトル",
+  "collaborationLoading": "エディタを読み込み中",
   "pageMenu": {
     "exportMarkdown": "Markdownでエクスポート",
     "copyMarkdown": "Markdownをコピー",


### PR DESCRIPTION
Show a prose-shaped skeleton while the collaborative editor initialises
so users see where their text will appear instead of a generic spinner
plus the technical "リアルタイム編集を準備中..." message. The legacy
text is removed (its detail isn't useful to readers) and replaced with
an i18n aria-label for screen readers.

協調編集の初期化中に文章レイアウト風のスケルトンを表示する。
旧テキストはユーザーにとって不要な技術情報のため削除し、
スクリーンリーダー向けの aria-label のみを残す。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned collaborative editor loading UI with an accessible skeleton placeholder, reduced layout shift, and improved visual realism; replaces previous spinner.
  * Added English and Japanese copy for the loading state.

* **Tests**
  * Added test coverage for the loading skeleton to verify accessibility attributes, localized label, rendered structure, and absence of legacy text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->