### PR TITLE
feat: Add client-side PDF export via html2pdf.js

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,7 @@
         "dompurify": "^3.3.3",
         "embla-carousel-react": "^8.6.0",
         "highlight.js": "^11.11.1",
+        "html2pdf.js": "^0.14.0",
         "i18next": "^26.0.1",
         "i18next-browser-languagedetector": "^8.2.1",
         "idb-keyval": "^6.2.2",
@@ -1425,7 +1426,11 @@
 
     "@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
+    "@types/pako": ["@types/pako@2.0.4", "", {}, "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw=="],
+
     "@types/pg": ["@types/pg@8.18.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q=="],
+
+    "@types/raf": ["@types/raf@3.4.3", "", {}, "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -1559,6 +1564,8 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
+
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
@@ -1604,6 +1611,8 @@
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001769", "", {}, "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg=="],
+
+    "canvg": ["canvg@3.0.11", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@types/raf": "^3.4.0", "core-js": "^3.8.3", "raf": "^3.4.1", "regenerator-runtime": "^0.13.7", "rgbcolor": "^1.0.1", "stackblur-canvas": "^2.0.0", "svg-pathdata": "^6.0.3" } }, "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -1671,6 +1680,8 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
@@ -1686,6 +1697,8 @@
     "cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css-line-break": ["css-line-break@2.1.0", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
@@ -1949,6 +1962,8 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-png": ["fast-png@6.4.0", "", { "dependencies": { "@types/pako": "^2.0.3", "iobuffer": "^5.3.2", "pako": "^2.1.0" } }, "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q=="],
+
     "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
@@ -1966,6 +1981,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
@@ -2093,6 +2110,10 @@
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
+    "html2canvas": ["html2canvas@1.4.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA=="],
+
+    "html2pdf.js": ["html2pdf.js@0.14.0", "", { "dependencies": { "dompurify": "^3.3.1", "html2canvas": "^1.0.0", "jspdf": "^4.0.0" } }, "sha512-yvNJgE/8yru2UeGflkPdjW8YEY+nDH5X7/2WG4uiuSCwYiCp8PZ8EKNiTAa6HxJ1NjC51fZSIEq6xld5CADKBQ=="],
+
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
@@ -2130,6 +2151,8 @@
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "iobuffer": ["iobuffer@5.4.0", "", {}, "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
@@ -2266,6 +2289,8 @@
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jspdf": ["jspdf@4.2.1", "", { "dependencies": { "@babel/runtime": "^7.28.6", "fast-png": "^6.2.0", "fflate": "^0.8.1" }, "optionalDependencies": { "canvg": "^3.0.11", "core-js": "^3.6.0", "dompurify": "^3.3.1", "html2canvas": "^1.0.0-rc.5" } }, "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
@@ -2573,6 +2598,8 @@
 
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
+    "pako": ["pako@2.1.0", "", {}, "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="],
+
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
@@ -2604,6 +2631,8 @@
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pdfjs-dist": ["pdfjs-dist@5.7.284", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.100" } }, "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw=="],
+
+    "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 
     "pg": ["pg@8.19.0", "", { "dependencies": { "pg-connection-string": "^2.11.0", "pg-pool": "^3.12.0", "pg-protocol": "^1.12.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-QIcLGi508BAHkQ3pJNptsFz5WQMlpGbuBGBaIaXsWK8mel2kQ/rThYI+DbgjUvZrIr7MiuEuc9LcChJoEZK1xQ=="],
 
@@ -2731,6 +2760,8 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "raf": ["raf@3.4.1", "", { "dependencies": { "performance-now": "^2.1.0" } }, "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA=="],
+
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
@@ -2806,6 +2837,8 @@
     "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "reusify": ["reusify@1.0.4", "", {}, "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="],
+
+    "rgbcolor": ["rgbcolor@1.0.1", "", {}, "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw=="],
 
     "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
@@ -2901,6 +2934,8 @@
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
+    "stackblur-canvas": ["stackblur-canvas@2.7.0", "", {}, "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ=="],
+
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
@@ -2947,6 +2982,8 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "svg-pathdata": ["svg-pathdata@6.0.3", "", {}, "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw=="],
+
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
@@ -2960,6 +2997,8 @@
     "tesseract.js": ["tesseract.js@7.0.0", "", { "dependencies": { "bmp-js": "^0.1.0", "idb-keyval": "^6.2.0", "is-url": "^1.2.4", "node-fetch": "^2.6.9", "opencollective-postinstall": "^2.0.3", "regenerator-runtime": "^0.13.3", "tesseract.js-core": "^7.0.0", "wasm-feature-detect": "^1.8.0", "zlibjs": "^0.3.1" } }, "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA=="],
 
     "tesseract.js-core": ["tesseract.js-core@7.0.0", "", {}, "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw=="],
+
+    "text-segmentation": ["text-segmentation@1.0.3", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -3074,6 +3113,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "utrie": ["utrie@1.0.2", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" } }, "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw=="],
 
     "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
@@ -3403,6 +3444,8 @@
 
     "bun-types/@types/node": ["@types/node@22.16.5", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ=="],
 
+    "canvg/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "cmdk/@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.14", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.10", "@radix-ui/react-focus-guards": "1.1.2", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.4", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw=="],
@@ -3462,6 +3505,8 @@
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "jsdom/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "jspdf/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "dompurify": "^3.3.3",
     "embla-carousel-react": "^8.6.0",
     "highlight.js": "^11.11.1",
+    "html2pdf.js": "^0.14.0",
     "i18next": "^26.0.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "idb-keyval": "^6.2.2",

--- a/src/components/editor/PageEditor/usePdfExport.test.tsx
+++ b/src/components/editor/PageEditor/usePdfExport.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const { mockDownloadPdf, mockToast } = vi.hoisted(() => ({
+  mockDownloadPdf: vi.fn(),
+  mockToast: vi.fn(),
+}));
+
+vi.mock("@/lib/tiptapToHtml", () => ({
+  downloadPdf: (...args: unknown[]) => mockDownloadPdf(...args),
+}));
+
+vi.mock("@zedi/ui", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => {
+      if (typeof fallback === "string") return fallback;
+      return key;
+    },
+  }),
+}));
+
+import { usePdfExport } from "./usePdfExport";
+
+function HookHarness({
+  title,
+  content,
+  sourceUrl,
+}: {
+  title: string;
+  content: string;
+  sourceUrl?: string | null;
+}) {
+  const { handleExportPdf } = usePdfExport(title, content, sourceUrl ?? null);
+  return (
+    <button type="button" onClick={handleExportPdf}>
+      export
+    </button>
+  );
+}
+
+describe("usePdfExport", () => {
+  beforeEach(() => {
+    mockDownloadPdf.mockReset();
+    mockToast.mockReset();
+  });
+
+  it("delegates to downloadPdf with title / content / sourceUrl and i18n options", async () => {
+    mockDownloadPdf.mockResolvedValueOnce(undefined);
+    render(<HookHarness title="My Page" content="{}" sourceUrl="https://example.com/article" />);
+
+    fireEvent.click(screen.getByText("export"));
+
+    await waitFor(() => {
+      expect(mockDownloadPdf).toHaveBeenCalledTimes(1);
+    });
+    const [title, content, sourceUrl, options] = mockDownloadPdf.mock.calls[0] ?? [];
+    expect(title).toBe("My Page");
+    expect(content).toBe("{}");
+    expect(sourceUrl).toBe("https://example.com/article");
+    expect(options).toMatchObject({
+      defaultTitle: "notes.untitledPage",
+      attributionLabel: "editor.pdfExport.sourceAttribution",
+    });
+  });
+
+  it("fires the success toast after downloadPdf resolves", async () => {
+    mockDownloadPdf.mockResolvedValueOnce(undefined);
+    render(<HookHarness title="t" content="c" sourceUrl={null} />);
+
+    fireEvent.click(screen.getByText("export"));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({
+        title: "editor.pdfExport.downloaded",
+      });
+    });
+  });
+
+  it("fires a destructive toast when downloadPdf rejects", async () => {
+    mockDownloadPdf.mockRejectedValueOnce(new Error("boom"));
+    render(<HookHarness title="t" content="c" sourceUrl={null} />);
+
+    fireEvent.click(screen.getByText("export"));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({
+        title: "editor.pdfExport.failed",
+        variant: "destructive",
+      });
+    });
+  });
+});

