### PR TITLE
feat: Add WikiLinkInputBar component for ghost link creation

### DIFF
--- a/src/components/editor/FloatingWikiLinkInputBar.tsx
+++ b/src/components/editor/FloatingWikiLinkInputBar.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { WikiLinkInputBar, type WikiLinkInputBarProps } from "./WikiLinkInputBar";
+
+/**
+ * `WikiLinkInputBar` を `ContentWithAIChat` の FAB スタックの左にレイアウト
+ * する固定配置コンテナ。`TiptapEditor` から呼び出してエディタ画面でのみ
+ * マウントする（読み取り専用画面・公開閲覧では呼び出さない）。
+ *
+ * Fixed-position wrapper that mounts {@link WikiLinkInputBar} just to the
+ * left of the FAB stack rendered by `ContentWithAIChat`. `TiptapEditor`
+ * decides when to mount the wrapper so the bar appears only on the editor
+ * screen (read-only / public views skip it).
+ */
+export const FloatingWikiLinkInputBar: React.FC<WikiLinkInputBarProps> = (props) => {
+  return (
+    <div
+      className="pointer-events-none fixed bottom-0 z-40 flex items-end p-2 pb-[env(safe-area-inset-bottom)]"
+      style={{
+        // FAB は約 64px 幅 + p-2 + safe-area-inset-right を取るため、バーを
+        // FAB の左隣にレイアウトするには 5rem 程度のオフセットが必要。
+        // ボトムナビ高さ (`--app-bottom-nav-height`) はモバイルでのみ非ゼロ。
+        // FAB occupies ~64px plus padding/safe-area. Offset the bar by
+        // ~5rem so it lands immediately to the left. The bottom-nav
+        // variable only contributes on mobile builds that mount it.
+        right: "calc(5rem + env(safe-area-inset-right))",
+        paddingBottom:
+          "calc(env(safe-area-inset-bottom) + var(--app-bottom-nav-height, 0px) + 0.5rem)",
+      }}
+    >
+      <WikiLinkInputBar {...props} />
+    </div>
+  );
+};
+
+export default FloatingWikiLinkInputBar;

--- a/src/components/editor/TiptapEditor.tsx
+++ b/src/components/editor/TiptapEditor.tsx
@@ -8,6 +8,7 @@ import type { TiptapEditorProps } from "./TiptapEditor/types";
 import { StorageSetupDialog } from "./TiptapEditor/StorageSetupDialog";
 import { DragOverlay } from "./TiptapEditor/DragOverlay";
 import { WikiLinkSuggestionLayer } from "./TiptapEditor/WikiLinkSuggestionLayer";
+import { FloatingWikiLinkInputBar } from "./FloatingWikiLinkInputBar";
 import { WikiLinkHoverCardLayer } from "./TiptapEditor/WikiLinkHoverCardLayer";
 import { TagSuggestionLayer } from "./TiptapEditor/TagSuggestionLayer";
 import { SlashSuggestionLayer } from "./TiptapEditor/SlashSuggestionLayer";
@@ -201,6 +202,14 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
         onOpenChange={setStorageSetupDialogOpen}
         onConfirm={handleGoToStorageSettings}
       />
+      {!isReadOnly && (
+        // FAB 左にピル型 Wiki Link 入力バーを常時表示する（issue #924 §2 / #926）。
+        // 役割はゴーストリンク作成 + 入力中の既存ページ候補提示の二役 UI。
+        // Always-on pill input bar mounted to the left of the FAB (issue
+        // #924 §2 / #926). Doubles as ghost-link creation and existing-link
+        // insertion via the shared suggestion popup.
+        <FloatingWikiLinkInputBar editor={editor} pageId={pageId} pageNoteId={resolvedPageNoteId} />
+      )}
     </div>
   );
 };

