### PR TITLE
feat(editor): インラインゴースト補完を追加 (#930)

### DIFF
--- a/e2e/wiki-link-ghost-completion.spec.ts
+++ b/e2e/wiki-link-ghost-completion.spec.ts
@@ -20,8 +20,6 @@ const GHOST_SELECTOR = ".wiki-link-ghost-completion";
 
 /**
  * Seed a single candidate page so the ghost completion has something to match.
- * Returns the title that was created.
- *
  * ゴーストが match できるように候補ページを 1 枚作る。
  */
 async function seedCandidatePage(
@@ -129,6 +127,7 @@ test.describe("Inline Ghost Completion (issue #930)", () => {
 
     await page.keyboard.type("h");
     // Now at 2 chars → ghost should appear.
+    // 2 文字に達したのでゴーストが出る。
     await expect(page.locator(GHOST_SELECTOR)).toBeVisible();
   });
 
@@ -147,6 +146,34 @@ test.describe("Inline Ghost Completion (issue #930)", () => {
     await page.keyboard.type("```");
     await page.keyboard.press("Enter");
     await page.keyboard.type("Gho");
+    await expect(page.locator(GHOST_SELECTOR)).toHaveCount(0);
+  });
+
+  test("does not fire inside inline code", async ({ page, helpers }) => {
+    // 受け入れ条件: インラインコード（バッククォート 1 つ）内ではゴースト不発火。
+    // 内部では `wikiLink` マークが付けられない（`excludes: "code"` 相当）ため、
+    // サジェストも出さない契約。
+    // Acceptance: ghost must not fire inside inline code (single backticks)
+    // since the WikiLink mark cannot apply there.
+    await seedCandidatePage(page, helpers, "Ghost Target");
+    await helpers.createNewPage(page);
+    await page.getByPlaceholder("タイトル").fill("Source InlineCode");
+    await page.waitForTimeout(800);
+
+    const editor = editorLocator(page);
+    await editor.click();
+    // Open an inline code span via Markdown input rule: typing "`Gho`" turns
+    // the text between backticks into inline code. We type the opening
+    // backtick + the prefix first to land the caret inside the active code
+    // mark, which mirrors what users do mid-line.
+    // Markdown 入力規則で「`Gho`」と打って `Gho` をインラインコードにする。
+    // 開きバッククォート + 接頭辞を打鍵した時点でキャレットは `code` マーク
+    // 内にあるので、その状態でゴーストが出ないことを確認する。
+    await page.keyboard.type("`Gho`");
+    // Move the caret back inside the code span and type another matching char.
+    // キャレットをインラインコード内に戻して 1 文字追加し、再度抑止を確認する。
+    await page.keyboard.press("ArrowLeft");
+    await page.keyboard.type("s");
     await expect(page.locator(GHOST_SELECTOR)).toHaveCount(0);
   });
 
@@ -180,6 +207,7 @@ test.describe("Inline Ghost Completion (issue #930)", () => {
     const editor = editorLocator(page);
     await editor.click();
     // Start a bullet list.
+    // 箇条書きリストを開始する。
     await page.keyboard.type("- first item");
     await page.keyboard.press("Enter");
     await page.keyboard.type("nested");

--- a/e2e/wiki-link-ghost-completion.spec.ts
+++ b/e2e/wiki-link-ghost-completion.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * E2E tests for the inline ghost completion (issue #930, parent #924 §4).
+ * インラインゴースト補完の E2E テスト（issue #930、親 #924 §4）。
+ *
+ * 受け入れ条件を End-to-End で固定する:
+ * - 既存ページ名の接頭辞を本文中で 2 文字以上タイプすると薄色のゴーストが
+ *   カーソル右に出る
+ * - Tab で確定すると `[data-wiki-link]` の Wiki Link マークが付与される
+ * - Escape または接頭辞が外れたらゴーストが消える
+ * - コードブロック / インラインコード内では発火しない
+ * - `[[` 入力中はゴースト補完が表示されない（`[[` サジェストが優先）
+ * - 1 文字ではゴーストが出ない（≥2 文字ルール）
+ * - サジェスト非アクティブ時の Tab は通常通り（リスト indent などを壊さない）
+ *
+ * Locks the acceptance criteria of issue #930 against the live editor.
+ */
+import { test, expect, type Page } from "./auth-mock";
+
+const GHOST_SELECTOR = ".wiki-link-ghost-completion";
+
+/**
+ * Seed a single candidate page so the ghost completion has something to match.
+ * Returns the title that was created.
+ *
+ * ゴーストが match できるように候補ページを 1 枚作る。
+ */
+async function seedCandidatePage(
+  page: Page,
+  helpers: { createNewPage: (page: Page) => Promise<{ noteId: string; pageId: string }> },
+  title: string,
+): Promise<void> {
+  await helpers.createNewPage(page);
+  await page.getByPlaceholder("タイトル").fill(title);
+  // タイトル保存（debounce 500ms + バッファ）が走るまで待つ。
+  // Wait for the debounced (500ms) title save to flush.
+  await page.waitForTimeout(1500);
+}
+
+/**
+ * Locator for the editor (Tiptap root).
+ * エディタ本体のロケータ。
+ */
+function editorLocator(page: Page) {
+  return page.locator(".tiptap").first();
+}
+
+test.describe("Inline Ghost Completion (issue #930)", () => {
+  test.setTimeout(90_000);
+
+  test.beforeEach(async ({ page, helpers }) => {
+    await helpers.goToHome(page);
+  });
+
+  test("shows the ghost suffix when the typed word prefix-matches a candidate", async ({
+    page,
+    helpers,
+  }) => {
+    await seedCandidatePage(page, helpers, "Ghost Target");
+
+    // 新しい源ページを作って候補一覧が読み込まれるのを待つ。
+    // Open a fresh page so candidates load fresh from the cache.
+    await helpers.createNewPage(page);
+    await page.getByPlaceholder("タイトル").fill("Source");
+    await page.waitForTimeout(800);
+
+    const editor = editorLocator(page);
+    await editor.click();
+    await page.keyboard.type("Gho");
+
+    // Ghost suffix appears with the remainder of the title.
+    // ゴーストにタイトルの残り部分が出る。
+    const ghost = page.locator(GHOST_SELECTOR);
+    await expect(ghost).toBeVisible();
+    await expect(ghost).toHaveText("st Target");
+  });
+
+  test("confirms with Tab — turns the typed prefix into a wiki link", async ({ page, helpers }) => {
+    await seedCandidatePage(page, helpers, "Ghost Target");
+    await helpers.createNewPage(page);
+    await page.getByPlaceholder("タイトル").fill("Source Confirm");
+    await page.waitForTimeout(800);
+
+    const editor = editorLocator(page);
+    await editor.click();
+    await page.keyboard.type("Gho");
+
+    await expect(page.locator(GHOST_SELECTOR)).toBeVisible();
+    await page.keyboard.press("Tab");
+
+    // Ghost is gone and a wiki-link mark covers the full title.
+    // ゴーストが消え、Wiki Link マークがタイトル全体を覆う。
+    await expect(page.locator(GHOST_SELECTOR)).toHaveCount(0);
+    const wikiLink = editor.locator('[data-wiki-link][data-title="Ghost Target"]');
+    await expect(wikiLink).toBeVisible();
+    await expect(wikiLink).toHaveAttribute("data-exists", "true");
+  });
+
+  test("Escape dismisses the ghost but keeps the typed text", async ({ page, helpers }) => {
+    await seedCandidatePage(page, helpers, "Ghost Target");
+    await helpers.createNewPage(page);
+    await page.getByPlaceholder("タイトル").fill("Source Escape");
+    await page.waitForTimeout(800);
+
+    const editor = editorLocator(page);
+    await editor.click();
+    await page.keyboard.type("Gho");
+
+    await expect(page.locator(GHOST_SELECTOR)).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.locator(GHOST_SELECTOR)).toHaveCount(0);
+
+    // The user's typed prefix stays in the editor (Escape only kills the
+    // preview, not the input). The wiki-link mark must NOT be applied.
+    // 入力済みの接頭辞は残り、Wiki Link マークは付かない。
+    await expect(editor).toContainText("Gho");
+    await expect(editor.locator('[data-wiki-link][data-title="Ghost Target"]')).toHaveCount(0);
+  });
+
+  test("does not fire on a single character (≥2 chars rule)", async ({ page, helpers }) => {
+    await seedCandidatePage(page, helpers, "Ghost Target");
+    await helpers.createNewPage(page);
+    await page.getByPlaceholder("タイトル").fill("Source Length");
+    await page.waitForTimeout(800);
+
+    const editor = editorLocator(page);
+    await editor.click();
+    await page.keyboard.type("G");
+    await expect(page.locator(GHOST_SELECTOR)).toHaveCount(0);
+
+    await page.keyboard.type("h");
+    // Now at 2 chars → ghost should appear.
+    await expect(page.locator(GHOST_SELECTOR)).toBeVisible();
+  });
+
+  test("does not fire inside a code block", async ({ page, helpers }) => {
+    await seedCandidatePage(page, helpers, "Ghost Target");
+    await helpers.createNewPage(page);
+    await page.getByPlaceholder("タイトル").fill("Source CodeBlock");
+    await page.waitForTimeout(800);
+
+    const editor = editorLocator(page);
+    await editor.click();
+    // Markdown shortcut for a code block (CodeBlockLowlight registers triple
+    // backtick + Enter as the input rule). After this the cursor sits inside
+    // the code block.
+    // ` ``` ` + Enter で code block に入る。以降 code block 内なのでゴースト不発火。
+    await page.keyboard.type("```");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Gho");
+    await expect(page.locator(GHOST_SELECTOR)).toHaveCount(0);
+  });
+
+  test("does not fire while the `[[` suggestion popup is active", async ({ page, helpers }) => {
+    await seedCandidatePage(page, helpers, "Ghost Target");
+    await helpers.createNewPage(page);
+    await page.getByPlaceholder("タイトル").fill("Source Brackets");
+    await page.waitForTimeout(800);
+
+    const editor = editorLocator(page);
+    await editor.click();
+    await page.keyboard.type("[[Gho");
+    // The `[[` suggestion popup owns this range, the ghost must stay hidden.
+    // `[[` サジェストがこの範囲を担当しているので、ゴーストは出ない。
+    await expect(page.locator(GHOST_SELECTOR)).toHaveCount(0);
+  });
+
+  test("Tab still indents list items when no ghost is active (regression guard)", async ({
+    page,
+    helpers,
+  }) => {
+    // We are not seeding candidates so the ghost never activates; if it did,
+    // it would also suppress Tab. This test pins the "Tab passes through"
+    // contract that protects existing list indent behaviour.
+    // 候補なしにしてゴーストを発火させない状態で Tab を打鍵し、リストの
+    // ネスト動作が壊れないこと（Tab 素通し）を保証する。
+    await helpers.createNewPage(page);
+    await page.getByPlaceholder("タイトル").fill("Tab Passthrough");
+    await page.waitForTimeout(800);
+
+    const editor = editorLocator(page);
+    await editor.click();
+    // Start a bullet list.
+    await page.keyboard.type("- first item");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("nested");
+    await page.keyboard.press("Home");
+    await page.keyboard.press("Tab");
+
+    // After Tab, the second item is nested → nested `<ul>` exists.
+    // Tab 後、2 つ目の `li` が入れ子になり `ul ul` が現れる。
+    await expect(editor.locator("ul ul")).toHaveCount(1);
+  });
+});

--- a/src/components/editor/TiptapEditor/editorConfig.ts
+++ b/src/components/editor/TiptapEditor/editorConfig.ts
@@ -37,6 +37,11 @@ import {
   type SlashSuggestionState,
 } from "../extensions/slashSuggestionPlugin";
 import { TagSuggestionPlugin, type TagSuggestionState } from "../extensions/tagSuggestionPlugin";
+import {
+  WikiLinkGhostCompletionPlugin,
+  type WikiLinkGhostCompletionCandidate,
+  type WikiLinkGhostCompletionState,
+} from "../extensions/wikiLinkGhostCompletionPlugin";
 import { HeadingLevelClamp } from "./headingLevelClampExtension";
 import type { Extension } from "@tiptap/core";
 import type * as Y from "yjs";
@@ -123,6 +128,26 @@ export interface EditorExtensionsOptions {
    * changes. See issue #767 (Phase 2).
    */
   onTagSuggestionStateChange: (state: TagSuggestionState) => void;
+  /**
+   * 既存ページタイトルとプレフィックス一致するインライン・ゴースト補完
+   * （issue #930）に渡す候補ソース。`useWikiLinkCandidates` の結果を ref で
+   * 包んで `() => ref.current` の形で渡すことを想定する。
+   *
+   * Inline ghost completion (issue #930) candidate source. Expected to be a
+   * getter over the latest `useWikiLinkCandidates` snapshot held in a ref so
+   * the editor instance does not have to be re-created when candidates
+   * update.
+   */
+  getGhostCompletionCandidates?: () => ReadonlyArray<WikiLinkGhostCompletionCandidate>;
+  /**
+   * Optional state observer for the ghost completion plugin (telemetry /
+   * tests). Confirmation is handled inside the plugin so most callers do
+   * not need this.
+   *
+   * ゴースト補完の状態通知（任意、テレメトリ・テスト用途）。確定処理は
+   * プラグイン内で完結するため通常は省略可。
+   */
+  onGhostCompletionStateChange?: (state: WikiLinkGhostCompletionState) => void;
   imageUploadOptions: Partial<ImageUploadOptions>;
   imageOptions: Partial<StorageImageOptions>;
   /** When set, enables Y.js collaboration and caret; StarterKit history is disabled */
@@ -144,6 +169,10 @@ interface CommonEditorExtensionsOptions {
   onStateChange?: (state: WikiLinkSuggestionState) => void;
   onSlashStateChange?: (state: SlashSuggestionState) => void;
   onTagSuggestionStateChange?: (state: TagSuggestionState) => void;
+  /** Inline ghost completion candidates (issue #930). / ゴースト補完候補ソース */
+  getGhostCompletionCandidates?: () => ReadonlyArray<WikiLinkGhostCompletionCandidate>;
+  /** Optional ghost completion state observer (issue #930). / ゴースト補完状態通知 */
+  onGhostCompletionStateChange?: (state: WikiLinkGhostCompletionState) => void;
   imageUploadOptions?: Partial<ImageUploadOptions>;
   imageOptions?: Partial<StorageImageOptions>;
   fileReference?: EditorExtensionsOptions["fileReference"];
@@ -272,6 +301,17 @@ function createCommonEditorExtensions(options: CommonEditorExtensionsOptions): E
           TagSuggestionPlugin.configure({
             onStateChange: options.onTagSuggestionStateChange ?? (() => undefined),
           }),
+          // --- Inline ghost completion (issue #930) ---
+          // 登録順は WikiLinkSuggestion → TagSuggestion → Ghost にすることで、
+          // 同一トランザクション内で `[[` / `#` のサジェスト状態が先に更新され、
+          // Ghost 側の `apply` がそれらの最新 `active` を参照して自己抑止できる。
+          // Order matters: registered after WikiLinkSuggestion and
+          // TagSuggestion so the ghost's `apply` can read their updated
+          // `active` flags within the same transaction and suppress itself.
+          WikiLinkGhostCompletionPlugin.configure({
+            getCandidates: options.getGhostCompletionCandidates ?? (() => []),
+            onStateChange: options.onGhostCompletionStateChange ?? (() => undefined),
+          }),
         ]
       : []),
     // --- Image ---
@@ -339,6 +379,8 @@ export function createEditorExtensions(options: EditorExtensionsOptions): Extens
     onStateChange: options.onStateChange,
     onSlashStateChange: options.onSlashStateChange,
     onTagSuggestionStateChange: options.onTagSuggestionStateChange,
+    getGhostCompletionCandidates: options.getGhostCompletionCandidates,
+    onGhostCompletionStateChange: options.onGhostCompletionStateChange,
     imageUploadOptions: options.imageUploadOptions,
     imageOptions: options.imageOptions,
     fileReference: options.fileReference,

--- a/src/components/editor/TiptapEditor/useEditorSetup.ts
+++ b/src/components/editor/TiptapEditor/useEditorSetup.ts
@@ -12,6 +12,7 @@ import type { Editor } from "@tiptap/core";
 import type { WikiLinkSuggestionState } from "../extensions/wikiLinkSuggestionPlugin";
 import type { SlashSuggestionState } from "../extensions/slashSuggestionPlugin";
 import type { TagSuggestionState } from "../extensions/tagSuggestionPlugin";
+import type { WikiLinkGhostCompletionCandidate } from "../extensions/wikiLinkGhostCompletionPlugin";
 import type { WikiLinkSuggestionHandle } from "../extensions/WikiLinkSuggestion";
 import type { TagSuggestionHandle } from "../extensions/TagSuggestion";
 import type { SlashSuggestionHandle } from "./SlashSuggestionLayer";
@@ -74,6 +75,15 @@ interface UseEditorSetupOptions {
   workspaceRoot: string | null;
   /** Current note id for Tauri workspace registry reads (Issue #461). */
   noteId: string | null;
+  /**
+   * インライン・ゴースト補完（issue #930）に渡す候補一覧の getter。ref ベースで
+   * 最新値を返すことで、候補が更新されても `useEditor` を再実行せずに済む。
+   *
+   * Getter returning the latest candidate list for inline ghost completion
+   * (issue #930). Ref-based so `useEditor` does not need to re-run when the
+   * candidate snapshot changes.
+   */
+  getGhostCompletionCandidates: () => ReadonlyArray<WikiLinkGhostCompletionCandidate>;
 }
 
 /**
@@ -110,6 +120,7 @@ export function useEditorSetup(options: UseEditorSetupOptions) {
     tagSuggestionRef,
     workspaceRoot,
     noteId,
+    getGhostCompletionCandidates,
   } = options;
 
   const isEditorInitializedRef = useRef(false);
@@ -197,6 +208,7 @@ export function useEditorSetup(options: UseEditorSetupOptions) {
           getWorkspaceRoot: () => workspaceRootRef.current,
           getNoteId: () => noteIdRef.current,
         },
+        getGhostCompletionCandidates,
       }),
       /* eslint-enable react-hooks/refs */
       content: useCollaborationMode ? undefined : initialParsedContent,

--- a/src/components/editor/TiptapEditor/useTiptapEditorController.ts
+++ b/src/components/editor/TiptapEditor/useTiptapEditorController.ts
@@ -1,13 +1,15 @@
-import { useMemo, useRef, useState, type MutableRefObject, type RefObject } from "react";
+import { useEffect, useMemo, useRef, useState, type MutableRefObject, type RefObject } from "react";
 import type { Editor } from "@tiptap/core";
 import type { WikiLinkSuggestionState } from "../extensions/wikiLinkSuggestionPlugin";
 import type { SlashSuggestionState } from "../extensions/slashSuggestionPlugin";
 import type { TagSuggestionState } from "../extensions/tagSuggestionPlugin";
+import type { WikiLinkGhostCompletionCandidate } from "../extensions/wikiLinkGhostCompletionPlugin";
 import type { WikiLinkSuggestionHandle } from "../extensions/WikiLinkSuggestion";
 import type { TagSuggestionHandle } from "../extensions/TagSuggestion";
 import type { SlashSuggestionHandle } from "./SlashSuggestionLayer";
 import { useAuth } from "@/hooks/useAuth";
 import { useGeneralSettings } from "@/hooks/useGeneralSettings";
+import { useWikiLinkCandidates } from "@/hooks/useWikiLinkCandidates";
 import { useWikiLinkNavigation } from "./useWikiLinkNavigation";
 import { useEditorSetup } from "./useEditorSetup";
 import { useSuggestionEffects } from "./useSuggestionEffects";
@@ -70,6 +72,16 @@ function useEditorControllers(args: {
    * checks (issue #713 Phase 4).
    */
   pageNoteId: string | null;
+  /**
+   * インライン・ゴースト補完（issue #930）に渡す候補一覧の getter。
+   * `useTiptapEditorController` で `useWikiLinkCandidates(pageNoteId)` を
+   * ref に保持し `() => ref.current` を渡す。
+   *
+   * Getter returning the latest candidate list for inline ghost completion
+   * (issue #930). Held as a ref in `useTiptapEditorController` to avoid
+   * editor re-creation on candidate updates.
+   */
+  getGhostCompletionCandidates: () => ReadonlyArray<WikiLinkGhostCompletionCandidate>;
 }) {
   const { editor, handleInsertMermaid, isEditorInitializedRef } = useEditorSetup({
     content: args.content,
@@ -100,6 +112,7 @@ function useEditorControllers(args: {
     tagSuggestionRef: args.tagSuggestionRef,
     workspaceRoot: args.workspaceRoot,
     noteId: args.noteId,
+    getGhostCompletionCandidates: args.getGhostCompletionCandidates,
   });
 
   const suggestionUi = useSuggestionEffects({
@@ -175,6 +188,17 @@ export function useTiptapEditorController({
     handleConfirmCreate,
     handleCancelCreate,
   } = useWikiLinkNavigation({ pageNoteId });
+  // Inline ghost completion (issue #930): keep the latest candidate list in a
+  // ref so the ProseMirror plugin can read it on every transaction without
+  // forcing `useEditor` to re-run when candidates change.
+  // インライン・ゴースト補完（issue #930）の候補一覧を ref に保持。
+  // 候補更新で `useEditor` が再実行されないように getter 経由で渡す。
+  const { pages: ghostCompletionCandidates } = useWikiLinkCandidates(pageNoteId);
+  const ghostCompletionCandidatesRef =
+    useRef<ReadonlyArray<WikiLinkGhostCompletionCandidate>>(ghostCompletionCandidates);
+  useEffect(() => {
+    ghostCompletionCandidatesRef.current = ghostCompletionCandidates;
+  }, [ghostCompletionCandidates]);
   const [mermaidDialogOpen, setMermaidDialogOpen] = useState(false);
   const {
     storageSettings,
@@ -246,6 +270,7 @@ export function useTiptapEditorController({
     workspaceRoot,
     noteId: noteIdForWorkspace,
     pageNoteId,
+    getGhostCompletionCandidates: () => ghostCompletionCandidatesRef.current,
   });
   const { handleInsertThumbnailImage } = useThumbnailController(
     editorRef,

--- a/src/components/editor/extensions/wikiLinkGhostCompletionPlugin.test.ts
+++ b/src/components/editor/extensions/wikiLinkGhostCompletionPlugin.test.ts
@@ -31,6 +31,7 @@ import {
 } from "./wikiLinkGhostCompletionPlugin";
 import { WikiLinkSuggestionPlugin, wikiLinkSuggestionPluginKey } from "./wikiLinkSuggestionPlugin";
 import { TagSuggestionPlugin, tagSuggestionPluginKey } from "./tagSuggestionPlugin";
+import { SlashSuggestionPlugin, slashSuggestionPluginKey } from "./slashSuggestionPlugin";
 
 /**
  * Minimal schema covering every node / mark the plugin needs to reason about.
@@ -145,7 +146,10 @@ function buildPlugin(opts: BuildOpts = {}): Plugin {
   });
 }
 
-/** Place caret at end of inline content in the given block. */
+/**
+ * Place caret at end of inline content in the given block.
+ * 指定ブロックのインライン末尾にキャレットを置く。
+ */
 function caretAtEnd(state: EditorState, text: string): EditorState {
   const tr = state.tr.setSelection(TextSelection.create(state.doc, 1 + text.length));
   return state.apply(tr);
@@ -175,6 +179,7 @@ function makeBlockquoteState(text: string, plugin: Plugin): EditorState {
   ]);
   const state = EditorState.create({ doc, schema, plugins: [plugin] });
   // doc(0)/blockquote(1)/paragraph(1)/text… → caret at 2 + text.length.
+  // ネスト 2 段なので caret 位置は 2 + text.length。
   const tr = state.tr.setSelection(TextSelection.create(state.doc, 2 + text.length));
   return state.apply(tr);
 }
@@ -189,6 +194,7 @@ function makeListItemState(text: string, plugin: Plugin): EditorState {
   ]);
   const state = EditorState.create({ doc, schema, plugins: [plugin] });
   // doc/bullet_list(1)/list_item(1)/paragraph(1)/text…
+  // ネスト 3 段なので caret 位置は 3 + text.length。
   const tr = state.tr.setSelection(TextSelection.create(state.doc, 3 + text.length));
   return state.apply(tr);
 }
@@ -205,6 +211,7 @@ function makeTableCellState(text: string, plugin: Plugin): EditorState {
   ]);
   const state = EditorState.create({ doc, schema, plugins: [plugin] });
   // doc/table(1)/table_row(1)/table_cell(1)/paragraph(1)/text…
+  // ネスト 4 段なので caret 位置は 4 + text.length。
   const tr = state.tr.setSelection(TextSelection.create(state.doc, 4 + text.length));
   return state.apply(tr);
 }
@@ -302,7 +309,8 @@ describe("wikiLinkGhostCompletionPlugin — activation", () => {
   it("matches CJK candidates", () => {
     const plugin = buildPlugin({ candidates: TARGETS });
     const state = makeParagraphState("技", plugin);
-    // 1 char only → ≥2 rule rejects
+    // 1 char only → ≥2 rule rejects.
+    // 1 文字なので 2 文字以上ルールにより不発火。
     expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
 
     const state2 = makeParagraphState("技術", plugin);
@@ -368,6 +376,7 @@ describe("wikiLinkGhostCompletionPlugin — minimum length and word boundary", (
     expect(ps?.active).toBe(true);
     expect(ps?.query).toBe("Gho");
     // "hello " is 6 chars → typed word starts at pos 7.
+    // 直前の "hello " が 6 文字なので入力中の単語は pos 7 から始まる。
     expect(ps?.range).toEqual({ from: 7, to: 10 });
   });
 
@@ -434,8 +443,10 @@ describe("wikiLinkGhostCompletionPlugin — coordination with other suggesters",
     state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 6)));
 
     // Wiki link suggestion must be active for this assertion to be meaningful.
+    // この assertion が意味を持つよう、Wiki サジェスト側が active であることを担保。
     expect(wikiLinkSuggestionPluginKey.getState(state)?.active).toBe(true);
     // Ghost completion must be suppressed.
+    // ゴースト補完は抑止されているべき。
     expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
   });
 
@@ -451,6 +462,32 @@ describe("wikiLinkGhostCompletionPlugin — coordination with other suggesters",
     state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 5)));
 
     expect(tagSuggestionPluginKey.getState(state)?.active).toBe(true);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("is suppressed when the `/` slash suggestion plugin is active (even mid-arg)", () => {
+    // SlashSuggestionPlugin は空白を含むクエリでも active を維持するため、
+    // 「`/cmd Ghost`」のような入力ではスラッシュメニューとゴーストが衝突しうる。
+    // ここでは両プラグインを同居させ、スラッシュ active 中はゴーストが立たない
+    // ことを保証する（Codex PR レビュー指摘）。
+    // SlashSuggestionPlugin stays active across whitespace, so an input like
+    // `/cmd Ghost` could double-fire the ghost. This test pins the mutual
+    // exclusion contract added in response to the PR review.
+    const ghost = buildPlugin({ candidates: TARGETS });
+    const slashExt = SlashSuggestionPlugin.configure({});
+    const addSlashPlugins = slashExt.config.addProseMirrorPlugins;
+    if (!addSlashPlugins) throw new Error("SlashSuggestionPlugin.addProseMirrorPlugins missing");
+    const slashPlugin = addSlashPlugins.call({ options: {} } as never)[0];
+
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("/cmd Gho")]),
+    ]);
+    let state = EditorState.create({ doc, schema, plugins: [slashPlugin, ghost] });
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 9)));
+
+    // Slash サジェスト側が active であることを前提に、ゴーストは抑止される。
+    // Slash side must be active for this assertion to be meaningful.
+    expect(slashSuggestionPluginKey.getState(state)?.active).toBe(true);
     expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
   });
 });