--- a/src/components/editor/PageEditor/usePdfExport.ts
+++ b/src/components/editor/PageEditor/usePdfExport.ts
@@ -1,0 +1,48 @@
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useToast } from "@zedi/ui";
+import { downloadPdf } from "@/lib/tiptapToHtml";
+
+/**
+ * `usePdfExport` の戻り値。Markdown エクスポート系フックと同じ形でハンドラだけを返す。
+ * Return type of {@link usePdfExport}. Matches the shape of the Markdown export
+ * hooks (handlers only) so menu wiring stays symmetric.
+ */
+interface UsePdfExportReturn {
+  handleExportPdf: () => Promise<void>;
+}
+
+/**
+ * ページエディタの「PDFで出力」アクションを駆動するフック。クライアント側で
+ * Tiptap JSON を HTML 化し、html2pdf.js で PDF をダウンロードする。成功 /
+ * 失敗時にはトーストを発火する。
+ *
+ * Hook that drives the page editor's "Export PDF" action. Converts Tiptap
+ * JSON to HTML in the browser and triggers an html2pdf.js download. Emits a
+ * success or destructive toast depending on the outcome.
+ */
+export function usePdfExport(
+  title: string,
+  content: string,
+  sourceUrl?: string | null,
+): UsePdfExportReturn {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+
+  const handleExportPdf = useCallback(async () => {
+    try {
+      await downloadPdf(title, content, sourceUrl, {
+        defaultTitle: t("notes.untitledPage"),
+        attributionLabel: t("editor.pdfExport.sourceAttribution"),
+      });
+      toast({ title: t("editor.pdfExport.downloaded") });
+    } catch {
+      toast({
+        title: t("editor.pdfExport.failed"),
+        variant: "destructive",
+      });
+    }
+  }, [title, content, sourceUrl, toast, t]);
+
+  return { handleExportPdf };
+}

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -6,6 +6,7 @@
   "collaborationLoading": "Loading editor",
   "pageMenu": {
     "exportMarkdown": "Export Markdown",
+    "exportPdf": "Export as PDF",
     "copyMarkdown": "Copy Markdown",
     "deletePage": "Delete"
   },
@@ -317,5 +318,10 @@
     "downloaded": "Markdown file downloaded",
     "copied": "Markdown copied to clipboard",
     "copyFailed": "Copy failed"
+  },
+  "pdfExport": {
+    "sourceAttribution": "📎 Source",
+    "downloaded": "PDF downloaded",
+    "failed": "Failed to generate PDF"
   }
 }

--- a/src/i18n/locales/ja/editor.json
+++ b/src/i18n/locales/ja/editor.json
@@ -6,6 +6,7 @@
   "collaborationLoading": "エディタを読み込み中",
   "pageMenu": {
     "exportMarkdown": "Markdownでエクスポート",
+    "exportPdf": "PDFで出力",
     "copyMarkdown": "Markdownをコピー",
     "deletePage": "削除"
   },
@@ -317,5 +318,10 @@
     "downloaded": "Markdownファイルをダウンロードしました",
     "copied": "Markdownをクリップボードにコピーしました",
     "copyFailed": "コピーに失敗しました"
+  },
+  "pdfExport": {
+    "sourceAttribution": "📎 引用元",
+    "downloaded": "PDFをダウンロードしました",
+    "failed": "PDFの生成に失敗しました"
   }
 }

--- a/src/lib/markdownExport.ts
+++ b/src/lib/markdownExport.ts
@@ -239,10 +239,13 @@ export function downloadMarkdown(
 }
 
 /**
- * Sanitize filename for safe file system usage
+ * ダウンロードファイル名で使えない文字を `_` に置換し、長さを 100 文字に制限する。
+ * Markdown / PDF 等エクスポート系コード間で共有する純粋関数。
+ *
+ * Replace characters that are invalid in filenames with `_` and clamp the
+ * length to 100 chars. Shared across export utilities (Markdown / PDF).
  */
