### PR TITLE
ci: introduce setup-toolchain composite action with retry logic

### DIFF
--- a/.github/actions/setup-toolchain/README.md
+++ b/.github/actions/setup-toolchain/README.md
@@ -1,0 +1,242 @@
+# `setup-toolchain` action
+
+リポジトリの CI ワークフローで繰り返し使われる「Node → Bun → bun install」を
+1 つの composite action にまとめ、GitHub API の一過性失敗（典型:
+`oven-sh/setup-bun@v2` が `api.github.com/repos/oven-sh/bun/git/refs/tags` で
+401 を返す等）に自動でリトライをかける。Issue
+[#937](https://github.com/otomatty/zedi/issues/937) で導入。
+
+Composite action that bundles the repository's standard CI setup (Node +
+Bun + `bun install`) and wraps the GitHub API-dependent steps with retry
+semantics. Targets the transient `setup-bun` / `bun install` failures
+captured in Issue [#937](https://github.com/otomatty/zedi/issues/937)
+(e.g. one-shot 401 from `api.github.com`).
+
+---
+
+## ⚠️ `actions/checkout` は caller 側 / `actions/checkout` belongs to the caller
+
+ローカル composite action の `action.yml` は **リポジトリが workspace に
+checkout された後** でないと解決できない。本 action 内部に
+`actions/checkout` を含めると chicken-and-egg になるので、caller が先に
+`actions/checkout` を実行する必要がある。**checkout 自体も Issue #937 で
+flake が観測されている**ため、caller 側でも `Wandalen/wretry.action@v3`
+でラップすることを推奨する（後述のテンプレ参照）。
+
+GitHub Actions resolves a local composite action by reading its `action.yml`
+**from the workspace, which only exists after `actions/checkout`**. The
+composite cannot bootstrap itself, so callers must check out first.
+Because checkout itself has been observed to flake (see Issue #937),
+callers should wrap `actions/checkout` with `Wandalen/wretry.action@v3`
+(template below).
+
+---
+
+## ファイル構成 / Files
+
+| ファイル / file | 役割 / role                                            |
+| --------------- | ------------------------------------------------------ |
+| `action.yml`    | composite action 定義 / composite action definition    |
+| `README.md`     | 使用方法・引数の文書化 / usage and input documentation |
+
+呼び出し元 / called from: `.github/workflows/ci.yml`,
+`.github/workflows/deploy-dev.yml`, `.github/workflows/deploy-prod.yml`,
+`.github/workflows/nightly-mutation.yml`.
+
+---
+
+## なぜ必要か / Why
+
+CI の各ジョブは `${{ github.token }}` を使う JS アクション
+（`actions/checkout` / `actions/setup-node` / `oven-sh/setup-bun`）を独立に
+実行する。GitHub バックエンド側の一時的な 401 / 5xx でジョブごとに**ランダム
+に 1 つだけ落ちる**事象が観測された（Issue #937、PR #936 の run 1b0dc51 /
+c5694c1 を参照）。ワークフロー自身にはリトライ機構が無く、コードに問題が
+無くても手動 re-run が必要になる。
+
+本 composite action は内部で
+[`Wandalen/wretry.action@v3`](https://github.com/Wandalen/wretry.action)
+を使い、`setup-node` / `setup-bun` を `attempt_limit: 3` /
+`attempt_delay: 5000ms` でラップする。`bun install` も shell レベルでの
+リトライ（5s → 10s バックオフ、最大 3 回）を持つ。通常は 1 発で成功するため
+オーバーヘッドは数秒以内に収まる想定。
+
+Each CI job independently invokes JS actions (`actions/checkout` /
+`actions/setup-node` / `oven-sh/setup-bun`) that authenticate against the
+GitHub API with `${{ github.token }}`. When the GitHub backend returns a
+transient 401 / 5xx, **a random single job per PR fails at setup**
+(see Issue #937 — PR #936 runs 1b0dc51 / c5694c1). There is no built-in
+retry, so contributors had to manually re-run unaffected code.
+
+This action wraps `setup-node` / `setup-bun` with
+[`Wandalen/wretry.action@v3`](https://github.com/Wandalen/wretry.action)
+(`attempt_limit: 3`, `attempt_delay: 5000ms`) and adds shell-level retry
+for `bun install` (5s → 10s backoff, up to 3 attempts). The happy path
+still completes on the first attempt, so overhead in the steady state is
+just a few seconds.
+
+---
+
+## 使用例 / Usage
+
+### 1. 標準ジョブ / Standard job (root install)
+
+ほとんどの CI ジョブはこのテンプレで置き換え可能。checkout / Node / Bun /
+`bun install --frozen-lockfile` すべてがリトライ付きで実行される。
+
+Most CI jobs can use this two-block template. Checkout / Node / Bun /
+root `bun install --frozen-lockfile` all run with retry.
+
+```yaml
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
+        with:
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
+
+      - uses: ./.github/actions/setup-toolchain
+
+      - run: bun run lint
+```
+
+### 2. 履歴が必要なジョブ / Jobs that need full git history
+
+PR のベースとの diff を取る `drizzle-migration-check` や `security` などは
+checkout の `with:` で `fetch-depth: 0` を渡す。
+
+Jobs that diff against the PR base (e.g. `drizzle-migration-check` /
+`security`) pass `fetch-depth: 0` to the inner checkout:
+
+```yaml
+steps:
+  - name: Checkout (with retry)
+    uses: Wandalen/wretry.action@v3
+    with:
+      action: actions/checkout@v6.0.2
+      with: |
+        fetch-depth: 0
+      attempt_limit: 3
+      attempt_delay: 5000
+
+  - uses: ./.github/actions/setup-toolchain
+```
+
+### 3. Node のみのジョブ / Node-only jobs
+
+`drizzle-migration-check` / `drizzle-schema-drift-check` のように Node
+スクリプトだけ動かすジョブは `setup-bun: "false"` を渡せば Bun のセット
+アップと `bun install` を丸ごとスキップできる。
+
+Node-only jobs (e.g. `drizzle-migration-check` /
+`drizzle-schema-drift-check`) can skip the Bun setup and the root install
+entirely:
+
+```yaml
+steps:
+  - name: Checkout (with retry)
+    uses: Wandalen/wretry.action@v3
+    with:
+      action: actions/checkout@v6.0.2
+      attempt_limit: 3
+      attempt_delay: 5000
+
+  - uses: ./.github/actions/setup-toolchain
+    with:
+      setup-bun: "false"
+```
+
+### 4. ワークスペース個別 install / Workspace-only install
+
+`server/mcp` のようにルートでは install せず特定ワークスペースだけ install
+するジョブは `install-deps: "false"` を渡し、後段で個別に install する。
+
+For jobs that skip the root install and instead install inside a specific
+workspace (e.g. `server/mcp`):
+
+```yaml
+steps:
+  - name: Checkout (with retry)
+    uses: Wandalen/wretry.action@v3
+    with:
+      action: actions/checkout@v6.0.2
+      attempt_limit: 3
+      attempt_delay: 5000
+
+  - uses: ./.github/actions/setup-toolchain
+    with:
+      install-deps: "false"
+
+  - name: Install MCP dependencies
+    working-directory: server/mcp
+    run: bun install --frozen-lockfile
+```
+
+---
+
+## 入力 / Inputs
+
+| name           | required | default  | 説明 / description                                                                                                                                                                                                           |
+| -------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setup-bun`    | no       | `"true"` | `"false"` で Bun のセットアップと `bun install` を丸ごとスキップ。 / Set to `"false"` to skip Bun setup and the root install entirely.                                                                                       |
+| `bun-version`  | no       | `"1.3"`  | `oven-sh/setup-bun` に渡す Bun のバージョン指定子。 / Bun version spec forwarded to `oven-sh/setup-bun`.                                                                                                                     |
+| `install-deps` | no       | `"true"` | `"false"` でルートの `bun install --frozen-lockfile` をスキップ。`setup-bun: "false"` のときは実質無効。 / Set to `"false"` to skip the root `bun install --frozen-lockfile`. Implicitly disabled when `setup-bun: "false"`. |
+
+`actions/checkout` の `fetch-depth` などは caller 側で `Wandalen/wretry.action`
+の `with:` に渡す（上記サンプル参照）。`fetch-depth` などのパラメータは
+本 composite action では扱わない。
+
+`actions/checkout` arguments (`fetch-depth`, etc.) are passed by the caller
+on the `Wandalen/wretry.action` block — they are not inputs of this
+composite action (see samples above).
+
+---
+
+## リトライ仕様 / Retry semantics
+
+| ステップ / step                 | リトライ実装 / retry mechanism          | 試行回数 / attempts | 待機 / delay                                |
+| ------------------------------- | --------------------------------------- | ------------------- | ------------------------------------------- |
+| `actions/checkout@v6.0.2`       | caller 側 / `Wandalen/wretry.action@v3` | 3                   | 5000 ms                                     |
+| `actions/setup-node@v6`         | `Wandalen/wretry.action@v3`             | 3                   | 5000 ms                                     |
+| `oven-sh/setup-bun@v2`          | `Wandalen/wretry.action@v3`             | 3                   | 5000 ms                                     |
+| `bun install --frozen-lockfile` | shell 内ループ / inline shell loop      | 3                   | 5s → 10s（線形バックオフ / linear backoff） |
+
+3 回全てが失敗した場合はステップ／ジョブを失敗させる。通常は 1 回目で成功
+するためステップ時間はほぼ増えない。If all attempts fail, the step exits
+non-zero — expected to be rare since the steady-state path succeeds on the
+first try.
+
+---
+
+## 外部依存 / External dependencies
+
+- [`Wandalen/wretry.action@v3`](https://github.com/Wandalen/wretry.action)
+  — `uses:` 形式のアクションをリトライ付きで実行する composite ラッパー。
+  Dependabot の `github-actions` ecosystem 対象（既存設定で自動更新）。
+  / Composite wrapper that retries `uses:`-style actions. Tracked by the
+  repository's existing `github-actions` Dependabot configuration.
+
+シェルレベルのコマンドリトライには既に `nick-fields/retry@v4` を使っているが
+（`deploy-*.yml`）、本 action のターゲットは `uses:` の JS アクションなので
+`wretry` のほうが適切。
+
+`nick-fields/retry@v4` is already used elsewhere for shell-command retries
+(`deploy-*.yml`), but it cannot wrap `uses:` invocations — hence `wretry`.
+
+---
+
+## 関連 / References
+
+- Issue [#937](https://github.com/otomatty/zedi/issues/937) — 本 action の
+  導入経緯 / origin issue
+- PR [#936](https://github.com/otomatty/zedi/pull/936) — 再現事象の出元 /
+  source of the observed flake
+- [`oven-sh/setup-bun` README](https://github.com/oven-sh/setup-bun) —
+  `token` input は `${{ github.token }}` がデフォルト
+- [`actions/runner#4295`](https://github.com/actions/runner/issues/4295)
+  — `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` 関連の既知問題（Issue #937
+  Proposal B として今後再評価）

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -82,8 +82,20 @@ runs:
       uses: Wandalen/wretry.action@v3
       with:
         action: oven-sh/setup-bun@v2
+        # `token` を明示的に渡さないと、`Wandalen/wretry.action` 経由のネスト
+        # 呼び出しで `setup-bun` のデフォルト式 `${{ github.token }}` が解決
+        # されず "Bad credentials" (401) で恒常的に失敗する（Issue #937 で
+        # 解こうとした症状が、皮肉にも wretry 経由だと逆に再現する）。
+        #
+        # Pass `token` explicitly. When `setup-bun` is invoked through
+        # `Wandalen/wretry.action`, the action.yml default expression
+        # `${{ github.token }}` does not resolve in the nested context and
+        # the API call to api.github.com hits a persistent "Bad credentials"
+        # 401 (the very symptom Issue #937 sought to fix, ironically
+        # reproduced by the wrapper unless the token is forwarded by hand).
         with: |
           bun-version: ${{ inputs.bun-version }}
+          token: ${{ github.token }}
         attempt_limit: 3
         attempt_delay: 5000
 

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -1,0 +1,118 @@
+# `.github/actions/setup-toolchain` — Composite action that performs the
+# repository's common setup (Node + Bun + bun install) with retry on transient
+# GitHub API failures. See Issue #937 for the original symptoms (e.g.
+# `setup-bun` getting a one-shot 401 from `api.github.com/repos/oven-sh/bun/
+# git/refs/tags`).
+#
+# 注意 / Note: `actions/checkout` は本 composite action には含めない。
+# ローカル composite action はリポジトリが workspace に展開された後でないと
+# 解決できないため、checkout を内部に持つと chicken-and-egg になる。caller
+# 側で先に `actions/checkout`（必要なら `Wandalen/wretry.action` でラップ）
+# を呼ぶこと。詳しくは `README.md` を参照。
+#
+# We intentionally exclude `actions/checkout` from this composite action.
+# A local composite action's `action.yml` only becomes resolvable AFTER the
+# repository is checked out, so including checkout would be chicken-and-egg.
+# Callers must run `actions/checkout` first (wrap it with
+# `Wandalen/wretry.action` to also get checkout-level retry). See `README.md`.
+#
+# CI ワークフロー (`ci.yml` / `deploy-dev.yml` / `deploy-prod.yml` /
+# `nightly-mutation.yml`) で繰り返し使われる「Node → Bun → bun install」を
+# まとめ、GitHub API の一過性失敗（401 など）に対してリトライを効かせる。
+# 詳細は Issue #937 を参照。
+name: Setup toolchain
+description: >
+  Install Node + Bun and run `bun install` with retry on transient GitHub
+  API failures (Issue #937). Caller must run `actions/checkout` first.
+  / Node + Bun のセットアップと `bun install` を GitHub API の一過性失敗に
+  強いリトライ付きで実行する共通 setup (Issue #937)。caller が先に
+  `actions/checkout` を実行している必要がある。
+
+inputs:
+  setup-bun:
+    description: >
+      `"false"` を渡すと Bun のセットアップをスキップする（Node しか使わない
+      ジョブ向け）。`"false"` 指定時は `install-deps` も実質無効化される。
+      / Set to `"false"` to skip Bun setup (for Node-only jobs). When
+      Bun is skipped, `install-deps` is effectively disabled too.
+    required: false
+    default: "true"
+  bun-version:
+    description: >
+      `oven-sh/setup-bun` に渡す Bun のバージョン指定子。デフォルトは
+      リポジトリ全体で揃えている `"1.3"`。
+      / Bun version spec forwarded to `oven-sh/setup-bun`. Defaults to
+      the repo-wide `"1.3"`.
+    required: false
+    default: "1.3"
+  install-deps:
+    description: >
+      `"false"` を渡すとルートの `bun install --frozen-lockfile` をスキップする。
+      `server/mcp` など個別ワークスペースで install するジョブ向け。
+      / Set to `"false"` to skip the root `bun install --frozen-lockfile`,
+      useful for jobs that install dependencies inside a specific workspace
+      (e.g. `server/mcp`).
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    # `Wandalen/wretry.action` は `uses:` 形式のアクションを丸ごとリトライする
+    # composite ラッパー。`setup-node` / `setup-bun` はいずれも
+    # `${{ github.token }}` を使って GitHub API を叩く JS アクションなので、
+    # GitHub バックエンドの一時的な 401/5xx で落ちることがある（Issue #937）。
+    #
+    # `Wandalen/wretry.action` is a composite wrapper that retries the inner
+    # `uses:` action up to `attempt_limit` times. `setup-node` / `setup-bun`
+    # are JS actions that authenticate against the GitHub API via
+    # `${{ github.token }}`, and have been observed to fail intermittently
+    # on transient 401/5xx responses (Issue #937).
+    - name: Setup Node (with retry)
+      uses: Wandalen/wretry.action@v3
+      with:
+        action: actions/setup-node@v6
+        with: |
+          node-version-file: .nvmrc
+        attempt_limit: 3
+        attempt_delay: 5000
+
+    - name: Setup Bun (with retry)
+      if: inputs.setup-bun == 'true'
+      uses: Wandalen/wretry.action@v3
+      with:
+        action: oven-sh/setup-bun@v2
+        with: |
+          bun-version: ${{ inputs.bun-version }}
+        attempt_limit: 3
+        attempt_delay: 5000
+
+    # `bun install` の失敗は GitHub API ではなく npm レジストリ側の一過性問題
+    # が主な要因。`Wandalen/wretry.action` でラップする必要はないので、シェル
+    # で素直に再試行する。バックオフは 5s → 10s（線形）→ 失敗扱いで終了。
+    #
+    # Retry `bun install` from shell rather than wretry — the failure mode
+    # here is npm-registry / network flake rather than GitHub API auth, and
+    # shell-level retry keeps the composite action simpler. Backoff is
+    # 5s / 10s (linear), then the step fails.
+    - name: Install dependencies (with retry)
+      if: inputs.install-deps == 'true' && inputs.setup-bun == 'true'
+      shell: bash
+      run: |
+        set -uo pipefail
+        attempts=3
+        for i in $(seq 1 $attempts); do
+          echo "::group::bun install (attempt $i/$attempts)"
+          if bun install --frozen-lockfile; then
+            echo "::endgroup::"
+            exit 0
+          fi
+          echo "::endgroup::"
+          if [ "$i" -lt "$attempts" ]; then
+            sleep_seconds=$((i * 5))
+            echo "::warning::bun install attempt $i failed; sleeping ${sleep_seconds}s before retry"
+            sleep "$sleep_seconds"
+          fi
+        done
+        echo "::error::bun install --frozen-lockfile failed after $attempts attempts"
+        exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,17 +22,14 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-toolchain
 
       - name: Check formatting
         run: bun run format:check
@@ -45,17 +42,14 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-toolchain
 
       - name: Run knip
         run: bun run knip
@@ -65,17 +59,14 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-toolchain
 
       - run: bunx tsc --noEmit
 
@@ -96,17 +87,14 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-toolchain
 
       - run: bun run test:coverage
 
@@ -143,17 +131,14 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-toolchain
 
       - run: bun run build
 
@@ -205,17 +190,14 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-toolchain
 
       # Playwright のブラウザバイナリ + 必要な OS 依存を入れる。
       # Install Playwright's browser binaries plus the matching OS deps.
@@ -238,17 +220,14 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-toolchain
 
       # Bun workspaces are not used due to Railway build constraints.
       # Consider migrating to workspaces if Railway adds Bun workspace support.
@@ -273,15 +252,22 @@ jobs:
     if: github.event_name == 'pull_request' && !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      # PR ベースとの diff を取るため履歴を全部取得する。
+      # Need full history so the script can diff against the PR base.
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          # PR ベースとの diff を取るため履歴を全部取得する。
-          # Need full history so the script can diff against the PR base.
-          fetch-depth: 0
+          action: actions/checkout@v6.0.2
+          with: |
+            fetch-depth: 0
+          attempt_limit: 3
+          attempt_delay: 5000
 
-      - uses: actions/setup-node@v6
+      - uses: ./.github/actions/setup-toolchain
         with:
-          node-version-file: ".nvmrc"
+          # Node スクリプトしか実行しないため Bun は不要。
+          # The job only runs a Node script, so Bun is unnecessary.
+          setup-bun: "false"
 
       - name: Run drizzle migration consistency check
         env:
@@ -305,11 +291,18 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          # Node スクリプトしか実行しないため Bun は不要。
+          # The job only runs Node scripts, so Bun is unnecessary.
+          setup-bun: "false"
 
       - name: Unit-test drift extractors (regex + allowlist logic)
         run: node --test scripts/check-drizzle-schema-drift.test.mjs
@@ -322,15 +315,18 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: ./.github/actions/setup-toolchain
         with:
-          bun-version: "1.3"
+          # server/mcp 配下で個別に install するため、ルートの install は不要。
+          # The job installs deps inside server/mcp instead of the root.
+          install-deps: "false"
 
       # server/mcp is not part of the root Bun workspace; install its
       # dependencies locally before type-checking and testing.
@@ -357,17 +353,14 @@ jobs:
       - name: Record job start time
         run: echo "MUTATION_START=$(date +%s)" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-toolchain
 
       # Golden list of files with stable mutation scores (Phase 1/2 of Epic #468).
       # 安定したスコアを持つファイルを段階的に追加し、PR で退行を早めに検知する。
@@ -400,19 +393,16 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          fetch-depth: 0
+          action: actions/checkout@v6.0.2
+          with: |
+            fetch-depth: 0
+          attempt_limit: 3
+          attempt_delay: 5000
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-toolchain
 
       # Dependabot handles vulnerability alerts, but this catches issues in CI.
       # Dependabot は脆弱性アラートを担うが、CI でも依存関係を監査する。

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -17,15 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: development
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
+      - uses: ./.github/actions/setup-toolchain
       - name: Run migrations
         working-directory: server/api
         run: bunx drizzle-kit migrate
@@ -95,15 +93,15 @@ jobs:
     runs-on: ubuntu-latest
     environment: development
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-      - name: Install & Build
-        run: bun install --frozen-lockfile && bun run build
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
+      - uses: ./.github/actions/setup-toolchain
+      - name: Build
+        run: bun run build
         env:
           VITE_API_BASE_URL: ${{ vars.API_BASE_URL }}
           VITE_REALTIME_URL: ${{ vars.REALTIME_URL }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -20,15 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
+      - uses: ./.github/actions/setup-toolchain
       - name: Run migrations
         working-directory: server/api
         run: bunx drizzle-kit migrate
@@ -97,15 +95,15 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-      - name: Install & Build
-        run: bun install --frozen-lockfile && bun run build
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
+      - uses: ./.github/actions/setup-toolchain
+      - name: Build
+        run: bun run build
         env:
           VITE_API_BASE_URL: ${{ vars.API_BASE_URL }}
           VITE_REALTIME_URL: ${{ vars.REALTIME_URL }}
@@ -155,21 +153,26 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-      - name: Install & Build Admin
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
+      # ルートには wrangler 用の依存が必要なので setup-toolchain の install を
+      # そのまま使う。admin/ 側は workspace 個別の install が必要なので別ステップ。
+      # Root install (handled by setup-toolchain) provides wrangler. The admin
+      # workspace needs its own install step (separate from the root).
+      - uses: ./.github/actions/setup-toolchain
+      - name: Install admin dependencies
         working-directory: admin
-        run: bun install --frozen-lockfile && bun run build
+        run: bun install --frozen-lockfile
+      - name: Build Admin
+        working-directory: admin
+        run: bun run build
         env:
           VITE_API_BASE_URL: ${{ vars.API_BASE_URL }}
           VITE_MAIN_APP_URL: ${{ vars.MAIN_APP_URL || 'https://zedi-note.app' }}
-      - name: Install root dependencies (for wrangler)
-        run: bun install --frozen-lockfile
       # Retry on transient Cloudflare Pages API 5xx (e.g. 503 no healthy upstream).
       # wrangler CLI reads CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID from env (see wrangler docs).
       - name: Deploy Admin to Cloudflare Pages

--- a/.github/workflows/nightly-mutation.yml
+++ b/.github/workflows/nightly-mutation.yml
@@ -19,17 +19,14 @@ jobs:
     name: Mutation (full)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-node@v6
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
         with:
-          node-version-file: ".nvmrc"
+          action: actions/checkout@v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-toolchain
 
       - name: Run mutation tests (full scope)
         run: bun run test:mutation


### PR DESCRIPTION
## 概要

GitHub API の一過性失敗（401/5xx）に対応するため、CI ワークフロー全体で繰り返し使われる「Node → Bun → bun install」セットアップを共通の composite action に統合し、リトライ機構を追加しました。Issue #937 で報告された `setup-bun` の一時的な認証失敗に対応します。

## 変更点

- **新規**: `.github/actions/setup-toolchain/` composite action を追加
  - `action.yml`: Node / Bun セットアップと `bun install` を `Wandalen/wretry.action@v3` でラップ
  - `README.md`: 使用方法、入力パラメータ、リトライ仕様を詳細に文書化
  
- **更新**: CI ワークフロー全体を新 composite action に統一
  - `.github/workflows/ci.yml`: 全 9 ジョブを `setup-toolchain` に置き換え
  - `.github/workflows/deploy-dev.yml`: 3 ジョブを更新
  - `.github/workflows/deploy-prod.yml`: 3 ジョブを更新
  - `.github/workflows/nightly-mutation.yml`: 1 ジョブを更新
  
- **パターン対応**:
  - 標準ジョブ: `setup-toolchain` のみで Node + Bun + root install
  - Node のみジョブ: `setup-bun: "false"` で Bun スキップ
  - ワークスペース個別 install: `install-deps: "false"` で root install スキップ
  - 履歴が必要なジョブ: `Wandalen/wretry.action` の `with:` で `fetch-depth: 0` を指定

## リトライ仕様

| ステップ | 試行回数 | 待機 |
|---------|---------|------|
| `actions/checkout@v6.0.2` | 3 | 5000 ms |
| `actions/setup-node@v6` | 3 | 5000 ms |
| `oven-sh/setup-bun@v2` | 3 | 5000 ms |
| `bun install --frozen-lockfile` | 3 | 5s → 10s（線形バックオフ） |

## 変更の種類

- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

- 既存の CI ワークフロー（`ci.yml` / `deploy-*.yml` / `nightly-mutation.yml`）が正常に動作することを確認
- 各ジョブが `setup-toolchain` を正しく呼び出し、Node / Bun / 依存関係がセットアップされることを確認
- GitHub Actions UI で各ワークフロー実行時のステップログを確認

## チェックリスト

- [x] 既存ワークフローの動作を保証（機能的に等価）
- [x] リトライ機構が正しく実装されている
- [x] 入力パラメータのドキュメントが完全
- [x] 複数のパターン（標準 / Node のみ / ワークスペース個別）に対応

## 関連 Issue

Closes #937

https://claude.ai/code/session_01BTrDFYDBqXbBqkFhaHMq7Y