--- a/src/components/editor/WikiLinkInputBar.test.tsx
+++ b/src/components/editor/WikiLinkInputBar.test.tsx
@@ -1,0 +1,326 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Editor } from "@tiptap/core";
+
+// `react-i18next` の `useTranslation` をスタブして、JSON キーをそのまま返す
+// ように振る舞わせる。これにより i18n プロバイダを用意せずに表示文字列の
+// アサーションができる（他テストでも採用されている軽量パターン）。
+// Stub `useTranslation` so it returns the key verbatim; lets us assert on
+// rendered strings without setting up the i18n provider (matches the lightweight
+// pattern used elsewhere in this repo).
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockUseWikiLinkCandidates = vi.fn();
+vi.mock("@/hooks/useWikiLinkCandidates", () => ({
+  useWikiLinkCandidates: (noteId: string | null) => mockUseWikiLinkCandidates(noteId),
+}));
+
+const mockCheckExistence = vi.fn();
+const mockCheckReferenced = vi.fn();
+vi.mock("@/hooks/usePageQueries", () => ({
+  useWikiLinkExistsChecker: () => ({ checkExistence: mockCheckExistence }),
+  useCheckGhostLinkReferenced: () => ({ checkReferenced: mockCheckReferenced }),
+}));
+
+import { WikiLinkInputBar } from "./WikiLinkInputBar";
+
+interface MockChainReturn {
+  focus: ReturnType<typeof vi.fn>;
+  insertContentAt: ReturnType<typeof vi.fn>;
+  setTextSelection: ReturnType<typeof vi.fn>;
+  run: ReturnType<typeof vi.fn>;
+}
+
+interface MockEditor extends Editor {
+  chainReturn: MockChainReturn;
+  commandsReturn: { focus: ReturnType<typeof vi.fn> };
+}
+
+function createMockEditor(
+  options: { selectionFrom?: number; selectionTo?: number } = {},
+): MockEditor {
+  const { selectionFrom = 5, selectionTo = 5 } = options;
+  const run = vi.fn();
+  const focusChain: ReturnType<typeof vi.fn> = vi.fn().mockReturnThis();
+  const insertContentAt: ReturnType<typeof vi.fn> = vi.fn().mockReturnThis();
+  const setTextSelection: ReturnType<typeof vi.fn> = vi.fn().mockReturnThis();
+  const chainReturn: MockChainReturn = {
+    focus: focusChain,
+    insertContentAt,
+    setTextSelection,
+    run,
+  };
+  const commandsReturn = { focus: vi.fn() };
+  const editor = {
+    state: {
+      selection: { from: selectionFrom, to: selectionTo },
+    },
+    chain: vi.fn(() => chainReturn),
+    commands: commandsReturn,
+    chainReturn,
+    commandsReturn,
+  } as unknown as MockEditor;
+  return editor;
+}
+
+describe("WikiLinkInputBar - 基本表示 / basic rendering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWikiLinkCandidates.mockReturnValue({ pages: [], isLoading: false });
+    mockCheckExistence.mockResolvedValue({
+      pageTitles: new Set(),
+      referencedTitles: new Set(),
+      pageTitleToId: new Map(),
+    });
+    mockCheckReferenced.mockResolvedValue(false);
+  });
+
+  it("プレースホルダ『ページを作成』を持つ入力欄を描画する / renders the input with the 'create page' placeholder key", () => {
+    const editor = createMockEditor();
+    render(<WikiLinkInputBar editor={editor} pageId="p1" pageNoteId={null} />);
+
+    const input = screen.getByTestId("wiki-link-input-bar-input") as HTMLInputElement;
+    // i18n キーは `useTranslation` モックで素通りするため、キー自体が
+    // placeholder として現れる。値そのものは `common.json` 側のテキスト。
+    // The `useTranslation` mock passes keys through, so the placeholder is the
+    // i18n key here. The actual text lives in `common.json`.
+    expect(input.placeholder).toBe("common.wikiLinkInputBar.placeholder");
+  });
+
+  it("入力が空のときはサジェストを描画しない / does not render the suggestion list when input is empty", () => {
+    const editor = createMockEditor();
+    mockUseWikiLinkCandidates.mockReturnValue({
+      pages: [{ id: "p-alpha", title: "Alpha", isDeleted: false }],
+      isLoading: false,
+    });
+    render(<WikiLinkInputBar editor={editor} pageId="p1" pageNoteId={null} />);
+
+    // 入力が空のうちは候補ポップアップを開かない（フォーカス前と同じ挙動）。
+    // While the input is empty, suggestions stay hidden — same as when the bar
+    // has not been focused at all.
+    expect(screen.queryByTestId("wiki-link-suggestion")).not.toBeInTheDocument();
+  });
+
+  it("入力したクエリで `useWikiLinkCandidates` の候補を絞り、サジェストを開く / opens the suggestion popup once the user types", async () => {
+    const user = userEvent.setup();
+    const editor = createMockEditor();
+    mockUseWikiLinkCandidates.mockReturnValue({
+      pages: [
+        { id: "p-alpha", title: "Alpha", isDeleted: false },
+        { id: "p-beta", title: "Beta", isDeleted: false },
+      ],
+      isLoading: false,
+    });
+    render(<WikiLinkInputBar editor={editor} pageId="p1" pageNoteId={null} />);
+
+    await user.type(screen.getByTestId("wiki-link-input-bar-input"), "Al");
+
+    expect(screen.getByTestId("wiki-link-suggestion")).toBeInTheDocument();
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+  });
+});
+
+describe("WikiLinkInputBar - 確定挙動 / confirm behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWikiLinkCandidates.mockReturnValue({ pages: [], isLoading: false });
+    mockCheckExistence.mockResolvedValue({
+      pageTitles: new Set(),
+      referencedTitles: new Set(),
+      pageTitleToId: new Map(),
+    });
+    mockCheckReferenced.mockResolvedValue(false);
+  });
+
+  it("Enter で完全一致が無いときはゴーストリンクを退避位置に挿入する / Enter inserts a ghost wiki link at the saved cursor when no exact match", async () => {
+    const user = userEvent.setup();
+    const editor = createMockEditor({ selectionFrom: 12, selectionTo: 12 });
+    mockCheckReferenced.mockResolvedValue(true);
+    render(<WikiLinkInputBar editor={editor} pageId="p1" pageNoteId={null} />);
+
+    const input = screen.getByTestId("wiki-link-input-bar-input");
+    await user.click(input);
+    // クリック時点で editor.state.selection を退避していることを担保するため、
+    // 入力中に editor.state.selection を変えてみる（フォーカス前位置で挿入される
+    // ことを確認）。
+    // Mutate `editor.state.selection` after focus to ensure the bar reuses the
+    // saved position rather than reading current state at confirm time.
+    (editor.state.selection as { from: number; to: number }).from = 999;
+    (editor.state.selection as { from: number; to: number }).to = 999;
+    await user.type(input, "New Topic");
+    await user.keyboard("{Enter}");
+
+    // `insertLink` は `void` で fire-and-forget するため、確定処理が次の
+    // microtask で完了するのを `waitFor` で待つ。
+    // The confirm path is fire-and-forget (`void insertLink(...)`), so we
+    // need `waitFor` to flush the resolved promise before asserting.
+    await waitFor(() => {
+      expect(editor.chainReturn.insertContentAt).toHaveBeenCalled();
+    });
+    expect(mockCheckExistence).toHaveBeenCalledWith(["New Topic"], "p1");
+    expect(mockCheckReferenced).toHaveBeenCalledWith("New Topic", "p1");
+    expect(editor.chainReturn.insertContentAt).toHaveBeenCalledWith(12, [
+      {
+        type: "text",
+        marks: [
+          {
+            type: "wikiLink",
+            attrs: { title: "New Topic", exists: false, referenced: true, targetId: null },
+          },
+        ],
+        text: "[[New Topic]]",
+      },
+    ]);
+    expect(editor.chainReturn.run).toHaveBeenCalled();
+  });
+
+  it("Enter で入力が候補と完全一致したら既存ページリンクを挿入する / Enter falls back to the existing page link on exact match", async () => {
+    const user = userEvent.setup();
+    const editor = createMockEditor({ selectionFrom: 3, selectionTo: 3 });
+    mockUseWikiLinkCandidates.mockReturnValue({
+      pages: [{ id: "p-alpha", title: "Alpha", isDeleted: false }],
+      isLoading: false,
+    });
+    mockCheckExistence.mockResolvedValue({
+      pageTitles: new Set(["alpha"]),
+      referencedTitles: new Set(),
+      pageTitleToId: new Map([["alpha", "p-alpha"]]),
+    });
+
+    render(<WikiLinkInputBar editor={editor} pageId="p1" pageNoteId={null} />);
+
+    const input = screen.getByTestId("wiki-link-input-bar-input");
+    await user.click(input);
+    await user.type(input, "Alpha");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(editor.chainReturn.insertContentAt).toHaveBeenCalled();
+    });
+    expect(editor.chainReturn.insertContentAt).toHaveBeenCalledWith(3, [
+      {
+        type: "text",
+        marks: [
+          {
+            type: "wikiLink",
+            attrs: { title: "Alpha", exists: true, referenced: false, targetId: "p-alpha" },
+          },
+        ],
+        text: "[[Alpha]]",
+      },
+    ]);
+    // ghost ではないので `checkReferenced` は呼ばれない。
+    // No ghost branch → `checkReferenced` is not consulted.
+    expect(mockCheckReferenced).not.toHaveBeenCalled();
+  });
+
+  it("候補クリックでも既存ページリンクを挿入し入力欄をクリアする / clicking a suggestion inserts the existing-page link and clears the input", async () => {
+    const user = userEvent.setup();
+    const editor = createMockEditor({ selectionFrom: 7, selectionTo: 7 });
+    mockUseWikiLinkCandidates.mockReturnValue({
+      pages: [{ id: "p-alpha", title: "Alpha", isDeleted: false }],
+      isLoading: false,
+    });
+    mockCheckExistence.mockResolvedValue({
+      pageTitles: new Set(["alpha"]),
+      referencedTitles: new Set(),
+      pageTitleToId: new Map([["alpha", "p-alpha"]]),
+    });
+
+    render(<WikiLinkInputBar editor={editor} pageId="p1" pageNoteId={null} />);
+
+    const input = screen.getByTestId("wiki-link-input-bar-input") as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, "Al");
+
+    await user.click(screen.getByText("Alpha"));
+
+    await waitFor(() => {
+      expect(editor.chainReturn.insertContentAt).toHaveBeenCalled();
+    });
+    expect(editor.chainReturn.insertContentAt).toHaveBeenCalledWith(7, [
+      {
+        type: "text",
+        marks: [
+          {
+            type: "wikiLink",
+            attrs: { title: "Alpha", exists: true, referenced: false, targetId: "p-alpha" },
+          },
+        ],
+        text: "[[Alpha]]",
+      },
+    ]);
+    await waitFor(() => {
+      expect(input.value).toBe("");
+    });
+  });
+
+  it("確定後にエディタへフォーカスを戻す / restores editor focus after confirming", async () => {
+    const user = userEvent.setup();
+    const editor = createMockEditor({ selectionFrom: 2, selectionTo: 2 });
+    render(<WikiLinkInputBar editor={editor} pageId="p1" pageNoteId={null} />);
+
+    const input = screen.getByTestId("wiki-link-input-bar-input");
+    await user.click(input);
+    await user.type(input, "Topic");
+    await user.keyboard("{Enter}");
+
+    // 挿入チェーンの `focus()` で確実にエディタへ戻る。
+    // The insertion chain's `focus()` ensures editor focus is restored.
+    await waitFor(() => {
+      expect(editor.chainReturn.focus).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("WikiLinkInputBar - ガード / guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWikiLinkCandidates.mockReturnValue({ pages: [], isLoading: false });
+  });
+
+  it("editor が null のときは何もしない / no-op when editor is null", async () => {
+    const user = userEvent.setup();
+    render(<WikiLinkInputBar editor={null} pageId="p1" pageNoteId={null} />);
+
+    const input = screen.getByTestId("wiki-link-input-bar-input");
+    await user.type(input, "Whatever");
+    await user.keyboard("{Enter}");
+
+    // editor が存在しないので外部依存は呼ばれない。
+    // External dependencies are untouched without an editor.
+    expect(mockCheckExistence).not.toHaveBeenCalled();
+    expect(mockCheckReferenced).not.toHaveBeenCalled();
+  });
+
+  it("空白だけの入力では確定処理を行わない / does not confirm an all-whitespace input", async () => {
+    const user = userEvent.setup();
+    const editor = createMockEditor();
+    render(<WikiLinkInputBar editor={editor} pageId="p1" pageNoteId={null} />);
+
+    const input = screen.getByTestId("wiki-link-input-bar-input");
+    await user.click(input);
+    await user.type(input, "   ");
+    await user.keyboard("{Enter}");
+
+    expect(editor.chain).not.toHaveBeenCalled();
+  });
+
+  it("Escape で入力欄をクリアしエディタへフォーカスを戻す / Escape clears the bar and refocuses the editor", async () => {
+    const user = userEvent.setup();
+    const editor = createMockEditor();
+    render(<WikiLinkInputBar editor={editor} pageId="p1" pageNoteId={null} />);
+
+    const input = screen.getByTestId("wiki-link-input-bar-input") as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, "Stuff");
+    await user.keyboard("{Escape}");
+
+    expect(input.value).toBe("");
+    expect(editor.commandsReturn.focus).toHaveBeenCalled();
+  });
+});

