### PR TITLE
feat: add Cmd/Ctrl+K and Cmd/Ctrl+Shift+L editor shortcuts (issue #928)

### DIFF
--- a/src/components/editor/TiptapEditor.tsx
+++ b/src/components/editor/TiptapEditor.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { EditorContent } from "@tiptap/react";
 import { cn } from "@zedi/ui";
@@ -16,6 +16,8 @@ import { EditorBubbleMenu } from "./TiptapEditor/EditorBubbleMenu";
 import { TableBubbleMenu } from "./TiptapEditor/TableBubbleMenu";
 import { PageActionHub } from "@/components/editor/PageActionHub/PageActionHub";
 import { useTiptapEditorController } from "./TiptapEditor/useTiptapEditorController";
+import { useBubbleMenuWikiLink } from "./TiptapEditor/useBubbleMenuWikiLink";
+import { useEditorWikiLinkShortcuts } from "@/hooks/useEditorWikiLinkShortcuts";
 import { SlashAgentLoadingOverlay } from "./TiptapEditor/SlashAgentLoadingOverlay";
 
 // Re-export types for consumers
@@ -114,6 +116,27 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
     pageNoteId,
   });
 
+  // 入力バーへフォーカスを移すための imperative ハンドル（issue #928 §Cmd+K）。
+  // 入力バー側の `useEffect` がここに focus 関数を割り当てる。
+  // Imperative handle that the bar populates with a focus function (issue
+  // #928 / Cmd+K).
+  const focusInputBarRef = useRef<(() => void) | null>(null);
+
+  // `Cmd/Ctrl+Shift+L` の実体。既存のバブルメニュー実装をそのまま再利用し、
+  // 「選択範囲を Wiki Link 化」操作のロジックを 1 箇所に集約する。
+  // Cmd/Ctrl+Shift+L is wired to the existing bubble-menu conversion so the
+  // "selection → wiki link" logic lives in a single place.
+  const { convertToWikiLink } = useBubbleMenuWikiLink({ editor, pageId });
+  const focusInputBar = useCallback(() => {
+    focusInputBarRef.current?.();
+  }, []);
+  useEditorWikiLinkShortcuts({
+    editor,
+    focusInputBar,
+    convertSelectionToWikiLink: convertToWikiLink,
+    isReadOnly,
+  });
+
   return (
     <div
       ref={editorContainerRef}
@@ -208,7 +231,12 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
         // Always-on pill input bar mounted to the left of the FAB (issue
         // #924 §2 / #926). Doubles as ghost-link creation and existing-link
         // insertion via the shared suggestion popup.
-        <FloatingWikiLinkInputBar editor={editor} pageId={pageId} pageNoteId={resolvedPageNoteId} />
+        <FloatingWikiLinkInputBar
+          editor={editor}
+          pageId={pageId}
+          pageNoteId={resolvedPageNoteId}
+          focusInputBarRef={focusInputBarRef}
+        />
       )}
     </div>
   );

--- a/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.ts
+++ b/src/components/editor/TiptapEditor/useBubbleMenuWikiLink.ts
@@ -11,7 +11,15 @@ import { useWikiLinkExistsChecker } from "@/hooks/usePageQueries";
  * existence checks (and to exclude self-references).
  */
 export interface UseBubbleMenuWikiLinkOptions {
-  editor: Editor;
+  /**
+   * 操作対象のエディタ。`null` の間（初期化前など）は `convertToWikiLink` /
+   * `unsetWikiLink` は no-op、`isWikiLinkSelection` は `false` を返す。
+   *
+   * Target editor. While `null` (e.g. during initialization), the returned
+   * `convertToWikiLink` / `unsetWikiLink` are no-ops and
+   * `isWikiLinkSelection` is `false`.
+   */
+  editor: Editor | null;
   pageId?: string;
 }
 
