### PR TITLE
refactor: decouple WikiLinkSuggestion from Editor context

### DIFF
--- a/src/components/editor/TiptapEditor/WikiLinkSuggestionLayer.tsx
+++ b/src/components/editor/TiptapEditor/WikiLinkSuggestionLayer.tsx
@@ -27,13 +27,18 @@ interface WikiLinkSuggestionLayerProps {
 }
 
 /**
- * WikiLink サジェスト UI のフローティング層。`useWikiLinkCandidates` で
- * スコープ（個人 / ノート）に応じた候補ページを取得し、`WikiLinkSuggestion`
- * に渡す。Issue #713 Phase 4。
+ * WikiLink サジェスト UI のフローティング層（本文中の `[[` 用）。
+ * `useWikiLinkCandidates` でスコープ（個人 / ノート）に応じた候補ページを
+ * 取得し、共通プレゼンテーションである `WikiLinkSuggestion` に流す。
+ * 確定時の範囲置換は `onSelect` 側（`useSuggestionEffects`）で行う。
+ * Issue #713 Phase 4 / Issue #925（共通化）。
  *
- * Floating layer for the WikiLink suggestion popup. Fetches scope-aware
- * candidate pages via `useWikiLinkCandidates` and forwards them to
- * `WikiLinkSuggestion`. See issue #713 Phase 4.
+ * Floating layer that mounts the shared `WikiLinkSuggestion` over the
+ * editor for the in-body `[[` flow. Scope-aware candidates come from
+ * `useWikiLinkCandidates`, and range replacement on confirm is handled
+ * by the caller's `onSelect`. The input bar (#924 §2) reuses the same
+ * presentation component via its own host. See issues #713 Phase 4 and
+ * #925.
  */
 export const WikiLinkSuggestionLayer: React.FC<WikiLinkSuggestionLayerProps> = ({
   editor,
@@ -58,9 +63,7 @@ export const WikiLinkSuggestionLayer: React.FC<WikiLinkSuggestionLayerProps> = (
     >
       <WikiLinkSuggestion
         ref={suggestionRef}
-        editor={editor}
         query={suggestionState.query}
-        range={suggestionState.range}
         onSelect={onSelect}
         onClose={onClose}
         pages={pages}

--- a/src/components/editor/extensions/WikiLinkSuggestion.test.tsx
+++ b/src/components/editor/extensions/WikiLinkSuggestion.test.tsx
@@ -1,6 +1,6 @@
 import React, { createRef } from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   WikiLinkSuggestion,
@@ -162,12 +162,14 @@ describe("WikiLinkSuggestion - 確定 / キーボード操作 / selection + keyb
     render(
       <WikiLinkSuggestion ref={ref} query="" onSelect={onSelect} onClose={vi.fn()} pages={pages} />,
     );
-    // 初回マウント直後の queueMicrotask(setSelectedIndex(0)) を act 内で
-    // 流して、後続の onKeyDown が確定済み state に対して走るようにする。
-    // Flush the initial-mount microtask (queueMicrotask → setSelectedIndex(0))
-    // inside act so subsequent onKeyDown calls run against a settled state.
-    await act(async () => {
-      await Promise.resolve();
+    // 初回マウント時の選択状態が確定する（先頭行に `bg-accent` が付く）まで待つ。
+    // `queueMicrotask` などの内部実装に依存せず、観測可能な副作用で同期する。
+    // Wait for the initial selection to settle by observing the highlight
+    // class on the first row, avoiding coupling to the internal
+    // `queueMicrotask` mechanism (gemini / CodeRabbit review feedback).
+    await waitFor(() => {
+      const buttons = screen.getAllByRole("button");
+      expect(buttons[0].className).toMatch(/\bbg-accent\b/);
     });
 
     // 最初は先頭が選択されている。Enter で確定して確認。

--- a/src/components/editor/extensions/WikiLinkSuggestion.test.tsx
+++ b/src/components/editor/extensions/WikiLinkSuggestion.test.tsx
@@ -1,0 +1,229 @@
+import React, { createRef } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  WikiLinkSuggestion,
+  type WikiLinkSuggestionHandle,
+  type WikiLinkSuggestionPage,
+  type SuggestionItem,
+} from "./WikiLinkSuggestion";
+
+/**
+ * 入力バー（#924 §2）と本文中 `[[` サジェスト（#925）両方で再利用される
+ * 共通コンポーネントとしての受け入れ条件をテストする。マウント位置や
+ * 呼び出し元コンテキスト（Editor / range）に依存しない pure presentation
+ * であることを保証する。
+ *
+ * Locks in the contract of the shared `WikiLinkSuggestion` component used
+ * by both the FAB input bar (#924 §2) and the in-body `[[` suggestion
+ * popup (#925). The component must remain mount-agnostic — no Editor or
+ * range coupling — so the same instance can be wrapped by either host.
+ */
+
+function makePage(overrides: Partial<WikiLinkSuggestionPage> = {}): WikiLinkSuggestionPage {
+  return {
+    id: overrides.id ?? "p-1",
+    title: overrides.title ?? "Untitled",
+    isDeleted: overrides.isDeleted ?? false,
+  };
+}
+
+/**
+ * `useImperativeHandle` 経由の `onKeyDown` を呼び出すヘルパ。
+ * Helper to invoke the imperative `onKeyDown` exposed via the ref.
+ */
+function fireKey(ref: React.RefObject<WikiLinkSuggestionHandle | null>, key: string): boolean {
+  const handle = ref.current;
+  if (!handle) throw new Error("WikiLinkSuggestion ref is not attached");
+  let handled = false;
+  act(() => {
+    handled = handle.onKeyDown(new KeyboardEvent("keydown", { key }));
+  });
+  return handled;
+}
+
+describe("WikiLinkSuggestion - 候補の描画 / item rendering", () => {
+  it("既存ページ候補をクエリに一致した順に最大 5 件まで描画する / renders up to 5 matching pages", () => {
+    const pages: WikiLinkSuggestionPage[] = [
+      makePage({ id: "p-1", title: "Alpha" }),
+      makePage({ id: "p-2", title: "Beta" }),
+      makePage({ id: "p-3", title: "Gamma" }),
+      makePage({ id: "p-4", title: "Delta" }),
+      makePage({ id: "p-5", title: "Epsilon" }),
+      makePage({ id: "p-6", title: "Zeta" }),
+    ];
+
+    render(<WikiLinkSuggestion query="" onSelect={vi.fn()} onClose={vi.fn()} pages={pages} />);
+
+    // 6 件あっても "create new" を入れずに 5 件で打ち切る。
+    // With 6 candidates and an empty query, exactly the first 5 are shown.
+    expect(screen.getAllByRole("button")).toHaveLength(5);
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Zeta")).not.toBeInTheDocument();
+  });
+
+  it("クエリに一致しないページは表示しない / filters by query (case-insensitive substring)", () => {
+    const pages = [
+      makePage({ id: "p-1", title: "React Hooks" }),
+      makePage({ id: "p-2", title: "TypeScript Guide" }),
+    ];
+
+    render(<WikiLinkSuggestion query="react" onSelect={vi.fn()} onClose={vi.fn()} pages={pages} />);
+
+    expect(screen.getByText("React Hooks")).toBeInTheDocument();
+    expect(screen.queryByText("TypeScript Guide")).not.toBeInTheDocument();
+  });
+
+  it("isDeleted のページは候補から除外する / excludes deleted pages", () => {
+    const pages = [
+      makePage({ id: "p-1", title: "Active" }),
+      makePage({ id: "p-2", title: "Archived", isDeleted: true }),
+    ];
+
+    render(<WikiLinkSuggestion query="" onSelect={vi.fn()} onClose={vi.fn()} pages={pages} />);
+
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.queryByText("Archived")).not.toBeInTheDocument();
+  });
+
+  it("完全一致が無い場合は『新規作成』エントリを末尾に追加する / appends a create entry when no exact match", () => {
+    const pages = [makePage({ id: "p-1", title: "Existing" })];
+
+    render(
+      <WikiLinkSuggestion query="New Page" onSelect={vi.fn()} onClose={vi.fn()} pages={pages} />,
+    );
+
+    expect(screen.getByText('"New Page" を作成')).toBeInTheDocument();
+  });
+
+  it("完全一致するページがあれば『新規作成』エントリは出さない / hides create entry on exact title match", () => {
+    const pages = [makePage({ id: "p-1", title: "Alpha" })];
+
+    render(<WikiLinkSuggestion query="Alpha" onSelect={vi.fn()} onClose={vi.fn()} pages={pages} />);
+
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText(/を作成$/)).not.toBeInTheDocument();
+  });
+
+  it("候補も新規作成エントリも無いときは null を返す / renders nothing with no items", () => {
+    const { container } = render(
+      <WikiLinkSuggestion query="" onSelect={vi.fn()} onClose={vi.fn()} pages={[]} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("ポジショニング class を一切付けない（マウント位置は呼び出し側の責務）/ does not impose absolute/fixed positioning", () => {
+    render(
+      <WikiLinkSuggestion
+        query=""
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+        pages={[makePage({ title: "Alpha" })]}
+      />,
+    );
+
+    // ルート要素に position 系のクラスを持たないことを確認する。これにより
+    // 入力バー（fixed）と本文中 `[[`（absolute）どちらの host にも適合する。
+    // The root must not carry position classes so it can be wrapped in
+    // either the input bar's `fixed` container or the editor's `absolute`
+    // overlay without bleeding through.
+    const root = screen.getByTestId("wiki-link-suggestion");
+    expect(root.className).not.toMatch(/\b(absolute|fixed|relative|sticky)\b/);
+  });
+});
+
+describe("WikiLinkSuggestion - 確定 / キーボード操作 / selection + keyboard", () => {
+  it("クリックで onSelect に対応する item が渡る / clicking a row fires onSelect with that item", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn<(item: SuggestionItem) => void>();
+    const pages = [makePage({ id: "p-1", title: "Alpha" }), makePage({ id: "p-2", title: "Beta" })];
+
+    render(<WikiLinkSuggestion query="" onSelect={onSelect} onClose={vi.fn()} pages={pages} />);
+
+    await user.click(screen.getByText("Beta"));
+    expect(onSelect).toHaveBeenCalledWith({ id: "p-2", title: "Beta", exists: true });
+  });
+
+  it("新規作成行をクリックすると exists=false の item が渡る / clicking create row fires create item", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn<(item: SuggestionItem) => void>();
+    render(<WikiLinkSuggestion query="Fresh" onSelect={onSelect} onClose={vi.fn()} pages={[]} />);
+
+    await user.click(screen.getByText('"Fresh" を作成'));
+    expect(onSelect).toHaveBeenCalledWith({ id: "create-new", title: "Fresh", exists: false });
+  });
+
+  it("ArrowDown / ArrowUp で選択行が循環する / ArrowDown and ArrowUp wrap around the list", async () => {
+    const ref = createRef<WikiLinkSuggestionHandle>();
+    const onSelect = vi.fn<(item: SuggestionItem) => void>();
+    const pages = [makePage({ id: "p-1", title: "Alpha" }), makePage({ id: "p-2", title: "Beta" })];
+
+    render(
+      <WikiLinkSuggestion ref={ref} query="" onSelect={onSelect} onClose={vi.fn()} pages={pages} />,
+    );
+    // 初回マウント直後の queueMicrotask(setSelectedIndex(0)) を act 内で
+    // 流して、後続の onKeyDown が確定済み state に対して走るようにする。
+    // Flush the initial-mount microtask (queueMicrotask → setSelectedIndex(0))
+    // inside act so subsequent onKeyDown calls run against a settled state.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // 最初は先頭が選択されている。Enter で確定して確認。
+    // First item highlighted initially; confirm by pressing Enter.
+    expect(fireKey(ref, "Enter")).toBe(true);
+    expect(onSelect).toHaveBeenLastCalledWith({ id: "p-1", title: "Alpha", exists: true });
+
+    // ArrowDown で 2 番目へ。
+    // ArrowDown moves selection to the second row.
+    expect(fireKey(ref, "ArrowDown")).toBe(true);
+    expect(fireKey(ref, "Enter")).toBe(true);
+    expect(onSelect).toHaveBeenLastCalledWith({ id: "p-2", title: "Beta", exists: true });
+
+    // 末尾で ArrowDown すると先頭に戻る（循環）。
+    // ArrowDown from last item wraps back to the first row.
+    expect(fireKey(ref, "ArrowDown")).toBe(true);
+    expect(fireKey(ref, "Enter")).toBe(true);
+    expect(onSelect).toHaveBeenLastCalledWith({ id: "p-1", title: "Alpha", exists: true });
+
+    // 先頭で ArrowUp すると末尾に飛ぶ。
+    // ArrowUp from first item wraps to the last row.
+    expect(fireKey(ref, "ArrowUp")).toBe(true);
+    expect(fireKey(ref, "Enter")).toBe(true);
+    expect(onSelect).toHaveBeenLastCalledWith({ id: "p-2", title: "Beta", exists: true });
+  });
+
+  it("Escape で onClose が呼ばれる / Escape closes the popup", () => {
+    const ref = createRef<WikiLinkSuggestionHandle>();
+    const onClose = vi.fn();
+    render(
+      <WikiLinkSuggestion
+        ref={ref}
+        query=""
+        onSelect={vi.fn()}
+        onClose={onClose}
+        pages={[makePage()]}
+      />,
+    );
+
+    expect(fireKey(ref, "Escape")).toBe(true);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("未処理のキーでは false を返し既定挙動を妨げない / returns false for unhandled keys", () => {
+    const ref = createRef<WikiLinkSuggestionHandle>();
+    render(
+      <WikiLinkSuggestion
+        ref={ref}
+        query=""
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+        pages={[makePage()]}
+      />,
+    );
+
+    expect(fireKey(ref, "a")).toBe(false);
+    expect(fireKey(ref, "Tab")).toBe(false);
+  });
+});

--- a/src/components/editor/extensions/WikiLinkSuggestion.tsx
+++ b/src/components/editor/extensions/WikiLinkSuggestion.tsx
@@ -1,5 +1,4 @@
 import { forwardRef, useEffect, useImperativeHandle, useState, useCallback } from "react";
-import { Editor } from "@tiptap/core";
 import { cn } from "@zedi/ui";
 import { FileText, Plus } from "lucide-react";
 
@@ -25,11 +24,45 @@ export interface WikiLinkSuggestionPage {
   isDeleted?: boolean;
 }
 
+/**
+ * `WikiLinkSuggestion` の props。本コンポーネントは
+ *
+ * - 本文中の `[[` サジェスト（`WikiLinkSuggestionLayer`、絶対配置）
+ * - FAB 横のリンク入力バー（#924 §2、固定配置）
+ *
+ * の両方で再利用するため、マウント位置（fixed / absolute）や
+ * Editor / ProseMirror の range などの呼び出し元コンテキストには一切
+ * 依存しない。確定処理（範囲置換 / リンク挿入 / 入力バークリア）は
+ * すべて `onSelect` の呼び出し側に委ねる。
+ *
+ * Props for `WikiLinkSuggestion`. Kept deliberately free of editor /
+ * range / positioning concerns so the same component can back both the
+ * in-body `[[` suggestion (absolutely positioned over the editor) and
+ * the FAB-adjacent input bar (#924 §2, fixed near the keyboard). The
+ * host owns mounting + post-select side effects (range replacement,
+ * link insertion, clearing the input bar). See issue #925.
+ */
 interface WikiLinkSuggestionProps {
-  editor: Editor;
+  /**
+   * 現在の入力クエリ。`[[` サジェストの場合は `[[` の後ろのテキスト、入力バー
+   * の場合は入力欄の値をそのまま渡す。
+   * Current input query — the text after `[[` for the in-body popup, or
+   * the input bar value verbatim.
+   */
   query: string;
-  range: { from: number; to: number };
+  /**
+   * 候補行 / 「新規作成」行が確定したときに呼ばれる。`item.exists` で既存
+   * ページか新規作成かを判別する。
+   * Invoked when an existing or create-new row is confirmed; `item.exists`
+   * distinguishes the two branches.
+   */
   onSelect: (item: SuggestionItem) => void;
+  /**
+   * Escape などでサジェストを閉じたいときに呼ばれる。クローズ後の挙動は
+   * 呼び出し側に任せる（プラグイン状態のリセット、入力バーのフォーカス制御等）。
+   * Fired when the popup should close. Host decides what closing means
+   * (plugin meta reset for the editor host; input-bar blur for the bar).
+   */
   onClose: () => void;
   /**
    * サジェスト候補として渡されるページ一覧。呼び出し側で WikiLink のスコープ

--- a/src/components/editor/extensions/WikiLinkSuggestion.tsx
+++ b/src/components/editor/extensions/WikiLinkSuggestion.tsx
@@ -42,7 +42,7 @@ export interface WikiLinkSuggestionPage {
  * host owns mounting + post-select side effects (range replacement,
  * link insertion, clearing the input bar). See issue #925.
  */
-interface WikiLinkSuggestionProps {
+export interface WikiLinkSuggestionProps {
   /**
    * 現在の入力クエリ。`[[` サジェストの場合は `[[` の後ろのテキスト、入力バー
    * の場合は入力欄の値をそのまま渡す。
@@ -187,6 +187,7 @@ export const WikiLinkSuggestion = forwardRef<WikiLinkSuggestionHandle, WikiLinkS
           {items.map((item, index) => (
             <button
               key={item.id}
+              type="button"
               onClick={() => selectItem(index)}
               className={cn(
                 "flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors",


### PR DESCRIPTION
## 概要

`WikiLinkSuggestion` コンポーネントを Editor / ProseMirror の range 依存から切り離し、マウント位置に依存しない純粋なプレゼンテーションコンポーネントに再設計しました。これにより、本文中の `[[` サジェスト（Issue #925）と FAB 横のリンク入力バー（Issue #924 §2）の両方で同一インスタンスを再利用できるようになります。

## 変更点

- **WikiLinkSuggestion.tsx**
  - `editor` と `range` props を削除し、`query` と `onSelect` / `onClose` コールバックのみに依存する設計に変更
  - Props インターフェースを詳細に文書化（日本語・英語併記）
  - 確定処理（範囲置換・リンク挿入）をすべて呼び出し側に委譲
  - ポジショニング class を一切付けず、マウント位置の責務を分離

- **WikiLinkSuggestionLayer.tsx**
  - `WikiLinkSuggestion` に `editor` と `range` を渡さないよう更新
  - コメントを更新し、本コンポーネントが in-body `[[` 用の host であることを明確化
  - 確定時の範囲置換は `onSelect` 側（`useSuggestionEffects`）で行うことを記載

- **WikiLinkSuggestion.test.tsx**（新規追加）
  - 共通コンポーネントとしての受け入れ条件をテスト
  - 候補の描画（フィルタリング、削除済みページ除外、「新規作成」エントリ）
  - キーボード操作（ArrowUp/Down の循環、Enter での確定、Escape でのクローズ）
  - マウント位置に依存しないことを保証（position class の不在確認）

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `bun run test` で新規テストスイート（WikiLinkSuggestion.test.tsx）が全てパスすることを確認
2. 既存の WikiLinkSuggestionLayer テストが引き続きパスすることを確認
3. `bun run lint` と `bun run format:check` が通ることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [x] コンポーネント Props に JSDoc / TSDoc を付与した
- [x] 日本語・英語のコメントを併記した

## 関連 Issue

Closes #925（本文中 `[[` サジェスト）
Related to #924 §2（FAB 横のリンク入力バー）

https://claude.ai/code/session_01TYnHkBNvRb9LhSA1KQ7ccJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for WikiLink suggestions: candidate rendering, filtering, keyboard navigation, and interaction behavior.

* **Bug Fixes**
  * Prevented suggestion buttons from triggering accidental form submissions when selected.

* **Refactor**
  * Decoupled the suggestion UI from editor internals to improve maintainability and flexibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->