-function sanitizeFilename(name: string): string {
-  // Remove or replace characters that are invalid in filenames
+export function sanitizeFilename(name: string): string {
   return name
     .replace(/[<>:"/\\|?*]/g, "_")
     .replace(/\s+/g, "_")

--- a/src/lib/tiptapToHtml.test.ts
+++ b/src/lib/tiptapToHtml.test.ts
@@ -233,11 +233,47 @@ describe("tiptapToHtml", () => {
     );
   });
 
-  it("returns plain-text fallback when content is not valid JSON", () => {
-    expect(tiptapToHtml("just text")).toContain("just text");
+  it("wraps non-JSON plain text in a single <p>", () => {
+    expect(tiptapToHtml("just text")).toBe("<p>just text</p>");
+  });
+
+  // PR #921 codex P1: 読み取り専用パスは Hocuspocus の `extractTextFromYXml`
+  // で抽出したプレーンテキスト（ブロック間に `\n`）を渡してくる。空行で
+  // 区切られた段落を `<p>` ブロックに、単独の `\n` を `<br />` に落とす。
+  //
+  // PR #921 codex P1: the read-only path feeds plain text whose blocks are
+  // separated by `\n` (and sometimes `\n\n`). Blank-line runs delimit `<p>`
+  // paragraphs; single `\n` becomes `<br />` to preserve line structure.
+  it("preserves paragraph and line-break structure for plain-text fallback", () => {
+    const text = "First paragraph\nstill first.\n\nSecond paragraph.\n\n\nThird paragraph.";
+    expect(tiptapToHtml(text)).toBe(
+      "<p>First paragraph<br />still first.</p><p>Second paragraph.</p><p>Third paragraph.</p>",
+    );
+  });
+
+  it("escapes HTML metacharacters in the plain-text fallback", () => {
+    expect(tiptapToHtml("<script>")).toBe("<p>&lt;script&gt;</p>");
+  });
+
+  it("normalises CRLF line endings in the plain-text fallback", () => {
+    expect(tiptapToHtml("a\r\n\r\nb")).toBe("<p>a</p><p>b</p>");
   });
 
   it("renders an empty string for empty input", () => {
     expect(tiptapToHtml("")).toBe("");
+  });
+
+  it("treats whitespace-only input as empty in the plain-text fallback", () => {
+    expect(tiptapToHtml("\n\n\n")).toBe("");
+  });
+
+  // PR #921 gemini-code-assist high: 相対 URL 内のドットを許可する。
+  // PR #921 gemini-code-assist high: dotted relative URLs must be allowed.
+  it("keeps dotted relative image paths through sanitizeUrl", () => {
+    const json = JSON.stringify({
+      type: "doc",
+      content: [{ type: "image", attrs: { src: "image.png", alt: "x" } }],
+    });
+    expect(tiptapToHtml(json)).toContain('src="image.png"');
   });
 });

--- a/src/lib/tiptapToHtml.test.ts
+++ b/src/lib/tiptapToHtml.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+import { tiptapToHtml } from "./tiptapToHtml";
+
+describe("tiptapToHtml", () => {
+  it("converts a paragraph node to a <p> block", () => {
+    const json = JSON.stringify({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "Hello world" }] }],
+    });
+    expect(tiptapToHtml(json)).toBe("<p>Hello world</p>");
+  });
+
+  it("converts body headings (levels 2–5) to matching h2–h5 tags", () => {
+    const json = JSON.stringify({
+      type: "doc",
+      content: [
+        { type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "H2" }] },
+        { type: "heading", attrs: { level: 3 }, content: [{ type: "text", text: "H3" }] },
+        { type: "heading", attrs: { level: 4 }, content: [{ type: "text", text: "H4" }] },
+        { type: "heading", attrs: { level: 5 }, content: [{ type: "text", text: "H5" }] },
+      ],
+    });
+    const html = tiptapToHtml(json);
+    expect(html).toContain("<h2>H2</h2>");
+    expect(html).toContain("<h3>H3</h3>");
+    expect(html).toContain("<h4>H4</h4>");
+    expect(html).toContain("<h5>H5</h5>");
+  });
+
+  // 旧データに残っている level 1 / 欠損 level は最小の本文見出し `h2` にフォールバックさせる。
+  // Legacy heading nodes with level 1 (or a missing level attribute) fall back to `h2`.
+  it("falls back to <h2> when heading level is missing or below 2", () => {
+    const json = JSON.stringify({
+      type: "doc",
+      content: [
+        { type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "Legacy" }] },
+        { type: "heading", content: [{ type: "text", text: "NoLevel" }] },
+      ],
+    });
+    const html = tiptapToHtml(json);
+    expect(html).toContain("<h2>Legacy</h2>");
+    expect(html).toContain("<h2>NoLevel</h2>");
+    expect(html).not.toContain("<h1>");
+  });
+
+  it("converts bullet and ordered lists, including nested lists", () => {
+    const json = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                { type: "paragraph", content: [{ type: "text", text: "A" }] },
+                {
+                  type: "bulletList",
+                  content: [
+                    {
+                      type: "listItem",
+                      content: [{ type: "paragraph", content: [{ type: "text", text: "A-1" }] }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [{ type: "paragraph", content: [{ type: "text", text: "B" }] }],
+            },
+          ],
+        },
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [{ type: "paragraph", content: [{ type: "text", text: "1st" }] }],
+            },
+          ],
+        },
+      ],
+    });
+    const html = tiptapToHtml(json);
+    expect(html).toContain("<ul>");
+    // ネストした `<ul>` が外側の `<li>` 内側に来ること。
+    // The nested `<ul>` appears inside the outer `<li>`.
+    expect(html).toMatch(/<li><p>A<\/p><ul><li><p>A-1<\/p><\/li><\/ul><\/li>/);
+    expect(html).toContain("<li><p>B</p></li>");
+    expect(html).toContain("<ol>");
+    expect(html).toContain("<li><p>1st</p></li>");
+  });
+
+  it("converts blockquote and horizontalRule", () => {
+    const json = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [{ type: "paragraph", content: [{ type: "text", text: "Quoted" }] }],
+        },
+        { type: "horizontalRule" },
+      ],
+    });
+    const html = tiptapToHtml(json);
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain("Quoted");
+    expect(html).toContain("</blockquote>");
+    expect(html).toContain("<hr");
+  });
+
+  it("renders codeBlock with language class and escapes HTML inside", () => {
+    const json = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "ts" },
+          content: [{ type: "text", text: "<script>alert(1)</script>" }],
+        },
+      ],
+    });
+    const html = tiptapToHtml(json);
+    expect(html).toContain('<pre><code class="language-ts">');
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+
+  it("applies bold, italic, strike, inline-code, and link marks", () => {
+    const json = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "b", marks: [{ type: "bold" }] },
+            { type: "text", text: "i", marks: [{ type: "italic" }] },
+            { type: "text", text: "s", marks: [{ type: "strike" }] },
+            { type: "text", text: "c", marks: [{ type: "code" }] },
+            {
+              type: "text",
+              text: "link",
+              marks: [{ type: "link", attrs: { href: "https://example.com/" } }],
+            },
+          ],
+        },
+      ],
+    });
+    const html = tiptapToHtml(json);
+    expect(html).toContain("<strong>b</strong>");
+    expect(html).toContain("<em>i</em>");
+    expect(html).toContain("<s>s</s>");
+    expect(html).toContain("<code>c</code>");
+    expect(html).toContain('<a href="https://example.com/">link</a>');
+  });
+
+  it("escapes HTML-special characters in text nodes and attributes", () => {
+    const json = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "<>&\"'" },
+            {
+              type: "text",
+              text: "x",
+              marks: [{ type: "link", attrs: { href: 'javascript:alert("x")' } }],
+            },
+          ],
+        },
+      ],
+    });
+    const html = tiptapToHtml(json);
+    expect(html).toContain("&lt;&gt;&amp;&quot;&#39;");
+    // 不正 scheme は完全に除外し、空 href として描画する（XSS 防止）。
+    // Reject non-http(s) schemes outright; emit an empty href to neutralise XSS.
+    expect(html).not.toContain('href="javascript:');
+  });
+
+  it("renders images with src/alt/title attribute escaping", () => {
+    const json = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "image",
+          attrs: {
+            src: "https://example.com/img.png",
+            alt: 'alt "quote"',
+            title: "t<itle>",
+          },
+        },
+      ],
+    });
+    const html = tiptapToHtml(json);
+    expect(html).toContain('src="https://example.com/img.png"');
+    expect(html).toContain('alt="alt &quot;quote&quot;"');
+    expect(html).toContain('title="t&lt;itle&gt;"');
+  });
+
+  it("renders wikiLink as bracketed text (no anchor target)", () => {
+    const json = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "wikiLink", attrs: { title: "Foo" } }],
+        },
+      ],
+    });
+    expect(tiptapToHtml(json)).toContain("[[Foo]]");
+  });
+
+  it("emits empty output for malformed youtubeEmbed and a safe anchor for valid id", () => {
+    const invalid = JSON.stringify({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "youtubeEmbed", attrs: { videoId: "" } }] }],
+    });
+    expect(tiptapToHtml(invalid)).toBe("<p></p>");
+
+    const valid = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "youtubeEmbed", attrs: { videoId: "abcdefghijk" } }],
+        },
+      ],
+    });
+    expect(tiptapToHtml(valid)).toContain(
+      '<a href="https://www.youtube.com/watch?v=abcdefghijk">YouTube</a>',
+    );
+  });
+
+  it("returns plain-text fallback when content is not valid JSON", () => {
+    expect(tiptapToHtml("just text")).toContain("just text");
+  });
+
+  it("renders an empty string for empty input", () => {
+    expect(tiptapToHtml("")).toBe("");
+  });
+});