@@ -53,9 +61,10 @@ export function useBubbleMenuWikiLink({
   const [isConverting, setIsConverting] = useState(false);
   const convertingRef = useRef(false);
 
-  const isWikiLinkSelection = editor.isActive("wikiLink");
+  const isWikiLinkSelection = editor?.isActive("wikiLink") ?? false;
 
   const convertToWikiLink = useCallback(async () => {
+    if (!editor) return;
     if (convertingRef.current) return;
 
     const { from, to } = editor.state.selection;
@@ -113,6 +122,7 @@ export function useBubbleMenuWikiLink({
   }, [editor, pageId, checkExistence]);
 
   const unsetWikiLink = useCallback(() => {
+    if (!editor) return;
     editor.chain().focus().unsetWikiLink().run();
   }, [editor]);
 

--- a/src/components/editor/WikiLinkInputBar.test.tsx
+++ b/src/components/editor/WikiLinkInputBar.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Editor } from "@tiptap/core";
 
@@ -335,6 +335,63 @@ describe("WikiLinkInputBar - ガード / guards", () => {
 
     expect(input.value).toBe("");
     expect(editor.commandsReturn.focus).toHaveBeenCalled();
+  });
+});
+
+describe("WikiLinkInputBar - 外部フォーカス / external focus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWikiLinkCandidates.mockReturnValue({ pages: [], isLoading: false });
+    mockUseWikiLinkExistsChecker.mockImplementation(() => ({
+      checkExistence: mockCheckExistence,
+    }));
+    mockCheckExistence.mockResolvedValue({
+      pageTitles: new Set(),
+      referencedTitles: new Set(),
+      pageTitleToId: new Map(),
+    });
+    mockCheckReferenced.mockResolvedValue(false);
+  });
+
+  it("`focusInputBarRef` 経由で input にフォーカスを移せる / lets the parent focus the input via `focusInputBarRef` (issue #928 / Cmd+K)", () => {
+    const editor = createMockEditor();
+    const focusInputBarRef: React.MutableRefObject<(() => void) | null> = { current: null };
+    render(
+      <WikiLinkInputBar
+        editor={editor}
+        pageId="p1"
+        pageNoteId={null}
+        focusInputBarRef={focusInputBarRef}
+      />,
+    );
+
+    // マウント時点で割り当てられている。
+    // The handle is wired on mount.
+    expect(typeof focusInputBarRef.current).toBe("function");
+
+    act(() => {
+      focusInputBarRef.current?.();
+    });
+
+    const input = screen.getByTestId("wiki-link-input-bar-input");
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("unmount で ref が null に戻る / clears the ref on unmount to avoid dangling references", () => {
+    const editor = createMockEditor();
+    const focusInputBarRef: React.MutableRefObject<(() => void) | null> = { current: null };
+    const { unmount } = render(
+      <WikiLinkInputBar
+        editor={editor}
+        pageId="p1"
+        pageNoteId={null}
+        focusInputBarRef={focusInputBarRef}
+      />,
+    );
+
+    expect(focusInputBarRef.current).not.toBeNull();
+    unmount();
+    expect(focusInputBarRef.current).toBeNull();
   });
 });
 

--- a/src/components/editor/WikiLinkInputBar.tsx
+++ b/src/components/editor/WikiLinkInputBar.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef, type MutableRefObject } from "react";
 import type { Editor } from "@tiptap/core";
 import { cn } from "@zedi/ui";
 import { useTranslation } from "react-i18next";