--- a/src/components/editor/extensions/wikiLinkGhostCompletionPlugin.test.ts
+++ b/src/components/editor/extensions/wikiLinkGhostCompletionPlugin.test.ts
@@ -1,0 +1,629 @@
+/**
+ * Tests for the inline ghost completion ProseMirror plugin (issue #930,
+ * parent #924 §4).
+ * インラインゴースト補完用 ProseMirror プラグインのテスト（issue #930、
+ * 親 #924 §4）。
+ *
+ * Same TDD-friendly approach as `tagSuggestionPlugin.test.ts`: build a minimal
+ * ProseMirror schema (paragraph / heading / blockquote / list / table cell /
+ * code block, plus `code` and `wikiLink` marks) and feed transactions directly
+ * so we can pin trigger / dismissal behaviour without spinning up a real
+ * Tiptap editor. Confirmation logic is exercised via `buildConfirmTransaction`
+ * which is a pure function over `EditorState`.
+ *
+ * `tagSuggestionPlugin.test.ts` と同じく最小スキーマと直接 transaction 適用
+ * でプラグインの挙動を固定する。確定パスは pure な
+ * `buildConfirmTransaction` で検証する（view 構築不要）。
+ */
+
+import type { Plugin } from "@tiptap/pm/state";
+import { EditorState, TextSelection } from "@tiptap/pm/state";
+import { Schema } from "@tiptap/pm/model";
+import { describe, expect, it, vi } from "vitest";
+import {
+  WikiLinkGhostCompletionPlugin,
+  wikiLinkGhostCompletionPluginKey,
+  buildConfirmTransaction,
+  buildGhostCompletionWidget,
+  type WikiLinkGhostCompletionCandidate,
+  type WikiLinkGhostCompletionState,
+  type WikiLinkGhostCompletionOptions,
+} from "./wikiLinkGhostCompletionPlugin";
+import { WikiLinkSuggestionPlugin, wikiLinkSuggestionPluginKey } from "./wikiLinkSuggestionPlugin";
+import { TagSuggestionPlugin, tagSuggestionPluginKey } from "./tagSuggestionPlugin";
+
+/**
+ * Minimal schema covering every node / mark the plugin needs to reason about.
+ * 本プラグインが判定する全ノード / マークを最小スキーマで再現。
+ */
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: {
+      group: "block",
+      content: "text*",
+      toDOM: () => ["p", 0],
+    },
+    heading: {
+      group: "block",
+      content: "text*",
+      attrs: { level: { default: 2 } },
+      toDOM: (n) => [`h${n.attrs.level as number}`, 0],
+    },
+    blockquote: {
+      group: "block",
+      content: "block+",
+      toDOM: () => ["blockquote", 0],
+    },
+    bullet_list: {
+      group: "block",
+      content: "list_item+",
+      toDOM: () => ["ul", 0],
+    },
+    list_item: {
+      content: "paragraph block*",
+      toDOM: () => ["li", 0],
+    },
+    table: {
+      group: "block",
+      content: "table_row+",
+      toDOM: () => ["table", ["tbody", 0]],
+    },
+    table_row: {
+      content: "table_cell+",
+      toDOM: () => ["tr", 0],
+    },
+    table_cell: {
+      content: "paragraph+",
+      toDOM: () => ["td", 0],
+    },
+    code_block: {
+      group: "block",
+      content: "text*",
+      code: true,
+      defining: true,
+      marks: "",
+      toDOM: () => ["pre", ["code", 0]],
+    },
+    // Used to verify ancestor-based suppression ("title / caption / 本文外").
+    // 「タイトル / キャプション / 本文外」の祖先抑止を検証するためのノード。
+    title: {
+      group: "block",
+      content: "text*",
+      toDOM: () => ["h1", 0],
+    },
+    caption: {
+      group: "block",
+      content: "text*",
+      toDOM: () => ["figcaption", 0],
+    },
+    text: { group: "inline" },
+  },
+  marks: {
+    code: {
+      code: true,
+      toDOM: () => ["code", 0],
+    },
+    wikiLink: {
+      attrs: {
+        title: { default: null },
+        exists: { default: true },
+        referenced: { default: false },
+        targetId: { default: null },
+      },
+      toDOM: () => ["span", { "data-wiki-link": "" }, 0],
+    },
+  },
+});
+
+/**
+ * Pulls the bare ProseMirror plugin out of the Tiptap extension wrapper so we
+ * can install it on a hand-built `EditorState`. Same pattern as
+ * `tagSuggestionPlugin.test.ts`.
+ *
+ * Tiptap 拡張ラッパーから素の ProseMirror プラグインを取り出す。
+ */
+function getPlugin(options: WikiLinkGhostCompletionOptions): Plugin {
+  const extension = WikiLinkGhostCompletionPlugin.configure(options);
+  const addPlugins = extension.config.addProseMirrorPlugins;
+  if (!addPlugins) throw new Error("addProseMirrorPlugins missing");
+  const plugins = addPlugins.call({ options } as never);
+  return plugins[0];
+}
+
+interface BuildOpts {
+  candidates?: ReadonlyArray<WikiLinkGhostCompletionCandidate>;
+  onStateChange?: (s: WikiLinkGhostCompletionState) => void;
+  allowedNodeTypes?: ReadonlySet<string>;
+}
+
+function buildPlugin(opts: BuildOpts = {}): Plugin {
+  return getPlugin({
+    getCandidates: () => opts.candidates ?? [],
+    onStateChange: opts.onStateChange,
+    allowedNodeTypes: opts.allowedNodeTypes,
+  });
+}
+
+/** Place caret at end of inline content in the given block. */
+function caretAtEnd(state: EditorState, text: string): EditorState {
+  const tr = state.tr.setSelection(TextSelection.create(state.doc, 1 + text.length));
+  return state.apply(tr);
+}
+
+function makeParagraphState(text: string, plugin: Plugin): EditorState {
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, text ? [schema.text(text)] : []),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [plugin] });
+  return caretAtEnd(state, text);
+}
+
+function makeHeadingState(text: string, plugin: Plugin): EditorState {
+  const doc = schema.node("doc", null, [
+    schema.node("heading", { level: 2 }, text ? [schema.text(text)] : []),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [plugin] });
+  return caretAtEnd(state, text);
+}
+
+function makeBlockquoteState(text: string, plugin: Plugin): EditorState {
+  const doc = schema.node("doc", null, [
+    schema.node("blockquote", null, [
+      schema.node("paragraph", null, text ? [schema.text(text)] : []),
+    ]),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [plugin] });
+  // doc(0)/blockquote(1)/paragraph(1)/text… → caret at 2 + text.length.
+  const tr = state.tr.setSelection(TextSelection.create(state.doc, 2 + text.length));
+  return state.apply(tr);
+}
+
+function makeListItemState(text: string, plugin: Plugin): EditorState {
+  const doc = schema.node("doc", null, [
+    schema.node("bullet_list", null, [
+      schema.node("list_item", null, [
+        schema.node("paragraph", null, text ? [schema.text(text)] : []),
+      ]),
+    ]),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [plugin] });
+  // doc/bullet_list(1)/list_item(1)/paragraph(1)/text…
+  const tr = state.tr.setSelection(TextSelection.create(state.doc, 3 + text.length));
+  return state.apply(tr);
+}
+
+function makeTableCellState(text: string, plugin: Plugin): EditorState {
+  const doc = schema.node("doc", null, [
+    schema.node("table", null, [
+      schema.node("table_row", null, [
+        schema.node("table_cell", null, [
+          schema.node("paragraph", null, text ? [schema.text(text)] : []),
+        ]),
+      ]),
+    ]),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [plugin] });
+  // doc/table(1)/table_row(1)/table_cell(1)/paragraph(1)/text…
+  const tr = state.tr.setSelection(TextSelection.create(state.doc, 4 + text.length));
+  return state.apply(tr);
+}
+
+function makeCodeBlockState(text: string, plugin: Plugin): EditorState {
+  const doc = schema.node("doc", null, [
+    schema.node("code_block", null, text ? [schema.text(text)] : []),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [plugin] });
+  return caretAtEnd(state, text);
+}
+
+function makeInlineCodeState(text: string, plugin: Plugin): EditorState {
+  const codeMark = schema.marks.code.create();
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, text ? [schema.text(text, [codeMark])] : []),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [plugin] });
+  return caretAtEnd(state, text);
+}
+
+function makeTitleNodeState(text: string, plugin: Plugin): EditorState {
+  const doc = schema.node("doc", null, [
+    schema.node("title", null, text ? [schema.text(text)] : []),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [plugin] });
+  return caretAtEnd(state, text);
+}
+
+function makeCaptionNodeState(text: string, plugin: Plugin): EditorState {
+  const doc = schema.node("doc", null, [
+    schema.node("caption", null, text ? [schema.text(text)] : []),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [plugin] });
+  return caretAtEnd(state, text);
+}
+
+function makeInsideWikiLinkState(text: string, plugin: Plugin): EditorState {
+  const linkMark = schema.marks.wikiLink.create({
+    title: "Existing",
+    exists: true,
+    referenced: false,
+    targetId: null,
+  });
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, text ? [schema.text(text, [linkMark])] : []),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [plugin] });
+  return caretAtEnd(state, text);
+}
+
+const TARGETS = [
+  { id: "id-ghost", title: "Ghost Target" },
+  { id: "id-another", title: "Another Note" },
+  { id: "id-technique", title: "技術メモ" },
+] as const satisfies ReadonlyArray<WikiLinkGhostCompletionCandidate>;
+
+describe("wikiLinkGhostCompletionPlugin — initial state", () => {
+  it("initialises as inactive", () => {
+    const plugin = buildPlugin();
+    const state = makeParagraphState("", plugin);
+    const pluginState = wikiLinkGhostCompletionPluginKey.getState(state);
+    expect(pluginState).toMatchObject({
+      active: false,
+      range: null,
+      query: "",
+      candidate: null,
+      suffix: "",
+    });
+  });
+});
+
+describe("wikiLinkGhostCompletionPlugin — activation", () => {
+  it("activates when the typed word prefix-matches a candidate title", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeParagraphState("Gho", plugin);
+    const pluginState = wikiLinkGhostCompletionPluginKey.getState(state);
+
+    expect(pluginState?.active).toBe(true);
+    expect(pluginState?.query).toBe("Gho");
+    expect(pluginState?.candidate).toMatchObject({ id: "id-ghost", title: "Ghost Target" });
+    expect(pluginState?.suffix).toBe("st Target");
+    expect(pluginState?.range).toEqual({ from: 1, to: 4 });
+  });
+
+  it("preserves the candidate's casing in the suffix even if the user typed lowercase", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeParagraphState("gho", plugin);
+    const pluginState = wikiLinkGhostCompletionPluginKey.getState(state);
+    expect(pluginState?.active).toBe(true);
+    expect(pluginState?.suffix).toBe("st Target");
+    expect(pluginState?.query).toBe("gho");
+  });
+
+  it("matches CJK candidates", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeParagraphState("技", plugin);
+    // 1 char only → ≥2 rule rejects
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+
+    const state2 = makeParagraphState("技術", plugin);
+    const ps = wikiLinkGhostCompletionPluginKey.getState(state2);
+    expect(ps?.active).toBe(true);
+    expect(ps?.suffix).toBe("メモ");
+    expect(ps?.candidate?.id).toBe("id-technique");
+  });
+
+  it("fires on heading, blockquote, list item, and table cell", () => {
+    const cases: Array<(t: string, p: Plugin) => EditorState> = [
+      makeHeadingState,
+      makeBlockquoteState,
+      makeListItemState,
+      makeTableCellState,
+    ];
+    for (const make of cases) {
+      const plugin = buildPlugin({ candidates: TARGETS });
+      const state = make("Gho", plugin);
+      const ps = wikiLinkGhostCompletionPluginKey.getState(state);
+      expect(ps?.active, `expected active in ${make.name}`).toBe(true);
+      expect(ps?.suffix).toBe("st Target");
+    }
+  });
+
+  it("calls onStateChange with the activation state", () => {
+    const onStateChange = vi.fn();
+    const plugin = buildPlugin({ candidates: TARGETS, onStateChange });
+    makeParagraphState("Gho", plugin);
+    expect(onStateChange).toHaveBeenCalled();
+    const calls = onStateChange.mock.calls;
+    const last = calls[calls.length - 1]?.[0] as WikiLinkGhostCompletionState;
+    expect(last.active).toBe(true);
+    expect(last.candidate?.title).toBe("Ghost Target");
+  });
+});
+
+describe("wikiLinkGhostCompletionPlugin — minimum length and word boundary", () => {
+  it("does not activate for a single-character word", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeParagraphState("G", plugin);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("does not activate when there are no candidate matches", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeParagraphState("Xyz", plugin);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("does not activate for an exact match (no suffix to show)", () => {
+    const plugin = buildPlugin({
+      candidates: [{ id: "x", title: "Hello" }],
+    });
+    const state = makeParagraphState("Hello", plugin);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("only considers the current word (post-whitespace)", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeParagraphState("hello Gho", plugin);
+    const ps = wikiLinkGhostCompletionPluginKey.getState(state);
+    expect(ps?.active).toBe(true);
+    expect(ps?.query).toBe("Gho");
+    // "hello " is 6 chars → typed word starts at pos 7.
+    expect(ps?.range).toEqual({ from: 7, to: 10 });
+  });
+
+  it("rejects words that start with `[`, `]`, `#`, `@`, or `/`", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    for (const leader of ["[", "]", "#", "@", "/"]) {
+      const state = makeParagraphState(`${leader}Gho`, plugin);
+      expect(
+        wikiLinkGhostCompletionPluginKey.getState(state)?.active,
+        `expected inactive for leader "${leader}"`,
+      ).toBe(false);
+    }
+  });
+});
+
+describe("wikiLinkGhostCompletionPlugin — code block / inline code suppression", () => {
+  it("does not activate inside a code block", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeCodeBlockState("Gho", plugin);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("does not activate inside an inline `code` mark", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeInlineCodeState("Gho", plugin);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+});
+
+describe("wikiLinkGhostCompletionPlugin — out-of-body suppression", () => {
+  it("does not activate inside a `title` node", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeTitleNodeState("Gho", plugin);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("does not activate inside a `caption` node", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeCaptionNodeState("Gho", plugin);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("does not activate inside an existing `wikiLink` mark", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeInsideWikiLinkState("Gho", plugin);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+});
+
+describe("wikiLinkGhostCompletionPlugin — coordination with other suggesters", () => {
+  it("is suppressed when the `[[` suggestion plugin is active", () => {
+    // We install both plugins so the `apply` of the wiki suggestion plugin
+    // populates its own state before ours runs.
+    // 両プラグインを併設し、wiki サジェスト側の `apply` でその状態が立ってから
+    // 本プラグインの `apply` が走る順序を再現する。
+    const ghost = buildPlugin({ candidates: TARGETS });
+    const wikiExt = WikiLinkSuggestionPlugin.configure({});
+    const addWikiPlugins = wikiExt.config.addProseMirrorPlugins;
+    if (!addWikiPlugins) throw new Error("WikiLinkSuggestionPlugin.addProseMirrorPlugins missing");
+    const wikiPlugin = addWikiPlugins.call({ options: {} } as never)[0];
+
+    const doc = schema.node("doc", null, [schema.node("paragraph", null, [schema.text("[[Gho")])]);
+    let state = EditorState.create({ doc, schema, plugins: [wikiPlugin, ghost] });
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 6)));
+
+    // Wiki link suggestion must be active for this assertion to be meaningful.
+    expect(wikiLinkSuggestionPluginKey.getState(state)?.active).toBe(true);
+    // Ghost completion must be suppressed.
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("is suppressed when the `#` tag suggestion plugin is active", () => {
+    const ghost = buildPlugin({ candidates: TARGETS });
+    const tagExt = TagSuggestionPlugin.configure({});
+    const addTagPlugins = tagExt.config.addProseMirrorPlugins;
+    if (!addTagPlugins) throw new Error("TagSuggestionPlugin.addProseMirrorPlugins missing");
+    const tagPlugin = addTagPlugins.call({ options: {} } as never)[0];
+
+    const doc = schema.node("doc", null, [schema.node("paragraph", null, [schema.text("#Gho")])]);
+    let state = EditorState.create({ doc, schema, plugins: [tagPlugin, ghost] });
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 5)));
+
+    expect(tagSuggestionPluginKey.getState(state)?.active).toBe(true);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+});
+
+describe("wikiLinkGhostCompletionPlugin — dismissal", () => {
+  it("turns off when the typed prefix no longer matches", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    let state = makeParagraphState("Gho", plugin);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(true);
+
+    state = state.apply(state.tr.insertText("x", 4));
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("turns off when selection becomes a non-empty range", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    let state = makeParagraphState("Gho", plugin);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(true);
+
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 1, 4)));
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("close meta clears the active state and notifies subscribers", () => {
+    const onStateChange = vi.fn();
+    const plugin = buildPlugin({ candidates: TARGETS, onStateChange });
+    let state = makeParagraphState("Gho", plugin);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(true);
+    onStateChange.mockClear();
+
+    state = state.apply(state.tr.setMeta(wikiLinkGhostCompletionPluginKey, { close: true }));
+    const ps = wikiLinkGhostCompletionPluginKey.getState(state);
+    expect(ps?.active).toBe(false);
+    expect(ps?.candidate).toBeNull();
+    expect(onStateChange).toHaveBeenCalledWith(ps);
+  });
+});
+
+describe("wikiLinkGhostCompletionPlugin — candidate filtering and tie-breaking", () => {
+  it("ignores soft-deleted candidates", () => {
+    const plugin = buildPlugin({
+      candidates: [{ id: "x", title: "Ghost Town", isDeleted: true }],
+    });
+    const state = makeParagraphState("Gho", plugin);
+    expect(wikiLinkGhostCompletionPluginKey.getState(state)?.active).toBe(false);
+  });
+
+  it("breaks ties by shortest title", () => {
+    const plugin = buildPlugin({
+      candidates: [
+        { id: "long", title: "Tested Across Suite" },
+        { id: "short", title: "Tested" },
+        { id: "mid", title: "Tested Path" },
+      ],
+    });
+    const state = makeParagraphState("Tes", plugin);
+    const ps = wikiLinkGhostCompletionPluginKey.getState(state);
+    expect(ps?.active).toBe(true);
+    expect(ps?.candidate?.id).toBe("short");
+    expect(ps?.suffix).toBe("ted");
+  });
+});
+
+describe("wikiLinkGhostCompletionPlugin — decorations", () => {
+  it("renders a widget decoration at the end of the typed range when active", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeParagraphState("Gho", plugin);
+    const ps = wikiLinkGhostCompletionPluginKey.getState(state);
+    expect(ps?.active).toBe(true);
+
+    const decos = ps?.decorations.find(0, state.doc.content.size) ?? [];
+    expect(decos).toHaveLength(1);
+    // Widget decorations have `from === to` at the insertion point.
+    // widget の from === to が widget 位置。
+    expect(decos[0].from).toBe(4);
+    expect(decos[0].to).toBe(4);
+  });
+
+  it("returns an empty decoration set when inactive", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeParagraphState("Xyz", plugin);
+    const ps = wikiLinkGhostCompletionPluginKey.getState(state);
+    expect(ps?.active).toBe(false);
+    const decos = ps?.decorations.find(0, state.doc.content.size) ?? [];
+    expect(decos).toHaveLength(0);
+  });
+});
+
+describe("buildGhostCompletionWidget", () => {
+  it("renders a span with the correct class, suffix, target id, and non-editable flag", () => {
+    const span = buildGhostCompletionWidget("st Target", { id: "id-ghost", title: "Ghost Target" });
+    expect(span.tagName).toBe("SPAN");
+    expect(span.className).toBe("wiki-link-ghost-completion");
+    expect(span.textContent).toBe("st Target");
+    expect(span.getAttribute("data-ghost-completion")).toBe("true");
+    expect(span.getAttribute("data-target-id")).toBe("id-ghost");
+    expect(span.getAttribute("contenteditable")).toBe("false");
+  });
+});
+
+describe("buildConfirmTransaction", () => {
+  it("replaces the typed range with the full title carrying a wikiLink mark", () => {
+    const plugin = buildPlugin({ candidates: TARGETS });
+    const state = makeParagraphState("Gho", plugin);
+    const ps = wikiLinkGhostCompletionPluginKey.getState(state);
+    if (!ps?.active || !ps.range || !ps.candidate) {
+      throw new Error("expected plugin state to be active with range + candidate");
+    }
+
+    const tr = buildConfirmTransaction(state, ps.range, ps.candidate);
+    if (!tr) throw new Error("expected non-null confirm transaction");
+    const next = state.apply(tr);
+
+    // After confirm, the paragraph contains the full title with a wikiLink mark.
+    // 確定後、段落はフルタイトル + wikiLink マークを持つ。
+    const para = next.doc.firstChild;
+    if (!para) throw new Error("expected doc to have a child");
+    expect(para.textContent).toBe("Ghost Target");
+    const firstText = para.firstChild;
+    if (!firstText) throw new Error("expected paragraph to have a text node");
+    const wikiMark = firstText.marks.find((m) => m.type === schema.marks.wikiLink);
+    expect(wikiMark).toBeDefined();
+    expect(wikiMark?.attrs).toMatchObject({
+      title: "Ghost Target",
+      exists: true,
+      referenced: false,
+      targetId: "id-ghost",
+    });
+
+    // Plugin state collapses to inactive on the same transaction (close meta).
+    // 同じ transaction の close メタで非アクティブに倒れる。
+    expect(wikiLinkGhostCompletionPluginKey.getState(next)?.active).toBe(false);
+
+    // Cursor lands right after the inserted title.
+    // 挿入直後（"Ghost Target".length = 12 → pos 1 + 12 = 13）に caret。
+    expect(next.selection.from).toBe(13);
+    expect(next.selection.to).toBe(13);
+
+    // Stored marks cleared so the next keystroke is not styled as a wikiLink.
+    // 直後のキーストロークがマークを引き継がないことを保証。
+    expect(next.storedMarks ?? []).toEqual([]);
+  });
+
+  it("returns null if the schema lacks a wikiLink mark", () => {
+    const slimSchema = new Schema({
+      nodes: {
+        doc: { content: "paragraph+" },
+        paragraph: { content: "text*", toDOM: () => ["p", 0] },
+        text: {},
+      },
+      marks: {},
+    });
+    const doc = slimSchema.node("doc", null, [
+      slimSchema.node("paragraph", null, [slimSchema.text("Gho")]),
+    ]);
+    const state = EditorState.create({ doc, schema: slimSchema });
+    const tr = buildConfirmTransaction(
+      state,
+      { from: 1, to: 4 },
+      { id: "x", title: "Ghost Target" },
+    );
+    expect(tr).toBeNull();
+  });
+});
+
+describe("WikiLinkGhostCompletionPlugin — extension wiring", () => {
+  it("declares the expected extension name", () => {
+    expect(WikiLinkGhostCompletionPlugin.name).toBe("wikiLinkGhostCompletion");
+  });
+
+  it("uses an empty default candidate list when no getCandidates is supplied", () => {
+    const ext = WikiLinkGhostCompletionPlugin.configure();
+    expect(ext.options.getCandidates()).toEqual([]);
+    expect(ext.options.onStateChange).toBeUndefined();
+  });
+});

--- a/src/components/editor/extensions/wikiLinkGhostCompletionPlugin.ts
+++ b/src/components/editor/extensions/wikiLinkGhostCompletionPlugin.ts
@@ -1,0 +1,578 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
+import type { MarkType, ResolvedPos } from "@tiptap/pm/model";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import type { EditorView } from "@tiptap/pm/view";
+import { wikiLinkSuggestionPluginKey } from "./wikiLinkSuggestionPlugin";
+import { tagSuggestionPluginKey } from "./tagSuggestionPlugin";
+
+/**
+ * Lightweight candidate page descriptor consumed by the ghost completion plugin.
+ * ゴースト補完プラグインが必要とする候補ページの最小情報。
+ *
+ * Mirrors the subset of `useWikiLinkCandidates` result shape that the plugin
+ * actually needs: id (for resolving the target page on confirm), title (for
+ * matching + ghost rendering), and an optional `isDeleted` flag so soft-deleted
+ * pages can be skipped at match time.
+ *
+ * `useWikiLinkCandidates` の戻り値のうち本プラグインが必要とする部分集合。
+ * `id`（確定時のターゲット解決）、`title`（マッチ + ゴースト表示）、削除済み
+ * ページを除外するための `isDeleted` を含む。
+ */
+export interface WikiLinkGhostCompletionCandidate {
+  id: string;
+  title: string;
+  isDeleted?: boolean;
+}
+
+/**
+ * Plugin state for the inline ghost completion.
+ * インラインゴースト補完のプラグイン状態。
+ *
+ * - `active`: ゴーストを表示中か / whether the ghost suffix is rendered.
+ * - `range`: 入力中の単語のドキュメント内範囲。確定時に置換に使う /
+ *            range covering the typed word; used as the replacement range on confirm.
+ * - `query`: 入力された接頭辞そのもの（タイプ時の大小区別を保持） /
+ *            the raw prefix the user typed (preserves case).
+ * - `candidate`: 一致した候補ページ（id + 完全な title） /
+ *                matched candidate (id + full title).
+ * - `suffix`: ゴーストとして表示する残り部分。`candidate.title.slice(query.length)` /
+ *             remainder shown as ghost = `candidate.title.slice(query.length)`.
+ * - `decorations`: ゴースト widget を含む装飾セット /
+ *                  decoration set holding the ghost widget.
+ */
+export interface WikiLinkGhostCompletionState {
+  active: boolean;
+  range: { from: number; to: number } | null;
+  query: string;
+  candidate: WikiLinkGhostCompletionCandidate | null;
+  suffix: string;
+  decorations: DecorationSet;
+}
+
+/**
+ * ProseMirror plugin key for {@link WikiLinkGhostCompletionPlugin}.
+ * {@link WikiLinkGhostCompletionPlugin} 用の ProseMirror プラグインキー。
+ */
+export const wikiLinkGhostCompletionPluginKey = new PluginKey<WikiLinkGhostCompletionState>(
+  "wikiLinkGhostCompletion",
+);
+
+/**
+ * Options for {@link WikiLinkGhostCompletionPlugin}.
+ * {@link WikiLinkGhostCompletionPlugin} のオプション。
+ */
+export interface WikiLinkGhostCompletionOptions {
+  /**
+   * Returns the latest candidate list. Called on every transaction (cheap;
+   * a linear prefix scan over the array is performed). The host should keep
+   * a ref to `useWikiLinkCandidates` output and return `ref.current` here so
+   * the editor instance does not have to be re-created when candidates change.
+   *
+   * 最新の候補一覧を返す。トランザクションごとに呼ばれる（線形 prefix scan を
+   * 行う）。ホストは `useWikiLinkCandidates` の戻り値を ref に保持し
+   * `ref.current` を返すことで、候補更新時にエディタを作り直さずに済む。
+   */
+  getCandidates: () => ReadonlyArray<WikiLinkGhostCompletionCandidate>;
+
+  /**
+   * Notifies the host on every state transition. Optional; the plugin handles
+   * confirmation internally so most hosts do not need to observe state.
+   *
+   * 状態遷移ごとに呼ばれる任意のコールバック。確定処理はプラグイン内で完結
+   * するため、ほとんどの呼び出し側は購読不要。
+   */
+  onStateChange?: (state: WikiLinkGhostCompletionState) => void;
+
+  /**
+   * Allow-list of parent node `type.name` values where the ghost may fire.
+   * Defaults to body-text containers (paragraph, heading, list items,
+   * blockquote, table cells). Configurable for tests.
+   *
+   * ゴーストを発火させて良い親ノード名のセット。本文系（段落・見出し・
+   * リスト・引用・テーブル）が既定。テストでの差し替えを可能にする。
+   */
+  allowedNodeTypes?: ReadonlySet<string>;
+}
+
+/**
+ * Default allow-listed parent node types for ghost activation.
+ * ゴースト発火を許容する親ノード名（既定）。
+ *
+ * Issue #930 acceptance criteria call for: paragraph / heading / list items /
+ * blockquote / table cells. We include both `code_block` style node names and
+ * Tiptap's PascalCase variants nowhere — the deny path uses
+ * `parent.type.spec.code` (covers any code-marked node) so only the explicit
+ * body types need to live here. Task items inherit `listItem` for body content
+ * but Tiptap names the node `taskItem`, so list both.
+ *
+ * 受け入れ条件に合わせて、本文系ノードのみを許容する。コード系は
+ * `parent.type.spec.code` の判定で別途排除するため、本セットには含めない。
+ */
+const DEFAULT_ALLOWED_NODE_TYPES: ReadonlySet<string> = new Set([
+  "paragraph",
+  "heading",
+  "listItem",
+  "list_item",
+  "taskItem",
+  "task_item",
+  "blockquote",
+  "tableCell",
+  "table_cell",
+  "tableHeader",
+  "table_header",
+]);
+
+/**
+ * Ancestor node names that disqualify the ghost completion even when the
+ * direct parent passes the allow-list. Mirrors the issue spec: "title /
+ * caption / 本文外". `code_block` is defensive — `parent.type.spec.code` is
+ * the primary guard.
+ *
+ * 直接の親が許容リストを満たしていても、祖先がこれらのいずれかなら不発火。
+ * Issue #930 の「タイトル / キャプション等の本文外」に対応。`code_block` は
+ * 念のための保険（メインの判定は `parent.type.spec.code`）。
+ */
+const EXCLUDED_ANCESTOR_NODE_TYPES: ReadonlySet<string> = new Set([
+  "title",
+  "caption",
+  "codeBlock",
+  "code_block",
+]);
+
+/**
+ * CSS class applied to the ghost widget DOM. Styled in `src/index.css`.
+ * ゴースト widget DOM に付与する CSS クラス。スタイルは `src/index.css`。
+ */
+const GHOST_CLASS = "wiki-link-ghost-completion";
+
+/**
+ * `data-*` attribute used by mouse/touch event delegation to detect a tap on
+ * the ghost suffix. Centralised so tests and CSS hooks stay in sync.
+ *
+ * ゴースト suffix のタップ判定で `closest()` する際の `data-*` 属性。
+ */
+const GHOST_DATA_ATTR = "data-ghost-completion";
+
+/**
+ * Empty (inactive) state factory. Used in every dismissal branch so the shape
+ * is consistent and ProseMirror does not retain a stale decoration set.
+ *
+ * 非アクティブ状態の生成ヘルパー。あらゆる dismiss 経路で同じ形を返すため。
+ */
+function createInactiveState(): WikiLinkGhostCompletionState {
+  return {
+    active: false,
+    range: null,
+    query: "",
+    candidate: null,
+    suffix: "",
+    decorations: DecorationSet.empty,
+  };
+}
+
+/**
+ * Collapse to inactive state without spamming `onStateChange` when the state
+ * was already inactive. Used by every dismissal branch in `apply` to keep the
+ * cyclomatic complexity manageable.
+ *
+ * 非アクティブに倒すヘルパー。前回も非アクティブなら no-op で `onStateChange`
+ * を再通知しない。`apply` の dismissal 分岐を一本化して複雑度を抑える。
+ */
+function deactivate(
+  prev: WikiLinkGhostCompletionState,
+  onStateChange: ((s: WikiLinkGhostCompletionState) => void) | undefined,
+): WikiLinkGhostCompletionState {
+  if (!prev.active) return prev;
+  const next = createInactiveState();
+  onStateChange?.(next);
+  return next;
+}
+
+/**
+ * Reasons that disqualify the cursor context from showing a ghost completion.
+ * Returns the first match, or `null` if the context is OK. Bundles the
+ * boundary-only checks that depend on the schema / selection but not on the
+ * candidate list, so `apply` can fast-bail.
+ *
+ * カーソル状況がゴーストを出すべきでない理由を返す（OK なら `null`）。
+ * 候補一覧に依存しない境界系の判定だけをまとめて、`apply` の早期 return に使う。
+ */
+function findContextSuppression(
+  newState: EditorState,
+  allowedNodeTypes: ReadonlySet<string>,
+): string | null {
+  const { selection, schema } = newState;
+  if (!selection.empty) return "range-selection";
+
+  if (wikiLinkSuggestionPluginKey.getState(newState)?.active) return "wiki-suggestion-active";
+  if (tagSuggestionPluginKey.getState(newState)?.active) return "tag-suggestion-active";
+
+  const { $from } = selection;
+  if ($from.parent.type.spec.code) return "code-block";
+  if (isInsideInlineCode($from, schema.marks)) return "inline-code";
+  if (isInsideExcludedAncestor($from)) return "excluded-ancestor";
+  if (!allowedNodeTypes.has($from.parent.type.name)) return "disallowed-parent";
+
+  const wikiLinkMark = schema.marks.wikiLink;
+  if (wikiLinkMark && wikiLinkMark.isInSet($from.marks())) return "inside-wiki-link";
+
+  return null;
+}
+
+/**
+ * Extract the current typed word from the paragraph-local text before the
+ * caret. Returns `null` when the word is missing, too short, contains a
+ * non-text node placeholder, or starts with a character reserved for another
+ * suggestion flow.
+ *
+ * カーソル直前の段落ローカルテキストから「現在タイプ中の単語」を抽出する。
+ * 単語がない / 2 文字未満 / 非テキストノード混在 / 他フローの先導文字始まり
+ * の場合は `null` を返す。
+ */
+function extractTypedWord($from: ResolvedPos): string | null {
+  const textBefore = $from.parent.textBetween(0, $from.parentOffset, null, "￼");
+  const match = textBefore.match(/(\S+)$/);
+  if (!match) return null;
+  const word = match[1];
+  if (word.includes("￼")) return null;
+  if (word.length < 2) return null;
+  const first = word[0];
+  if (first === "[" || first === "]" || first === "#" || first === "@" || first === "/") {
+    return null;
+  }
+  return word;
+}
+
+/**
+ * Find the best prefix-matching candidate for a typed word. Filters out
+ * soft-deleted pages and exact matches (no remainder to show), and breaks
+ * ties by shortest title — the most likely intended completion.
+ *
+ * 入力済み接頭辞に対する最良の候補を返す。削除済み・完全一致を除外し、
+ * 同 prefix の複数候補は最短タイトル優先で選ぶ。
+ */
+function findBestCandidate(
+  typedWord: string,
+  pages: ReadonlyArray<WikiLinkGhostCompletionCandidate>,
+): WikiLinkGhostCompletionCandidate | null {
+  const lowered = typedWord.toLowerCase();
+  let best: WikiLinkGhostCompletionCandidate | null = null;
+  for (const p of pages) {
+    if (p.isDeleted) continue;
+    if (p.title.length <= typedWord.length) continue;
+    if (!p.title.toLowerCase().startsWith(lowered)) continue;
+    if (!best || p.title.length < best.title.length) {
+      best = p;
+    }
+  }
+  return best;
+}
+
+/**
+ * Walk the resolved position to detect whether the caret sits inside an inline
+ * `code` mark. Mirrors the helper used in `tagSuggestionPlugin`.
+ *
+ * カーソル位置がインライン `code` マーク内にあるかを判定する。
+ * `tagSuggestionPlugin` の同名ヘルパーと同じロジック。
+ */
+function isInsideInlineCode($from: ResolvedPos, schemaMarks: Record<string, MarkType>): boolean {
+  const codeMark = schemaMarks.code;
+  if (!codeMark) return false;
+  return Boolean(codeMark.isInSet($from.marks()));
+}
+
+/**
+ * Walk ancestors to detect title/caption/code_block containers that disqualify
+ * the ghost even when the inner block looks permissible.
+ *
+ * 祖先ノードを辿って、ゴーストを出してはいけないコンテナ内（タイトル・
+ * キャプション・コードブロック）かを判定する。
+ */
+function isInsideExcludedAncestor($from: ResolvedPos): boolean {
+  for (let depth = $from.depth; depth >= 0; depth--) {
+    const name = $from.node(depth).type.name;
+    if (EXCLUDED_ANCESTOR_NODE_TYPES.has(name)) return true;
+  }
+  return false;
+}
+
+/**
+ * Builds the DOM node rendered as a ProseMirror widget decoration for the
+ * ghost suffix. Kept as a free function so tests can call it without spinning
+ * up a view, and so the mousedown/touchstart event delegation can target a
+ * stable `[data-ghost-completion="true"]` selector.
+ *
+ * ゴースト suffix を描画する DOM を生成する。テストでビューなしに呼べるよう
+ * 自由関数化し、タップ判定で `[data-ghost-completion="true"]` セレクタが
+ * 安定して効くようにする。
+ */
+export function buildGhostCompletionWidget(
+  suffix: string,
+  candidate: WikiLinkGhostCompletionCandidate,
+): HTMLElement {
+  const span = document.createElement("span");
+  span.className = GHOST_CLASS;
+  span.textContent = suffix;
+  span.setAttribute(GHOST_DATA_ATTR, "true");
+  span.setAttribute("data-target-id", candidate.id);
+  // Prevent the caret from entering the widget — critical for IME and
+  // mobile, where the browser may otherwise place the selection inside.
+  // キャレットが widget 内部に入るのを防ぐ。IME / モバイルで重要。
+  span.setAttribute("contenteditable", "false");
+  return span;
+}
+
+/**
+ * Pure-function transaction builder for the Tab / tap confirmation path.
+ * Replaces the typed prefix with the full candidate title wrapped in a
+ * `wikiLink` mark (`exists: true`, `targetId: candidate.id`), and sends a
+ * `close` meta so the plugin collapses to inactive on the same transaction.
+ *
+ * Tab / タップ確定時のトランザクション生成。入力済み接頭辞を candidate の
+ * 完全タイトルへ差し替え、`wikiLink` マーク（`exists: true`、
+ * `targetId: candidate.id`）を付与する。同じトランザクションで `close`
+ * メタを送ってプラグインを非アクティブに倒す。
+ *
+ * Exported for unit testing — the runtime path goes through
+ * `confirmGhostCompletion`.
+ *
+ * 単体テスト目的でエクスポート。実行時は `confirmGhostCompletion` 経由。
+ */
+export function buildConfirmTransaction(
+  state: EditorState,
+  range: { from: number; to: number },
+  candidate: WikiLinkGhostCompletionCandidate,
+): Transaction | null {
+  const wikiLinkMarkType = state.schema.marks.wikiLink;
+  if (!wikiLinkMarkType) return null;
+  const mark = wikiLinkMarkType.create({
+    title: candidate.title,
+    exists: true,
+    referenced: false,
+    targetId: candidate.id,
+  });
+  const tr = state.tr.replaceWith(range.from, range.to, state.schema.text(candidate.title, [mark]));
+  // Place the cursor right after the inserted title so the user can keep
+  // typing. `replaceWith` maps selection forward but we set it explicitly
+  // for clarity (and to defeat any sticky-mark inheritance).
+  // 挿入直後に caret を置く。マークの sticky inheritance を防ぐためにも明示。
+  const cursorAt = range.from + candidate.title.length;
+  tr.setSelection(TextSelection.create(tr.doc, cursorAt));
+  // Strip stored marks so the user's next keystroke is not styled as a wikiLink.
+  // 次の打鍵が wikiLink マークを引き継がないように storedMarks をクリア。
+  tr.setStoredMarks([]);
+  tr.setMeta(wikiLinkGhostCompletionPluginKey, { close: true });
+  return tr;
+}
+
+/**
+ * Runtime confirmation helper shared by the Tab handler and the
+ * mousedown/touchstart delegation. Dispatches the transaction built by
+ * {@link buildConfirmTransaction} on the editor view.
+ *
+ * Tab ハンドラと mousedown/touchstart 経由のタップ確定で共有する確定処理。
+ * {@link buildConfirmTransaction} で組んだトランザクションを dispatch する。
+ */
+function confirmGhostCompletion(view: EditorView, state: WikiLinkGhostCompletionState): boolean {
+  if (!state.active || !state.range || !state.candidate) return false;
+  const tr = buildConfirmTransaction(view.state, state.range, state.candidate);
+  if (!tr) return false;
+  view.dispatch(tr);
+  return true;
+}
+
+/**
+ * ProseMirror plugin that shows an inline "ghost completion" while the user
+ * types a plain word that prefix-matches an existing page title. Pressing
+ * Tab (desktop) or tapping the chip (mobile) confirms by replacing the typed
+ * prefix with the full title wrapped in a `wikiLink` mark.
+ *
+ * ユーザーが通常のテキストをタイプ中、既存ページタイトルの接頭辞に一致した
+ * 単語があれば、その続きをインラインのゴーストテキストとしてカーソル右に
+ * 表示する ProseMirror プラグイン。Tab（デスクトップ）またはチップタップ
+ * （モバイル）で確定し、入力済み接頭辞をフルタイトルに置換、`wikiLink`
+ * マーク（`exists: true`, `targetId: candidate.id`）を付与する。
+ *
+ * 設計は `wikiLinkSuggestionPlugin`（`[[...]]`）と `tagSuggestionPlugin`
+ * （`#name`）と同形の Tiptap `Extension` + ProseMirror `Plugin`。`onStateChange`
+ * で React 側に状態を流せるが、ポップオーバー UI は不要（widget 自体が UI）
+ * のためホスト側に追加コンポーネントは不要。
+ *
+ * 抑止条件:
+ * - 範囲選択中 / 入力中の単語が 2 文字未満 / IME 変換中（compositionstart で
+ *   即時 close）
+ * - コードブロック (`parent.type.spec.code`) / インラインコード
+ *   (`code` mark) / `title` / `caption` などの本文外
+ * - `wikiLinkSuggestionPlugin` か `tagSuggestionPlugin` が active のとき
+ *   （`[[`・`#` 入力が優先）
+ * - 既存 `wikiLink` マーク内
+ * - 単語の先頭が `[`, `]`, `#`, `@`, `/`（他フローへ譲る）
+ * - 候補に prefix 一致するページがない、または完全一致で suffix が空
+ *
+ * 親 issue #924 §4 / 子 issue #930。
+ */
+export const WikiLinkGhostCompletionPlugin = Extension.create<WikiLinkGhostCompletionOptions>({
+  name: "wikiLinkGhostCompletion",
+
+  addOptions() {
+    return {
+      getCandidates: () => [],
+      onStateChange: undefined,
+      allowedNodeTypes: undefined,
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const { onStateChange, getCandidates } = this.options;
+    const allowedNodeTypes = this.options.allowedNodeTypes ?? DEFAULT_ALLOWED_NODE_TYPES;
+
+    return [
+      new Plugin<WikiLinkGhostCompletionState>({
+        key: wikiLinkGhostCompletionPluginKey,
+
+        state: {
+          init() {
+            return createInactiveState();
+          },
+
+          apply(tr, prev, _oldState, newState) {
+            // Explicit close meta (Escape, confirm, compositionstart) wins
+            // over everything else.
+            // 明示的な close メタ（Esc / 確定 / IME 開始）は最優先で適用。
+            if (tr.getMeta(wikiLinkGhostCompletionPluginKey)?.close) {
+              return deactivate(prev, onStateChange);
+            }
+
+            // Context-level disqualifiers (selection / sibling plugins / node
+            // type / existing mark). Bundled in `findContextSuppression` so
+            // this branch list does not balloon the apply cyclomatic complexity.
+            // 文脈レベルの抑止理由（選択 / 他プラグイン active / ノード種別 /
+            // 既存マーク）はまとめてヘルパーで判定する。
+            if (findContextSuppression(newState, allowedNodeTypes)) {
+              return deactivate(prev, onStateChange);
+            }
+
+            const { $from } = newState.selection;
+            const typedWord = extractTypedWord($from);
+            if (!typedWord) {
+              return deactivate(prev, onStateChange);
+            }
+
+            const candidate = findBestCandidate(typedWord, getCandidates());
+            if (!candidate) {
+              return deactivate(prev, onStateChange);
+            }
+
+            const suffix = candidate.title.slice(typedWord.length);
+            if (suffix.length === 0) {
+              return deactivate(prev, onStateChange);
+            }
+
+            const range = { from: $from.pos - typedWord.length, to: $from.pos };
+            const widget = Decoration.widget(
+              range.to,
+              () => buildGhostCompletionWidget(suffix, candidate),
+              {
+                side: 1,
+                ignoreSelection: true,
+                // Stable key so ProseMirror reuses the DOM node when the
+                // suffix is unchanged across rapid transactions → no flicker.
+                // suffix 不変なら ProseMirror が DOM を再利用してフリッカ抑止。
+                key: `ghost:${candidate.id}:${suffix}`,
+              },
+            );
+            const decorations = DecorationSet.create(newState.doc, [widget]);
+
+            const next: WikiLinkGhostCompletionState = {
+              active: true,
+              range,
+              query: typedWord,
+              candidate: {
+                id: candidate.id,
+                title: candidate.title,
+                isDeleted: candidate.isDeleted,
+              },
+              suffix,
+              decorations,
+            };
+            onStateChange?.(next);
+            return next;
+          },
+        },
+
+        props: {
+          decorations(state) {
+            return this.getState(state)?.decorations ?? DecorationSet.empty;
+          },
+
+          handleKeyDown(view: EditorView, event: KeyboardEvent) {
+            const pluginState = wikiLinkGhostCompletionPluginKey.getState(view.state);
+            if (!pluginState?.active) return false;
+
+            // Never interfere with IME composition.
+            // IME 変換中は一切干渉しない。
+            if (view.composing) return false;
+
+            if (event.key === "Escape") {
+              view.dispatch(
+                view.state.tr.setMeta(wikiLinkGhostCompletionPluginKey, { close: true }),
+              );
+              return true;
+            }
+
+            if (
+              event.key === "Tab" &&
+              !event.shiftKey &&
+              !event.metaKey &&
+              !event.ctrlKey &&
+              !event.altKey
+            ) {
+              event.preventDefault();
+              return confirmGhostCompletion(view, pluginState);
+            }
+
+            return false;
+          },
+
+          handleDOMEvents: {
+            // Mobile chip tap / desktop mouse confirmation. Use mousedown
+            // (not click) so we beat ProseMirror's own selection handling.
+            // モバイルのチップタップ・デスクトップのマウス確定。`mousedown`
+            // で ProseMirror の selection 処理より先に確定する。
+            mousedown(view, event) {
+              const target = event.target as HTMLElement | null;
+              if (!target?.closest(`[${GHOST_DATA_ATTR}="true"]`)) return false;
+              const pluginState = wikiLinkGhostCompletionPluginKey.getState(view.state);
+              if (!pluginState?.active) return false;
+              event.preventDefault();
+              return confirmGhostCompletion(view, pluginState);
+            },
+
+            touchstart(view, event) {
+              const target = event.target as HTMLElement | null;
+              if (!target?.closest(`[${GHOST_DATA_ATTR}="true"]`)) return false;
+              const pluginState = wikiLinkGhostCompletionPluginKey.getState(view.state);
+              if (!pluginState?.active) return false;
+              event.preventDefault();
+              return confirmGhostCompletion(view, pluginState);
+            },
+
+            // Dismiss the moment IME composition starts. The next apply after
+            // `compositionend` re-evaluates against the committed text.
+            // IME 変換開始時にゴーストを消す。`compositionend` 後は通常通り。
+            compositionstart(view) {
+              const pluginState = wikiLinkGhostCompletionPluginKey.getState(view.state);
+              if (!pluginState?.active) return false;
+              view.dispatch(
+                view.state.tr.setMeta(wikiLinkGhostCompletionPluginKey, { close: true }),
+              );
+              return false;
+            },
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/src/components/editor/extensions/wikiLinkGhostCompletionPlugin.ts
+++ b/src/components/editor/extensions/wikiLinkGhostCompletionPlugin.ts
@@ -6,6 +6,7 @@ import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import type { EditorView } from "@tiptap/pm/view";
 import { wikiLinkSuggestionPluginKey } from "./wikiLinkSuggestionPlugin";
 import { tagSuggestionPluginKey } from "./tagSuggestionPlugin";
+import { slashSuggestionPluginKey } from "./slashSuggestionPlugin";
 
 /**
  * Lightweight candidate page descriptor consumed by the ghost completion plugin.
@@ -208,6 +209,14 @@ function findContextSuppression(
 
   if (wikiLinkSuggestionPluginKey.getState(newState)?.active) return "wiki-suggestion-active";
   if (tagSuggestionPluginKey.getState(newState)?.active) return "tag-suggestion-active";
+  // Slash サジェストが開いている間は同時に発火させない。`SlashSuggestionPlugin`
+  // は空白を含むクエリでも active を保つため (`/(^|\\s)\\/([^\\n]*)$/`)、
+  // 「`/cmd Ghost`」のような入力でゴーストと UI が二重に出るのを抑止する。
+  // また Tab を奪われずスラッシュメニュー側のキー操作を維持する。
+  // Mutually exclude with the slash menu: `SlashSuggestionPlugin` stays
+  // active across spaces, so `/cmd Ghost` would otherwise double-fire the
+  // ghost widget and steal Tab from the slash command flow.
+  if (slashSuggestionPluginKey.getState(newState)?.active) return "slash-suggestion-active";
 
   const { $from } = selection;
   if ($from.parent.type.spec.code) return "code-block";
@@ -405,8 +414,8 @@ function confirmGhostCompletion(view: EditorView, state: WikiLinkGhostCompletion
  *   即時 close）
  * - コードブロック (`parent.type.spec.code`) / インラインコード
  *   (`code` mark) / `title` / `caption` などの本文外
- * - `wikiLinkSuggestionPlugin` か `tagSuggestionPlugin` が active のとき
- *   （`[[`・`#` 入力が優先）
+ * - `wikiLinkSuggestionPlugin` / `tagSuggestionPlugin` / `slashSuggestionPlugin`
+ *   のいずれかが active のとき（`[[`・`#`・`/` 入力が優先）
  * - 既存 `wikiLink` マーク内
  * - 単語の先頭が `[`, `]`, `#`, `@`, `/`（他フローへ譲る）
  * - 候補に prefix 一致するページがない、または完全一致で suffix が空
@@ -542,8 +551,13 @@ export const WikiLinkGhostCompletionPlugin = Extension.create<WikiLinkGhostCompl
             // モバイルのチップタップ・デスクトップのマウス確定。`mousedown`
             // で ProseMirror の selection 処理より先に確定する。
             mousedown(view, event) {
-              const target = event.target as HTMLElement | null;
-              if (!target?.closest(`[${GHOST_DATA_ATTR}="true"]`)) return false;
+              // `event.target` はテキストノードなど `Element` ではないことも
+              // ある。`closest` を安全に呼ぶため `instanceof Element` で絞る。
+              // Guard against non-Element targets (e.g. text nodes) so we can
+              // safely call `closest` without runtime errors.
+              const target = event.target;
+              if (!(target instanceof Element)) return false;
+              if (!target.closest(`[${GHOST_DATA_ATTR}="true"]`)) return false;
               const pluginState = wikiLinkGhostCompletionPluginKey.getState(view.state);
               if (!pluginState?.active) return false;
               event.preventDefault();
@@ -551,8 +565,11 @@ export const WikiLinkGhostCompletionPlugin = Extension.create<WikiLinkGhostCompl
             },
 
             touchstart(view, event) {
-              const target = event.target as HTMLElement | null;
-              if (!target?.closest(`[${GHOST_DATA_ATTR}="true"]`)) return false;
+              // mousedown と同じ理由で `instanceof Element` ガード。
+              // Same Element guard as mousedown above.
+              const target = event.target;
+              if (!(target instanceof Element)) return false;
+              if (!target.closest(`[${GHOST_DATA_ATTR}="true"]`)) return false;
               const pluginState = wikiLinkGhostCompletionPluginKey.getState(view.state);
               if (!pluginState?.active) return false;
               event.preventDefault();

--- a/src/index.css
+++ b/src/index.css
@@ -885,6 +885,32 @@
     border-radius: 2px;
   }
 
+  /* Inline ghost completion preview (issue #930). Rendered as a
+     `Decoration.widget` next to the caret while the typed word prefix-matches
+     an existing page title. Tap (mobile) or press Tab (desktop) to confirm. */
+  /* インライン・ゴースト補完（issue #930）。入力中の単語が既存ページ名の
+     接頭辞に一致した時に `Decoration.widget` でカーソル右に出す薄色のプレビュー。
+     Tab（デスクトップ）またはチップタップ（モバイル）で確定する。 */
+  .wiki-link-ghost-completion {
+    color: hsl(var(--muted-foreground));
+    opacity: 0.55;
+    font-style: italic;
+    /* widget の pointer-events は editor 親から none を継承し得るため明示。
+       Widgets may inherit pointer-events: none from the editor host; opt back
+       in so the chip is tappable on mobile. */
+    pointer-events: auto;
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+    background: transparent;
+    border: none;
+    text-decoration: none;
+  }
+
+  .wiki-link-ghost-completion:hover {
+    opacity: 0.8;
+  }
+
   /* Tag styling — shares the WikiLink color scheme so existing/referenced/ghost
      states are visually consistent across both mark types. See issue #725. */
   /* タグのスタイル。WikiLink と同じ色系列を共有し、existing / referenced /


### PR DESCRIPTION
タイピング中、既存ページ名の接頭辞に一致する単語があれば残り部分を
カーソル右に薄色のゴーストとして表示し、Tab（デスクトップ）または
チップタップ（モバイル）で WikiLink マークに確定する ProseMirror
プラグインを追加（親 issue #924 §4）。

- `wikiLinkGhostCompletionPlugin.ts`: `Extension.create` + `Plugin`
  構成で `wikiLinkSuggestionPlugin` / `tagSuggestionPlugin` と
  ライフサイクルを揃える。`useWikiLinkCandidates` の結果は ref 経由の
  getter で受け取り、候補更新でエディタ再生成を避ける
- 抑止条件: 範囲選択中・他サジェスト系 active・コードブロック・
  インラインコード・title / caption 等本文外・既存 WikiLink マーク内・
  ≥2 文字未満・先頭 `[` `]` `#` `@` `/`・候補なし or 完全一致
- 確定パスはタブとタップで共用（`handleKeyDown` + `mousedown` /
  `touchstart` の DOM event delegation）
- IME 中は `compositionstart` で即時クローズ、`view.composing` で
  Tab を奪わない
- Vitest 30 ケース（最小スキーマで状態遷移を網羅）、Playwright 7 ケース
  （ハッピー / Esc / 1 文字 / コードブロック / `[[` 競合 / Tab 素通し）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added inline ghost completion for wiki links: As you type a wiki link prefix (2+ characters), the editor previews the matched page title. Press Tab or click the preview to automatically insert the wiki link.

* **Tests**
  * Added comprehensive E2E and unit tests covering ghost completion behavior, including activation rules, edge cases like code blocks and IME composition, and integration with existing editor features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/940?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->