### PR TITLE
refactor(page): remove mobile-only delete button from PageCard

### DIFF
--- a/src/components/page/PageCard.tsx
+++ b/src/components/page/PageCard.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Link2, Copy, Trash2 } from "lucide-react";
 import type { PageSummary } from "@/types/page";
 import { ZEDI_PAGE_MIME_TYPE } from "@/types/aiChat";
-import { Button, cn } from "@zedi/ui";
+import { cn } from "@zedi/ui";
 import { useCreatePage, useDeletePage, usePage } from "@/hooks/usePageQueries";
 import { useRemovePageFromNote } from "@/hooks/useNoteQueries";
 import { useToast } from "@zedi/ui";
@@ -281,43 +281,12 @@ const PageCard: React.FC<PageCardProps> = ({ page, index = 0, noteId, canDelete 
   // Don't open the context menu if no actions remain (e.g. read-only viewer).
   const hasMenuItems = showDuplicate || canDelete;
 
-  // モバイルではコンテキストメニューが出せないため、ノート文脈で削除権限が
-  // ある場合は旧 `NoteViewPageGrid` と同様、カード右上に常設のゴミ箱ボタン
-  // を出す。`isMobile` 判定を採用するのは、デスクトップでは右クリックの
-  // ContextMenu を主動線にするため（重複表示を避ける）。
-  // Touch devices can't trigger the right-click context menu, so when a note
-  // editor/owner is allowed to delete a page we surface a permanent trash
-  // overlay (matching the previous `NoteViewPageGrid` UX). Desktop keeps the
-  // context menu as the primary action to avoid double UI.
-  const showMobileNoteDeleteButton = isMobile && Boolean(noteId) && canDelete;
-
-  const cardWithMobileDelete = showMobileNoteDeleteButton ? (
-    <div className="relative">
-      {cardButton}
-      <Button
-        type="button"
-        variant="secondary"
-        size="icon"
-        className="absolute top-2 right-2 h-7 w-7"
-        aria-label={t("common.page.delete")}
-        onClick={(e) => {
-          e.stopPropagation();
-          setIsDeleteDialogOpen(true);
-        }}
-      >
-        <Trash2 className="h-4 w-4" />
-      </Button>
-    </div>
-  ) : (
-    cardButton
-  );
-
   return (
     <>
       {isMobile || !hasMenuItems ? (
         // モバイル or メニュー項目なし: コンテキストメニューを出さない
         // Mobile, or no available actions → render bare card without ContextMenu
-        cardWithMobileDelete
+        cardButton
       ) : (
         // デスクトップ: 右クリックで ContextMenu を表示 / Desktop: right-click opens ContextMenu
         <ContextMenu modal={false}>


### PR DESCRIPTION
モバイルでページカード右上に常設していた削除ボタンを廃止。デスクトップの
ContextMenu からの削除導線は維持する。

Remove the always-on trash overlay shown on mobile in the top-right of each
PageCard. Desktop continues to use the right-click ContextMenu for deletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified mobile delete button behavior for improved consistency
  * Removed redundant delete overlay on mobile devices
  * Desktop context menu interaction remains unchanged

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->