### PR TITLE
fix(review): apply PR #917 review feedback

### DIFF
--- a/packages/ui/src/components/calendar.tsx
+++ b/packages/ui/src/components/calendar.tsx
@@ -17,7 +17,7 @@ export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 /**
  * Themed wrapper around react-day-picker `DayPicker`.
  *
- * Uses the v9/v10 `classNames` keys (e.g. `month_caption`, `button_previous`,
+ * Uses the v10 `classNames` keys (e.g. `month_caption`, `button_previous`,
  * `day_button`, `selected`, `today`). When upgrading react-day-picker, check
  * `UI` / `SelectionState` / `DayFlag` enums in the package types.
  *
@@ -33,7 +33,6 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         month: "space-y-4",
         month_caption: "flex justify-center pt-1 relative items-center",
         caption_label: "text-sm font-medium",
-        nav: "flex items-center",
         button_previous: cn(
           buttonVariants({ variant: "outline" }),
           "absolute left-1 h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",

--- a/src/components/note/PageEditorContent.tsx
+++ b/src/components/note/PageEditorContent.tsx
@@ -227,12 +227,19 @@ export const PageEditorContent: React.FC<PageEditorContentProps> = ({
           )}
         </div>
 
-        {/* Linked Pages Section */}
+        {/* Linked Pages Section
+            ゴーストリンクは編集可能なときだけ表示する。`isEditorReadOnly` は
+            読み取り専用ページ（公開ゲスト閲覧や Wiki 生成中）で true になるため、
+            それらの経路では `useCreatePage` mutation を呼び得ない UI を出さない。
+            Ghost links render only while the editor is writable. `isEditorReadOnly`
+            covers guest public views and Wiki generation, both of which must not
+            expose the authenticated `useCreatePage` mutation. */}
         {currentPageId && (
           <LinkedPagesSection
             pageId={currentPageId}
             isSyncingLinks={isSyncingLinks}
             mode={linkedPagesMode}
+            showGhostLinks={!isEditorReadOnly}
           />
         )}
 

--- a/src/components/page/LinkedPagesSection.test.tsx
+++ b/src/components/page/LinkedPagesSection.test.tsx
@@ -324,4 +324,44 @@ describe("LinkedPagesSection", () => {
       expect(container.firstChild).toBeNull();
     });
   });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // `showGhostLinks` は `mode` と独立してゴーストリンクの可視性を制御する。
