### PR TITLE
feat: add mobile selection sheet for text formatting

### DIFF
--- a/src/components/editor/TiptapEditor.tsx
+++ b/src/components/editor/TiptapEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { EditorContent } from "@tiptap/react";
-import { cn } from "@zedi/ui";
+import { cn, useIsMobile } from "@zedi/ui";
 import { MermaidGeneratorDialog } from "./MermaidGeneratorDialog";
 import { CreatePageDialog } from "./TiptapEditor/CreatePageDialog";
 import type { TiptapEditorProps } from "./TiptapEditor/types";
@@ -13,6 +13,7 @@ import { WikiLinkHoverCardLayer } from "./TiptapEditor/WikiLinkHoverCardLayer";
 import { TagSuggestionLayer } from "./TiptapEditor/TagSuggestionLayer";
 import { SlashSuggestionLayer } from "./TiptapEditor/SlashSuggestionLayer";
 import { EditorBubbleMenu } from "./TiptapEditor/EditorBubbleMenu";
+import { MobileSelectionSheet } from "./TiptapEditor/MobileSelectionSheet";
 import { TableBubbleMenu } from "./TiptapEditor/TableBubbleMenu";
 import { PageActionHub } from "@/components/editor/PageActionHub/PageActionHub";
 import { useTiptapEditorController } from "./TiptapEditor/useTiptapEditorController";
