### PR TITLE
fix: clarify admin error response payload

### DIFF
--- a/admin/src/api/admin.test.ts
+++ b/admin/src/api/admin.test.ts
@@ -291,7 +291,7 @@ describe("getApiErrorById", () => {
       id: "550e8400-e29b-41d4-a716-446655440000/with+reserved",
     };
     vi.mocked(adminFetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ error: rowNeedsEncoding }), { status: 200 }),
+      new Response(JSON.stringify({ apiError: rowNeedsEncoding }), { status: 200 }),
     );
     const out = await getApiErrorById(rowNeedsEncoding.id);
     expect(out).toEqual(rowNeedsEncoding);
@@ -309,7 +309,7 @@ describe("patchApiErrorStatus", () => {
   it("PATCH に status を載せ、更新後の row を返す", async () => {
     const updated = { ...sampleErrorRow, status: "investigating" as const };
     vi.mocked(adminFetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ error: updated }), { status: 200 }),
+      new Response(JSON.stringify({ apiError: updated }), { status: 200 }),
     );
     const out = await patchApiErrorStatus(sampleErrorRow.id, "investigating");
     expect(out.status).toBe("investigating");

--- a/admin/src/api/admin.ts
+++ b/admin/src/api/admin.ts
@@ -462,8 +462,8 @@ export async function getApiErrorById(id: string): Promise<ApiErrorRow> {
   if (!res.ok) {
     throw new Error(await getErrorMessage(res, "Failed to fetch API error"));
   }
-  const data: { error: ApiErrorRow } = await res.json();
-  return data.error;
+  const data: { apiError: ApiErrorRow } = await res.json();
+  return data.apiError;
 }
 
 /**
@@ -485,8 +485,8 @@ export async function patchApiErrorStatus(
   if (!res.ok) {
     throw new Error(await getErrorMessage(res, "Failed to update API error status"));
   }
-  const data: { error: ApiErrorRow } = await res.json();
-  return data.error;
+  const data: { apiError: ApiErrorRow } = await res.json();
+  return data.apiError;
 }
 
 /**

--- a/server/api/src/__tests__/routes/admin/errors.test.ts
+++ b/server/api/src/__tests__/routes/admin/errors.test.ts
@@ -145,8 +145,8 @@ describe("GET /api/admin/errors/:id", () => {
     });
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { error: { id: string } };
-    expect(body.error.id).toBe("00000000-0000-0000-0000-000000000010");
+    const body = (await res.json()) as { apiError: { id: string } };
+    expect(body.apiError.id).toBe("00000000-0000-0000-0000-000000000010");
   });
 
   it("returns 404 when the row is not found", async () => {
@@ -196,8 +196,8 @@ describe("PATCH /api/admin/errors/:id", () => {
     });
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { error: { status: string } };
-    expect(body.error.status).toBe("investigating");
+    const body = (await res.json()) as { apiError: { status: string } };
+    expect(body.apiError.status).toBe("investigating");
   });
 
   it("returns 200 (no-op) when transitioning to the same status", async () => {

--- a/server/api/src/routes/admin/errors.ts
+++ b/server/api/src/routes/admin/errors.ts
@@ -277,7 +277,7 @@ app.get("/:id", async (c) => {
   if (!row) {
     return c.json({ error: "Not found" }, 404);
   }
-  return c.json({ error: row });
+  return c.json({ apiError: row });
 });
 
 /**
@@ -334,7 +334,7 @@ app.patch("/:id", async (c) => {
     // Notify SSE subscribers; errors here must not flip the PATCH response from
     // 200 to 5xx because the DB write already succeeded.
     publishApiErrorUpdate(row);
-    return c.json({ error: row });
+    return c.json({ apiError: row });
   } catch (err) {
     if (err instanceof ApiErrorStatusConflictError) {
       return c.json({ error: "status changed concurrently; refetch and retry" }, 409);


### PR DESCRIPTION
## 概要

PR #905 のレビュー指摘に対応し、admin errors API の成功レスポンスで行データを `error` キーではなく `apiError` キーで返すようにしました。エラー応答の `error` キーと成功時の payload が混同されないようにします。

## 変更点

- `server/api`: `GET /api/admin/errors/:id` と `PATCH /api/admin/errors/:id` の成功レスポンスを `{ apiError: row }` に変更
- `admin`: `getApiErrorById` / `patchApiErrorStatus` のレスポンス読み取りを `apiError` に追従
- `tests`: API route test と admin client test の期待値を更新

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `cd server/api && bun run test:run src/__tests__/routes/admin/errors.test.ts`
2. `cd admin && bun run test:run src/api/admin.test.ts`
3. `bunx prettier --check "admin/src/api/admin.ts" "admin/src/api/admin.test.ts" "server/api/src/routes/admin/errors.ts" "server/api/src/__tests__/routes/admin/errors.test.ts"`
4. `bun run lint`（警告のみ、exit 0）

補足: `bun run lint && bun run format:check && bun run test:run` も試行しましたが、リポジトリ全体の既存 Prettier 差分（790 files）で `format:check` が失敗したため、`test:run` までは到達していません。今回変更した 4 ファイルに限定した Prettier check は通過しています。

## チェックリスト

- [ ] テストがすべてパスする
- [x] Lint エラーがない
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

UI 表示変更なし（admin API クライアントのレスポンスキー追従のみ）。

## 関連 Issue

Related to #905

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the response structure in admin error management endpoints to ensure consistent and reliable API behavior when retrieving and updating error information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->