### PR TITLE
feat(pages): リンク一覧をノート内スコープ化しゲストにも開放する

### DIFF
--- a/server/api/src/__tests__/routes/pages.test.ts
+++ b/server/api/src/__tests__/routes/pages.test.ts
@@ -706,3 +706,170 @@ describe("GET /api/pages/:id/public-content", () => {
     expect(res.headers.get("cache-control")).toBe("public, max-age=60, must-revalidate");
   });
 });
+
+// ── GET /api/pages/:id/public-links (note-scoped link graph for read-only callers) ─
+//
+// `LinkedPagesSection` をログイン編集者だけでなく公開ノート閲覧ゲストでも表示する
+// ため、ページ単位の outgoing / backlinks / ghost-links をノート内スコープで返す
+// 読み取り専用エンドポイント。サーバ側で `pages.note_id` の一致を強制し、別ノートの
+// 行が応答に混入しないようにする。`authOptional` + `getNoteRole` で公開ノート閲覧者
+// にも開放する。
+//
+// `LinkedPagesSection` is rendered for guests on public/unlisted notes too, so
+// this endpoint returns the per-page link graph (outgoing wiki edges, backlinks,
+// unresolved ghost-link titles) scoped to the page's owning note. The note-scope
+// filter is enforced server-side via `pages.note_id`. `authOptional` plus
+// `getNoteRole` opens the route to anonymous readers on public/unlisted notes.
+describe("GET /api/pages/:id/public-links", () => {
+  /**
+   * outgoing / backlinks の各レスポンス行は `PageCard` 由来のフィールドだけを返す。
+   * Each outgoing/backlink row exposes `PageCard`-shaped columns only.
+   */
+  function makeLinkedPageRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "linked-page-1",
+      noteId: NOTE_ID,
+      title: "Linked",
+      contentPreview: "preview",
+      updatedAt: new Date("2026-05-19T00:00:00Z"),
+      sourceUrl: null,
+      ...overrides,
+    };
+  }
+
+  it("returns note-scoped outgoing, backlinks, and ghost-links for the owner", async () => {
+    const app = createPagesApp([
+      // SELECT pages (page row)
+      [{ id: PAGE_ID, noteId: NOTE_ID }],
+      // getNoteRole → findActiveNoteById (owner short-circuit)
+      [mockNoteRow()],
+      // outgoing links (links INNER JOIN pages, note-scoped)
+      [makeLinkedPageRow({ id: "out-1", title: "Out 1" })],
+      // backlinks (links INNER JOIN pages, note-scoped)
+      [makeLinkedPageRow({ id: "back-1", title: "Back 1" })],
+      // ghost_links DISTINCT link_text
+      [{ linkText: "Ghost Title" }],
+    ]);
+
+    const res = await app.request(`/api/pages/${PAGE_ID}/public-links`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      outgoing_links: Array<Record<string, unknown>>;
+      backlinks: Array<Record<string, unknown>>;
+      ghost_links: string[];
+    };
+    expect(body.outgoing_links).toHaveLength(1);
+    expect(body.outgoing_links[0]).toMatchObject({
+      id: "out-1",
+      note_id: NOTE_ID,
+      title: "Out 1",
+      content_preview: "preview",
+      updated_at: "2026-05-19T00:00:00.000Z",
+    });
+    expect(body.backlinks).toHaveLength(1);
+    expect(body.backlinks[0]).toMatchObject({ id: "back-1", note_id: NOTE_ID, title: "Back 1" });
+    expect(body.ghost_links).toEqual(["Ghost Title"]);
+    expect(res.headers.get("cache-control")).toBe("private, must-revalidate");
+  });
+
+  it("returns 404 when the page row is missing or already soft-deleted", async () => {
+    const app = createPagesApp([[]]);
+
+    const res = await app.request(`/api/pages/${PAGE_ID}/public-links`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when caller has no role on the owning private note", async () => {
+    const privateNote = {
+      ...mockNoteRow(),
+      ownerId: "other-user",
+      visibility: "private" as const,
+    };
+    const app = createPagesApp([
+      [{ id: PAGE_ID, noteId: NOTE_ID }],
+      [privateNote], // note row
+      [], // member SELECT empty
+      [], // domain SELECT empty
+    ]);
+
+    const res = await app.request(`/api/pages/${PAGE_ID}/public-links`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("allows guest access on a public note with edge-cacheable Cache-Control", async () => {
+    const publicNote = {
+      ...mockNoteRow(),
+      ownerId: "other-user",
+      visibility: "public" as const,
+    };
+    const app = createPagesApp([
+      [{ id: PAGE_ID, noteId: NOTE_ID }],
+      [publicNote],
+      [makeLinkedPageRow({ id: "out-guest" })],
+      [], // no backlinks
+      [], // no ghosts
+    ]);
+
+    const res = await app.request(`/api/pages/${PAGE_ID}/public-links`, {
+      method: "GET",
+      // no auth header → guest path
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      outgoing_links: unknown[];
+      backlinks: unknown[];
+      ghost_links: string[];
+    };
+    expect(body.outgoing_links).toHaveLength(1);
+    expect(body.backlinks).toEqual([]);
+    expect(body.ghost_links).toEqual([]);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=60, must-revalidate");
+  });
+
+  it("filters cross-note backlinks via the WHERE clause on pages.note_id", async () => {
+    // ノートスコープの強制：ルートは links INNER JOIN pages の WHERE で
+    // `pages.note_id = currentPage.note_id` を要求する。createMockDb は
+    // チェーンの WHERE 句を実際に評価しないため、本テストでは「ノート外の行が
+    // DB から返らない」前提のもとで応答が空になることを担保する。
+    //
+    // Scope enforcement: the route's INNER JOIN includes a `pages.note_id =
+    // currentPage.note_id` predicate. createMockDb does not evaluate the WHERE
+    // clause, so this test feeds an *empty* result for backlinks to model the
+    // expected DB behavior and asserts the response stays empty.
+    const app = createPagesApp([
+      [{ id: PAGE_ID, noteId: NOTE_ID }],
+      [mockNoteRow()],
+      [], // outgoing: none in scope
+      [], // backlinks: cross-note rows filtered out at DB
+      [], // ghost: none
+    ]);
+
+    const res = await app.request(`/api/pages/${PAGE_ID}/public-links`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      outgoing_links: unknown[];
+      backlinks: unknown[];
+      ghost_links: string[];
+    };
+    expect(body.outgoing_links).toEqual([]);
+    expect(body.backlinks).toEqual([]);
+    expect(body.ghost_links).toEqual([]);
+  });
+});

--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -25,7 +25,7 @@
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { eq, and, sql } from "drizzle-orm";
-import { pages, pageContents, type Page } from "../schema/index.js";
+import { pages, pageContents, links, ghostLinks, type Page } from "../schema/index.js";
 import { authRequired, authOptional } from "../middleware/auth.js";
 import type { AppEnv, Database } from "../types/index.js";
 import { ensureDefaultNote, getDefaultNoteOrNull } from "../services/defaultNoteService.js";
@@ -675,6 +675,142 @@ app.get("/:id/public-content", authOptional, async (c) => {
     content_preview: row.contentPreview ?? null,
     version: content?.version ?? 0,
     updated_at: (content?.updatedAt ?? row.updatedAt).toISOString(),
+  });
+});
+
+// ── GET /pages/:id/public-links (note-scoped link graph for read-only callers) ─
+/**
+ * `GET /api/pages/:pageId/public-links` — ノート内スコープのリンクグラフを返す
+ * 読み取り専用 API。`LinkedPagesSection` をログイン編集者だけでなく公開ノートの
+ * 閲覧ゲストにも表示するために用意する。
+ *
+ * 返却内容:
+ * - `outgoing_links`: このページから張られている WikiLink の解決済み先（同一ノート内）
+ * - `backlinks`: このページを指している WikiLink の発信元ページ（同一ノート内）
+ * - `ghost_links`: 未解決の WikiLink テキスト（タイトル文字列のみ）
+ *
+ * 2-hop（`outgoingLinksWithChildren`）は本ルートでは返さない。負荷とゲスト権限の
+ * 観点から、ログイン編集者向けの IndexedDB ベース計算のみで提供する。
+ *
+ * `authOptional` + `getNoteRole` で `public-content` と同じ閲覧権限を踏襲し、
+ * `pages.note_id` の JOIN 条件でクロスノート行をサーバ側で排除する。
+ *
+ * `GET /api/pages/:pageId/public-links` returns the note-scoped link graph
+ * (outgoing wiki edges, backlinks, ghost-link titles) so the
+ * `LinkedPagesSection` component can render for unauthenticated guests on
+ * public/unlisted notes as well as for signed-in editors.
+ *
+ * The endpoint deliberately omits 2-hop (`outgoingLinksWithChildren`) data —
+ * that view stays on the IndexedDB-driven path for signed-in editors only.
+ * Auth follows the `public-content` precedent (`authOptional` + `getNoteRole`),
+ * and the INNER JOIN on `pages.note_id` enforces note-scoping server-side so
+ * cross-note rows can never leak into the response.
+ *
+ * @returns 200 + `{ outgoing_links, backlinks, ghost_links }`.
+ *          404 when the page row is missing or already soft-deleted.
+ *          403 when no role is resolved on the owning note.
+ */
+app.get("/:id/public-links", authOptional, async (c) => {
+  const pageId = c.req.param("id");
+  const userId = c.get("userId");
+  const userEmail = c.get("userEmail");
+  const db = c.get("db");
+
+  const pageRows = await db
+    .select({ id: pages.id, noteId: pages.noteId })
+    .from(pages)
+    .where(and(eq(pages.id, pageId), eq(pages.isDeleted, false)))
+    .limit(1);
+
+  const page = pageRows[0];
+  if (!page) throw new HTTPException(404, { message: "Page not found" });
+
+  const { role } = await getNoteRole(page.noteId, userId, userEmail, db);
+  if (!role) throw new HTTPException(403, { message: "Forbidden" });
+
+  // outgoing: このページから出ている wiki link のうち、同一ノート内に解決した行のみ。
+  // outgoing: wiki edges from this page resolved to a page inside the same note.
+  const outgoingRows = await db
+    .select({
+      id: pages.id,
+      noteId: pages.noteId,
+      title: pages.title,
+      contentPreview: pages.contentPreview,
+      updatedAt: pages.updatedAt,
+      sourceUrl: pages.sourceUrl,
+    })
+    .from(links)
+    .innerJoin(pages, eq(pages.id, links.targetId))
+    .where(
+      and(
+        eq(links.sourceId, pageId),
+        eq(links.linkType, "wiki"),
+        eq(pages.noteId, page.noteId),
+        eq(pages.isDeleted, false),
+      ),
+    )
+    .limit(50);
+
+  // backlinks: このページを指している wiki link のうち、発信元が同一ノートのもの。
+  // backlinks: wiki edges pointing at this page whose source page lives in the same note.
+  const backlinkRows = await db
+    .select({
+      id: pages.id,
+      noteId: pages.noteId,
+      title: pages.title,
+      contentPreview: pages.contentPreview,
+      updatedAt: pages.updatedAt,
+      sourceUrl: pages.sourceUrl,
+    })
+    .from(links)
+    .innerJoin(pages, eq(pages.id, links.sourceId))
+    .where(
+      and(
+        eq(links.targetId, pageId),
+        eq(links.linkType, "wiki"),
+        eq(pages.noteId, page.noteId),
+        eq(pages.isDeleted, false),
+      ),
+    )
+    .limit(50);
+
+  // ghost: 未解決リンクのタイトル文字列のみ。source page に紐付くため自然にスコープ済み。
+  // ghost: unresolved link titles. Source-page-bound rows are already note-scoped.
+  const ghostRows = await db
+    .select({ linkText: ghostLinks.linkText })
+    .from(ghostLinks)
+    .where(and(eq(ghostLinks.sourcePageId, pageId), eq(ghostLinks.linkType, "wiki")))
+    .limit(50);
+
+  // public-content と同じキャッシュ方針：ゲストはエッジで短期キャッシュ可能、
+  // ログイン済みは個人スコープに留める。
+  // Same Cache-Control story as public-content: guests get a short edge cache,
+  // logged-in callers stay private.
+  c.header(
+    "Cache-Control",
+    userId ? "private, must-revalidate" : "public, max-age=60, must-revalidate",
+  );
+
+  const toCard = (r: {
+    id: string;
+    noteId: string;
+    title: string | null;
+    contentPreview: string | null;
+    updatedAt: Date;
+    sourceUrl: string | null;
+  }) => ({
+    id: r.id,
+    note_id: r.noteId,
+    title: r.title,
+    content_preview: r.contentPreview,
+    updated_at: r.updatedAt.toISOString(),
+    source_url: r.sourceUrl,
+  });
+
+  return c.json({
+    outgoing_links: outgoingRows.map(toCard),
+    backlinks: backlinkRows.map(toCard),
+    ghost_links: ghostRows.map((r) => r.linkText),
   });
 });
 

--- a/src/components/note/NotePagePublicView.test.tsx
+++ b/src/components/note/NotePagePublicView.test.tsx
@@ -62,7 +62,7 @@ vi.mock("./PageEditorContent", () => ({
         data-testid="page-editor-content"
         data-title={String(props.title ?? "")}
         data-read-only={String(props.isReadOnly ?? false)}
-        data-show-linked-pages={String(props.showLinkedPages ?? false)}
+        data-linked-pages-mode={String(props.linkedPagesMode ?? "repo")}
         data-show-toolbar={String(props.showToolbar ?? false)}
         data-current-page-id={String(props.currentPageId ?? "null")}
         data-page-id={String(props.pageId ?? "")}
@@ -154,9 +154,16 @@ describe("NotePagePublicView", () => {
     const editor = await screen.findByTestId("page-editor-content");
     expect(editor).toHaveAttribute("data-title", "Public title");
     expect(editor).toHaveAttribute("data-read-only", "true");
-    expect(editor).toHaveAttribute("data-show-linked-pages", "false");
+    // ゲスト向けに LinkedPagesSection を `/public-links` API 経由で描画する。
+    // The section renders for guests via the `/public-links` API path.
+    expect(editor).toHaveAttribute("data-linked-pages-mode", "api");
     expect(editor).toHaveAttribute("data-show-toolbar", "false");
-    expect(editor).toHaveAttribute("data-current-page-id", "null");
+    // 公開ノート閲覧でも `currentPageId` を渡し、LinkedPagesSection を描画する。
+    // `LintSuggestions` は内部で `isSignedIn` をチェックしてゲスト時は描画しない。
+    // `currentPageId` is now provided so the LinkedPagesSection renders even
+    // for guests; `LintSuggestions` self-gates on `isSignedIn` so it stays
+    // hidden for unauthenticated callers.
+    expect(editor).toHaveAttribute("data-current-page-id", "page-1");
     expect(editor).toHaveAttribute("data-page-id", "page-1");
 
     // `content` should be a JSON.stringify-ed Tiptap doc containing the two

--- a/src/components/note/NotePagePublicView.tsx
+++ b/src/components/note/NotePagePublicView.tsx
@@ -121,17 +121,21 @@ export const NotePagePublicView: React.FC<NotePagePublicViewProps> = ({ pageId, 
       content={tiptapContent}
       title={data?.title ?? page.title ?? ""}
       sourceUrl={page.sourceUrl}
-      // `currentPageId={null}` で LinkedPagesSection と LintSuggestions の描画を抑止する
-      // (どちらも認証必須エンドポイントを叩くためゲスト互換性のために必須)。
-      // Suppress LinkedPagesSection / LintSuggestions (both call authenticated
-      // endpoints) by leaving currentPageId null. WikiLink scope still works
-      // via the `pageId` prop below.
-      currentPageId={null}
+      // ゲスト向けでも `LinkedPagesSection` を描画するため `currentPageId` を
+      // 渡す。リンク一覧は `linkedPagesMode="api"` で公開 API 経路を使う。
+      // `LintSuggestions` は内部で `useAuth().isSignedIn` を確認し、ゲスト時は
+      // 描画しない。
+      //
+      // Pass `currentPageId` so `LinkedPagesSection` can render for guests;
+      // the section switches to the `/public-links` API path via
+      // `linkedPagesMode="api"`. `LintSuggestions` self-gates on
+      // `useAuth().isSignedIn` and renders nothing for unauthenticated callers.
+      currentPageId={page.id}
       pageId={page.id}
       isNewPage={false}
       isWikiGenerating={false}
       isReadOnly
-      showLinkedPages={false}
+      linkedPagesMode="api"
       showToolbar={false}
       onContentChange={NOOP}
       onContentError={NOOP}

--- a/src/components/note/PageEditorContent.tsx
+++ b/src/components/note/PageEditorContent.tsx
@@ -66,7 +66,16 @@ interface PageEditorContentProps {
   isWikiGenerating: boolean;
   isReadOnly?: boolean;
   isSyncingLinks?: boolean;
-  showLinkedPages?: boolean;
+  /**
+   * `LinkedPagesSection` のデータ取得経路。`"repo"`（既定）は IndexedDB から、
+   * `"api"` は `/public-links` 経由でリンク一覧を取得する。公開ノートの
+   * 閲覧ゲスト向け `NotePagePublicView` からは `"api"` を渡す。
+   *
+   * Data source for `LinkedPagesSection`. `"repo"` (default) reads from
+   * IndexedDB; `"api"` calls `/public-links`. `NotePagePublicView` passes
+   * `"api"` so guests on public/unlisted notes can render the section.
+   */
+  linkedPagesMode?: "repo" | "api";
   showToolbar?: boolean;
   onContentChange: (content: string) => void;
   onContentError: (error: ContentError | null) => void;
@@ -118,7 +127,7 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
   isWikiGenerating,
   isReadOnly,
   isSyncingLinks = false,
-  showLinkedPages = true,
+  linkedPagesMode = "repo",
   showToolbar = true,
   onContentChange,
   onContentError,
@@ -219,8 +228,12 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
         </div>
 
         {/* Linked Pages Section */}
-        {showLinkedPages && currentPageId && (
-          <LinkedPagesSection pageId={currentPageId} isSyncingLinks={isSyncingLinks} />
+        {currentPageId && (
+          <LinkedPagesSection
+            pageId={currentPageId}
+            isSyncingLinks={isSyncingLinks}
+            mode={linkedPagesMode}
+          />
         )}
 
         {/* Lint Suggestions */}

--- a/src/components/page/LinkedPagesSection.test.tsx
+++ b/src/components/page/LinkedPagesSection.test.tsx
@@ -273,4 +273,51 @@ describe("LinkedPagesSection", () => {
     // Ghost links renamed
     expect(screen.getByText("新しいリンク (1)")).toBeInTheDocument();
   });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // ゲスト向け (mode="api") ではゴーストリンクを非表示にする。`useCreatePage`
+  // mutation は認証必須で、ゲストがクリックしても失敗するため UI 自体を出さない。
+  //
+  // In `mode="api"` (guest view) ghost links are suppressed because the
+  // `useCreatePage` mutation requires authentication and would fail for
+  // unauthenticated callers.
+  // ──────────────────────────────────────────────────────────────────────
+  describe("mode='api'", () => {
+    const renderWithMode = () => {
+      const queryClient = createTestQueryClient();
+      return render(
+        <TestWrapper queryClient={queryClient}>
+          <LinkedPagesSection pageId="test-page-id" mode="api" />
+        </TestWrapper>,
+      );
+    };
+
+    it("hides ghost links when mode is api", () => {
+      mockLinkedPagesData.outgoingLinks = [
+        {
+          id: "page-1",
+          noteId: "note-1",
+          title: "Outgoing Page",
+          preview: "Preview",
+          updatedAt: Date.now(),
+        },
+      ];
+      mockLinkedPagesData.ghostLinks = ["NotYetCreated"];
+
+      renderWithMode();
+
+      // outgoing は表示される / outgoing links should still render
+      expect(screen.getByText("Outgoing Page")).toBeInTheDocument();
+      // ゴーストリンクは描画されない / ghost cards must not render
+      expect(screen.queryByText("NotYetCreated")).not.toBeInTheDocument();
+      expect(screen.queryByText("新しいリンク (1)")).not.toBeInTheDocument();
+    });
+
+    it("renders nothing when only ghost links exist in api mode", () => {
+      mockLinkedPagesData.ghostLinks = ["Ghost1", "Ghost2"];
+
+      const { container } = renderWithMode();
+      expect(container.firstChild).toBeNull();
+    });
+  });
 });

--- a/src/components/page/LinkedPagesSection.test.tsx
+++ b/src/components/page/LinkedPagesSection.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { LinkedPagesSection } from "./LinkedPagesSection";
 import { TestWrapper, createTestQueryClient } from "@/test/testWrapper";
 import type { LinkedPagesData } from "@/hooks/useLinkedPages";
+import { useLinkedPages } from "@/hooks/useLinkedPages";
 
 // Mock the hooks
 const mockNavigate = vi.fn();
@@ -306,6 +307,9 @@ describe("LinkedPagesSection", () => {
 
       renderWithMode();
 
+      // mode が hook に正しく伝搬していることをロックする (coderabbitai review)。
+      // Lock the mode-threading contract from component → hook.
+      expect(vi.mocked(useLinkedPages)).toHaveBeenCalledWith("test-page-id", { mode: "api" });
       // outgoing は表示される / outgoing links should still render
       expect(screen.getByText("Outgoing Page")).toBeInTheDocument();
       // ゴーストリンクは描画されない / ghost cards must not render

--- a/src/components/page/LinkedPagesSection.tsx
+++ b/src/components/page/LinkedPagesSection.tsx
@@ -40,7 +40,26 @@ function LinkedPagesSkeleton() {
 }
 
 /**
+ * ページ本文の下に表示するリンク済みページ一覧。同一ノート内の
+ * outgoing WikiLink・backlink・ゴーストリンクを描画する。
  *
+ * - `mode="repo"` (既定): IndexedDB から取得し 2-hop も表示する。編集者向け。
+ * - `mode="api"`: `GET /api/pages/:id/public-links` から取得し、ゴーストカードを
+ *   非表示にする (新規ページ作成 mutation が認証必須のため)。公開ノートを
+ *   ゲストが閲覧する `NotePagePublicView` から呼ばれる経路。
+ * - `isSyncingLinks=true` の間は skeleton を返す。
+ *
+ * Renders the linked-pages section below the page body, listing same-note
+ * outgoing WikiLinks, backlinks, and ghost links.
+ *
+ * - `mode="repo"` (default): reads from IndexedDB and includes 2-hop content
+ *   (editor flow).
+ * - `mode="api"`: reads from `GET /api/pages/:id/public-links` and hides ghost
+ *   cards (page-creation requires auth). Used by `NotePagePublicView` for
+ *   guests on public / unlisted notes.
+ * - While `isSyncingLinks=true`, a skeleton is rendered instead.
+ *
+ * @see {@link LinkedPagesSectionProps}
  */
 export function LinkedPagesSection({
   pageId,

--- a/src/components/page/LinkedPagesSection.tsx
+++ b/src/components/page/LinkedPagesSection.tsx
@@ -11,6 +11,16 @@ import { useCreatePage } from "@/hooks/usePageQueries";
 interface LinkedPagesSectionProps {
   pageId: string;
   isSyncingLinks?: boolean;
+  /**
+   * データ取得経路。`"repo"`（既定）は IndexedDB から、`"api"` は
+   * `GET /api/pages/:id/public-links` 経由で取得する。
+   * `"api"` ではゴーストリンク（新規ページ作成 UI）を非表示にする。
+   *
+   * Data source. `"repo"` (default) reads IndexedDB; `"api"` calls
+   * `GET /api/pages/:id/public-links`. Ghost links (which trigger
+   * authenticated page creation) are hidden in `"api"` mode.
+   */
+  mode?: "repo" | "api";
 }
 
 function LinkedPagesSkeleton() {
@@ -32,12 +42,16 @@ function LinkedPagesSkeleton() {
 /**
  *
  */
-export function LinkedPagesSection({ pageId, isSyncingLinks = false }: LinkedPagesSectionProps) {
+export function LinkedPagesSection({
+  pageId,
+  isSyncingLinks = false,
+  mode = "repo",
+}: LinkedPagesSectionProps) {
   const { t } = useTranslation();
   /**
    *
    */
-  const { data, isLoading } = useLinkedPages(pageId);
+  const { data, isLoading } = useLinkedPages(pageId, { mode });
   /**
    *
    */
@@ -64,11 +78,16 @@ export function LinkedPagesSection({ pageId, isSyncingLinks = false }: LinkedPag
    */
   const allLinks = [...outgoingLinks, ...backlinks];
 
+  // api モードではゴーストリンクを非表示にするため、表示判定からも除外する。
+  // In api mode ghost links are hidden, so they should not keep the section
+  // from collapsing into nothing.
+  const ghostLinksVisible = mode === "repo" && ghostLinks.length > 0;
+
   /**
    *
    */
   const hasAnyLinks =
-    allLinks.length > 0 || outgoingLinksWithChildren.length > 0 || ghostLinks.length > 0;
+    allLinks.length > 0 || outgoingLinksWithChildren.length > 0 || ghostLinksVisible;
 
   if (!hasAnyLinks) return null;
 
@@ -123,8 +142,11 @@ export function LinkedPagesSection({ pageId, isSyncingLinks = false }: LinkedPag
         />
       )}
 
-      {/* Ghost Links (renamed to 新しいリンク) */}
-      {ghostLinks.length > 0 && (
+      {/* Ghost Links (renamed to 新しいリンク) — repo モードのみ表示。
+          api モードはゲスト向けで `useCreatePage` mutation が失敗するため抑止。
+          Ghost Links — shown only in repo mode. Suppressed under api mode
+          because the `useCreatePage` mutation requires an authenticated user. */}
+      {mode === "repo" && ghostLinks.length > 0 && (
         <div className="space-y-3">
           <div className="text-muted-foreground flex items-center gap-2 text-sm font-medium">
             <FilePlus className="h-4 w-4" />

--- a/src/components/page/LintSuggestions.tsx
+++ b/src/components/page/LintSuggestions.tsx
@@ -13,6 +13,7 @@ import {
 import { Badge, Button, Skeleton } from "@zedi/ui";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { useAuth } from "@/hooks/useAuth";
 
 /**
  * Lint finding の型（API レスポンス）。
@@ -167,6 +168,7 @@ interface LintSuggestionsProps {
 export function LintSuggestions({ pageId }: LintSuggestionsProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  const { isSignedIn, isLoaded: isAuthLoaded } = useAuth();
 
   const ruleLabel = (rule: string) => {
     const key = `common.page.lintRule.${rule}` as const;
@@ -184,6 +186,13 @@ export function LintSuggestions({ pageId }: LintSuggestionsProps) {
     queryKey: ["lintFindings", pageId],
     queryFn: () => fetchPageFindings(pageId),
     staleTime: 1000 * 60, // 1 minute
+    // ゲスト（未認証）では `/api/lint/findings/page/:id` が 401/403 を返すため
+    // クエリを発火させない。`fetchPageFindings` 側でも空配列にフォールバックする。
+    // The findings endpoint requires auth (401/403 for guests). Skip the query
+    // entirely for unauthenticated viewers — `fetchPageFindings` also falls
+    // back to an empty array, but disabling the call avoids the wasted round
+    // trip.
+    enabled: isAuthLoaded && isSignedIn,
   });
 
   const resolveMutation = useMutation({
@@ -192,6 +201,14 @@ export function LintSuggestions({ pageId }: LintSuggestionsProps) {
       void queryClient.invalidateQueries({ queryKey: ["lintFindings", pageId] });
     },
   });
+
+  // 未認証 (ゲスト) では LintSuggestions 自体を描画しない。
+  // 公開ノートの閲覧経路 `NotePagePublicView` でも `currentPageId` を渡すように
+  // なったため、ここでゲストを除外しないと毎回 401 を返すリクエストが走る。
+  // Skip rendering entirely for unauthenticated viewers. `NotePagePublicView`
+  // now passes `currentPageId`, so without this gate guests would issue
+  // requests that always 401.
+  if (!isAuthLoaded || !isSignedIn) return null;
 
   if (isLoading) {
     return (

--- a/src/hooks/useLinkedPages.test.ts
+++ b/src/hooks/useLinkedPages.test.ts
@@ -705,4 +705,77 @@ describe("calculateLinkedPagesOptimized", () => {
 
     expect(result.outgoingLinks).toHaveLength(2);
   });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // ノートスコープ：呼び出し側で `allPagesSummary` を `currentPage.noteId` に
+  // 絞り込んだ前提で、別ノートの WikiLink がゴーストへ降格し、別ノートの
+  // backlink が結果から除外されることを担保する。`calculateLinkedPagesOptimized`
+  // 自体は無変更で、入力をスコープ済みにするだけで意図が満たされる。
+  //
+  // Note-scoping: when the caller pre-filters `allPagesSummary` to the current
+  // page's note, links pointing to pages in other notes become ghost links and
+  // cross-note backlink IDs are dropped. The pure function does not need to
+  // change — passing scoped inputs is enough to achieve the desired behavior.
+  // ──────────────────────────────────────────────────────────────────────
+  describe("note-scoped inputs (Issue: LinkedPagesSection scoping)", () => {
+    it("demotes cross-note WikiLinks to ghost links when summary is pre-filtered to the note", () => {
+      const currentPage = createTestPage(
+        "current",
+        "Current Page",
+        createWikiLinkContent(["Same Note", "Other Note Page"]),
+        { noteId: "note-A" },
+      );
+      const sameNote = createTestPage("page-same", "Same Note", createPlainTextContent("body"), {
+        noteId: "note-A",
+      });
+      // 別ノートの「Other Note Page」は呼び出し側でフィルタ済みのため summary に存在しない。
+      // The cross-note "Other Note Page" is absent from the pre-filtered summary.
+      const scopedSummaries: PageSummary[] = [
+        createTestSummary("page-same", "Same Note", { noteId: "note-A" }),
+      ];
+
+      const result = calculateLinkedPagesOptimized({
+        currentPage,
+        pageId: "current",
+        allPagesSummary: scopedSummaries,
+        outgoingPages: [sameNote],
+        backlinkPages: [],
+        backlinkIds: [],
+      });
+
+      expect(result.outgoingLinks).toHaveLength(1);
+      expect(result.outgoingLinks[0]?.id).toBe("page-same");
+      expect(result.ghostLinks).toContain("Other Note Page");
+    });
+
+    it("drops cross-note backlinks because their IDs do not resolve in the scoped summary", () => {
+      const currentPage = createTestPage("current", "Current", createPlainTextContent(""), {
+        noteId: "note-A",
+      });
+      const scopedSummaries: PageSummary[] = [
+        createTestSummary("in-note", "In Note", { noteId: "note-A" }),
+      ];
+      const inNoteBacklink = createTestPage(
+        "in-note",
+        "In Note",
+        createPlainTextContent("links here"),
+        { noteId: "note-A" },
+      );
+      // backlinkIds には別ノート ("cross-note") からの参照が含まれているが、
+      // scoped summary には存在しないため除外される。
+      // backlinkIds carries a cross-note id ("cross-note") that does not appear
+      // in the scoped summary, so it falls through.
+      const result = calculateLinkedPagesOptimized({
+        currentPage,
+        pageId: "current",
+        allPagesSummary: scopedSummaries,
+        outgoingPages: [],
+        backlinkPages: [inNoteBacklink],
+        backlinkIds: ["in-note", "cross-note"],
+      });
+
+      expect(result.backlinks).toHaveLength(1);
+      expect(result.backlinks[0]?.id).toBe("in-note");
+    });
+  });
 });

--- a/src/hooks/useLinkedPages.ts
+++ b/src/hooks/useLinkedPages.ts
@@ -400,7 +400,7 @@ export function useLinkedPages(pageId: string, options?: UseLinkedPagesOptions) 
 
       // OPTIMIZED: Get summaries for title matching (no content)
       const allPagesSummary = await repo.getPagesSummary(userId);
-      const backlinkIds = await repo.getBacklinks(pageId);
+      const rawBacklinkIds = await repo.getBacklinks(pageId);
 
       // ノートスコープ：現在のページが属するノート内のページだけを評価対象に
       // する。これにより別ノートの WikiLink は自然にゴーストへ降格し、別ノート
@@ -409,6 +409,20 @@ export function useLinkedPages(pageId: string, options?: UseLinkedPagesOptions) 
       // Cross-note WikiLink targets become ghosts and cross-note backlink IDs
       // fall through during summary lookup.
       const scopedSummary = allPagesSummary.filter((p) => p.noteId === currentPage.noteId);
+
+      // backlink ID は `links` テーブルから note 越境して返るため、scopedSummary
+      // に存在する ID だけに事前フィルタする。これがないと `getPagesByIds` が
+      // 別ノートのページ本体を解決し、`calculateLinkedPagesOptimized` が
+      // 「Page 本体あり」を優先するロジックでクロスノート backlink を昇格させて
+      // しまう（coderabbitai review on PR #915）。
+      // backlink IDs come from the `links` table without a note filter. Without
+      // pre-filtering here, `getPagesByIds` resolves cross-note pages and
+      // `calculateLinkedPagesOptimized` (which prefers full Page over summary)
+      // would surface them. Restrict to ids present in `scopedSummary` so the
+      // backlink scope is enforced before hydration (coderabbitai review on
+      // PR #915).
+      const scopedIds = new Set(scopedSummary.map((p) => p.id));
+      const backlinkIds = rawBacklinkIds.filter((id) => scopedIds.has(id));
 
       // Extract WikiLinks to identify which pages need full content
       const wikiLinks = extractWikiLinksFromContent(currentPage.content);

--- a/src/hooks/useLinkedPages.ts
+++ b/src/hooks/useLinkedPages.ts
@@ -1,8 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { useRepository, usePage, pageKeys } from "./usePageQueries";
+import { useNoteApi } from "./useNoteQueries";
 import { extractWikiLinksFromContent, getUniqueWikiLinkTitles } from "@/lib/wikiLinkUtils";
 import { getContentPreview } from "@/lib/contentUtils";
 import type { Page, PageSummary } from "@/types/page";
+import type { PagePublicLinksResponse, PagePublicLinkCard } from "@/lib/api/types";
 
 /**
  * Card data for linked pages display
@@ -305,20 +307,81 @@ const emptyLinkedPagesData: LinkedPagesData = {
 };
 
 /**
- * Hook to fetch linked pages data for a given page
+ * 公開リンク API レスポンスを `LinkedPagesData` に変換する。2-hop は提供
+ * しないため `outgoingLinksWithChildren` / `twoHopLinks` は空配列で返す。
  *
- * OPTIMIZED:
+ * Adapt the `/public-links` API payload to `LinkedPagesData`. The endpoint
+ * does not surface 2-hop data, so `outgoingLinksWithChildren` and
+ * `twoHopLinks` are returned as empty arrays.
+ */
+function apiToLinkedPagesData(resp: PagePublicLinksResponse): LinkedPagesData {
+  const toCard = (r: PagePublicLinkCard): PageCard => ({
+    id: r.id,
+    noteId: r.note_id,
+    title: r.title ?? "",
+    preview: r.content_preview ?? "",
+    updatedAt: new Date(r.updated_at).getTime(),
+    sourceUrl: r.source_url ?? undefined,
+  });
+  return {
+    outgoingLinks: resp.outgoing_links.map(toCard),
+    outgoingLinksWithChildren: [],
+    backlinks: resp.backlinks.map(toCard),
+    twoHopLinks: [],
+    ghostLinks: resp.ghost_links,
+  };
+}
+
+/**
+ * `useLinkedPages` のオプション。`mode` でデータ取得経路を切り替える。
+ *
+ * - `"repo"` (既定): ログイン編集者向け。IndexedDB の `StorageAdapter`
+ *   から read し、`currentPage.noteId` でクライアントサイドにスコープする。
+ * - `"api"`: 公開ノートを閲覧するゲスト用。`GET /api/pages/:id/public-links`
+ *   を呼び、サーバが返したノートスコープ済みデータを利用する。
+ *
+ * Options for `useLinkedPages`. `mode` selects the data source:
+ *
+ * - `"repo"` (default): for signed-in editors. Reads `StorageAdapter`
+ *   (IndexedDB) and filters by `currentPage.noteId` client-side.
+ * - `"api"`: for guests viewing public/unlisted notes. Calls
+ *   `GET /api/pages/:id/public-links`; the server already enforces the
+ *   note-scope filter and returns ready-to-render cards.
+ */
+export interface UseLinkedPagesOptions {
+  mode?: "repo" | "api";
+}
+
+/**
+ * Hook to fetch linked pages data for a given page.
+ *
+ * OPTIMIZED (mode="repo"):
  * - Uses getPagesSummary() for title matching (no content, reduces Rows Read by ~95%)
  * - Only fetches content for outgoing link pages (needed for 2-hop calculation)
  * - Only fetches content for backlink pages (needed for preview)
+ *
+ * Note-scoped: link graph is restricted to pages within `currentPage.noteId`.
+ * Cross-note WikiLink targets become ghost links; cross-note backlinks are
+ * dropped.
+ *
+ * mode="api": calls `/public-links` so unauthenticated guests can render the
+ * linked pages section. The server returns note-scoped cards and does not
+ * include 2-hop data.
  */
-export function useLinkedPages(pageId: string) {
+export function useLinkedPages(pageId: string, options?: UseLinkedPagesOptions) {
+  const mode = options?.mode ?? "repo";
   const { getRepository, userId, isLoaded } = useRepository();
   const { data: currentPage } = usePage(pageId);
+  const { api } = useNoteApi();
 
   return useQuery({
-    queryKey: [...pageKeys.all, "linkedPages", userId, pageId],
+    queryKey: [...pageKeys.all, "linkedPages", mode, userId, pageId],
     queryFn: async (): Promise<LinkedPagesData> => {
+      if (mode === "api") {
+        const resp = await api.getPagePublicLinks(pageId);
+        return apiToLinkedPagesData(resp);
+      }
+
       if (!currentPage) {
         return emptyLinkedPagesData;
       }
@@ -329,12 +392,20 @@ export function useLinkedPages(pageId: string) {
       const allPagesSummary = await repo.getPagesSummary(userId);
       const backlinkIds = await repo.getBacklinks(pageId);
 
+      // ノートスコープ：現在のページが属するノート内のページだけを評価対象に
+      // する。これにより別ノートの WikiLink は自然にゴーストへ降格し、別ノート
+      // からの backlink は ID 解決に失敗して結果から落ちる。
+      // Note-scoping: restrict the candidate set to pages in the current note.
+      // Cross-note WikiLink targets become ghosts and cross-note backlink IDs
+      // fall through during summary lookup.
+      const scopedSummary = allPagesSummary.filter((p) => p.noteId === currentPage.noteId);
+
       // Extract WikiLinks to identify which pages need full content
       const wikiLinks = extractWikiLinksFromContent(currentPage.content);
       const linkTitles = getUniqueWikiLinkTitles(wikiLinks);
 
-      // Map titles to page IDs
-      const summaryByTitle = new Map(allPagesSummary.map((p) => [p.title.toLowerCase().trim(), p]));
+      // Map titles to page IDs (scoped)
+      const summaryByTitle = new Map(scopedSummary.map((p) => [p.title.toLowerCase().trim(), p]));
 
       // Identify outgoing page IDs (need content for 2-hop calculation)
       const outgoingPageIds: string[] = [];
@@ -354,13 +425,13 @@ export function useLinkedPages(pageId: string) {
       return calculateLinkedPagesOptimized({
         currentPage,
         pageId,
-        allPagesSummary,
+        allPagesSummary: scopedSummary,
         outgoingPages,
         backlinkPages,
         backlinkIds,
       });
     },
-    enabled: isLoaded && !!pageId && !!currentPage,
+    enabled: mode === "api" ? !!pageId : isLoaded && !!pageId && !!currentPage,
     staleTime: 1000 * 30, // 30 seconds
   });
 }

--- a/src/hooks/useLinkedPages.ts
+++ b/src/hooks/useLinkedPages.ts
@@ -310,9 +310,19 @@ const emptyLinkedPagesData: LinkedPagesData = {
  * 公開リンク API レスポンスを `LinkedPagesData` に変換する。2-hop は提供
  * しないため `outgoingLinksWithChildren` / `twoHopLinks` は空配列で返す。
  *
+ * 表示上限は `calculateLinkedPagesOptimized` と揃え、repo モード（IndexedDB
+ * 経路）と UI 上のカード枚数が一致するようにする：outgoing / backlinks は
+ * それぞれ 10 件、ghost は 5 件まで。サーバは既に 50 件で打ち切るが、
+ * クライアント側でも明示的に slice する。
+ *
  * Adapt the `/public-links` API payload to `LinkedPagesData`. The endpoint
  * does not surface 2-hop data, so `outgoingLinksWithChildren` and
  * `twoHopLinks` are returned as empty arrays.
+ *
+ * Display caps mirror `calculateLinkedPagesOptimized` so the repo-mode and
+ * api-mode UIs render the same number of cards: outgoing / backlinks cap at
+ * 10, ghosts at 5. The server already truncates at 50; the client repeats
+ * the slice explicitly so the limit is documented at both layers.
  */
 function apiToLinkedPagesData(resp: PagePublicLinksResponse): LinkedPagesData {
   const toCard = (r: PagePublicLinkCard): PageCard => ({
@@ -324,11 +334,11 @@ function apiToLinkedPagesData(resp: PagePublicLinksResponse): LinkedPagesData {
     sourceUrl: r.source_url ?? undefined,
   });
   return {
-    outgoingLinks: resp.outgoing_links.map(toCard),
+    outgoingLinks: resp.outgoing_links.slice(0, 10).map(toCard),
     outgoingLinksWithChildren: [],
-    backlinks: resp.backlinks.map(toCard),
+    backlinks: resp.backlinks.slice(0, 10).map(toCard),
     twoHopLinks: [],
-    ghostLinks: resp.ghost_links,
+    ghostLinks: resp.ghost_links.slice(0, 5),
   };
 }
 

--- a/src/lib/api/apiClient.test.ts
+++ b/src/lib/api/apiClient.test.ts
@@ -649,6 +649,38 @@ describe("apiClient", () => {
       const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
       expect(init.method).toBe("DELETE");
     });
+
+    it("getPagePublicLinks sends GET to /api/pages/:id/public-links and returns the payload", async () => {
+      const payload = {
+        outgoing_links: [
+          {
+            id: "out-1",
+            note_id: "note-1",
+            title: "Out",
+            content_preview: "p",
+            updated_at: "2026-05-19T00:00:00.000Z",
+            source_url: null,
+          },
+        ],
+        backlinks: [],
+        ghost_links: ["Missing"],
+      };
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify(payload)),
+        headers: new Headers(),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = createApiClient({ baseUrl: "https://api.test.example.com" });
+      const result = await client.getPagePublicLinks("page-1");
+
+      expect(result).toEqual(payload);
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.test.example.com/api/pages/page-1/public-links");
+      expect(init.method).toBe("GET");
+    });
   });
 
   // ── getNoteWithCache (ETag / 304, Issue #853) ────────────────────────

--- a/src/lib/api/apiClient.ts
+++ b/src/lib/api/apiClient.ts
@@ -8,6 +8,7 @@ import type {
   PostSyncPagesBody,
   PostSyncPagesResponse,
   PagePublicContentResponse,
+  PagePublicLinksResponse,
   UpdatePageMetadataBody,
   UpdatePageMetadataResponse,
   CreatePageBody,
@@ -351,6 +352,24 @@ export function createApiClient(options?: Partial<ApiClientOptions>) {
       return reqOptionalAuth<PagePublicContentResponse>(
         "GET",
         `/api/pages/${encodeURIComponent(pageId)}/public-content`,
+      );
+    },
+
+    /**
+     * `GET /api/pages/:id/public-links` — ノート内スコープのリンクグラフを取得する。
+     * 公開ノート閲覧ゲストでも `LinkedPagesSection` を描画するため、IndexedDB を
+     * 持たないクライアントのためにサーバが計算結果を返す。2-hop は含まない。
+     *
+     * `GET /api/pages/:id/public-links` returns the note-scoped link graph
+     * (outgoing wiki edges, backlinks, ghost-link titles) so the
+     * `LinkedPagesSection` can render for guests on public/unlisted notes
+     * without an IndexedDB store. 2-hop (`outgoingLinksWithChildren`) is not
+     * included by design.
+     */
+    async getPagePublicLinks(pageId: string): Promise<PagePublicLinksResponse> {
+      return reqOptionalAuth<PagePublicLinksResponse>(
+        "GET",
+        `/api/pages/${encodeURIComponent(pageId)}/public-links`,
       );
     },
 

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -149,6 +149,38 @@ export interface PagePublicContentResponse {
   updated_at: string;
 }
 
+/**
+ * `GET /api/pages/:id/public-links` で返される 1 件分のリンク先（または発信元）。
+ * `LinkedPagesSection` の `PageCard` を直接組み立てるためのフィールドのみ含む。
+ *
+ * Shape of a single linked / backlinking page returned by
+ * `GET /api/pages/:id/public-links`. Contains exactly the fields required to
+ * construct a `PageCard` for `LinkedPagesSection`.
+ */
+export interface PagePublicLinkCard {
+  id: string;
+  note_id: string;
+  title: string | null;
+  content_preview: string | null;
+  updated_at: string;
+  source_url: string | null;
+}
+
+/**
+ * `GET /api/pages/:id/public-links` レスポンス。ノート内スコープで解決済みの
+ * `outgoing_links` / `backlinks` と、未解決リンクのタイトル文字列 `ghost_links`
+ * を返す。2-hop（`outgoingLinksWithChildren`）は意図的に含めない。
+ *
+ * `GET /api/pages/:id/public-links` response. Returns the note-scoped resolved
+ * `outgoing_links` and `backlinks` plus unresolved-link titles (`ghost_links`).
+ * 2-hop data (`outgoingLinksWithChildren`) is intentionally omitted.
+ */
+export interface PagePublicLinksResponse {
+  outgoing_links: PagePublicLinkCard[];
+  backlinks: PagePublicLinkCard[];
+  ghost_links: string[];
+}
+
 /** POST /api/pages body. */
 export interface CreatePageBody {
   id?: string;

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -462,7 +462,6 @@ function NotePageEditorEditable({
           isNewPage={false}
           isWikiGenerating={false}
           isReadOnly={false}
-          showLinkedPages={false}
           showToolbar
           onContentChange={setEditorContent}
           onContentError={() => undefined}

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -462,6 +462,20 @@ function NotePageEditorEditable({
           isNewPage={false}
           isWikiGenerating={false}
           isReadOnly={false}
+          // ノートネイティブページは IndexedDB に永続化されない（個人ページ
+          // しか同期しない）ため、`linkedPagesMode="repo"` だと `usePage` が
+          // null を返し `LinkedPagesSection` が常時空になる。サーバの
+          // `/public-links` 経路は `authOptional` + `getNoteRole` で
+          // owner/editor/viewer もハンドリングするので、認証済みでも API モード
+          // で取得する（codex review on PR #915）。
+          //
+          // Note-native pages are not persisted to IndexedDB (only personal
+          // pages sync there), so `linkedPagesMode="repo"` would always end
+          // up with `usePage` returning null and the section empty. The
+          // `/public-links` endpoint is `authOptional` + `getNoteRole`, so it
+          // serves authenticated owner/editor/viewer flows just as well as
+          // guests (codex review on PR #915).
+          linkedPagesMode="api"
           showToolbar
           onContentChange={setEditorContent}
           onContentError={() => undefined}


### PR DESCRIPTION
issue #889 で `/notes/:noteId/:pageId` に統合した際 `NotePageView` で
`showLinkedPages={false}` が残り、編集ビューでも非表示になっていた。
さらに「リンクの範囲をノート内に限定する」「公開ノートのゲストにも
リンク一覧を見せる」要望に沿って以下を実装:

- `showLinkedPages` プロップを撤去し常時描画に変更。
- `useLinkedPages` で `currentPage.noteId` フィルタを適用してノート内
  スコープを実現。クロスノートの wiki link は自然にゴースト降格。
- 新規 `GET /api/pages/:id/public-links` を追加。`authOptional` +
  `getNoteRole` + `pages.note_id` JOIN でスコープを強制。2-hop は除外。
- `useLinkedPages` に `mode: "repo" | "api"` を追加し、
  `NotePagePublicView` は `linkedPagesMode="api"` で公開 API を使う。
- リンク一覧コンポーネントは `mode="api"` でゴーストカードを非表示
  (新規ページ作成 mutation が認証必須のため)。
- lint 提案 UI に `isSignedIn` ガードを追加し、ゲストでは描画と
  認証必須 API 呼び出しを抑止。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public linked-pages API for guests to fetch outgoing links, backlinks, and ghost links for public notes
  * Guest view now displays linked-pages via the public API

* **Improvements**
  * Guest responses use short edge caching (public, max-age=60)
  * Cross-note references are treated as ghost links (excluded from backlinks)
  * Result sets capped at 50 items per category
  * Lint suggestions hidden for unauthenticated users

* **Tests**
  * Added coverage for public-links API, guest rendering, and note-scoped link behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->