--- a/src/lib/tiptapToHtml.ts
+++ b/src/lib/tiptapToHtml.ts
@@ -1,0 +1,330 @@
+import { sanitizeFilename } from "./markdownExport";
+
+/**
+ * Tiptap JSON を HTML 文字列へ変換し、html2pdf.js による PDF 書き出しを行う。
+ * `markdownExport.ts` と同じノード dispatch 方式で実装し、エクスポート経路で
+ * 重い React Node View 拡張を読み込まずに済むようにしている。
+ *
+ * Convert Tiptap JSON into HTML and drive html2pdf.js for client-side PDF
+ * export. Mirrors the dispatch pattern in `markdownExport.ts` so the
+ * export path avoids pulling heavy React node-view extensions.
+ */
+
+interface TiptapNode {
+  type: string;
+  attrs?: Record<string, unknown>;
+  content?: TiptapNode[];
+  text?: string;
+  marks?: TiptapMark[];
+}
+
+interface TiptapMark {
+  type: string;
+  attrs?: Record<string, unknown>;
+}
+
+/**
+ * Tiptap JSON 文字列を export 用 HTML 文字列へ変換する。
+ * 入力が JSON でなければプレーンテキストとしてそのままエスケープして返す。
+ *
+ * Convert a Tiptap JSON string to an HTML string suitable for PDF export.
+ * Non-JSON inputs are returned as escaped plain text.
+ */
+export function tiptapToHtml(content: string): string {
+  if (!content) return "";
+
+  try {
+    const doc = JSON.parse(content) as TiptapNode;
+    return convertNode(doc);
+  } catch {
+    // JSON でない場合はプレーンテキストとして扱う。
+    // Treat non-JSON inputs as plain text (still escape HTML metacharacters).
+    return escapeHtml(content);
+  }
+}
+
+type NodeHandler = (node: TiptapNode) => string;
+
+const nodeHandlers: Record<string, NodeHandler> = {};
+
+function convertNode(node: TiptapNode): string {
+  if (!node) return "";
+  const handler = nodeHandlers[node.type];
+  return handler ? handler(node) : convertChildren(node);
+}
+
+function convertChildren(node: TiptapNode): string {
+  if (!node.content) return "";
+  return node.content.map(convertNode).join("");
+}
+
+Object.assign(nodeHandlers, {
+  doc: (n) => convertChildren(n),
+  paragraph: (n) => `<p>${convertChildren(n)}</p>`,
+  heading: (n) => {
+    // 本文の見出しは body schema 上 h2–h5。`level` が欠落 / 1 以下の旧データは
+    // ページタイトル `h1` と衝突しないよう最小の本文見出し `h2` にフォールバック。
+    // Body headings span h2–h5; legacy `level: 1` / missing falls back to `h2`
+    // so it never collides with the page-title `h1`.
+    const rawLevel = n.attrs?.level;
+    const level = typeof rawLevel === "number" && rawLevel >= 2 && rawLevel <= 6 ? rawLevel : 2;
+    return `<h${level}>${convertChildren(n)}</h${level}>`;
+  },
+  bulletList: (n) => `<ul>${convertListChildren(n)}</ul>`,
+  orderedList: (n) => `<ol>${convertListChildren(n)}</ol>`,
+  listItem: (n) => `<li>${convertChildren(n)}</li>`,
+  taskList: (n) => `<ul class="task-list">${convertChildren(n)}</ul>`,
+  taskItem: (n) => {
+    const checked = Boolean(n.attrs?.checked);
+    const box = `<input type="checkbox" disabled${checked ? ' checked="checked"' : ""} />`;
+    return `<li class="task-list-item">${box} ${convertChildren(n)}</li>`;
+  },
+  blockquote: (n) => `<blockquote>${convertChildren(n)}</blockquote>`,
+  codeBlock: (n) => {
+    const language = typeof n.attrs?.language === "string" ? n.attrs.language : "";
+    const codeText = collectPlainText(n);
+    const langAttr = language ? ` class="language-${escapeHtmlAttr(language)}"` : "";
+    return `<pre><code${langAttr}>${escapeHtml(codeText)}</code></pre>`;
+  },
+  horizontalRule: () => "<hr />",
+  hardBreak: () => "<br />",
+  text: (n) => applyMarks(escapeHtml(n.text || ""), n.marks || []),
+  wikiLink: (n) => {
+    const title = typeof n.attrs?.title === "string" ? n.attrs.title : "";
+    return `[[${escapeHtml(title)}]]`;
+  },
+  image: (n) => {
+    const src = typeof n.attrs?.src === "string" ? n.attrs.src : "";
+    const alt = typeof n.attrs?.alt === "string" ? n.attrs.alt : "";
+    const title = typeof n.attrs?.title === "string" ? n.attrs.title : "";
+    const safeSrc = sanitizeUrl(src);
+    if (!safeSrc) return "";
+    const attrs = [`src="${escapeHtmlAttr(safeSrc)}"`, `alt="${escapeHtmlAttr(alt)}"`];
+    if (title) attrs.push(`title="${escapeHtmlAttr(title)}"`);
+    return `<img ${attrs.join(" ")} />`;
+  },
+  youtubeEmbed: (n) => {
+    const rawVideoId = n.attrs?.videoId;
+    const videoId = typeof rawVideoId === "string" ? rawVideoId.trim() : "";
+    // 異常な videoId をそのまま href に入れないよう厳格に検証する。
+    // Strictly validate videoId before composing the anchor href.
+    if (!/^[a-zA-Z0-9_-]{11}$/.test(videoId)) return "";
+    return `<a href="https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}">YouTube</a>`;
+  },
+  link: (n) => convertChildren(n),
+  // 表組みのフィデリティは print 時に効くので最低限 HTML <table> に落とす。
+  // Render tables as real HTML tables so print layout stays usable.
+  table: (n) => `<table>${convertChildren(n)}</table>`,
+  tableRow: (n) => `<tr>${convertChildren(n)}</tr>`,
+  tableCell: (n) => `<td>${convertChildren(n)}</td>`,
+  tableHeader: (n) => `<th>${convertChildren(n)}</th>`,
+} satisfies Record<string, NodeHandler>);
+
+function convertListChildren(node: TiptapNode): string {
+  if (!node.content) return "";
+  return node.content.map(convertNode).join("");
+}
+
+/**
+ * codeBlock のテキストノードはマークを無視して raw 文字列を集める。
+ * Collect raw text content of a node tree (used by codeBlock).
+ */
+function collectPlainText(node: TiptapNode): string {
+  if (node.type === "text") return node.text ?? "";
+  if (!node.content) return "";
+  return node.content.map(collectPlainText).join("");
+}
+
+function applyMarks(text: string, marks: TiptapMark[]): string {
+  if (!marks || marks.length === 0) return text;
+  let result = text;
+  for (const mark of marks) {
+    switch (mark.type) {
+      case "bold":
+        result = `<strong>${result}</strong>`;
+        break;
+      case "italic":
+        result = `<em>${result}</em>`;
+        break;
+      case "strike":
+        result = `<s>${result}</s>`;
+        break;
+      case "underline":
+        result = `<u>${result}</u>`;
+        break;
+      case "code":
+        result = `<code>${result}</code>`;
+        break;
+      case "link": {
+        const href = typeof mark.attrs?.href === "string" ? mark.attrs.href : "";
+        const safeHref = sanitizeUrl(href);
+        if (!safeHref) break;
+        result = `<a href="${escapeHtmlAttr(safeHref)}">${result}</a>`;
+        break;
+      }
+      // 他の mark（highlight / color など）は print 時の重要度が低いので無視する。
+      // Other marks (highlight / color etc.) are dropped for export simplicity.
+    }
+  }
+  return result;
+}
+
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+/** Escape text nodes for safe HTML body insertion. */
+function escapeHtml(input: string): string {
+  return input.replace(/[&<>"']/g, (c) => HTML_ESCAPES[c] ?? c);
+}
+
+/** Escape attribute values. Same set as body, but kept as a separate fn for clarity. */
+function escapeHtmlAttr(input: string): string {
+  return escapeHtml(input);
+}
+
+/**
+ * 安全な URL スキームだけを許可する。`javascript:` 等をはじいて XSS を防ぐ。
+ * Allow only safe URL schemes; strip `javascript:` and friends to prevent XSS.
+ */
+function sanitizeUrl(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return "";
+  if (/^(https?:|mailto:|tel:|\/|#)/i.test(trimmed)) return trimmed;
+  if (/^data:image\//i.test(trimmed)) return trimmed;
+  // 相対 URL（先頭が `./` or 英数字）は許可する。
+  // Allow relative URLs (starts with `./` or alphanumeric path).
+  if (/^(\.{0,2}\/|[a-zA-Z0-9_-]+(\/|$))/.test(trimmed)) return trimmed;
+  return "";
+}
+
+/**
+ * PDF エクスポートのオプション。
+ * Options for {@link downloadPdf}.
+ */
+export interface PdfExportOptions {
+  /** Default title when the page title is empty. */
+  defaultTitle?: string;
+  /** Label for the source-attribution block (e.g. "📎 引用元"). */
+  attributionLabel?: string;
+  /** Page format. Defaults to `"a4"`. */
+  format?: "a4" | "letter";
+}
+
+/**
+ * 引用元ブロックを HTML として組み立てる。`sourceUrl` が空のときは空文字列を返す。
+ * Build the source-attribution block. Returns "" when `sourceUrl` is empty.
+ */
+function buildSourceAttribution(sourceUrl?: string | null, attributionLabel?: string): string {
+  if (!sourceUrl?.trim()) return "";
+  const safeUrl = sanitizeUrl(sourceUrl.trim());
+  if (!safeUrl) return "";
+  const label = (attributionLabel?.trim() || "📎 Source") + ":";
+  return (
+    `<blockquote class="zedi-source">` +
+    `${escapeHtml(label)} <a href="${escapeHtmlAttr(safeUrl)}">${escapeHtml(safeUrl)}</a>` +
+    `</blockquote>`
+  );
+}
+
+/**
+ * オフスクリーン DOM に組み立てたエクスポート用ルート要素を返す。
+ * Compose the offscreen export root used as html2pdf.js source.
+ */
+function buildExportRoot(html: string): HTMLDivElement {
+  const root = document.createElement("div");
+  root.className = "zedi-pdf-root";
+  root.style.cssText = [
+    "position:fixed",
+    "left:-99999px",
+    "top:0",
+    // A4 width at ~96dpi (210mm ≈ 794px). html2canvas captures this width.
+    "width:794px",
+    "padding:0",
+    "background:#fff",
+    "color:#111",
+    "font-family:'Hiragino Kaku Gothic ProN','Hiragino Sans','Yu Gothic','Meiryo','Noto Sans JP',system-ui,-apple-system,sans-serif",
+    "font-size:14px",
+    "line-height:1.7",
+  ].join(";");
+  root.innerHTML = html;
+  return root;
+}
+
+/**
+ * `downloadPdf` の内部で `html2pdf.js` を遅延 import するための疎結合点。
+ * テストで `vi.mock("html2pdf.js")` 経由でモックしやすくしてある。
+ *
+ * Indirection so tests can `vi.mock("html2pdf.js")` and assert calls without
+ * pulling the real library (which depends on canvas / DOM features absent in
+ * jsdom).
+ */
+async function loadHtml2Pdf(): Promise<typeof import("html2pdf.js").default> {
+  const mod = await import("html2pdf.js");
+  return mod.default;
+}
+
+/**
+ * ページ本文を PDF として保存する。`tiptapToHtml` で組み立てた HTML を
+ * オフスクリーン要素に流し込み、`html2pdf.js`（html2canvas + jsPDF）で
+ * 直接ダウンロードを発火する。
+ *
+ * Save the page body as a PDF. Renders `tiptapToHtml` output into an
+ * offscreen element and pipes it through `html2pdf.js` (html2canvas + jsPDF).
+ */
+export async function downloadPdf(
+  title: string,
+  content: string,
+  sourceUrl?: string | null,
+  options?: PdfExportOptions,
+): Promise<void> {
+  const { defaultTitle = "Untitled", attributionLabel, format = "a4" } = options ?? {};
+  const normalizedTitle = title.trim();
+  const bodyHtml = tiptapToHtml(content);
+  const attributionHtml = buildSourceAttribution(sourceUrl, attributionLabel);
+  const titleHtml = normalizedTitle
+    ? `<h1 style="margin:0 0 16px 0;font-size:24px;">${escapeHtml(normalizedTitle)}</h1>`
+    : "";
+
+  // 上下左右の余白は CSS padding に寄せず、jsPDF の `margin` で管理する。
+  // Manage margins via jsPDF options rather than CSS to keep page breaks predictable.
+  const root = buildExportRoot(`${titleHtml}${attributionHtml}${bodyHtml}`);
+  document.body.appendChild(root);
+
+  try {
+    const html2pdf = await loadHtml2Pdf();
+    const filename = sanitizeFilename(normalizedTitle || defaultTitle) + ".pdf";
+    // `pagebreak` は html2pdf.js v0.10+ の実機能だが、同梱の `.d.ts` には未定義。
+    // また `html2pdf()` のオーバーロード解決の都合で戻り値が
+    // `Html2PdfWorker | Promise<void>` のユニオンに見えるため、ここで
+    // `unknown` 経由のキャストで最小限の構造的型に寄せる。
+    //
+    // `pagebreak` is supported at runtime since html2pdf.js v0.10 but is not
+    // in the bundled `.d.ts`. The `html2pdf()` overload resolution also widens
+    // the return type to a union, so we narrow it through `unknown` to a
+    // chainable worker that matches what the library exposes at runtime.
+    const opts = {
+      filename,
+      margin: [12, 12, 16, 12] as [number, number, number, number],
+      image: { type: "jpeg" as const, quality: 0.95 },
+      enableLinks: true,
+      html2canvas: { scale: 2, useCORS: true, backgroundColor: "#ffffff" },
+      jsPDF: { unit: "mm", format, orientation: "portrait" as const },
+      pagebreak: { mode: ["css", "legacy"], avoid: ["pre", "table", "img", "blockquote"] },
+    };
+
+    interface Html2PdfChain {
+      set(options: typeof opts): Html2PdfChain;
+      from(src: HTMLElement): Html2PdfChain;
+      save(): Promise<void>;
+    }
+    const worker = html2pdf() as unknown as Html2PdfChain;
+    await worker.set(opts).from(root).save();
+  } finally {
+    root.remove();
+  }
+}

--- a/src/lib/tiptapToHtml.ts
+++ b/src/lib/tiptapToHtml.ts
@@ -25,10 +25,16 @@ interface TiptapMark {
 
 /**
  * Tiptap JSON 文字列を export 用 HTML 文字列へ変換する。
- * 入力が JSON でなければプレーンテキストとしてそのままエスケープして返す。
+ * 入力が JSON でなければプレーンテキストとみなし、`\n` を段落区切りとして
+ * `<p>` ブロックに包んで返す。これにより、読み取り専用パスから渡される
+ * Hocuspocus 抽出の `content_text`（ブロック間に `\n` を挟むプレーンテキスト）
+ * が PDF 上で 1 行に潰れずに描画される（PR #921 codex P1）。
  *
  * Convert a Tiptap JSON string to an HTML string suitable for PDF export.
- * Non-JSON inputs are returned as escaped plain text.
+ * For non-JSON inputs (e.g. the Y.Doc-extracted `content_text` fed from the
+ * read-only path) split on consecutive newlines and emit each chunk as a
+ * `<p>` block so paragraphs survive html2canvas rasterisation. Single `\n`
+ * inside a chunk becomes `<br />` (PR #921 codex P1).
  */
 export function tiptapToHtml(content: string): string {
   if (!content) return "";
@@ -37,10 +43,35 @@ export function tiptapToHtml(content: string): string {
     const doc = JSON.parse(content) as TiptapNode;
     return convertNode(doc);
   } catch {
-    // JSON でない場合はプレーンテキストとして扱う。
-    // Treat non-JSON inputs as plain text (still escape HTML metacharacters).
-    return escapeHtml(content);
+    return plainTextToHtmlParagraphs(content);
   }
+}
+
+/**
+ * プレーンテキストを段落 (`<p>`) と改行 (`<br />`) 構造の HTML に変換する。
+ * 連続した空行をブロック区切り、単独の `\n` を行内改行として扱う。
+ *
+ * Convert plain text into a paragraph/`<br>` HTML structure: blank-line runs
+ * delimit blocks, single `\n` becomes `<br />` inside a block.
+ */
+function plainTextToHtmlParagraphs(input: string): string {
+  // 改行コードを LF に統一してから、空行区切りでブロックに分割する。
+  // Normalise line endings then split on one-or-more blank lines.
+  const normalised = input.replace(/\r\n?/g, "\n");
+  const blocks = normalised
+    .split(/\n{2,}/)
+    .map((block) => block.replace(/^\n+|\n+$/g, ""))
+    .filter((block) => block.length > 0);
+  if (blocks.length === 0) return "";
+  return blocks
+    .map(
+      (block) =>
+        `<p>${block
+          .split("\n")
+          .map((line) => escapeHtml(line))
+          .join("<br />")}</p>`,
+    )
+    .join("");
 }
 
 type NodeHandler = (node: TiptapNode) => string;
@@ -62,10 +93,10 @@ Object.assign(nodeHandlers, {
   doc: (n) => convertChildren(n),
   paragraph: (n) => `<p>${convertChildren(n)}</p>`,
   heading: (n) => {
-    // 本文の見出しは body schema 上 h2–h5。`level` が欠落 / 1 以下の旧データは
+    // 本文の見出しは body schema 上 h2–h6。`level` が欠落 / 1 以下の旧データは
     // ページタイトル `h1` と衝突しないよう最小の本文見出し `h2` にフォールバック。
-    // Body headings span h2–h5; legacy `level: 1` / missing falls back to `h2`
-    // so it never collides with the page-title `h1`.
+    // Body headings span h2–h6; legacy `level: 1` / missing falls back to `h2`
+    // so it never collides with the page-title `h1` (PR #921 gemini medium).
     const rawLevel = n.attrs?.level;
     const level = typeof rawLevel === "number" && rawLevel >= 2 && rawLevel <= 6 ? rawLevel : 2;
     return `<h${level}>${convertChildren(n)}</h${level}>`;
@@ -196,9 +227,14 @@ function sanitizeUrl(input: string): string {
   if (!trimmed) return "";
   if (/^(https?:|mailto:|tel:|\/|#)/i.test(trimmed)) return trimmed;
   if (/^data:image\//i.test(trimmed)) return trimmed;
-  // 相対 URL（先頭が `./` or 英数字）は許可する。
-  // Allow relative URLs (starts with `./` or alphanumeric path).
-  if (/^(\.{0,2}\/|[a-zA-Z0-9_-]+(\/|$))/.test(trimmed)) return trimmed;
+  // 相対 URL（先頭が `./`・`../`・拡張子付きファイル名・パス断片）を許可する。
+  // 文字クラスに `.` を含めることで `image.png` 等のドット入りパスも通す
+  // （PR #921 gemini-code-assist high）。
+  //
+  // Allow relative URLs: `./`, `../`, or a first segment built from
+  // alphanumeric / `.` / `_` / `-` characters. Including `.` in the class
+  // lets dotted filenames like `image.png` through (PR #921 review).
+  if (/^(\.{0,2}\/|[a-zA-Z0-9_.-]+(\/|$))/.test(trimmed)) return trimmed;
   return "";
 }
 

--- a/src/pages/NotePageView.test.tsx
+++ b/src/pages/NotePageView.test.tsx
@@ -22,6 +22,7 @@ const {
   mockSetPageContext,
   mockExportMarkdown,
   mockCopyMarkdown,
+  mockExportPdf,
   mockRemoveFromNoteMutate,
   mockUseMarkdownExport,
 } = vi.hoisted(() => ({
@@ -39,6 +40,7 @@ const {
   mockSetPageContext: vi.fn(),
   mockExportMarkdown: vi.fn(),
   mockCopyMarkdown: vi.fn().mockResolvedValue(undefined),
+  mockExportPdf: vi.fn().mockResolvedValue(undefined),
   mockRemoveFromNoteMutate: vi.fn(),
   // `useMarkdownExport(title, body, sourceUrl)` の呼び出し引数を捕捉するための
   // モック。Codex P1 (PR #893) の「export/copy が `page.content` を読んで空に
@@ -141,6 +143,12 @@ vi.mock("@/components/editor/PageEditor/useMarkdownExport", () => ({
       handleCopyMarkdown: mockCopyMarkdown,
     };
   },
+}));
+
+vi.mock("@/components/editor/PageEditor/usePdfExport", () => ({
+  usePdfExport: () => ({
+    handleExportPdf: mockExportPdf,
+  }),
 }));
 
 // 読み取り専用経路の Markdown export ソースは `usePagePublicContent` 経由で
@@ -323,6 +331,7 @@ describe("NotePageView", () => {
     mockApi.updatePageMetadata.mockReset();
     mockExportMarkdown.mockReset();
     mockCopyMarkdown.mockReset().mockResolvedValue(undefined);
+    mockExportPdf.mockReset().mockResolvedValue(undefined);
     mockRemoveFromNoteMutate.mockReset();
     mockUseMarkdownExport.mockReset();
     // 既定: read-only 経路の公開コンテンツは「ロード完了 + 本文あり」。
@@ -500,6 +509,7 @@ describe("NotePageView", () => {
 
       expect(screen.getByText("editor.pageHistory.menuButton")).toBeInTheDocument();
       expect(screen.getByText("editor.pageMenu.exportMarkdown")).toBeInTheDocument();
+      expect(screen.getByText("editor.pageMenu.exportPdf")).toBeInTheDocument();
       expect(screen.getByText("editor.pageMenu.copyMarkdown")).toBeInTheDocument();
       expect(screen.getByText("editor.pageMenu.deletePage")).toBeInTheDocument();
       // 旧「個人に取り込み」項目は削除されていることを明示的に検証する。
@@ -507,7 +517,7 @@ describe("NotePageView", () => {
       expect(screen.queryByText("notes.copyToPersonal")).not.toBeInTheDocument();
     });
 
-    it("read-only 時、削除以外の3項目だけを出す / shows history/export/copy but hides delete in read-only mode", () => {
+    it("read-only 時、削除以外の4項目だけを出す / shows history/export-md/export-pdf/copy but hides delete in read-only mode", () => {
       vi.mocked(useNote).mockReturnValue({
         note: { id: "note-1" },
         access: { canView: true, canEdit: false },
@@ -529,6 +539,7 @@ describe("NotePageView", () => {
 
       expect(screen.getByText("editor.pageHistory.menuButton")).toBeInTheDocument();
       expect(screen.getByText("editor.pageMenu.exportMarkdown")).toBeInTheDocument();
+      expect(screen.getByText("editor.pageMenu.exportPdf")).toBeInTheDocument();
       expect(screen.getByText("editor.pageMenu.copyMarkdown")).toBeInTheDocument();
       // read-only では削除は出さない（権限がないため）。
       // Delete is hidden in read-only mode (no permission).
@@ -577,6 +588,7 @@ describe("NotePageView", () => {
 
       expect(screen.queryByText("editor.pageHistory.menuButton")).not.toBeInTheDocument();
       expect(screen.getByText("editor.pageMenu.exportMarkdown")).toBeInTheDocument();
+      expect(screen.getByText("editor.pageMenu.exportPdf")).toBeInTheDocument();
       expect(screen.getByText("editor.pageMenu.copyMarkdown")).toBeInTheDocument();
       expect(screen.queryByText("editor.pageMenu.deletePage")).not.toBeInTheDocument();
     });
@@ -625,6 +637,15 @@ describe("NotePageView", () => {
       fireEvent.click(screen.getByText("editor.pageMenu.exportMarkdown"));
 
       expect(mockExportMarkdown).toHaveBeenCalledTimes(1);
+    });
+
+    it("`PDFで出力` で `handleExportPdf` を呼ぶ / invokes handleExportPdf on PDF export click", () => {
+      setupEditableRender();
+      renderNotePageView();
+
+      fireEvent.click(screen.getByText("editor.pageMenu.exportPdf"));
+
+      expect(mockExportPdf).toHaveBeenCalledTimes(1);
     });
 
     it("`Markdownをコピー` で `handleCopyMarkdown` を呼ぶ / invokes handleCopyMarkdown on copy click", () => {
@@ -1039,8 +1060,10 @@ describe("NotePageView", () => {
     renderNotePageView();
 
     const exportItem = screen.getByText("editor.pageMenu.exportMarkdown").closest("button");
+    const pdfItem = screen.getByText("editor.pageMenu.exportPdf").closest("button");
     const copyItem = screen.getByText("editor.pageMenu.copyMarkdown").closest("button");
     expect(exportItem).toBeDisabled();
+    expect(pdfItem).toBeDisabled();
     expect(copyItem).toBeDisabled();
   });
 

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
-import { Copy, Download, History, Trash2 } from "lucide-react";
+import { Copy, Download, FileText, History, Trash2 } from "lucide-react";
 import { PageLoadingOrDenied } from "@/components/layout/PageLoadingOrDenied";
 import { PageEditorContent } from "@/components/note/PageEditorContent";
 import { NotePagePublicView } from "@/components/note/NotePagePublicView";
@@ -35,6 +35,7 @@ import { NoteWorkspaceProvider, useNoteWorkspaceOptional } from "@/contexts/Note
 import { useAIChatContext } from "@/contexts/AIChatContext";
 import { NoteWorkspaceToolbar } from "@/components/note/NoteWorkspaceToolbar";
 import { useMarkdownExport } from "@/components/editor/PageEditor/useMarkdownExport";
+import { usePdfExport } from "@/components/editor/PageEditor/usePdfExport";
 import { usePagePublicContent } from "@/hooks/usePagePublicContent";
 import { PageHistoryModal } from "@/components/editor/pageHistory/PageHistoryModal";
 import { convertMarkdownToTiptapContent } from "@/lib/markdownToTiptap";
@@ -85,11 +86,13 @@ function buildSharedMenuItems({
   t,
   onOpenHistory,
   onExportMarkdown,
+  onExportPdf,
   onCopyMarkdown,
 }: {
   t: (key: string) => string;
   onOpenHistory: () => void;
   onExportMarkdown: () => void;
+  onExportPdf: () => void;
   onCopyMarkdown: () => void;
 }): PageDetailToolbarAction[] {
   return [
@@ -104,6 +107,12 @@ function buildSharedMenuItems({
       label: t("editor.pageMenu.exportMarkdown"),
       icon: Download,
       onClick: onExportMarkdown,
+    },
+    {
+      id: "export-pdf",
+      label: t("editor.pageMenu.exportPdf"),
+      icon: FileText,
+      onClick: onExportPdf,
     },
     {
       id: "copy-markdown",
@@ -199,6 +208,7 @@ function NotePageEditorEditable({
     editorContent,
     page.sourceUrl,
   );
+  const { handleExportPdf } = usePdfExport(title, editorContent, page.sourceUrl);
 
   useEffect(() => {
     setPageContext({
@@ -418,6 +428,7 @@ function NotePageEditorEditable({
         t,
         onOpenHistory: handleOpenHistory,
         onExportMarkdown: handleExportMarkdown,
+        onExportPdf: handleExportPdf,
         onCopyMarkdown: handleCopyMarkdown,
       }),
       {
@@ -434,6 +445,7 @@ function NotePageEditorEditable({
       t,
       handleOpenHistory,
       handleExportMarkdown,
+      handleExportPdf,
       handleCopyMarkdown,
       onRequestDelete,
       isDeletePending,
@@ -568,6 +580,11 @@ function NotePageReadOnly({
     exportSource,
     page.sourceUrl,
   );
+  const { handleExportPdf } = usePdfExport(
+    publicContent?.title ?? page.title,
+    exportSource,
+    page.sourceUrl,
+  );
 
   const handleOpenHistory = useCallback(() => {
     setHistoryOpen(true);
@@ -599,6 +616,15 @@ function NotePageReadOnly({
         disabled: !isExportSourceReady,
       },
       {
+        id: "export-pdf",
+        label: t("editor.pageMenu.exportPdf"),
+        icon: FileText,
+        onClick: handleExportPdf,
+        // Markdown と同じ理由で公開コンテンツ未到着時は無効化する。
+        // Same gating as Markdown: block until public-content resolves.
+        disabled: !isExportSourceReady,
+      },
+      {
         id: "copy-markdown",
         label: t("editor.pageMenu.copyMarkdown"),
         icon: Copy,
@@ -612,6 +638,7 @@ function NotePageReadOnly({
     canViewHistory,
     handleOpenHistory,
     handleExportMarkdown,
+    handleExportPdf,
     handleCopyMarkdown,
     isExportSourceReady,
   ]);


### PR DESCRIPTION
## 概要

ページエディタに「PDFで出力」機能を追加しました。Tiptap JSON を HTML に変換し、html2pdf.js（html2canvas + jsPDF）を使用してクライアント側で PDF をダウンロードします。既存の Markdown エクスポート機能と同じ dispatch パターンで実装し、エクスポート経路で重い React Node View 拡張を読み込まずに済むようにしています。

## 変更点

- **`src/lib/tiptapToHtml.ts`** (新規)
  - `tiptapToHtml()`: Tiptap JSON を HTML 文字列に変換する関数
  - `downloadPdf()`: HTML をオフスクリーン DOM に組み立て、html2pdf.js で PDF をダウンロード
  - ノードハンドラ dispatch パターンで段落・見出し・リスト・コードブロック・テーブル・画像・リンク・YouTube 埋め込みなどをサポート
  - XSS 対策として URL スキーム検証と HTML エスケープを実装
  - 旧データの heading level 1 は h2 にフォールバック（ページタイトル h1 との衝突回避）

- **`src/lib/tiptapToHtml.test.ts`** (新規)
  - 各ノードタイプの変換テスト（段落・見出し・リスト・コードブロック等）
  - マーク（bold・italic・link等）の適用テスト
  - HTML エスケープと URL サニタイズのセキュリティテスト
  - 非 JSON 入力のフォールバック動作テスト

- **`src/components/editor/PageEditor/usePdfExport.ts`** (新規)
  - ページエディタの「PDFで出力」アクションを駆動するカスタムフック
  - `downloadPdf()` を呼び出し、成功/失敗時にトーストを発火
  - i18n オプション（デフォルトタイトル・引用元ラベル）を渡す

- **`src/components/editor/PageEditor/usePdfExport.test.tsx`** (新規)
  - `usePdfExport` の統合テスト
  - `downloadPdf` への引数渡しと成功/失敗時のトースト発火を検証

- **`src/pages/NotePageView.tsx`** (修正)
  - `usePdfExport` をインポート・呼び出し
  - ページメニューに「Export as PDF / PDFで出力」アクションを追加
  - `FileText` アイコンを使用

- **`src/pages/NotePageView.test.tsx`** (修正)
  - `usePdfExport` のモック追加
  - PDF エクスポートアクションのテストケース追加

- **`src/lib/markdownExport.ts`** (修正)
  - `sanitizeFilename()` を export（Markdown・PDF 等エクスポート系で共有）

- **`src/i18n/locales/en/editor.json`** (修正)
  - `editor.pageMenu.exportPdf`: "Export as PDF"
  - `editor.pdfExport.downloaded`: "PDF file downloaded"
  - `editor.pdfExport.failed`: "Failed to export PDF"
  - `editor.pdfExport.sourceAttribution`: "📎 Source"

- **`src/i18n/locales/ja/editor.json`** (修正)
  - `editor

https://claude.ai/code/session_01Ndhx8x4YVFXiXH62dmQf1D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PDF export: notes can be saved as PDFs with proper formatting and source attribution.
  * "Export as PDF" menu option available in both edit and read-only views; disabled until content loads.

* **Localization**
  * PDF export UI and messages added for multiple languages.

* **Tests**
  * New tests covering PDF export flow, content-to-HTML conversion, and success/failure notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->