@@ -51,6 +52,7 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
   pageNoteId = null,
 }) => {
   const { t } = useTranslation();
+  const isMobile = useIsMobile();
   const resolvedPlaceholder = placeholder ?? t("editor.startWritingPlaceholder");
   const {
     editor,
@@ -165,7 +167,16 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
       <EditorContent editor={editor} />
       {editor && !isReadOnly && (
         <>
-          <EditorBubbleMenu editor={editor} pageId={pageId} />
+          {/*
+            BubbleMenu はモバイルでは仮想キーボードと干渉するため非表示にし、
+            代わりにキーボード直上のシート (MobileSelectionSheet) で同等の
+            装飾アクションを提供する（issue #924 §2 / #929）。
+            The bubble menu collides with the on-screen keyboard on phones,
+            so we hide it on mobile and route the same actions through the
+            keyboard-aware sheet instead (issue #924 §2 / #929).
+          */}
+          {!isMobile && <EditorBubbleMenu editor={editor} pageId={pageId} />}
+          {isMobile && <MobileSelectionSheet editor={editor} pageId={pageId} />}
           <TableBubbleMenu editor={editor} />
         </>
       )}

--- a/src/components/editor/TiptapEditor/MobileSelectionSheet.test.tsx
+++ b/src/components/editor/TiptapEditor/MobileSelectionSheet.test.tsx
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
+
+// `react-i18next` を素通りモック。
+// Pass-through i18n mock.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// `useBubbleMenuWikiLink` は内部で API 問い合わせが走るためここでは無効化し、
+// テストの主目的（表示/非表示・ボタン配線）に集中する。
+// Stub out wiki-link existence checking so we can focus on visibility and
+// the button wiring without spinning up the page-queries hook.
+vi.mock("@/hooks/usePageQueries", () => ({
+  useWikiLinkExistsChecker: () => ({
+    checkExistence: vi.fn().mockResolvedValue({
+      pageTitles: new Set(),
+      referencedTitles: new Set(),
+      pageTitleToId: new Map(),
+    }),
+  }),
+}));
+
+// キーボードオフセットは別の hook で検証済みのため、本コンポーネントの
+// テストでは固定値を返すモックに置き換える。
+// Keyboard offset is exercised by its own hook test; here we stub it so we
+// can assert the sheet just applies the value verbatim.
+let mockKeyboardOffset = 0;
+vi.mock("@/hooks/useVirtualKeyboardOffset", () => ({
+  useVirtualKeyboardOffset: () => mockKeyboardOffset,
+}));
+
+import { MobileSelectionSheet } from "./MobileSelectionSheet";
+
+interface EditorMockOptions {
+  selectionEmpty?: boolean;
+  hasFocus?: boolean;
+  isEditable?: boolean;
+  activeMarks?: ReadonlySet<string>;
+}
+
+/**
+ * 表示判定とボタン配線を検証するための最小エディタモック。
+ * - `on/off` で `selectionUpdate` / `focus` / `blur` を購読できる
+ * - `setActive`/`setHasFocus` でテストから内部状態を切り替えて `fireEvents` で通知
+ * - `chain().focus().toggleX().run()` のチェーンを vi.fn() で観測する
+ *
+ * Minimal editor mock for the visibility logic and button wiring. Supports
+ * subscribing to selectionUpdate / focus / blur, mutating state, and
+ * observing chain command invocations via vi.fn().
+ */
+function createMockEditor(initial: EditorMockOptions = {}) {
+  let selectionEmpty = initial.selectionEmpty ?? false;
+  let hasFocus = initial.hasFocus ?? true;
+  let isEditable = initial.isEditable ?? true;
+  let activeMarks = new Set<string>(initial.activeMarks ?? []);
+  const listeners = new Map<string, Set<() => void>>();
+
+  const run = vi.fn();
+  const chainable = {
+    focus: vi.fn(() => chainable),
+    toggleBold: vi.fn(() => chainable),
+    toggleItalic: vi.fn(() => chainable),
+    toggleStrike: vi.fn(() => chainable),
+    toggleCode: vi.fn(() => chainable),
+    deleteRange: vi.fn(() => chainable),
+    insertContent: vi.fn(() => chainable),
+    unsetWikiLink: vi.fn(() => chainable),
+    run,
+  };
+
+  const editor = {
+    isActive: (name: string) => activeMarks.has(name),
+    get isEditable() {
+      return isEditable;
+    },
+    state: {
+      get selection() {
+        return { empty: selectionEmpty, from: 0, to: 0 };
+      },
+      doc: { textBetween: () => "selected" },
+    },
+    view: { hasFocus: () => hasFocus },
+    chain: () => chainable,
+    on(event: string, cb: () => void) {
+      let set = listeners.get(event);
+      if (!set) {
+        set = new Set();
+        listeners.set(event, set);
+      }
+      set.add(cb);
+    },
+    off(event: string, cb: () => void) {
+      listeners.get(event)?.delete(cb);
+    },
+  } as unknown as Editor;
+
+  const fire = (event: string) => {
+    const set = listeners.get(event);
+    if (!set) return;
+    for (const cb of set) cb();
+  };
+
+  return {
+    editor,
+    chainable,
+    runMock: run,
+    setSelectionEmpty(v: boolean) {
+      selectionEmpty = v;
+    },
+    setHasFocus(v: boolean) {
+      hasFocus = v;
+    },
+    setIsEditable(v: boolean) {
+      isEditable = v;
+    },
+    setActiveMarks(marks: Iterable<string>) {
+      activeMarks = new Set(marks);
+    },
+    fire,
+    listenerCount(event: string) {
+      return listeners.get(event)?.size ?? 0;
+    },
+  };
+}
+
+describe("MobileSelectionSheet", () => {
+  beforeEach(() => {
+    mockKeyboardOffset = 0;
+  });
+
+  it("選択が空かつ wikiLink でないときは描画しない / does not render with empty non-wikiLink selection", () => {
+    const m = createMockEditor({ selectionEmpty: true, hasFocus: true });
+    render(<MobileSelectionSheet editor={m.editor} />);
+    expect(screen.queryByTestId("mobile-selection-sheet")).not.toBeInTheDocument();
+  });
+
+  it("選択があるときに描画する / renders when there is a non-empty selection", () => {
+    const m = createMockEditor({ selectionEmpty: false, hasFocus: true });
+    render(<MobileSelectionSheet editor={m.editor} />);
+    expect(screen.getByTestId("mobile-selection-sheet")).toBeInTheDocument();
+  });
+
+  it("選択が空でも wikiLink アクティブなら描画する / shows on caret inside a wikiLink", () => {
+    const m = createMockEditor({
+      selectionEmpty: true,
+      hasFocus: true,
+      activeMarks: new Set(["wikiLink"]),
+    });
+    render(<MobileSelectionSheet editor={m.editor} />);
+    expect(screen.getByTestId("mobile-selection-sheet")).toBeInTheDocument();
+  });
+
+  it("コードブロック内では描画しない / hides while caret is inside a codeBlock", () => {
+    const m = createMockEditor({
+      selectionEmpty: false,
+      hasFocus: true,
+      activeMarks: new Set(["codeBlock"]),
+    });
+    render(<MobileSelectionSheet editor={m.editor} />);
+    expect(screen.queryByTestId("mobile-selection-sheet")).not.toBeInTheDocument();
+  });
+
+  it("エディタが編集不可なら描画しない / hides while the editor is not editable", () => {
+    const m = createMockEditor({ selectionEmpty: false, isEditable: false });
+    render(<MobileSelectionSheet editor={m.editor} />);
+    expect(screen.queryByTestId("mobile-selection-sheet")).not.toBeInTheDocument();
+  });
+
+  it("選択解除イベントで閉じる / closes when the user clears the selection", () => {
+    const m = createMockEditor({ selectionEmpty: false, hasFocus: true });
+    render(<MobileSelectionSheet editor={m.editor} />);
+    expect(screen.getByTestId("mobile-selection-sheet")).toBeInTheDocument();
+
+    act(() => {
+      m.setSelectionEmpty(true);
+      m.fire("selectionUpdate");
+    });
+
+    expect(screen.queryByTestId("mobile-selection-sheet")).not.toBeInTheDocument();
+  });
+
+  it("blur で閉じ、focus で再表示する / hides on blur and shows again on focus", () => {
+    const m = createMockEditor({ selectionEmpty: false, hasFocus: true });
+    render(<MobileSelectionSheet editor={m.editor} />);
+    expect(screen.getByTestId("mobile-selection-sheet")).toBeInTheDocument();
+
+    act(() => {
+      m.setHasFocus(false);
+      m.fire("blur");
+    });
+    expect(screen.queryByTestId("mobile-selection-sheet")).not.toBeInTheDocument();
+
+    act(() => {
+      m.setHasFocus(true);
+      m.fire("focus");
+    });
+    expect(screen.getByTestId("mobile-selection-sheet")).toBeInTheDocument();
+  });
+
+  it("unmount でエディタリスナーを解除する / detaches editor listeners on unmount", () => {
+    const m = createMockEditor({ selectionEmpty: false });
+    const { unmount } = render(<MobileSelectionSheet editor={m.editor} />);
+    expect(m.listenerCount("selectionUpdate")).toBeGreaterThan(0);
+    unmount();
+    expect(m.listenerCount("selectionUpdate")).toBe(0);
+    expect(m.listenerCount("focus")).toBe(0);
+    expect(m.listenerCount("blur")).toBe(0);
+  });
+
+  it("editor が null のときは何も描画しない / renders nothing when editor is null", () => {
+    render(<MobileSelectionSheet editor={null} />);
+    expect(screen.queryByTestId("mobile-selection-sheet")).not.toBeInTheDocument();
+  });
+
+  it("キーボード高さ分だけ bottom をオフセットする / lifts the sheet by the keyboard offset", () => {
+    mockKeyboardOffset = 320;
+    const m = createMockEditor({ selectionEmpty: false, hasFocus: true });
+    render(<MobileSelectionSheet editor={m.editor} />);
+    const sheet = screen.getByTestId("mobile-selection-sheet");
+    expect(sheet.style.bottom).toBe("320px");
+  });
+
+  it("Bold / Italic / Strike / Code / WikiLink の 5 アクションを描画する / renders the five required actions", () => {
+    const m = createMockEditor({ selectionEmpty: false, hasFocus: true });
+    render(<MobileSelectionSheet editor={m.editor} />);
+    expect(screen.getByRole("button", { name: /bold/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /italic/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /strike/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /code/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /wiki link/i })).toBeInTheDocument();
+  });
+
+  it("Bold ボタンで toggleBold が呼ばれる / clicking Bold runs toggleBold", () => {
+    const m = createMockEditor({ selectionEmpty: false, hasFocus: true });
+    render(<MobileSelectionSheet editor={m.editor} />);
+    fireEvent.click(screen.getByRole("button", { name: /bold/i }));
+    expect(m.chainable.toggleBold).toHaveBeenCalled();
+    expect(m.runMock).toHaveBeenCalled();
+  });
+
+  it("wikiLink アクティブ時は解除ボタンを出す / shows the unset button when caret is inside a wikiLink", () => {
+    const m = createMockEditor({
+      selectionEmpty: true,
+      hasFocus: true,
+      activeMarks: new Set(["wikiLink"]),
+    });
+    render(<MobileSelectionSheet editor={m.editor} />);
+    expect(screen.getByRole("button", { name: /unset wiki link/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/editor/TiptapEditor/MobileSelectionSheet.tsx
+++ b/src/components/editor/TiptapEditor/MobileSelectionSheet.tsx
@@ -1,0 +1,166 @@
+import React, { useCallback } from "react";
+import type { Editor } from "@tiptap/core";
+import { Bold, Italic, Strikethrough, Code, Link2, Link2Off } from "lucide-react";
+import { useVirtualKeyboardOffset } from "@/hooks/useVirtualKeyboardOffset";
+import { BubbleMenuButton } from "./BubbleMenuButton";
+import { useBubbleMenuWikiLink } from "./useBubbleMenuWikiLink";
+import { useMobileSelectionVisible } from "./useMobileSelectionVisible";
+
+/**
+ * `MobileSelectionSheet` の props。モバイルで本文を選択中のとき、画面下端
+ * （キーボードがあればその直上）にシートを表示するために、操作対象の
+ * エディタと現在のページ id を受け取る。`pageId` は WikiLink 変換時の
+ * `referenced` 判定 / 自己参照除外に使う。
+ *
+ * Props for {@link MobileSelectionSheet}. The host (`TiptapEditor`) mounts
+ * the sheet only on mobile and passes the editor plus the editing page id.
+ * `pageId` is forwarded to the wiki-link converter so the resulting mark
+ * carries the correct `referenced` flag and skips self-references.
+ */
+export interface MobileSelectionSheetProps {
+  /** 操作対象のエディタ。`null` の間は何も描画しない。 / Target editor; renders nothing while `null`. */
+  editor: Editor | null;
+  /** 現在のページ id。WikiLink 変換時の参照スコープに使う。 / Current page id used by the wiki-link converter. */
+  pageId?: string;
+}
+
+/**
+ * モバイルで本文を選択中のとき、キーボード直上に固定表示するシート。
+ * デスクトップの `EditorBubbleMenu` は仮想キーボードと干渉するため
+ * モバイルでは非表示にし、その代替としてこのシートを表示する
+ * （issue #924 §2 / #929）。
+ *
+ * 表示条件は `EditorBubbleMenu` の `shouldShow` と同一で、選択が空で
+ * かつ `wikiLink` マーク外、または `codeBlock` 内、または編集不可・
+ * 非フォーカスの場合は描画しない（`useMobileSelectionVisible` に委譲）。
+ *
+ * 仮想キーボードの追従は `useVirtualKeyboardOffset` を使い、シートが
+ * 表示されている間だけ `visualViewport` のリスナーを登録する
+ * （issue #927 と同じ仕組み）。
+ *
+ * 提供アクション（最小セット）: Wiki Link 化（または解除）/ Bold /
+ * Italic / Code / Strike。最終的なボタン一覧は要望に応じて段階的に
+ * 拡張する想定。
+ *
+ * Sheet pinned to the bottom edge (and tracking the virtual keyboard via
+ * `visualViewport`) that replaces the desktop bubble menu on mobile. The
+ * bubble menu collides with the on-screen keyboard on phones, so it is
+ * hidden on mobile and this sheet takes over for the same set of editing
+ * actions (issue #924 §2 / #929). Visibility mirrors the bubble menu's
+ * `shouldShow` predicate (see `useMobileSelectionVisible`). Initial action
+ * set per the issue: convert/unset wiki link plus Bold / Italic / Code /
+ * Strike — additional toolbar items can be folded in as the UX evolves.
+ */
+export const MobileSelectionSheet: React.FC<MobileSelectionSheetProps> = ({ editor, pageId }) => {
+  const visible = useMobileSelectionVisible(editor);
+  const keyboardOffset = useVirtualKeyboardOffset(visible);
+  const { isWikiLinkSelection, convertToWikiLink, unsetWikiLink, isConverting } =
+    useBubbleMenuWikiLink({ editor, pageId });
+
+  const toggleBold = useCallback(() => {
+    if (!editor) return;
+    editor.chain().focus().toggleBold().run();
+  }, [editor]);
+
+  const toggleItalic = useCallback(() => {
+    if (!editor) return;
+    editor.chain().focus().toggleItalic().run();
+  }, [editor]);
+
+  const toggleStrike = useCallback(() => {
+    if (!editor) return;
+    editor.chain().focus().toggleStrike().run();
+  }, [editor]);
+
+  const toggleCode = useCallback(() => {
+    if (!editor) return;
+    editor.chain().focus().toggleCode().run();
+  }, [editor]);
+
+  if (!editor || !visible) return null;
+
+  // キーボードが出ているときは safe-area 余白は不要（キーボードが既に
+  // その領域を占有しているため）。0.25rem だけ視覚的なすき間を確保。
+  // When the keyboard is up, the safe-area padding is hidden behind the
+  // keyboard anyway; collapse it to a small gap to keep the sheet pinned
+  // to the keyboard's top edge.
+  const isKeyboardOpen = keyboardOffset > 0;
+  const bottomStyle = isKeyboardOpen ? `${keyboardOffset}px` : undefined;
+  const paddingBottomStyle = isKeyboardOpen
+    ? "0.25rem"
+    : "calc(env(safe-area-inset-bottom) + var(--app-bottom-nav-height, 0px) + 0.25rem)";
+
+  return (
+    <div
+      data-testid="mobile-selection-sheet"
+      role="toolbar"
+      aria-label="モバイル選択シート"
+      className="border-border bg-popover fixed inset-x-0 z-40 flex items-center justify-center gap-1 border-t px-2 pt-1 shadow-[0_-4px_12px_rgba(0,0,0,0.08)]"
+      style={{
+        bottom: bottomStyle,
+        paddingBottom: paddingBottomStyle,
+      }}
+    >
+      <BubbleMenuButton
+        onClick={toggleBold}
+        isActive={editor.isActive("bold")}
+        aria-label="Bold"
+        title="Bold"
+      >
+        <Bold className="h-5 w-5" />
+      </BubbleMenuButton>
+
+      <BubbleMenuButton
+        onClick={toggleItalic}
+        isActive={editor.isActive("italic")}
+        aria-label="Italic"
+        title="Italic"
+      >
+        <Italic className="h-5 w-5" />
+      </BubbleMenuButton>
+
+      <BubbleMenuButton
+        onClick={toggleStrike}
+        isActive={editor.isActive("strike")}
+        aria-label="Strike"
+        title="Strike"
+      >
+        <Strikethrough className="h-5 w-5" />
+      </BubbleMenuButton>
+
+      <BubbleMenuButton
+        onClick={toggleCode}
+        isActive={editor.isActive("code")}
+        aria-label="Code"
+        title="Inline code"
+      >
+        <Code className="h-5 w-5" />
+      </BubbleMenuButton>
+
+      <div className="bg-border mx-1 h-5 w-px" />
+
+      {isWikiLinkSelection ? (
+        <BubbleMenuButton
+          onClick={unsetWikiLink}
+          isActive
+          aria-label="Unset Wiki Link"
+          title="Unset Wiki Link"
+        >
+          <Link2Off className="h-5 w-5" />
+        </BubbleMenuButton>
+      ) : (
+        <BubbleMenuButton
+          onClick={convertToWikiLink}
+          isActive={false}
+          disabled={isConverting}
+          aria-label="Wiki Link"
+          title="Convert to Wiki Link"
+        >
+          <Link2 className="h-5 w-5" />
+        </BubbleMenuButton>
+      )}
+    </div>
+  );
+};
+
+export default MobileSelectionSheet;

--- a/src/components/editor/TiptapEditor/useMobileSelectionVisible.ts
+++ b/src/components/editor/TiptapEditor/useMobileSelectionVisible.ts
@@ -1,0 +1,72 @@
+import { useCallback, useSyncExternalStore } from "react";
+import type { Editor } from "@tiptap/core";
+
+/**
+ * `MobileSelectionSheet` の表示判定を計算する内部フック。
+ *
+ * デスクトップ用 `EditorBubbleMenu` の `shouldShow` と同じ条件を素直に
+ * 移植している（issue #929 §「BubbleMenu はキーボードと干渉するため
+ * モバイルでは非表示」）。
+ *
+ * - 編集可能 (`isEditable`)
+ * - エディタにフォーカスがある (`view.hasFocus()`)
+ * - 選択が空ではない、または `wikiLink` マーク内にキャレットがある
+ * - `codeBlock` 内にキャレットがない
+ *
+ * `selectionUpdate` / `focus` / `blur` / `transaction` を購読して
+ * エディタ状態の変化を React に反映する。`useSyncExternalStore` を
+ * 使うことで「subscribe / unsubscribe」と「現在値の読み出し」を
+ * React の規約通り分離し、effect 内で `setState` を呼ばずに済む
+ * （`react-hooks/set-state-in-effect`）。
+ *
+ * Computes visibility for {@link MobileSelectionSheet}. Mirrors the
+ * `shouldShow` predicate used by the desktop `EditorBubbleMenu` so the
+ * mobile sheet appears in the exact same situations the bubble menu would
+ * on desktop (issue #929: the bubble menu is hidden on mobile because it
+ * collides with the on-screen keyboard). Uses `useSyncExternalStore` so
+ * subscribe / read are split per React's contract and we don't call
+ * `setState` inside an effect body (`react-hooks/set-state-in-effect`).
+ *
+ * @param editor - 操作対象のエディタ。`null` の間は常に `false`。 / Editor instance, or `null` while initializing.
+ * @returns シートを表示すべきか。 / Whether the mobile sheet should be visible.
+ */
+export function useMobileSelectionVisible(editor: Editor | null): boolean {
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      if (!editor) return noop;
+      editor.on("selectionUpdate", onChange);
+      editor.on("focus", onChange);
+      editor.on("blur", onChange);
+      editor.on("transaction", onChange);
+      return () => {
+        editor.off("selectionUpdate", onChange);
+        editor.off("focus", onChange);
+        editor.off("blur", onChange);
+        editor.off("transaction", onChange);
+      };
+    },
+    [editor],
+  );
+
+  const getSnapshot = useCallback(() => computeVisible(editor), [editor]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+function computeVisible(editor: Editor | null): boolean {
+  if (!editor) return false;
+  if (!editor.isEditable) return false;
+  if (!editor.view?.hasFocus?.()) return false;
+  if (editor.isActive("codeBlock")) return false;
+  if (!editor.state.selection.empty) return true;
+  return editor.isActive("wikiLink");
+}
+
+function noop(): void {
+  // no-op cleanup used while editor is null.
+}
+
+function getServerSnapshot(): boolean {
+  // SSR: editors are never focused. / SSR has no editor focus.
+  return false;
+}


### PR DESCRIPTION
## 概要

モバイルデバイスでのテキスト編集時に、仮想キーボードの直上に固定表示されるシートを追加しました。デスクトップの `EditorBubbleMenu` はキーボードと干渉するため、モバイルではこのシートで代替します（issue #924 §2 / #929）。

## 変更点

- **新規コンポーネント**: `MobileSelectionSheet` — モバイル用の固定シート
  - テキスト選択時に画面下部に表示
  - Bold / Italic / Strike / Code / Wiki Link の 5 つのアクションを提供
  - Wiki Link 選択時は「解除」ボタンに切り替わる
  - 仮想キーボードの高さに追従（`useVirtualKeyboardOffset` を使用）

- **新規フック**: `useMobileSelectionVisible` — 表示判定ロジック
  - デスクトップの `EditorBubbleMenu.shouldShow` と同一の条件を実装
  - `useSyncExternalStore` で外部ストア（エディタ）の変化を購読
  - 編集可能 / フォーカス / 選択状態 / codeBlock 判定を統合

- **統合**: `TiptapEditor` に `MobileSelectionSheet` をマウント
  - `useIsMobile()` でモバイル判定し、モバイル環境でのみ表示
  - `pageId` を渡して Wiki Link 変換時の参照スコープを指定

- **テスト**: `MobileSelectionSheet.test.tsx` — 252 行の包括的なテストスイート
  - 表示/非表示の条件（選択状態、フォーカス、編集可能性、codeBlock）
  - ボタン配線（各アクションの実行確認）
  - キーボードオフセットの適用
  - エディタリスナーのクリーンアップ

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `bun run test` で新規テストスイート `MobileSelectionSheet.test.tsx` が全てパスすることを確認
2. モバイルデバイス（またはブラウザの DevTools モバイルモード）でテキストを選択し、キーボード直上にシートが表示されることを確認
3. 各ボタン（Bold / Italic など）をタップして対応するマークが適用されることを確認
4. Wiki Link 選択時に「解除」ボタンが表示されることを確認
5. キーボードが表示/非表示になるとシートが追従することを確認

## チェックリスト

- [x] テストがすべてパスする（252 行のテストスイート）
- [x] Lint エラーがない（TypeScript 厳格モード、JSDoc/TSDoc 付与）
- [x] 日本語・英語の両言語でコメント・ドキュメントを記載
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #924 #929

https://claude.ai/code/session_01E6vuWu3V4LQKWc8CLR6U72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced mobile text formatting toolbar that appears contextually while editing on mobile devices, offering Bold, Italic, Strikethrough, Code, and WikiLink formatting options.
  * Toolbar automatically repositions above the virtual keyboard to ensure accessibility while typing.

* **Tests**
  * Added comprehensive test coverage for the mobile formatting toolbar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/939?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->