+  // ノートネイティブページ（IndexedDB に永続化されない）を編集する場合は
+  // `mode="api"` + `showGhostLinks=true` を渡すことで認証済み編集者にも
+  // ゴーストリンクを提示できる。
+  //
+  // `showGhostLinks` controls ghost-link visibility independently of `mode`.
+  // Authenticated editors of note-native pages (not persisted in IndexedDB)
+  // pass `mode="api"` + `showGhostLinks=true` to keep ghost links available.
+  // ──────────────────────────────────────────────────────────────────────
+  describe("showGhostLinks prop", () => {
+    it("renders ghost links in api mode when showGhostLinks is true", () => {
+      mockLinkedPagesData.ghostLinks = ["NotYetCreated"];
+
+      const queryClient = createTestQueryClient();
+      render(
+        <TestWrapper queryClient={queryClient}>
+          <LinkedPagesSection pageId="test-page-id" mode="api" showGhostLinks />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText("新しいリンク (1)")).toBeInTheDocument();
+      expect(screen.getByText("NotYetCreated")).toBeInTheDocument();
+    });
+
+    it("hides ghost links in repo mode when showGhostLinks is false", () => {
+      mockLinkedPagesData.ghostLinks = ["NotYetCreated"];
+
+      const queryClient = createTestQueryClient();
+      render(
+        <TestWrapper queryClient={queryClient}>
+          <LinkedPagesSection pageId="test-page-id" showGhostLinks={false} />
+        </TestWrapper>,
+      );
+
+      expect(screen.queryByText("新しいリンク (1)")).not.toBeInTheDocument();
+      expect(screen.queryByText("NotYetCreated")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/page/LinkedPagesSection.tsx
+++ b/src/components/page/LinkedPagesSection.tsx
@@ -14,13 +14,25 @@ interface LinkedPagesSectionProps {
   /**
    * データ取得経路。`"repo"`（既定）は IndexedDB から、`"api"` は
    * `GET /api/pages/:id/public-links` 経由で取得する。
-   * `"api"` ではゴーストリンク（新規ページ作成 UI）を非表示にする。
    *
    * Data source. `"repo"` (default) reads IndexedDB; `"api"` calls
-   * `GET /api/pages/:id/public-links`. Ghost links (which trigger
-   * authenticated page creation) are hidden in `"api"` mode.
+   * `GET /api/pages/:id/public-links`.
    */
   mode?: "repo" | "api";
+  /**
+   * ゴーストリンク（新規ページ作成 UI）を表示するかどうか。
+   * 既定では `mode === "repo"` のときのみ表示する（後方互換）。
+   * 認証済み編集者が `mode="api"` を使うケース（ノートネイティブページ等）では
+   * 明示的に `true` を渡すことでゴーストリンクを表示できる。逆にゲストには
+   * `false` を渡して `useCreatePage` mutation 失敗を防ぐ。
+   *
+   * Whether to render ghost links (new-page-creation UI). Defaults to
+   * `mode === "repo"` for backward compatibility. Authenticated editors using
+   * `mode="api"` (e.g. note-native pages) can opt into ghost links by passing
+   * `true`. Guest views must pass `false` to avoid triggering the
+   * authenticated `useCreatePage` mutation.
+   */
+  showGhostLinks?: boolean;
 }
 
 function LinkedPagesSkeleton() {
@@ -44,9 +56,11 @@ function LinkedPagesSkeleton() {
  * outgoing WikiLink・backlink・ゴーストリンクを描画する。
  *
  * - `mode="repo"` (既定): IndexedDB から取得し 2-hop も表示する。編集者向け。
- * - `mode="api"`: `GET /api/pages/:id/public-links` から取得し、ゴーストカードを
- *   非表示にする (新規ページ作成 mutation が認証必須のため)。公開ノートを
- *   ゲストが閲覧する `NotePagePublicView` から呼ばれる経路。
+ * - `mode="api"`: `GET /api/pages/:id/public-links` から取得する。公開ノートを
+ *   ゲストが閲覧する `NotePagePublicView` や、IndexedDB に永続化されない
+ *   ノートネイティブページの編集者からも呼ばれる経路。
+ * - `showGhostLinks`: ゴーストリンクの表示可否。既定は `mode === "repo"`。
+ *   認証済み編集者が `mode="api"` を使う場合は `true` を渡せば表示できる。
  * - `isSyncingLinks=true` の間は skeleton を返す。
  *
  * Renders the linked-pages section below the page body, listing same-note
@@ -54,9 +68,12 @@ function LinkedPagesSkeleton() {
  *
  * - `mode="repo"` (default): reads from IndexedDB and includes 2-hop content
  *   (editor flow).
- * - `mode="api"`: reads from `GET /api/pages/:id/public-links` and hides ghost
- *   cards (page-creation requires auth). Used by `NotePagePublicView` for
- *   guests on public / unlisted notes.
+ * - `mode="api"`: reads from `GET /api/pages/:id/public-links`. Used by
+ *   `NotePagePublicView` for guests and by editors of note-native pages
+ *   that are not persisted to IndexedDB.
+ * - `showGhostLinks`: gates the ghost-link UI. Defaults to `mode === "repo"`.
+ *   Authenticated editors using `mode="api"` can pass `true` to keep ghost
+ *   cards visible.
  * - While `isSyncingLinks=true`, a skeleton is rendered instead.
  *
  * @see {@link LinkedPagesSectionProps}
@@ -65,6 +82,7 @@ export function LinkedPagesSection({
   pageId,
   isSyncingLinks = false,
   mode = "repo",
+  showGhostLinks = mode === "repo",
 }: LinkedPagesSectionProps) {
   const { t } = useTranslation();
   /**
@@ -97,10 +115,11 @@ export function LinkedPagesSection({
    */
   const allLinks = [...outgoingLinks, ...backlinks];
 
-  // api モードではゴーストリンクを非表示にするため、表示判定からも除外する。
-  // In api mode ghost links are hidden, so they should not keep the section
-  // from collapsing into nothing.
-  const ghostLinksVisible = mode === "repo" && ghostLinks.length > 0;
+  // `showGhostLinks` で抑止されている場合は、その存在をセクション全体の
+  // 表示判定からも除外する（ゴーストだけのとき空セクションが残らないように）。
+  // When ghost links are gated off via `showGhostLinks`, exclude them from
+  // the overall visibility check so the section can collapse cleanly.
+  const ghostLinksVisible = showGhostLinks && ghostLinks.length > 0;
 
   /**
    *
@@ -161,11 +180,11 @@ export function LinkedPagesSection({
         />
       )}
 
-      {/* Ghost Links (renamed to 新しいリンク) — repo モードのみ表示。
-          api モードはゲスト向けで `useCreatePage` mutation が失敗するため抑止。
-          Ghost Links — shown only in repo mode. Suppressed under api mode
-          because the `useCreatePage` mutation requires an authenticated user. */}
-      {mode === "repo" && ghostLinks.length > 0 && (
+      {/* Ghost Links (renamed to 新しいリンク) — `showGhostLinks` で制御。
+          ゲスト経路では `useCreatePage` mutation が失敗するため抑止する。
+          Ghost Links — gated by `showGhostLinks`. Guest paths must keep it
+          false because the `useCreatePage` mutation requires authentication. */}
+      {showGhostLinks && ghostLinks.length > 0 && (
         <div className="space-y-3">
           <div className="text-muted-foreground flex items-center gap-2 text-sm font-medium">
             <FilePlus className="h-4 w-4" />


### PR DESCRIPTION
## Summary

PR #917 のレビューコメントに対応する修正。develop に直接 push できないためこの PR 経由でマージする。

### 修正内容

**Gemini Code Assist (high)** — `LinkedPagesSection` / `PageEditorContent`
- `LinkedPagesSection` に `showGhostLinks?: boolean` prop を追加し、`mode` と独立してゴーストリンクの可視性を制御できるようにした。既定は `mode === "repo"` で後方互換。
- `PageEditorContent` から `showGhostLinks={!isEditorReadOnly}` を渡す。`NotePageView` がノートネイティブページで `linkedPagesMode="api"` を使う場合でも、認証済み編集者にはゴーストリンク（新規ページ作成 UI）が出続けるよう退行を解消。
- ゲスト閲覧 (`NotePagePublicView` は `isReadOnly`) や Wiki 生成中は引き続き抑止される。

**CodeRabbit (critical)** — `packages/ui/src/components/calendar.tsx`
- react-day-picker v10 で無効になった `nav` className キーを削除（v9 互換キーで型エラーの原因になり得る）。
- ヘッダコメントを「v9/v10」→「v10」に修正し、現状に合わせた表現にした。

**テスト**
- `LinkedPagesSection.test.tsx` に `showGhostLinks` の override 挙動 (`mode="api"` + `showGhostLinks=true`、`mode="repo"` + `showGhostLinks=false`) を追加。

## Test plan

- [x] `bunx vitest run src/components/page/LinkedPagesSection.test.tsx` → 13 件 pass
- [x] `bunx vitest run src/components/note/NotePagePublicView` → 7 件 pass
- [x] `packages/ui` の vitest スイート → 30 件 pass
- [x] `bun run lint` → 既存警告のみ、エラー 0
- [x] `bun run format:check` → OK


---
_Generated by [Claude Code](https://claude.ai/code/session_011UCEvYNNKDyEwXBbYdEAdx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ghost links (suggested page connections) are now properly hidden in read-only editor modes such as public guest views and wiki generation, preventing exposure of authenticated page-creation operations in restricted contexts.

* **Documentation & Improvements**
  * Enhanced linked pages visibility controls with conditional ghost-link display. Updated calendar component documentation for classNames targeting and styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->