--- a/src/components/editor/WikiLinkInputBar.test.tsx
+++ b/src/components/editor/WikiLinkInputBar.test.tsx
@@ -21,8 +21,9 @@ vi.mock("@/hooks/useWikiLinkCandidates", () => ({
 
 const mockCheckExistence = vi.fn();
 const mockCheckReferenced = vi.fn();
+const mockUseWikiLinkExistsChecker = vi.fn(() => ({ checkExistence: mockCheckExistence }));
 vi.mock("@/hooks/usePageQueries", () => ({
-  useWikiLinkExistsChecker: () => ({ checkExistence: mockCheckExistence }),
+  useWikiLinkExistsChecker: (options: unknown) => mockUseWikiLinkExistsChecker(options),
   useCheckGhostLinkReferenced: () => ({ checkReferenced: mockCheckReferenced }),
 }));
 
@@ -71,6 +72,9 @@ describe("WikiLinkInputBar - 基本表示 / basic rendering", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseWikiLinkCandidates.mockReturnValue({ pages: [], isLoading: false });
+    mockUseWikiLinkExistsChecker.mockImplementation(() => ({
+      checkExistence: mockCheckExistence,
+    }));
     mockCheckExistence.mockResolvedValue({
       pageTitles: new Set(),
       referencedTitles: new Set(),
@@ -79,16 +83,19 @@ describe("WikiLinkInputBar - 基本表示 / basic rendering", () => {
     mockCheckReferenced.mockResolvedValue(false);
   });
 
-  it("プレースホルダ『ページを作成』を持つ入力欄を描画する / renders the input with the 'create page' placeholder key", () => {
+  it("プレースホルダ『ページを作成』と aria-label を持つ入力欄を描画する / renders the input with the placeholder + aria-label i18n keys", () => {
     const editor = createMockEditor();
     render(<WikiLinkInputBar editor={editor} pageId="p1" pageNoteId={null} />);
 
     const input = screen.getByTestId("wiki-link-input-bar-input") as HTMLInputElement;
     // i18n キーは `useTranslation` モックで素通りするため、キー自体が
-    // placeholder として現れる。値そのものは `common.json` 側のテキスト。
-    // The `useTranslation` mock passes keys through, so the placeholder is the
-    // i18n key here. The actual text lives in `common.json`.
+    // placeholder / aria-label として現れる。値そのものは `common.json` 側の
+    // テキスト。Accessible-name の i18n key 連結が崩れていないことを担保する。
+    // The `useTranslation` mock passes keys through, so the placeholder and
+    // aria-label show up as the i18n keys themselves. Pinning both keys keeps
+    // the accessible-name spec from silently regressing.
     expect(input.placeholder).toBe("common.wikiLinkInputBar.placeholder");
+    expect(input.getAttribute("aria-label")).toBe("common.wikiLinkInputBar.ariaLabel");
   });
 
   it("入力が空のときはサジェストを描画しない / does not render the suggestion list when input is empty", () => {
@@ -128,6 +135,9 @@ describe("WikiLinkInputBar - 確定挙動 / confirm behavior", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseWikiLinkCandidates.mockReturnValue({ pages: [], isLoading: false });
+    mockUseWikiLinkExistsChecker.mockImplementation(() => ({
+      checkExistence: mockCheckExistence,
+    }));
     mockCheckExistence.mockResolvedValue({
       pageTitles: new Set(),
       referencedTitles: new Set(),
@@ -281,6 +291,9 @@ describe("WikiLinkInputBar - ガード / guards", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseWikiLinkCandidates.mockReturnValue({ pages: [], isLoading: false });
+    mockUseWikiLinkExistsChecker.mockImplementation(() => ({
+      checkExistence: mockCheckExistence,
+    }));
   });
 
   it("editor が null のときは何もしない / no-op when editor is null", async () => {
@@ -322,5 +335,58 @@ describe("WikiLinkInputBar - ガード / guards", () => {
 
     expect(input.value).toBe("");
     expect(editor.commandsReturn.focus).toHaveBeenCalled();
+  });
+});
+
+describe("WikiLinkInputBar - スコープ転送 / scope forwarding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWikiLinkExistsChecker.mockImplementation(() => ({
+      checkExistence: mockCheckExistence,
+    }));
+    mockCheckExistence.mockResolvedValue({
+      pageTitles: new Set(),
+      referencedTitles: new Set(),
+      pageTitleToId: new Map(),
+    });
+    mockCheckReferenced.mockResolvedValue(false);
+  });
+
+  it("ノートスコープでは候補ページを `notePages` として exists checker に渡す / forwards note-scope candidates as `notePages` so the Enter fallback can resolve same-note pages (Codex P1, PR #934)", () => {
+    const editor = createMockEditor();
+    const notePages = [
+      { id: "p-alpha", title: "Alpha", isDeleted: false },
+      { id: "p-beta", title: "Beta", isDeleted: false },
+    ];
+    mockUseWikiLinkCandidates.mockReturnValue({ pages: notePages, isLoading: false });
+
+    render(<WikiLinkInputBar editor={editor} pageId="p1" pageNoteId="note-1" />);
+
+    // `useWikiLinkExistsChecker` がノートスコープで呼ばれるとき、候補ページを
+    // `notePages` として渡していないと checker が空集合を返し、Enter による
+    // 完全一致フォールバックが効かなくなる（同名既存ページがあってもゴーストを
+    // 挿入してしまう）。
+    // Without forwarding `notePages` in note scope the checker returns empty
+    // sets and the Enter exact-match fallback silently inserts a ghost link
+    // even when an existing same-note page matches.
+    expect(mockUseWikiLinkExistsChecker).toHaveBeenCalledWith({
+      pageNoteId: "note-1",
+      notePages,
+    });
+  });
+
+  it("個人スコープでは `notePages` を渡さず checker 既定の個人ページ取得に任せる / leaves `notePages` undefined for personal scope to keep the checker's `getPagesSummary` path", () => {
+    const editor = createMockEditor();
+    mockUseWikiLinkCandidates.mockReturnValue({
+      pages: [{ id: "p-alpha", title: "Alpha", isDeleted: false }],
+      isLoading: false,
+    });
+
+    render(<WikiLinkInputBar editor={editor} pageId="p1" pageNoteId={null} />);
+
+    expect(mockUseWikiLinkExistsChecker).toHaveBeenCalledWith({
+      pageNoteId: null,
+      notePages: undefined,
+    });
   });
 });

--- a/src/components/editor/WikiLinkInputBar.tsx
+++ b/src/components/editor/WikiLinkInputBar.tsx
@@ -1,0 +1,123 @@
+import React, { useRef } from "react";
+import type { Editor } from "@tiptap/core";
+import { cn } from "@zedi/ui";
+import { useTranslation } from "react-i18next";
+import { WikiLinkSuggestion } from "./extensions/WikiLinkSuggestion";
+import { useWikiLinkInputBar } from "./useWikiLinkInputBar";
+
+/**
+ * `WikiLinkInputBar` の props。FAB 左に常時表示されるピル型入力バーを
+ * 駆動するために必要な最小限の依存（編集中エディタ、ページ id、所属ノート
+ * id）だけを受け取る。マウントは呼び出し側の責務（通常は `TiptapEditor` 内）。
+ *
+ * Props for the FAB-adjacent WikiLink input bar (#924 §2, #926). Takes only
+ * the bare minimum — the active editor, the editing page id, and the owning
+ * note id used to scope suggestions. The host (`TiptapEditor`) decides when
+ * to mount the bar.
+ */
+export interface WikiLinkInputBarProps {
+  /**
+   * 操作対象のエディタ。`null` の間（初期化前）は入力を受け付けない。
+   * The editor the bar inserts into. `null` while the editor is being
+   * initialized; the bar disables itself in that state.
+   */
+  editor: Editor | null;
+  /** 編集中ページの id。referenced チェック / 自己参照除外のスコープに使う。 / Current page id for the referenced lookups. */
+  pageId?: string;
+  /**
+   * 編集中ページが所属するノート id。`null` は個人ページ、文字列はノート
+   * ネイティブページ。`useWikiLinkCandidates` のスコープに直接渡す。
+   * Owning note id. Forwarded to `useWikiLinkCandidates` to scope the
+   * candidate list (personal vs. same-note). See issue #713 Phase 4.
+   */
+  pageNoteId: string | null;
+  /** 追加でルートに付ける className。 / Optional class name for the outer container. */
+  className?: string;
+}
+
+/**
+ * FAB 左に常時表示されるピル型入力バー。役割はゴーストリンク作成を主目的と
+ * しつつ、入力中に既存ページ候補を提示して既存リンク挿入もできる二役 UI
+ * （issue #924 §2 / #926）。フォーカス時にエディタのカーソル位置を退避し、
+ * 確定（Enter / 候補クリック）でその位置に Wiki Link を挿入してから
+ * エディタへフォーカスを戻す。状態管理は `useWikiLinkInputBar` フックに
+ * 委譲する。
+ *
+ * Pill-shaped input bar mounted next to the FAB. Primary purpose is creating
+ * ghost wiki links; typing also shows existing-page suggestions for
+ * inserting resolved links. On focus the bar saves the editor cursor so the
+ * link lands where the user was writing; on confirm it inserts and returns
+ * focus to the editor. Stateful logic lives in {@link useWikiLinkInputBar}.
+ * See parent issue #924 §2 and sub-issue #926.
+ */
+export const WikiLinkInputBar: React.FC<WikiLinkInputBarProps> = ({
+  editor,
+  pageId,
+  pageNoteId,
+  className,
+}) => {
+  const { t } = useTranslation();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const {
+    value,
+    setValue,
+    pages,
+    showSuggestions,
+    suggestionRef,
+    handleFocus,
+    handleBlur,
+    handleKeyDown,
+    handleSuggestionSelect,
+    handleSuggestionClose,
+  } = useWikiLinkInputBar({ editor, pageId, pageNoteId });
+
+  return (
+    <div
+      className={cn("pointer-events-auto flex flex-col items-stretch gap-2", className)}
+      data-testid="wiki-link-input-bar"
+    >
+      {showSuggestions && (
+        // mousedown を抑止することで候補クリック時に入力欄が blur せず、
+        // クリック→確定の流れがそのまま走るようにする（リスト全体に効く）。
+        // input の `onBlur` が先に発火するとリストが unmount され、後続の
+        // click イベントが届かない問題を回避する。
+        // Prevent the default mousedown action so clicking a candidate does
+        // not blur the input — without this the list would unmount on blur
+        // and the click event would never reach the candidate row.
+        <div className="self-stretch" onMouseDown={(e) => e.preventDefault()}>
+          <WikiLinkSuggestion
+            ref={suggestionRef}
+            query={value}
+            pages={pages}
+            onSelect={handleSuggestionSelect}
+            onClose={handleSuggestionClose}
+          />
+        </div>
+      )}
+      <input
+        ref={inputRef}
+        data-testid="wiki-link-input-bar-input"
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        placeholder={t("common.wikiLinkInputBar.placeholder")}
+        aria-label={t("common.wikiLinkInputBar.ariaLabel")}
+        disabled={!editor}
+        className={cn(
+          "h-12 w-[min(20rem,calc(100vw-7rem))] rounded-full px-5",
+          "bg-secondary/80 text-secondary-foreground placeholder:text-muted-foreground",
+          "shadow-lg backdrop-blur-sm",
+          "border border-transparent",
+          "focus:border-ring focus:bg-secondary focus:ring-ring/40 focus:ring-2 focus:outline-none",
+          "transition-colors duration-150",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+        )}
+      />
+    </div>
+  );
+};
+
+export default WikiLinkInputBar;

--- a/src/components/editor/useWikiLinkInputBar.ts
+++ b/src/components/editor/useWikiLinkInputBar.ts
@@ -1,0 +1,263 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Editor } from "@tiptap/core";
+import { useWikiLinkCandidates } from "@/hooks/useWikiLinkCandidates";
+import { useCheckGhostLinkReferenced, useWikiLinkExistsChecker } from "@/hooks/usePageQueries";
+import type {
+  SuggestionItem,
+  WikiLinkSuggestionHandle,
+  WikiLinkSuggestionPage,
+} from "./extensions/WikiLinkSuggestion";
+
+/**
+ * `useWikiLinkInputBar` のオプション。`WikiLinkInputBar` から関心事
+ * （状態保持・退避選択範囲・確定処理）を抜き出してテスタブルに保つための
+ * 内部 API。
+ *
+ * Options for {@link useWikiLinkInputBar}. The hook isolates the bar's
+ * stateful concerns (saved selection, async confirm, suggestion plumbing)
+ * from rendering so the component itself stays small and the logic is
+ * unit-testable.
+ */
+export interface UseWikiLinkInputBarOptions {
+  editor: Editor | null;
+  pageId?: string;
+  pageNoteId: string | null;
+}
+
+/**
+ * `useWikiLinkInputBar` の戻り値。`WikiLinkInputBar` が描画と DOM 配線に
+ * 必要な値・ハンドラだけを返す（内部 ref は隠す）。
+ *
+ * Return shape of {@link useWikiLinkInputBar}. Limited to what the
+ * rendering component needs — internal refs (saved selection, re-entrancy
+ * guard) stay encapsulated inside the hook.
+ */
+export interface UseWikiLinkInputBarResult {
+  value: string;
+  setValue: (next: string) => void;
+  pages: WikiLinkSuggestionPage[];
+  showSuggestions: boolean;
+  suggestionRef: React.MutableRefObject<WikiLinkSuggestionHandle | null>;
+  handleFocus: () => void;
+  handleBlur: () => void;
+  handleKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  handleSuggestionSelect: (item: SuggestionItem) => void;
+  handleSuggestionClose: () => void;
+}
+
+/**
+ * 退避するエディタ選択範囲。バーをフォーカスする直前の状態を覚えておき、
+ * 確定時にその位置へ Wiki Link を挿入する。
+ *
+ * Saved editor selection used to insert the link back at the cursor the
+ * user left when they jumped into the bar.
+ */
+interface SavedSelection {
+  from: number;
+  to: number;
+}
+
+/**
+ * 入力バーから WikiLink を挿入する共通処理。`existing` 経路は候補側の
+ * `targetId` をそのまま使う。`ghost` 経路は `checkExistence` で完全一致を
+ * もう一度引いて、当たれば既存リンクへ自動フォールバックする
+ * （issue #926 受け入れ条件）。
+ *
+ * Shared insertion path used by both the standalone-Enter and the
+ * suggestion-click flows. The existing branch trusts the resolved
+ * `targetId` from the candidate; the ghost branch re-runs `checkExistence`
+ * so an exact-match still falls back to the existing link
+ * (issue #926 acceptance criterion).
+ */
+async function buildLinkAttrs(
+  trimmed: string,
+  forceExists: boolean | null,
+  forceTargetId: string | null,
+  pageId: string | undefined,
+  checkExistence: ReturnType<typeof useWikiLinkExistsChecker>["checkExistence"],
+  checkReferenced: ReturnType<typeof useCheckGhostLinkReferenced>["checkReferenced"],
+): Promise<{ exists: boolean; referenced: boolean; targetId: string | null }> {
+  if (forceExists === true) {
+    return { exists: true, referenced: false, targetId: forceTargetId };
+  }
+  const { pageTitles, referencedTitles, pageTitleToId } = await checkExistence([trimmed], pageId);
+  const normalized = trimmed.toLowerCase();
+  const exists = pageTitles.has(normalized);
+  const targetId = exists ? (pageTitleToId.get(normalized) ?? null) : null;
+  let referenced = !exists && referencedTitles.has(normalized);
+  if (!exists && !referenced) {
+    // `referencedTitles` で拾えなかった ghost も `ghost_links` をもう一度参照
+    // して、他ページからの参照があれば `referenced=true` を立てる。
+    // Double-check the ghost branch against `ghost_links` to mirror the
+    // in-body suggestion flow in `useSuggestionEffects`.
+    referenced = await checkReferenced(trimmed, pageId);
+  }
+  return { exists, referenced, targetId };
+}
+
+/**
+ * `WikiLinkInputBar` の状態と確定処理を担うフック。レンダリング層から
+ * 状態管理を切り出し、`max-lines-per-function` 制約に収めるための分離。
+ *
+ * State + confirm hook for {@link WikiLinkInputBar}. Splits the stateful
+ * core out of the rendering component so the FC stays small enough to
+ * satisfy the project's `max-lines-per-function` rule and the logic is
+ * unit-testable in isolation.
+ */
+export function useWikiLinkInputBar({
+  editor,
+  pageId,
+  pageNoteId,
+}: UseWikiLinkInputBarOptions): UseWikiLinkInputBarResult {
+  const [value, setValue] = useState("");
+  const [isFocused, setIsFocused] = useState(false);
+  const savedSelectionRef = useRef<SavedSelection | null>(null);
+  const suggestionRef = useRef<WikiLinkSuggestionHandle | null>(null);
+  // 確定処理中フラグ。Promise 中に二重 Enter / クリックが入っても 1 回しか
+  // 挿入が走らないようにする。
+  // Re-entrancy guard so a second Enter or click during the async confirm
+  // does not trigger a duplicate insertion.
+  const isConfirmingRef = useRef(false);
+
+  const { pages } = useWikiLinkCandidates(pageNoteId);
+  const { checkExistence } = useWikiLinkExistsChecker({ pageNoteId });
+  const { checkReferenced } = useCheckGhostLinkReferenced();
+
+  const handleFocus = useCallback(() => {
+    setIsFocused(true);
+    if (editor) {
+      const { from, to } = editor.state.selection;
+      savedSelectionRef.current = { from, to };
+    }
+  }, [editor]);
+
+  const handleBlur = useCallback(() => {
+    setIsFocused(false);
+  }, []);
+
+  const insertLink = useCallback(
+    async (title: string, forceExists: boolean | null, forceTargetId: string | null) => {
+      if (!editor) return;
+      if (isConfirmingRef.current) return;
+      const trimmed = title.trim();
+      if (!trimmed) return;
+
+      isConfirmingRef.current = true;
+      try {
+        const savedFrom = savedSelectionRef.current?.from ?? editor.state.selection.from;
+        const { exists, referenced, targetId } = await buildLinkAttrs(
+          trimmed,
+          forceExists,
+          forceTargetId,
+          pageId,
+          checkExistence,
+          checkReferenced,
+        );
+
+        editor
+          .chain()
+          .focus()
+          .insertContentAt(savedFrom, [
+            {
+              type: "text",
+              marks: [
+                {
+                  type: "wikiLink",
+                  attrs: { title: trimmed, exists, referenced, targetId },
+                },
+              ],
+              text: `[[${trimmed}]]`,
+            },
+          ])
+          .run();
+      } finally {
+        isConfirmingRef.current = false;
+        setValue("");
+        savedSelectionRef.current = null;
+      }
+    },
+    [editor, pageId, checkExistence, checkReferenced],
+  );
+
+  const handleSuggestionSelect = useCallback(
+    (item: SuggestionItem) => {
+      if (item.exists) {
+        void insertLink(item.title, true, item.id);
+      } else {
+        // 「+ 新規作成」エントリ。完全一致の自動フォールバックは
+        // `buildLinkAttrs` 側に任せる。
+        // Synthetic "+ create" row; let `buildLinkAttrs` re-run the
+        // exact-match fallback in case the candidate list is stale.
+        void insertLink(item.title, null, null);
+      }
+    },
+    [insertLink],
+  );
+
+  const handleSuggestionClose = useCallback(() => {
+    setIsFocused(false);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      // Escape は常にバー側で処理する。サジェスト側に渡してしまうと入力値が
+      // 残るため、明示的にクリア + エディタへフォーカスを戻す。
+      // Always handle Escape at the bar level — delegating to the
+      // suggestion would only fire `onClose` and leave the input value
+      // behind, which feels broken.
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setValue("");
+        savedSelectionRef.current = null;
+        editor?.commands.focus();
+        return;
+      }
+
+      // ↑↓ / Enter はサジェスト UI に委譲する。サジェストが消費した場合は
+      // 重複挿入を防ぐためバーの Enter 処理は走らせない。
+      // Delegate ArrowUp / ArrowDown / Enter to the shared suggestion
+      // handle; skip the bar's Enter fallback when the suggestion already
+      // confirmed (avoids a double insertion).
+      const handle = suggestionRef.current;
+      if (handle) {
+        const handled = handle.onKeyDown(event.nativeEvent);
+        if (handled) {
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
+      }
+
+      if (event.key === "Enter") {
+        event.preventDefault();
+        const trimmed = value.trim();
+        if (!trimmed) return;
+        void insertLink(trimmed, null, null);
+      }
+    },
+    [editor, insertLink, value],
+  );
+
+  // editor が外れたタイミング（読み取り専用切替・unmount 前）で残った状態を
+  // 掃除する。保存していた選択範囲は無効なので破棄する。
+  // Clean up the saved selection when the editor unmounts or becomes
+  // unavailable — the position is no longer valid.
+  useEffect(() => {
+    if (!editor) {
+      savedSelectionRef.current = null;
+    }
+  }, [editor]);
+
+  return {
+    value,
+    setValue,
+    pages,
+    showSuggestions: isFocused && value.trim().length > 0,
+    suggestionRef,
+    handleFocus,
+    handleBlur,
+    handleKeyDown,
+    handleSuggestionSelect,
+    handleSuggestionClose,
+  };
+}

--- a/src/components/editor/useWikiLinkInputBar.ts
+++ b/src/components/editor/useWikiLinkInputBar.ts
@@ -120,7 +120,25 @@ export function useWikiLinkInputBar({
   const isConfirmingRef = useRef(false);
 
   const { pages } = useWikiLinkCandidates(pageNoteId);
-  const { checkExistence } = useWikiLinkExistsChecker({ pageNoteId });
+  // ノートスコープでは `useWikiLinkExistsChecker` が `notePages` 無しに呼ば
+  // れると意図的に空の集合を返し、Enter フォールバックが既存ページを解決
+  // できずゴーストを挿入してしまう（Codex P1, PR #934）。サジェスト用に
+  // 既に取得済みの候補ページを `notePages` としてそのまま流し込み、同じ
+  // データソースで完全一致判定できるようにする。`useWikiLinkStatusSync`
+  // と同じ流儀。個人スコープでは未指定のまま渡し、checker 側の
+  // `repo.getPagesSummary(userId)` 経路を維持する。
+  //
+  // In note scope `useWikiLinkExistsChecker` returns empty sets when
+  // `notePages` is missing, causing the bar's exact-match fallback to
+  // never resolve existing note-scope pages and always insert a ghost
+  // (Codex P1, PR #934). Reuse the suggestion candidates we already
+  // fetched here so the checker has the same data — mirrors
+  // `useWikiLinkStatusSync`. Personal scope stays unchanged: the checker
+  // ignores `notePages` and falls back to `repo.getPagesSummary(userId)`.
+  const { checkExistence } = useWikiLinkExistsChecker({
+    pageNoteId,
+    notePages: pageNoteId !== null ? pages : undefined,
+  });
   const { checkReferenced } = useCheckGhostLinkReferenced();
 
   const handleFocus = useCallback(() => {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -131,5 +131,9 @@
     "notCreated": "This page does not exist yet.",
     "notCreatedWithRefs": "This page does not exist yet, and is referenced from others.",
     "clickToCreate": "Click to create"
+  },
+  "wikiLinkInputBar": {
+    "placeholder": "Create a page",
+    "ariaLabel": "Create or link a page"
   }
 }

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -131,5 +131,9 @@
     "notCreated": "まだ作成されていないページです。",
     "notCreatedWithRefs": "まだ作成されていないページです。他のページからも参照されています。",
     "clickToCreate": "クリックして作成"
+  },
+  "wikiLinkInputBar": {
+    "placeholder": "ページを作成",
+    "ariaLabel": "ページを作成またはリンク"
   }
 }


### PR DESCRIPTION
## 概要

FAB 左に常時表示されるピル型入力バー `WikiLinkInputBar` を実装し、ゴーストリンク作成と既存ページリンク挿入の両機能を提供します。フォーカス時にエディタのカーソル位置を退避し、確定時にその位置に Wiki Link を挿入してからエディタへフォーカスを戻します。

## 変更点

- **新規コンポーネント `WikiLinkInputBar`**: FAB 左に配置されるピル型入力バー。ゴーストリンク作成を主目的としつつ、入力中に既存ページ候補を提示して既存リンク挿入も可能
- **新規フック `useWikiLinkInputBar`**: 入力バーの状態管理と確定処理を担当。状態管理をレンダリング層から分離し、テスト可能性を向上
- **新規コンポーネント `FloatingWikiLinkInputBar`**: `WikiLinkInputBar` を固定配置でラップし、FAB スタックの左にレイアウト
- **`TiptapEditor` 統合**: `FloatingWikiLinkInputBar` をエディタ画面でマウント
- **i18n 対応**: 日本語・英語のプレースホルダとアリアラベルを追加
- **包括的なテストスイート**: `WikiLinkInputBar.test.tsx` で基本表示、確定挙動、ガード条件をカバー（326 行）

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `bun run test` で新規テストスイート `WikiLinkInputBar.test.tsx` が全てパスすることを確認
2. エディタ画面でバーが FAB 左に表示されることを確認
3. バーにフォーカスしてテキストを入力し、既存ページ候補が表示されることを確認
4. Enter キーでゴーストリンクが挿入されることを確認
5. 候補をクリックして既存ページリンクが挿入されることを確認
6. Escape キーでバーがクリアされ、エディタへフォーカスが戻ることを確認

## チェックリスト

- [x] テストがすべてパスする（326 行の包括的なテストスイート）
- [x] Lint エラーがない
- [x] i18n 対応（日本語・英語）
- [x] コミットメッセージが Conventional Commits に従っている

## 実装の詳細

### `useWikiLinkInputBar` フック

状態管理と確定処理を担当：
- 入力値、フォーカス状態、候補リストの管理
- フォーカス時にエディタのカーソル位置を退避（`SavedSelection`）
- 確定時に `buildLinkAttrs` で既存ページの有無を判定
- 既存ページ候補との完全一致時は自動フォールバック（issue #926 受け入れ条件）
- ゴーストリンク時は `checkReferenced` で他ページからの参照を確認
- 再入力ガード（`isConfirmingRef`）で二重挿入を防止

### `WikiLinkInputBar` コンポーネント

レン

https://claude.ai/code/session_01TqenYeR55zDPZB1QAnbMEv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Floating wiki-link input bar added to the editor, anchored near the bottom for quick create-or-link workflows.
  * Input shows suggestions and supports keyboard and click confirmation flows.
  * Localization added for English and Japanese UI/ARIA copy.

* **Tests**
  * Comprehensive test coverage for rendering, suggestion behavior, insertion/confirmation flows, focus/restoration, and edge-case guards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->