@@ -33,6 +33,17 @@ export interface WikiLinkInputBarProps {
   pageNoteId: string | null;
   /** 追加でルートに付ける className。 / Optional class name for the outer container. */
   className?: string;
+  /**
+   * バーの input にフォーカスを移すための imperative ハンドル。`focusContentRef`
+   * 等と同じ `MutableRefObject<(() => void) | null>` 規約。`useEditorWikiLinkShortcuts`
+   * の `Cmd/Ctrl+K` 経由で外部からフォーカスを移すために使う（issue #928）。
+   *
+   * Imperative handle for focusing the bar's input. Follows the project's
+   * `MutableRefObject<(() => void) | null>` convention (same as
+   * `focusContentRef`). Used by `useEditorWikiLinkShortcuts` to focus the
+   * bar via `Cmd/Ctrl+K` (issue #928).
+   */
+  focusInputBarRef?: MutableRefObject<(() => void) | null>;
 }
 
 /**
@@ -55,9 +66,27 @@ export const WikiLinkInputBar: React.FC<WikiLinkInputBarProps> = ({
   pageId,
   pageNoteId,
   className,
+  focusInputBarRef,
 }) => {
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // imperative ハンドル: 親（TiptapEditor 経由のショートカットフック）が
+  // バーの input にフォーカスを移すための関数を ref に割り当てる。unmount
+  // 時に null クリアして dangling reference を残さない。
+  // Imperative handle: parent (the shortcut hook wired through TiptapEditor)
+  // gets a function to focus the bar's input. Cleared on unmount to avoid
+  // dangling references.
+  useEffect(() => {
+    if (!focusInputBarRef) return;
+    focusInputBarRef.current = () => {
+      inputRef.current?.focus();
+    };
+    return () => {
+      focusInputBarRef.current = null;
+    };
+  }, [focusInputBarRef]);
+
   const {
     value,
     setValue,

--- a/src/hooks/useEditorWikiLinkShortcuts.test.ts
+++ b/src/hooks/useEditorWikiLinkShortcuts.test.ts
@@ -100,6 +100,18 @@ describe("useEditorWikiLinkShortcuts - Cmd/Ctrl+K", () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
+  it("Caps Lock で `event.key` が 'K' になっても捕捉する / matches uppercase 'K' too (Caps Lock without Shift) — Codex P2", () => {
+    const editor = createMockEditor({ isFocused: true });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "K", metaKey: true });
+
+    expect(focusInputBar).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it("Alt 併用は無視する / ignores when Alt is held", () => {
     const editor = createMockEditor({ isFocused: true });
     renderHook(() =>
@@ -180,6 +192,34 @@ describe("useEditorWikiLinkShortcuts - Cmd/Ctrl+Shift+L", () => {
 
     expect(convertSelectionToWikiLink).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("convertSelectionToWikiLink が reject しても unhandled rejection を出さない / swallows rejections from convertSelectionToWikiLink so the document keydown handler does not leak unhandled rejections (CodeRabbit / Gemini review)", async () => {
+    const editor = createMockEditor({ isFocused: true, selection: { from: 3, to: 8 } });
+    const rejection = new Error("boom");
+    const rejecting = vi.fn().mockRejectedValue(rejection);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      renderHook(() =>
+        useEditorWikiLinkShortcuts({
+          editor,
+          focusInputBar,
+          convertSelectionToWikiLink: rejecting,
+        }),
+      );
+
+      dispatchKeyDown({ key: "L", metaKey: true, shiftKey: true });
+
+      // microtask まで待って catch が走ったことを確認する。
+      // Flush microtasks so the catch handler runs.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(rejecting).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it("Shift 無しの Cmd+L は捕捉しない / does not capture Cmd+L without Shift", () => {

--- a/src/hooks/useEditorWikiLinkShortcuts.test.ts
+++ b/src/hooks/useEditorWikiLinkShortcuts.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
+import { useEditorWikiLinkShortcuts } from "./useEditorWikiLinkShortcuts";
+
+/**
+ * テスト用のミニマル Editor モック。`isFocused` / `isEditable` / `state.selection`
+ * を本フックが参照するためだけに最低限の形で公開する。
+ *
+ * Minimal `Editor` mock exposing only the surface `useEditorWikiLinkShortcuts`
+ * reads: `isFocused`, `isEditable`, and `state.selection`.
+ */
+function createMockEditor(
+  options: {
+    isFocused?: boolean;
+    isEditable?: boolean;
+    selection?: { from: number; to: number };
+  } = {},
+): Editor {
+  const { isFocused = true, isEditable = true, selection = { from: 5, to: 5 } } = options;
+  return {
+    isFocused,
+    isEditable,
+    state: { selection: { from: selection.from, to: selection.to } },
+  } as unknown as Editor;
+}
+
+/**
+ * `KeyboardEvent` を dispatch して `defaultPrevented` 結果を返すヘルパー。
+ * `cancelable: true` を必ず付け、`preventDefault` の呼び出しがフラグに反映
+ * されるようにする（jsdom）。
+ *
+ * Dispatch a `KeyboardEvent` and return whether `preventDefault` was called.
+ * Always set `cancelable: true` so jsdom honors `preventDefault`.
+ */
+function dispatchKeyDown(init: KeyboardEventInit & { key: string }): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  document.dispatchEvent(event);
+  return event;
+}
+
+describe("useEditorWikiLinkShortcuts - Cmd/Ctrl+K", () => {
+  let focusInputBar: ReturnType<typeof vi.fn>;
+  let convertSelectionToWikiLink: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    focusInputBar = vi.fn();
+    convertSelectionToWikiLink = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it("Cmd+K (mac) を捕捉して focusInputBar を呼び preventDefault する / catches Cmd+K on mac and invokes focusInputBar with preventDefault", () => {
+    const editor = createMockEditor({ isFocused: true });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "k", metaKey: true });
+
+    expect(focusInputBar).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("Ctrl+K (windows/linux) を捕捉する / catches Ctrl+K cross-platform", () => {
+    const editor = createMockEditor({ isFocused: true });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "k", ctrlKey: true });
+
+    expect(focusInputBar).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("エディタ非フォーカス時は無視する（グローバル検索に委ねる） / ignores when editor is not focused so the global search shortcut wins", () => {
+    const editor = createMockEditor({ isFocused: false });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "k", metaKey: true });
+
+    expect(focusInputBar).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("Cmd+Shift+K は捕捉しない（modifier 弁別） / does not capture Cmd+Shift+K (modifier discrimination)", () => {
+    const editor = createMockEditor({ isFocused: true });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "k", metaKey: true, shiftKey: true });
+
+    expect(focusInputBar).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("Alt 併用は無視する / ignores when Alt is held", () => {
+    const editor = createMockEditor({ isFocused: true });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "k", metaKey: true, altKey: true });
+
+    expect(focusInputBar).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+describe("useEditorWikiLinkShortcuts - Cmd/Ctrl+Shift+L", () => {
+  let focusInputBar: ReturnType<typeof vi.fn>;
+  let convertSelectionToWikiLink: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    focusInputBar = vi.fn();
+    convertSelectionToWikiLink = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it("非空選択時に convertSelectionToWikiLink を呼ぶ / invokes convertSelectionToWikiLink when selection is non-empty", () => {
+    const editor = createMockEditor({ isFocused: true, selection: { from: 3, to: 8 } });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "L", metaKey: true, shiftKey: true });
+
+    expect(convertSelectionToWikiLink).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("Ctrl+Shift+L もクロスプラットフォームで動く / Ctrl+Shift+L also fires cross-platform", () => {
+    const editor = createMockEditor({ isFocused: true, selection: { from: 3, to: 8 } });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "L", ctrlKey: true, shiftKey: true });
+
+    expect(convertSelectionToWikiLink).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("key が小文字 'l' でも shift と組み合わさっていれば反応する / matches both 'L' and 'l' when shift is held (some browsers/keymaps)", () => {
+    const editor = createMockEditor({ isFocused: true, selection: { from: 1, to: 4 } });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "l", metaKey: true, shiftKey: true });
+
+    expect(convertSelectionToWikiLink).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("選択範囲が空のときは no-op で preventDefault も呼ばない / no-op + does NOT preventDefault when selection is empty", () => {
+    const editor = createMockEditor({ isFocused: true, selection: { from: 5, to: 5 } });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "L", metaKey: true, shiftKey: true });
+
+    expect(convertSelectionToWikiLink).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("エディタ非フォーカス時は無視する / ignores when editor is not focused", () => {
+    const editor = createMockEditor({ isFocused: false, selection: { from: 3, to: 8 } });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "L", metaKey: true, shiftKey: true });
+
+    expect(convertSelectionToWikiLink).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("Shift 無しの Cmd+L は捕捉しない / does not capture Cmd+L without Shift", () => {
+    const editor = createMockEditor({ isFocused: true, selection: { from: 3, to: 8 } });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "l", metaKey: true });
+
+    expect(convertSelectionToWikiLink).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+describe("useEditorWikiLinkShortcuts - 共通ガード / shared guards", () => {
+  let focusInputBar: ReturnType<typeof vi.fn>;
+  let convertSelectionToWikiLink: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    focusInputBar = vi.fn();
+    convertSelectionToWikiLink = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it("editor が null のときは何もしない / no-op when editor is null", () => {
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({
+        editor: null,
+        focusInputBar,
+        convertSelectionToWikiLink,
+      }),
+    );
+
+    const event = dispatchKeyDown({ key: "k", metaKey: true });
+
+    expect(focusInputBar).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("editor.isEditable が false なら何もしない / no-op when editor is not editable", () => {
+    const editor = createMockEditor({ isFocused: true, isEditable: false });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "k", metaKey: true });
+
+    expect(focusInputBar).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("isReadOnly が true なら何もしない / no-op when isReadOnly is true", () => {
+    const editor = createMockEditor({ isFocused: true });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({
+        editor,
+        focusInputBar,
+        convertSelectionToWikiLink,
+        isReadOnly: true,
+      }),
+    );
+
+    const event = dispatchKeyDown({ key: "k", metaKey: true });
+
+    expect(focusInputBar).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("IME 変換中 (isComposing) は何もしない / no-op while IME composition is active", () => {
+    const editor = createMockEditor({ isFocused: true, selection: { from: 1, to: 4 } });
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    const event = dispatchKeyDown({ key: "k", metaKey: true, isComposing: true });
+    const event2 = dispatchKeyDown({ key: "L", metaKey: true, shiftKey: true, isComposing: true });
+
+    expect(focusInputBar).not.toHaveBeenCalled();
+    expect(convertSelectionToWikiLink).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+    expect(event2.defaultPrevented).toBe(false);
+  });
+
+  it("unmount でリスナーが解除される / removes the document listener on unmount", () => {
+    const editor = createMockEditor({ isFocused: true });
+    const { unmount } = renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+
+    unmount();
+
+    const event = dispatchKeyDown({ key: "k", metaKey: true });
+
+    expect(focusInputBar).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("後から登録された bubble phase リスナーより先に走り、event 伝播を止める / runs before later-registered bubble-phase listeners and stops propagation so they do not fire (issue #928 collision guard)", () => {
+    const editor = createMockEditor({ isFocused: true });
+    const laterBubbleListener = vi.fn();
+
+    renderHook(() =>
+      useEditorWikiLinkShortcuts({ editor, focusInputBar, convertSelectionToWikiLink }),
+    );
+    // capture phase 登録の後に追加された bubble phase リスナーは、capture が
+    // stopPropagation を呼んだら呼ばれない。これにより `useGlobalSearchShortcut`
+    // のような既存の document リスナーをエディタ側が優先できる。
+    // A bubble-phase listener registered after the hook should not fire when
+    // the hook's capture handler stops propagation — this is what lets the
+    // editor shortcut preempt the global search shortcut.
+    document.addEventListener("keydown", laterBubbleListener);
+
+    try {
+      act(() => {
+        dispatchKeyDown({ key: "k", metaKey: true });
+      });
+
+      expect(focusInputBar).toHaveBeenCalledTimes(1);
+      expect(laterBubbleListener).not.toHaveBeenCalled();
+    } finally {
+      document.removeEventListener("keydown", laterBubbleListener);
+    }
+  });
+});

--- a/src/hooks/useEditorWikiLinkShortcuts.ts
+++ b/src/hooks/useEditorWikiLinkShortcuts.ts
@@ -85,9 +85,15 @@ export function useEditorWikiLinkShortcuts({
       const mod = event.metaKey || event.ctrlKey;
       if (!mod) return;
 
+      // Caps Lock 等で `event.key` が大文字になっても拾えるよう `toLowerCase()`
+      // で正規化する（Codex P2: Caps Lock 中の `Cmd+K` が無視されていた問題）。
+      // Normalize case so Caps Lock-uppercased `event.key` still matches
+      // (Codex P2: previously Cmd+K was skipped while Caps Lock was on).
+      const normalizedKey = event.key.toLowerCase();
+
       // Cmd/Ctrl + K (Shift 無し) → 入力バーへフォーカス。
       // Cmd/Ctrl + K (no Shift) → focus the Wiki Link input bar.
-      if (!event.shiftKey && event.key === "k") {
+      if (!event.shiftKey && normalizedKey === "k") {
         event.preventDefault();
         event.stopPropagation();
         focusInputBar();
@@ -95,19 +101,22 @@ export function useEditorWikiLinkShortcuts({
       }
 
       // Cmd/Ctrl + Shift + L → 選択範囲を Wiki Link 化。
-      // Shift を押すと `key` が大文字になる実装が大半だが、`l` も許容して
-      // キーボードレイアウト差や synthetic イベント差に強くしておく。
-      // Cmd/Ctrl + Shift + L → convert selection to wiki link. Most layouts
-      // uppercase `key` while Shift is held, but accept lowercase `l` too
-      // for robustness against synthetic events and layout edge cases.
-      if (event.shiftKey && (event.key === "L" || event.key === "l")) {
+      // Cmd/Ctrl + Shift + L → convert selection to wiki link.
+      if (event.shiftKey && normalizedKey === "l") {
         const { from, to } = editor.state.selection;
         // 空選択は no-op、preventDefault も呼ばない（受け入れ条件）。
         // Empty selection is a no-op; do not even preventDefault (issue #928 AC).
         if (from === to) return;
         event.preventDefault();
         event.stopPropagation();
-        void convertSelectionToWikiLink();
+        // 非同期処理の rejection はログだけ取る。document の keydown ハンドラ
+        // 経由で unhandled rejection を出さないための防御（CodeRabbit / Gemini）。
+        // Swallow rejections after logging; prevents unhandled promise
+        // rejections from leaking out of the document keydown handler
+        // (CodeRabbit / Gemini review).
+        void convertSelectionToWikiLink().catch((error: unknown) => {
+          console.error("[useEditorWikiLinkShortcuts] convertSelectionToWikiLink failed", error);
+        });
       }
     };
 

--- a/src/hooks/useEditorWikiLinkShortcuts.ts
+++ b/src/hooks/useEditorWikiLinkShortcuts.ts
@@ -1,0 +1,119 @@
+import { useEffect } from "react";
+import type { Editor } from "@tiptap/core";
+
+/**
+ * `useEditorWikiLinkShortcuts` のオプション。
+ *
+ * Options for {@link useEditorWikiLinkShortcuts}.
+ */
+export interface UseEditorWikiLinkShortcutsOptions {
+  /**
+   * 対象 Tiptap エディタ。`null` の間はショートカットを無効化する。
+   * The target Tiptap editor; shortcuts are disabled while it is `null`.
+   */
+  editor: Editor | null;
+  /**
+   * `Cmd/Ctrl+K` 時に Wiki Link 入力バーへフォーカスを移すコールバック。
+   * 入力バーが自身の `onFocus` でエディタの選択位置を退避するため、ここでは
+   * 「フォーカスを移す」だけ実装すれば十分。
+   *
+   * Callback invoked on `Cmd/Ctrl+K` that focuses the Wiki Link input bar.
+   * The bar itself snapshots the editor selection in its own `onFocus`, so
+   * this only needs to move focus.
+   */
+  focusInputBar: () => void;
+  /**
+   * `Cmd/Ctrl+Shift+L` 時に現在の選択範囲を `[[Title]]` の Wiki Link に
+   * 変換する非同期コールバック。実体は通常
+   * `useBubbleMenuWikiLink({editor, pageId}).convertToWikiLink` を渡す。
+   *
+   * Async callback that converts the current editor selection into a
+   * `[[Title]]` wiki link on `Cmd/Ctrl+Shift+L`. Typically wired to
+   * `useBubbleMenuWikiLink({editor, pageId}).convertToWikiLink`.
+   */
+  convertSelectionToWikiLink: () => Promise<void>;
+  /**
+   * true の間は両ショートカットを無効化する。
+   * Disables both shortcuts while true.
+   */
+  isReadOnly?: boolean;
+}
+
+/**
+ * デスクトップ向けのエディタショートカットを登録するフック（issue #928）。
+ *
+ * - `Cmd/Ctrl + K`: エディタフォーカス時に Wiki Link 入力バーへフォーカス。
+ * - `Cmd/Ctrl + Shift + L`: エディタフォーカスかつ非空選択時に選択範囲を
+ *   即 Wiki Link 化（空選択時は no-op）。
+ *
+ * 既存のグローバル検索（`useGlobalSearchShortcut`）および Tiptap `Link` 拡張の
+ * `Mod-k` と衝突するため、リスナーは **capture phase** で登録し、消費時に
+ * `preventDefault()` + `stopPropagation()` を呼ぶ。これによりエディタ
+ * フォーカス時はエディタ側ハンドラが先に処理し、`useGlobalSearchShortcut`
+ * 側は `defaultPrevented` を見て早期 return する契約となる。
+ *
+ * Desktop Wiki Link shortcut hook (issue #928):
+ *
+ * - `Cmd/Ctrl + K` focuses the Wiki Link input bar while the editor is
+ *   focused.
+ * - `Cmd/Ctrl + Shift + L` converts the current editor selection into a
+ *   `[[Title]]` wiki link (no-op on empty selection).
+ *
+ * Listener is attached in the **capture phase** so it preempts the
+ * document-level global search shortcut and the Tiptap `Link` extension's
+ * `Mod-k` keymap. When consumed, the handler calls `preventDefault()` and
+ * `stopPropagation()`; `useGlobalSearchShortcut` cooperates by bailing out
+ * when `defaultPrevented` is already true.
+ */
+export function useEditorWikiLinkShortcuts({
+  editor,
+  focusInputBar,
+  convertSelectionToWikiLink,
+  isReadOnly,
+}: UseEditorWikiLinkShortcutsOptions): void {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // IME 変換中はキー入力をフックしない（日本語等）。
+      // Don't intercept while an IME composition is in progress (CJK input).
+      if (event.isComposing) return;
+      // Alt 併用は別ショートカット領域に予約する。
+      // Reserve Alt-modified combinations for other shortcuts.
+      if (event.altKey) return;
+      if (!editor || !editor.isEditable || isReadOnly) return;
+      if (!editor.isFocused) return;
+
+      const mod = event.metaKey || event.ctrlKey;
+      if (!mod) return;
+
+      // Cmd/Ctrl + K (Shift 無し) → 入力バーへフォーカス。
+      // Cmd/Ctrl + K (no Shift) → focus the Wiki Link input bar.
+      if (!event.shiftKey && event.key === "k") {
+        event.preventDefault();
+        event.stopPropagation();
+        focusInputBar();
+        return;
+      }
+
+      // Cmd/Ctrl + Shift + L → 選択範囲を Wiki Link 化。
+      // Shift を押すと `key` が大文字になる実装が大半だが、`l` も許容して
+      // キーボードレイアウト差や synthetic イベント差に強くしておく。
+      // Cmd/Ctrl + Shift + L → convert selection to wiki link. Most layouts
+      // uppercase `key` while Shift is held, but accept lowercase `l` too
+      // for robustness against synthetic events and layout edge cases.
+      if (event.shiftKey && (event.key === "L" || event.key === "l")) {
+        const { from, to } = editor.state.selection;
+        // 空選択は no-op、preventDefault も呼ばない（受け入れ条件）。
+        // Empty selection is a no-op; do not even preventDefault (issue #928 AC).
+        if (from === to) return;
+        event.preventDefault();
+        event.stopPropagation();
+        void convertSelectionToWikiLink();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [editor, focusInputBar, convertSelectionToWikiLink, isReadOnly]);
+}

--- a/src/hooks/useGlobalSearchShortcut.test.ts
+++ b/src/hooks/useGlobalSearchShortcut.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useGlobalSearchShortcut } from "./useGlobalSearchShortcut";
+
+/**
+ * `KeyboardEvent` を dispatch するヘルパー。`cancelable: true` を必ず付け、
+ * `preventDefault` がフラグに反映されるようにする。
+ *
+ * Dispatch helper that always sets `cancelable: true` so `preventDefault`
+ * reflects on the returned event.
+ */
+function dispatchKeyDown(init: KeyboardEventInit & { key: string }): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  document.dispatchEvent(event);
+  return event;
+}
+
+describe("useGlobalSearchShortcut", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("Cmd+K で onOpen を呼び preventDefault する / triggers onOpen on Cmd+K with preventDefault", () => {
+    const onOpen = vi.fn();
+    renderHook(() => useGlobalSearchShortcut(onOpen));
+
+    const event = dispatchKeyDown({ key: "k", metaKey: true });
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("Ctrl+K でも動く / also triggers on Ctrl+K", () => {
+    const onOpen = vi.fn();
+    renderHook(() => useGlobalSearchShortcut(onOpen));
+
+    const event = dispatchKeyDown({ key: "k", ctrlKey: true });
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("他のリスナーが capture phase で preventDefault 済みなら onOpen を呼ばない / does not fire onOpen when an earlier capture-phase listener already preventDefault'd (issue #928)", () => {
+    const onOpen = vi.fn();
+    // 先に capture phase のリスナーを登録して preventDefault を発生させる。
+    // これにより、エディタ側ショートカット（capture phase で登録される
+    // useEditorWikiLinkShortcuts）が Cmd+K を消費した場合のグローバル検索の
+    // 抑制契約を担保する。
+    // Register a capture-phase listener that preventDefault's first to model
+    // the editor shortcut. This pins the contract that the global search
+    // bows out when the editor consumed the event (issue #928).
+    const capturePreventer = (e: Event) => {
+      e.preventDefault();
+    };
+    document.addEventListener("keydown", capturePreventer, true);
+
+    try {
+      renderHook(() => useGlobalSearchShortcut(onOpen));
+
+      dispatchKeyDown({ key: "k", metaKey: true });
+
+      expect(onOpen).not.toHaveBeenCalled();
+    } finally {
+      document.removeEventListener("keydown", capturePreventer, true);
+    }
+  });
+
+  it("修飾キー無しの 'k' では発火しない / ignores plain 'k' without modifier", () => {
+    const onOpen = vi.fn();
+    renderHook(() => useGlobalSearchShortcut(onOpen));
+
+    const event = dispatchKeyDown({ key: "k" });
+
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("unmount でリスナーが解除される / removes the listener on unmount", () => {
+    const onOpen = vi.fn();
+    const { unmount } = renderHook(() => useGlobalSearchShortcut(onOpen));
+
+    unmount();
+    dispatchKeyDown({ key: "k", metaKey: true });
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useGlobalSearchShortcut.ts
+++ b/src/hooks/useGlobalSearchShortcut.ts
@@ -1,18 +1,35 @@
 import { useEffect } from "react";
 
 /**
- * Hook to handle global keyboard shortcut for opening search
- * Cmd+K on Mac, Ctrl+K on Windows/Linux
+ * グローバル検索を `Cmd/Ctrl + K` で開くショートカット。
+ *
+ * Hook to handle global keyboard shortcut for opening search.
+ * Cmd+K on Mac, Ctrl+K on Windows/Linux.
+ *
+ * 衝突契約 / collision contract:
+ * - エディタ用 `useEditorWikiLinkShortcuts` が capture phase で `Cmd+K` を
+ *   消費する場合、こちらは bubble phase で `event.defaultPrevented` を
+ *   見て早期 return する（issue #928）。これによりエディタフォーカス時は
+ *   入力バーが優先され、それ以外ではグローバル検索が動く。
+ * - When `useEditorWikiLinkShortcuts` (capture phase) consumes `Cmd+K`
+ *   inside a focused editor, this bubble-phase handler bails out via
+ *   `event.defaultPrevented` (issue #928). Result: editor-focused → focus
+ *   the Wiki Link input bar; otherwise → open global search.
+ *
  * @param onOpen - Callback function when shortcut is triggered
  */
 export function useGlobalSearchShortcut(onOpen: () => void) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Cmd+K (Mac) or Ctrl+K (Windows/Linux)
-      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
-        e.preventDefault();
-        onOpen();
-      }
+      if (!((e.metaKey || e.ctrlKey) && e.key === "k")) return;
+      // capture phase の他リスナー（エディタショートカット等）が消費済みなら
+      // グローバル検索は呼ばない（issue #928 の衝突回避）。
+      // Skip when an earlier capture-phase listener already consumed the
+      // event (issue #928 collision guard).
+      if (e.defaultPrevented) return;
+      e.preventDefault();
+      onOpen();
     };
 
     document.addEventListener("keydown", handleKeyDown);


### PR DESCRIPTION
## 概要

エディタ内で Wiki Link 操作を行うためのキーボードショートカットを実装しました。

- **`Cmd/Ctrl + K`**: Wiki Link 入力バーへフォーカスを移す
- **`Cmd/Ctrl + Shift + L`**: 現在の選択範囲を `[[Title]]` 形式の Wiki Link に変換

グローバル検索（`useGlobalSearchShortcut`）との衝突を回避するため、エディタ側のリスナーを **capture phase** で登録し、消費時に `preventDefault()` + `stopPropagation()` を呼び出します。グローバル検索側は `event.defaultPrevented` を確認して早期 return する契約となります（issue #928）。

## 変更点

- **新規**: `src/hooks/useEditorWikiLinkShortcuts.ts` - エディタショートカットフック
  - `Cmd/Ctrl+K` でバーへフォーカス
  - `Cmd/Ctrl+Shift+L` で選択範囲を Wiki Link 化
  - IME 変換中、Alt 併用、エディタ非フォーカス時は無視
  - capture phase リスナーで既存のグローバル検索を優先制御

- **新規**: `src/hooks/useEditorWikiLinkShortcuts.test.ts` - 包括的なテストスイート（306 行）
  - 両ショートカットの基本動作
  - 修飾キー弁別（Shift、Alt など）
  - エディタ状態ガード（フォーカス、編集可能性、読み取り専用）
  - IME 変換中の無視
  - capture phase による伝播制御と衝突回避

- **新規**: `src/hooks/useGlobalSearchShortcut.test.ts` - グローバル検索のテスト（91 行）
  - `Cmd/Ctrl+K` の基本動作
  - capture phase リスナーによる `defaultPrevented` チェック（issue #928 衝突契約）
  - unmount 時のリスナー解除

- **修正**: `src/hooks/useGlobalSearchShortcut.ts`
  - `event.defaultPrevented` チェックを追加し、エディタ側が消費した場合は早期 return
  - コメント・ドキュメントを日本語・英語で充実

- **修正**: `src/components/editor/TiptapEditor.tsx`
  - `useEditorWikiLinkShortcuts` フックを統合
  - `focusInputBarRef` を管理し、バーへのフォーカス機能を提供
  - `useBubbleMenuWikiLink` の `convertToWikiLink` を `Cmd/Ctrl+Shift+L` に接続

- **修正**: `src/components/editor/WikiLinkInputBar.tsx`
  - `focusInputBarRef` prop を追加（imperative ハンドル）
  - `useEffect` で ref に focus 関数を割り当て、unmount 時に null クリア

- **修正**: `src/components/editor/WikiLinkInputBar.test.tsx`
  - 外部フォーカス機能のテストを追加（`focusInputBarRef` 経由）

- **修正**: `src/components/editor/TiptapEditor/useBubbleMenuWikiLink.ts`
  - `editor` を `Editor | null` に対応（初期化前の null 状態を許容）
  - `convertTo

https://claude.ai/code/session_018SWqs6vMEyXzW6cm75q8Fp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cmd+K / Ctrl+K keyboard shortcut to open and focus the wiki link input bar
  * Added Cmd+Ctrl+Shift+L keyboard shortcut to convert selected text to wiki links

* **Bug Fixes**
  * Resolved keyboard shortcut collision issues to prevent double-handling of Cmd+K
  * Improved null-safety in editor operations when editor is not initialized

* **Tests**
  * Added comprehensive test coverage for wiki link keyboard shortcuts and collision detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/936?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->