### PR TITLE
feat: normalize mermaid code blocks to dedicated mermaid nodes

### DIFF
--- a/src/components/editor/TiptapEditor/editorConfig.ts
+++ b/src/components/editor/TiptapEditor/editorConfig.ts
@@ -43,6 +43,7 @@ import {
   type WikiLinkGhostCompletionState,
 } from "../extensions/wikiLinkGhostCompletionPlugin";
 import { HeadingLevelClamp } from "./headingLevelClampExtension";
+import { MermaidCodeBlockNormalize } from "./mermaidCodeBlockNormalizeExtension";
 import type { Extension } from "@tiptap/core";
 import type * as Y from "yjs";
 import type { Awareness } from "y-protocols/awareness";
@@ -338,6 +339,13 @@ function createCommonEditorExtensions(options: CommonEditorExtensionsOptions): E
     // --- 統合メディア挿入プレースホルダー（/image、/video スラッシュコマンド） ---
     MediaPlaceholderExtension,
     Mermaid,
+    // ``` ```mermaid ``` ``` 由来の codeBlock を mermaid ノードに正規化する。
+    // Mermaid 拡張より後に登録することで、変換先の `mermaid` ノードがスキーマに
+    // 存在することを保証する（Issue #945）。
+    // Lazy-migrate legacy `codeBlock(language=mermaid)` to `mermaid` nodes.
+    // Registered after `Mermaid` so the target node is guaranteed to be in the
+    // schema (Issue #945).
+    MermaidCodeBlockNormalize,
     // --- YouTube Embed ---
     YouTubeEmbed,
     McpResource,

--- a/src/components/editor/TiptapEditor/mermaidCodeBlockNormalizeExtension.test.ts
+++ b/src/components/editor/TiptapEditor/mermaidCodeBlockNormalizeExtension.test.ts
@@ -164,4 +164,32 @@ describe("MermaidCodeBlockNormalize", () => {
     expect(editor.state.doc.firstChild?.type.name).toBe("mermaid");
     expect(editor.state.doc.firstChild?.attrs.code).toBe("graph TD");
   });
+
+  // CodeRabbit のレビュー (PR #946) で指摘された undo 履歴混入バグの回帰テスト。
+  // 正規化トランザクションが undo 履歴に積まれると、Cmd+Z で `mermaid` → `codeBlock`
+  // に戻り、次の編集で再度プラグインが変換するループになる。
+  // Regression test for the CodeRabbit finding on PR #946: normalisation
+  // transactions must not enter the undo history, otherwise Cmd+Z would
+  // revert `mermaid` back to `codeBlock` and the plugin would re-convert it
+  // on the next edit, causing an undo/redo bounce.
+  it("does not push the migration transaction onto the undo history", async () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+          content: [{ type: "text", text: "graph TD" }],
+        },
+      ],
+    });
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+    expect(editor.state.doc.firstChild?.type.name).toBe("mermaid");
+
+    // Tiptap (StarterKit) の undo コマンドを実行しても、正規化は元に戻らない。
+    // Invoking the editor's undo command must not roll the migration back.
+    editor.commands.undo();
+    expect(editor.state.doc.firstChild?.type.name).toBe("mermaid");
+    expect(editor.state.doc.firstChild?.attrs.code).toBe("graph TD");
+  });
 });

--- a/src/components/editor/TiptapEditor/mermaidCodeBlockNormalizeExtension.test.ts
+++ b/src/components/editor/TiptapEditor/mermaidCodeBlockNormalizeExtension.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { Mermaid } from "../extensions/MermaidExtension";
+import { MermaidCodeBlockNormalize } from "./mermaidCodeBlockNormalizeExtension";
+
+/**
+ * `MermaidCodeBlockNormalize` は、エディタロード時に `codeBlock` +
+ * `language: "mermaid"` を `mermaid` ノードへ自動変換することを検証する。
+ *
+ * `MermaidCodeBlockNormalize` should rewrite legacy `codeBlock` nodes with
+ * `language: "mermaid"` into dedicated `mermaid` nodes on editor load.
+ */
+describe("MermaidCodeBlockNormalize", () => {
+  const editors: Editor[] = [];
+
+  afterEach(() => {
+    for (const ed of editors) {
+      ed.destroy();
+    }
+    editors.length = 0;
+  });
+
+  /**
+   * 共通のエディタ生成ヘルパー。`MermaidNodeView` は React に依存するため、
+   * NodeView を取り外したテスト用 Mermaid 拡張を用意して使う。
+   *
+   * Builds an Editor with `MermaidCodeBlockNormalize` plus a NodeView-less
+   * Mermaid node (the real NodeView relies on React rendering inside the DOM,
+   * which isn't needed for these unit tests).
+   */
+  function createEditor(content: unknown): Editor {
+    const el = document.createElement("div");
+    const editor = new Editor({
+      element: el,
+      extensions: [
+        StarterKit.configure({
+          heading: { levels: [2, 3, 4, 5] },
+        }),
+        Mermaid.extend({
+          addNodeView: () => null as unknown as never,
+        }),
+        MermaidCodeBlockNormalize,
+      ],
+      content,
+    });
+    editors.push(editor);
+    return editor;
+  }
+
+  it("rewrites a legacy codeBlock(language=mermaid) into a mermaid node on load", async () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+          content: [{ type: "text", text: "graph TD\nA-->B" }],
+        },
+      ],
+    });
+
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    const first = editor.state.doc.firstChild;
+    expect(first?.type.name).toBe("mermaid");
+    expect(first?.attrs.code).toBe("graph TD\nA-->B");
+  });
+
+  it("does not touch code blocks with a different language", async () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "ts" },
+          content: [{ type: "text", text: "const x = 1;" }],
+        },
+      ],
+    });
+
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    const first = editor.state.doc.firstChild;
+    expect(first?.type.name).toBe("codeBlock");
+    expect(first?.attrs.language).toBe("ts");
+  });
+
+  it("strips trailing newlines from the converted source", async () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+          content: [{ type: "text", text: "graph TD\nA-->B\n\n" }],
+        },
+      ],
+    });
+
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    expect(editor.state.doc.firstChild?.attrs.code).toBe("graph TD\nA-->B");
+  });
+
+  it("rewrites multiple mermaid code blocks in the same document", async () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+          content: [{ type: "text", text: "graph TD" }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "between" }],
+        },
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+          content: [{ type: "text", text: "sequenceDiagram" }],
+        },
+      ],
+    });
+
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Tiptap がトレーリング paragraph を補う可能性があるため、最初の 3 ノードだけ
+    // 厳密に検証する。両方のコードブロックが正しい順序で `mermaid` ノードに
+    // 変換されていることだけ確認する。
+    // Tiptap may append a trailing empty paragraph; assert only the first
+    // three children so both mermaid blocks are validated in order.
+    const doc = editor.state.doc;
+    expect(doc.childCount).toBeGreaterThanOrEqual(3);
+    expect(doc.child(0).type.name).toBe("mermaid");
+    expect(doc.child(0).attrs.code).toBe("graph TD");
+    expect(doc.child(1).type.name).toBe("paragraph");
+    expect(doc.child(2).type.name).toBe("mermaid");
+    expect(doc.child(2).attrs.code).toBe("sequenceDiagram");
+  });
+
+  it("normalises a code block that is later switched to `mermaid` at runtime", async () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "ts" },
+          content: [{ type: "text", text: "graph TD" }],
+        },
+      ],
+    });
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+    expect(editor.state.doc.firstChild?.type.name).toBe("codeBlock");
+
+    // `appendTransaction` 経路で言語属性を変更すると、再度走査されて mermaid に変換される。
+    // Changing the language attribute fires `appendTransaction`, which then
+    // rewrites the codeBlock to a mermaid node.
+    const codeBlockType = editor.schema.nodes.codeBlock;
+    expect(codeBlockType).toBeDefined();
+    editor.view.dispatch(editor.state.tr.setNodeMarkup(0, codeBlockType, { language: "mermaid" }));
+
+    expect(editor.state.doc.firstChild?.type.name).toBe("mermaid");
+    expect(editor.state.doc.firstChild?.attrs.code).toBe("graph TD");
+  });
+});

--- a/src/components/editor/TiptapEditor/mermaidCodeBlockNormalizeExtension.ts
+++ b/src/components/editor/TiptapEditor/mermaidCodeBlockNormalizeExtension.ts
@@ -1,0 +1,141 @@
+import { Extension } from "@tiptap/core";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+
+/**
+ * `MermaidCodeBlockNormalize` のプラグインキー。拡張再初期化のたびに
+ * `PluginKey` を作り直さないようトップレベルで定義する。
+ *
+ * Plugin key for `MermaidCodeBlockNormalize`. Declared at module scope so it
+ * is stable across extension re-initialisations.
+ */
+const mermaidCodeBlockNormalizeKey = new PluginKey("mermaidCodeBlockNormalize");
+
+/**
+ * ノード型名が `codeBlock`（または互換の `code_block`）かを判定する。
+ * Returns whether a ProseMirror node type name represents a code block.
+ */
+function isCodeBlockType(typeName: string): boolean {
+  return typeName === "codeBlock" || typeName === "code_block";
+}
+
+/**
+ * 与えられたノードの `language` 属性が `"mermaid"`（大文字小文字無視）かを判定する。
+ * Returns whether the node's `language` attribute selects the Mermaid renderer.
+ */
+function isMermaidLanguage(attrs: Record<string, unknown> | null | undefined): boolean {
+  const value = attrs?.language;
+  if (typeof value !== "string") return false;
+  return value.trim().toLowerCase() === "mermaid";
+}
+
+/**
+ * `state.doc` を 1 度走査し、`language: "mermaid"` の codeBlock を `mermaid`
+ * ノードに置換するトランザクションを構築する。対象がなければ `null` を返す。
+ *
+ * Walk the document once and build a transaction that replaces every
+ * `codeBlock` with `language: "mermaid"` by a dedicated `mermaid` node.
+ * Returns `null` when nothing needs to change so the caller can skip dispatch.
+ *
+ * 走査は降順 (`-pos`) で置換することにより、先に置換した範囲のオフセット変動が
+ * 後続の置換位置に影響しないようにしている（Issue #945）。
+ *
+ * Replacements are applied in descending document order so that splicing
+ * earlier in the tree does not invalidate the positions of later targets
+ * (Issue #945).
+ *
+ * @param state - 走査対象のエディタ状態 / Editor state to scan.
+ * @returns 変換トランザクション、または変換不要なら null / Transaction or `null`.
+ */
+function buildMermaidNormalizeTr(state: EditorState): Transaction | null {
+  const mermaidType = state.schema.nodes.mermaid;
+  // mermaid ノードがスキーマに存在しない（プレビュー用拡張セット等）場合は何もしない。
+  // Bail out gracefully when the `mermaid` node is not part of the schema
+  // (e.g. lightweight preview extension sets).
+  if (!mermaidType) return null;
+
+  type Target = { pos: number; nodeSize: number; code: string };
+  const targets: Target[] = [];
+
+  state.doc.descendants((node, pos) => {
+    if (!isCodeBlockType(node.type.name)) {
+      // 内部に codeBlock がさらに入れ子になることは無いが、ネストブロック（list 等）の
+      // 走査を続けるため true を返す。
+      // Continue descending into other block types (lists, tables, etc.).
+      return true;
+    }
+    if (!isMermaidLanguage(node.attrs)) {
+      // 非 mermaid の codeBlock 配下にはこれ以上探す対象がない。
+      // No mermaid targets nest inside non-mermaid code blocks.
+      return false;
+    }
+    targets.push({ pos, nodeSize: node.nodeSize, code: node.textContent });
+    return false;
+  });
+
+  if (targets.length === 0) return null;
+
+  let tr: Transaction | null = null;
+  // 末尾から置換することでオフセットの巻き戻りを避ける。
+  // Replace from the end backwards to keep positions stable across edits.
+  for (let i = targets.length - 1; i >= 0; i -= 1) {
+    const { pos, nodeSize, code } = targets[i];
+    // 末尾の改行は描画時のノイズになるため除去する（pasted/imported source も同様）。
+    // Strip trailing newlines so the rendered diagram does not have stray
+    // whitespace, matching the paste-side `transformMermaidCodeBlocksInContent`.
+    const trimmedCode = code.replace(/\n+$/u, "");
+    const mermaidNode = mermaidType.create({ code: trimmedCode });
+    tr ??= state.tr;
+    tr.replaceWith(pos, pos + nodeSize, mermaidNode);
+  }
+  return tr;
+}
+
+/**
+ * 既存ドキュメント内の Mermaid フェンス由来の `codeBlock` を、エディタ表示時に
+ * `mermaid` ノードへ正規化する Tiptap 拡張。
+ *
+ * Tiptap extension that lazily migrates legacy `codeBlock` nodes with
+ * `language: "mermaid"` to dedicated `mermaid` nodes. The transform runs once
+ * on view mount (because the initial document does not always pass through
+ * `appendTransaction`) and additionally on each transaction so that runtime
+ * language changes (e.g. via the code-block language selector) also pick up
+ * the conversion.
+ *
+ * Y.js 協調編集環境でも、変換トランザクションは通常のドキュメント編集として
+ * 他クライアントへ同期される（意図した lazy migration）。
+ *
+ * Under Y.js collaborative editing the rewrite is a regular doc transaction
+ * and therefore propagates to peers as expected.
+ *
+ * 参考: `HeadingLevelClamp`（`headingLevelClampExtension.ts`）。
+ * See `HeadingLevelClamp` for the structural template (Issue #945).
+ */
+export const MermaidCodeBlockNormalize = Extension.create({
+  name: "mermaidCodeBlockNormalize",
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: mermaidCodeBlockNormalizeKey,
+        view(view) {
+          queueMicrotask(() => {
+            if (view.isDestroyed) return;
+            const tr = buildMermaidNormalizeTr(view.state);
+            if (tr) {
+              view.dispatch(tr);
+            }
+          });
+          return {};
+        },
+        appendTransaction(transactions, _oldState, newState) {
+          // `docChanged` の無いトランザクション（選択変更など）は対象外。
+          // Skip transactions that don't touch the doc (selection-only changes).
+          if (!transactions.some((tr) => tr.docChanged)) {
+            return null;
+          }
+          return buildMermaidNormalizeTr(newState);
+        },
+      }),
+    ];
+  },
+});

--- a/src/components/editor/TiptapEditor/mermaidCodeBlockNormalizeExtension.ts
+++ b/src/components/editor/TiptapEditor/mermaidCodeBlockNormalizeExtension.ts
@@ -85,7 +85,17 @@ function buildMermaidNormalizeTr(state: EditorState): Transaction | null {
     // whitespace, matching the paste-side `transformMermaidCodeBlocksInContent`.
     const trimmedCode = code.replace(/\n+$/u, "");
     const mermaidNode = mermaidType.create({ code: trimmedCode });
-    tr ??= state.tr;
+    if (!tr) {
+      tr = state.tr;
+      // 自動的なフォーマット移行（lazy migration）はユーザー操作ではないため、
+      // undo 履歴に積まない。これを忘れると Cmd+Z で `mermaid` → `codeBlock` に
+      // 戻ってしまい、再度プラグインが変換してループする恐れがある。
+      // The lazy migration is a passive normalisation, not a user edit, so it
+      // must stay out of the undo stack—otherwise Cmd+Z would revert the
+      // `mermaid` node back to a `codeBlock`, only for the plugin to convert
+      // it again on the next transaction (potential undo/redo bounce).
+      tr.setMeta("addToHistory", false);
+    }
     tr.replaceWith(pos, pos + nodeSize, mermaidNode);
   }
   return tr;

--- a/src/components/editor/extensions/MarkdownPasteExtension.test.ts
+++ b/src/components/editor/extensions/MarkdownPasteExtension.test.ts
@@ -318,3 +318,103 @@ describe("MarkdownPaste extension - wiki links", () => {
     expect(mockEditor.commands.insertContent).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Mermaid コードブロックペーストの統合テスト / Mermaid code block paste integration tests
+// ---------------------------------------------------------------------------
+
+describe("MarkdownPaste extension - mermaid code blocks", () => {
+  /**
+   * `@tiptap/markdown` の `parse` が Mermaid フェンスを `codeBlock` +
+   * `language: "mermaid"` として返す挙動をモックする。
+   * Mocks `@tiptap/markdown` parsing a mermaid fence into a `codeBlock`
+   * node with `language: "mermaid"`.
+   */
+  function createMermaidParse(code: string) {
+    return vi.fn(() => ({
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+          content: [{ type: "text", text: code }],
+        },
+      ],
+    }));
+  }
+
+  it("converts a pasted mermaid fence into a mermaid node", () => {
+    const code = "graph TD\n  A-->B";
+    const { handlePaste, mockEditor } = getHandlePaste({
+      parse: createMermaidParse(code),
+    });
+
+    const event = createMockPasteEvent("```mermaid\ngraph TD\n  A-->B\n```");
+    expect(handlePaste(null, event, null)).toBe(true);
+
+    const inserted = mockEditor.commands.insertContent.mock.calls[0]?.[0] as {
+      content: Array<{ type: string; attrs?: { code?: string } }>;
+    };
+    expect(inserted.content[0]).toEqual({
+      type: "mermaid",
+      attrs: { code },
+    });
+  });
+
+  it("leaves non-mermaid fenced code blocks untouched", () => {
+    const parsed = {
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "ts" },
+          content: [{ type: "text", text: "const x = 1" }],
+        },
+      ],
+    };
+    const { handlePaste, mockEditor } = getHandlePaste({
+      parse: vi.fn(() => parsed),
+    });
+
+    const event = createMockPasteEvent("```ts\nconst x = 1\n```");
+    expect(handlePaste(null, event, null)).toBe(true);
+    expect(mockEditor.commands.insertContent).toHaveBeenCalledWith(parsed);
+  });
+
+  it("handles mermaid fences mixed with wiki links in one paste", () => {
+    const { handlePaste, mockEditor } = getHandlePaste({
+      parse: vi.fn(() => ({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "see [[Ref]]" }],
+          },
+          {
+            type: "codeBlock",
+            attrs: { language: "mermaid" },
+            content: [{ type: "text", text: "graph TD" }],
+          },
+        ],
+      })),
+    });
+
+    const event = createMockPasteEvent("see [[Ref]]\n\n```mermaid\ngraph TD\n```");
+    expect(handlePaste(null, event, null)).toBe(true);
+
+    const inserted = mockEditor.commands.insertContent.mock.calls[0]?.[0] as {
+      content: Array<{
+        type: string;
+        attrs?: { code?: string };
+        content?: Array<{ marks?: Array<{ type: string }> }>;
+      }>;
+    };
+    // Wiki link がマーク付きで残り、Mermaid ブロックが `mermaid` ノードに置換される。
+    // Wiki link survives as a marked text node, mermaid block becomes a mermaid node.
+    expect(inserted.content[0].content?.[1]?.marks?.[0]?.type).toBe("wikiLink");
+    expect(inserted.content[1]).toEqual({
+      type: "mermaid",
+      attrs: { code: "graph TD" },
+    });
+  });
+});

--- a/src/components/editor/extensions/MarkdownPasteExtension.ts
+++ b/src/components/editor/extensions/MarkdownPasteExtension.ts
@@ -4,6 +4,10 @@ import {
   containsWikiLinkPattern,
   transformWikiLinksInContent,
 } from "./transformWikiLinksInContent";
+import {
+  containsMermaidFence,
+  transformMermaidCodeBlocksInContent,
+} from "./transformMermaidCodeBlocksInContent";
 
 /**
  * ProseMirror プラグインキー（拡張再初期化時の再生成を避けるためトップレベルで定義）。
@@ -80,11 +84,20 @@ export const MarkdownPaste = Extension.create({
               // 後処理で `wikiLink` マークを付与する。
               // `@tiptap/markdown` leaves `[[...]]` as plain text, so post-process
               // the parsed JSON to apply the `wikiLink` mark.
-              const content = hasWikiLink
+              let content = hasWikiLink
                 ? transformWikiLinksInContent(
                     parsed as Parameters<typeof transformWikiLinksInContent>[0],
                   )
-                : parsed;
+                : (parsed as Parameters<typeof transformWikiLinksInContent>[0]);
+              // ```mermaid``` フェンスは `@tiptap/markdown` が `codeBlock` ノード
+              // （`language: "mermaid"`）として生成するので、後処理で専用の
+              // `mermaid` ノードに置換してダイアグラム描画に回す。
+              // `@tiptap/markdown` parses ```mermaid``` fences into `codeBlock`
+              // nodes with `language: "mermaid"`; convert them to dedicated
+              // `mermaid` nodes here so they render as diagrams downstream.
+              if (containsMermaidFence(text)) {
+                content = transformMermaidCodeBlocksInContent(content);
+              }
               return editor.commands.insertContent(content);
             } catch {
               // パース失敗時は ProseMirror のデフォルトペースト処理にフォールバック

--- a/src/components/editor/extensions/transformMermaidCodeBlocksInContent.test.ts
+++ b/src/components/editor/extensions/transformMermaidCodeBlocksInContent.test.ts
@@ -265,6 +265,62 @@ describe("transformMermaidCodeBlocksInContent", () => {
     expect(doc).toEqual(snapshot);
   });
 
+  // ディープクローンを削除し、変更が無いノードは同一参照のまま返す構造共有方式に
+  // した（gemini-code-assist のレビュー、PR #946 高優先）。大きなドキュメントで
+  // 不要なメモリ確保と GC 圧を避けるため、参照同値性で検証する。
+  // The transform now returns the original reference when nothing changes
+  // (structural sharing) instead of deep-cloning up front, per the high-priority
+  // gemini-code-assist review on PR #946. Verify via reference equality.
+  it("returns the same reference when there is no mermaid block", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "plain" }],
+        },
+      ],
+    };
+
+    expect(transformMermaidCodeBlocksInContent(doc)).toBe(doc);
+  });
+
+  it("shares structure for unaffected sibling subtrees", () => {
+    const untouchedList = {
+      type: "bulletList",
+      content: [
+        {
+          type: "listItem",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "item" }],
+            },
+          ],
+        },
+      ],
+    };
+    const doc = {
+      type: "doc",
+      content: [
+        untouchedList,
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+          content: [{ type: "text", text: "graph TD" }],
+        },
+      ],
+    };
+
+    const result = transformMermaidCodeBlocksInContent(doc) as unknown as {
+      content: Array<unknown>;
+    };
+    // ルートと content 配列は新しく作られるが、変更されていない兄弟は同一参照を共有する。
+    // The root and content array are reallocated, but unchanged siblings share refs.
+    expect(result).not.toBe(doc);
+    expect(result.content[0]).toBe(untouchedList);
+  });
+
   it("transforms multiple mermaid code blocks in the same document", () => {
     const doc = {
       type: "doc",

--- a/src/components/editor/extensions/transformMermaidCodeBlocksInContent.test.ts
+++ b/src/components/editor/extensions/transformMermaidCodeBlocksInContent.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from "vitest";
+import {
+  containsMermaidFence,
+  transformMermaidCodeBlocksInContent,
+} from "./transformMermaidCodeBlocksInContent";
+
+describe("containsMermaidFence", () => {
+  it("returns true for a fenced mermaid block", () => {
+    expect(containsMermaidFence("```mermaid\ngraph TD\nA-->B\n```")).toBe(true);
+  });
+
+  it("matches uppercase / mixed case language identifiers", () => {
+    expect(containsMermaidFence("```Mermaid\ngraph TD\n```")).toBe(true);
+    expect(containsMermaidFence("```MERMAID\ngraph TD\n```")).toBe(true);
+  });
+
+  it("tolerates leading whitespace and spaces after the fence", () => {
+    expect(containsMermaidFence("   ```   mermaid\nx\n```")).toBe(true);
+  });
+
+  it("returns false for non-mermaid fences", () => {
+    expect(containsMermaidFence("```ts\nconsole.log()\n```")).toBe(false);
+  });
+
+  it("returns false when the language is just a prefix of 'mermaid'", () => {
+    // `mer` は `mermaid` の接頭辞だが別言語として扱う。`\b` で完全一致のみマッチする。
+    // `mer` happens to be a prefix of `mermaid` but is a different language;
+    // the `\b` word-boundary anchor keeps the check strict.
+    expect(containsMermaidFence("```mer\nx\n```")).toBe(false);
+  });
+
+  it("returns false for inline backticks", () => {
+    expect(containsMermaidFence("see `mermaid` for details")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(containsMermaidFence("")).toBe(false);
+  });
+});
+
+describe("transformMermaidCodeBlocksInContent", () => {
+  it("replaces a top-level mermaid codeBlock with a mermaid node", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+          content: [{ type: "text", text: "graph TD\n  A-->B" }],
+        },
+      ],
+    };
+
+    expect(transformMermaidCodeBlocksInContent(doc)).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "mermaid",
+          attrs: { code: "graph TD\n  A-->B" },
+        },
+      ],
+    });
+  });
+
+  it("supports the snake-cased `code_block` variant", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "code_block",
+          attrs: { language: "mermaid" },
+          content: [{ type: "text", text: "graph LR\n  X-->Y" }],
+        },
+      ],
+    };
+
+    expect(transformMermaidCodeBlocksInContent(doc)).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "mermaid",
+          attrs: { code: "graph LR\n  X-->Y" },
+        },
+      ],
+    });
+  });
+
+  it("treats the language attribute case-insensitively", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "Mermaid" },
+          content: [{ type: "text", text: "graph TD\nA-->B" }],
+        },
+      ],
+    };
+
+    const result = transformMermaidCodeBlocksInContent(doc) as unknown as {
+      content: Array<{ type: string; attrs: { code: string } }>;
+    };
+    expect(result.content[0].type).toBe("mermaid");
+    expect(result.content[0].attrs.code).toBe("graph TD\nA-->B");
+  });
+
+  it("does not touch non-mermaid code blocks", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "ts" },
+          content: [{ type: "text", text: "console.log()" }],
+        },
+      ],
+    };
+
+    expect(transformMermaidCodeBlocksInContent(doc)).toEqual(doc);
+  });
+
+  it("does not touch code blocks without a language attribute", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          content: [{ type: "text", text: "graph TD" }],
+        },
+      ],
+    };
+
+    expect(transformMermaidCodeBlocksInContent(doc)).toEqual(doc);
+  });
+
+  it("concatenates multiple text nodes within a code block", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+          content: [
+            { type: "text", text: "graph TD" },
+            { type: "hardBreak" },
+            { type: "text", text: "A-->B" },
+          ],
+        },
+      ],
+    };
+
+    const result = transformMermaidCodeBlocksInContent(doc) as unknown as {
+      content: Array<{ type: string; attrs: { code: string } }>;
+    };
+    expect(result.content[0]).toEqual({
+      type: "mermaid",
+      attrs: { code: "graph TD\nA-->B" },
+    });
+  });
+
+  it("produces an empty code string when the code block has no children", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+        },
+      ],
+    };
+
+    expect(transformMermaidCodeBlocksInContent(doc)).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "mermaid",
+          attrs: { code: "" },
+        },
+      ],
+    });
+  });
+
+  it("strips trailing newlines from the extracted source", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+          content: [{ type: "text", text: "graph TD\nA-->B\n\n" }],
+        },
+      ],
+    };
+
+    const result = transformMermaidCodeBlocksInContent(doc) as unknown as {
+      content: Array<{ attrs: { code: string } }>;
+    };
+    expect(result.content[0].attrs.code).toBe("graph TD\nA-->B");
+  });
+
+  it("transforms mermaid code blocks nested inside lists", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "codeBlock",
+                  attrs: { language: "mermaid" },
+                  content: [{ type: "text", text: "graph TD" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = transformMermaidCodeBlocksInContent(doc) as unknown as {
+      content: Array<{
+        content: Array<{
+          content: Array<{ type: string; attrs?: { code?: string } }>;
+        }>;
+      }>;
+    };
+    expect(result.content[0].content[0].content[0]).toEqual({
+      type: "mermaid",
+      attrs: { code: "graph TD" },
+    });
+  });
+
+  it("returns unchanged content when no mermaid block exists", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "plain text" }],
+        },
+      ],
+    };
+
+    expect(transformMermaidCodeBlocksInContent(doc)).toEqual(doc);
+  });
+
+  it("does not mutate the input object", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+          content: [{ type: "text", text: "graph TD" }],
+        },
+      ],
+    };
+    const snapshot = JSON.parse(JSON.stringify(doc));
+
+    transformMermaidCodeBlocksInContent(doc);
+
+    expect(doc).toEqual(snapshot);
+  });
+
+  it("transforms multiple mermaid code blocks in the same document", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+          content: [{ type: "text", text: "graph TD" }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "between" }],
+        },
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+          content: [{ type: "text", text: "sequenceDiagram" }],
+        },
+      ],
+    };
+
+    const result = transformMermaidCodeBlocksInContent(doc) as unknown as {
+      content: Array<{ type: string; attrs?: { code?: string } }>;
+    };
+    expect(result.content[0]).toEqual({ type: "mermaid", attrs: { code: "graph TD" } });
+    expect(result.content[1].type).toBe("paragraph");
+    expect(result.content[2]).toEqual({
+      type: "mermaid",
+      attrs: { code: "sequenceDiagram" },
+    });
+  });
+});

--- a/src/components/editor/extensions/transformMermaidCodeBlocksInContent.ts
+++ b/src/components/editor/extensions/transformMermaidCodeBlocksInContent.ts
@@ -89,12 +89,17 @@ function extractCodeText(nodes: NodeJSON[] | undefined): string {
 
 /**
  * 1 つのノードに対して、Mermaid コードブロックを `mermaid` ノードに置換する。
- * テキスト末尾の改行は表示時のノイズになるため削除する。
+ * テキスト末尾の改行は表示時のノイズになるため削除する。子ノードに変更が
+ * 無い場合は同一参照を返し、構造共有によって不要な配列・オブジェクト生成を
+ * 避ける（入力は不変）。
  *
  * Replace a `codeBlock` with `language: "mermaid"` by an equivalent `mermaid`
  * node, or recurse into the node's children otherwise. Trailing newlines in
  * the extracted source are stripped because Mermaid does not require them and
- * they would otherwise leak into the rendered diagram's caption area.
+ * they would otherwise leak into the rendered diagram's caption area. The
+ * function returns the original reference whenever no descendant was rewritten,
+ * which lets callers rely on referential equality to detect changes and avoids
+ * unnecessary allocations (the input is never mutated either way).
  *
  * @param node - 走査対象のノード / The node to inspect.
  * @returns 変換後のノード / The (possibly transformed) node.
@@ -108,32 +113,48 @@ function transformNode(node: NodeJSON): NodeJSON {
     };
   }
 
-  if (!node.content || node.content.length === 0) {
+  const content = node.content;
+  if (!content || content.length === 0) {
     return node;
   }
 
-  const newContent = node.content.map((child) => transformNode(child));
-  return { ...node, content: newContent };
+  let changedContent: NodeJSON[] | null = null;
+  for (let i = 0; i < content.length; i += 1) {
+    const child = content[i];
+    const transformed = transformNode(child);
+    if (transformed !== child) {
+      // 最初の変更を検出した時点で配列を複製し、先行する未変更ノードをコピーする。
+      // Lazily clone the array on the first change, preserving prior children.
+      if (!changedContent) {
+        changedContent = content.slice(0, i);
+      }
+      changedContent.push(transformed);
+    } else if (changedContent) {
+      changedContent.push(child);
+    }
+  }
+
+  return changedContent ? { ...node, content: changedContent } : node;
 }
 
 /**
  * ProseMirror JSON ドキュメント全体を走査し、`language === "mermaid"` の
  * コードブロックを `mermaid` ノードに置換した新しいドキュメントを返す。
- * 入力は不変。
+ * 入力は不変。変換対象が無い場合は同一参照を返す。
  *
  * Walk a ProseMirror JSON document, replacing every `codeBlock` whose
  * `language` is `"mermaid"` (case-insensitive) with a `mermaid` node so it
- * renders as a diagram. The input is not mutated.
+ * renders as a diagram. The input is not mutated. When no mermaid block is
+ * found, the original reference is returned unchanged—`transformNode` only
+ * allocates along the path of actual changes, so large pasted/loaded docs
+ * without diagrams incur zero copying.
  *
  * @param content - `editor.markdown.parse()` などで得た ProseMirror JSON。
  *                  Document JSON produced by e.g. `editor.markdown.parse()`.
  * @returns 変換後の JSON（入力は不変）/ Transformed JSON (input untouched).
  */
 export function transformMermaidCodeBlocksInContent<T extends NodeJSON>(content: T): T {
-  // 入力を不変に保つためディープクローン
-  // Deep-clone to keep the input immutable
-  const cloned = JSON.parse(JSON.stringify(content)) as T;
-  return transformNode(cloned) as T;
+  return transformNode(content) as T;
 }
 
 /**

--- a/src/components/editor/extensions/transformMermaidCodeBlocksInContent.ts
+++ b/src/components/editor/extensions/transformMermaidCodeBlocksInContent.ts
@@ -1,0 +1,153 @@
+/**
+ * Markdown のフェンス言語 `mermaid` で書かれたコードブロック（Tiptap JSON 上では
+ * `codeBlock` + `attrs.language === "mermaid"`）を、専用の `mermaid` ノードに
+ * 変換するためのユーティリティ。
+ *
+ * Utility that converts Markdown fenced code blocks tagged with the language
+ * identifier `mermaid` (represented as `codeBlock` nodes with
+ * `attrs.language === "mermaid"` in the Tiptap JSON tree) into dedicated
+ * `mermaid` nodes so they render as SVG diagrams via the existing
+ * `MermaidNodeView`.
+ *
+ * `@tiptap/markdown` はフェンス言語にかかわらず `codeBlock` を生成するため、
+ * Wiki リンクの後処理（`transformWikiLinksInContent`）と同様に、パース後の
+ * ProseMirror JSON を走査して該当ノードを差し替える。
+ *
+ * Since `@tiptap/markdown` always produces a `codeBlock` regardless of fence
+ * language, we post-process the parsed ProseMirror JSON—mirroring the pattern
+ * used by `transformWikiLinksInContent`—and replace matching code blocks with
+ * `mermaid` nodes.
+ */
+
+/**
+ * ProseMirror のマーク定義（最小限の構造）。
+ * Minimal shape of a ProseMirror mark definition.
+ */
+interface MarkJSON {
+  type: string;
+  attrs?: Record<string, unknown>;
+}
+
+/**
+ * ProseMirror のノード定義（最小限の構造）。
+ * Minimal shape of a ProseMirror node.
+ */
+interface NodeJSON {
+  type: string;
+  text?: string;
+  attrs?: Record<string, unknown>;
+  marks?: MarkJSON[];
+  content?: NodeJSON[];
+}
+
+/**
+ * 与えられたコードブロックノードの `language` 属性が "mermaid" を示すかを判定する。
+ * 大文字小文字を無視（`"Mermaid"` / `"MERMAID"` も対象）し、前後の空白はトリムする。
+ *
+ * Returns whether a code block node's `language` attribute refers to mermaid.
+ * The comparison is case-insensitive (so `"Mermaid"` / `"MERMAID"` also match)
+ * and surrounding whitespace is trimmed.
+ *
+ * @param attrs - codeBlock ノードの属性 / Attributes of the codeBlock node.
+ */
+function isMermaidLanguage(attrs: Record<string, unknown> | undefined): boolean {
+  const language = attrs?.language;
+  if (typeof language !== "string") return false;
+  return language.trim().toLowerCase() === "mermaid";
+}
+
+/**
+ * ノード配列内の `text` ノードを連結して 1 つの文字列にする。
+ * Mermaid のソースコードは複数の `text` ノードに分かれている場合があるため、
+ * `hardBreak` を改行に展開しつつ平坦化する。
+ *
+ * Concatenate the textual content of a node's children. Mermaid source code
+ * may be split across multiple `text` nodes; `hardBreak` nodes are expanded
+ * to newlines so the resulting string is suitable as raw Mermaid source.
+ *
+ * @param nodes - 抽出対象のノード配列 / Child nodes to flatten.
+ * @returns 連結したテキスト / The concatenated text.
+ */
+function extractCodeText(nodes: NodeJSON[] | undefined): string {
+  if (!nodes || nodes.length === 0) return "";
+  let result = "";
+  for (const node of nodes) {
+    if (node.type === "text") {
+      result += node.text ?? "";
+      continue;
+    }
+    if (node.type === "hardBreak") {
+      result += "\n";
+      continue;
+    }
+    if (node.content && node.content.length > 0) {
+      result += extractCodeText(node.content);
+    }
+  }
+  return result;
+}
+
+/**
+ * 1 つのノードに対して、Mermaid コードブロックを `mermaid` ノードに置換する。
+ * テキスト末尾の改行は表示時のノイズになるため削除する。
+ *
+ * Replace a `codeBlock` with `language: "mermaid"` by an equivalent `mermaid`
+ * node, or recurse into the node's children otherwise. Trailing newlines in
+ * the extracted source are stripped because Mermaid does not require them and
+ * they would otherwise leak into the rendered diagram's caption area.
+ *
+ * @param node - 走査対象のノード / The node to inspect.
+ * @returns 変換後のノード / The (possibly transformed) node.
+ */
+function transformNode(node: NodeJSON): NodeJSON {
+  if ((node.type === "codeBlock" || node.type === "code_block") && isMermaidLanguage(node.attrs)) {
+    const code = extractCodeText(node.content).replace(/\n+$/u, "");
+    return {
+      type: "mermaid",
+      attrs: { code },
+    };
+  }
+
+  if (!node.content || node.content.length === 0) {
+    return node;
+  }
+
+  const newContent = node.content.map((child) => transformNode(child));
+  return { ...node, content: newContent };
+}
+
+/**
+ * ProseMirror JSON ドキュメント全体を走査し、`language === "mermaid"` の
+ * コードブロックを `mermaid` ノードに置換した新しいドキュメントを返す。
+ * 入力は不変。
+ *
+ * Walk a ProseMirror JSON document, replacing every `codeBlock` whose
+ * `language` is `"mermaid"` (case-insensitive) with a `mermaid` node so it
+ * renders as a diagram. The input is not mutated.
+ *
+ * @param content - `editor.markdown.parse()` などで得た ProseMirror JSON。
+ *                  Document JSON produced by e.g. `editor.markdown.parse()`.
+ * @returns 変換後の JSON（入力は不変）/ Transformed JSON (input untouched).
+ */
+export function transformMermaidCodeBlocksInContent<T extends NodeJSON>(content: T): T {
+  // 入力を不変に保つためディープクローン
+  // Deep-clone to keep the input immutable
+  const cloned = JSON.parse(JSON.stringify(content)) as T;
+  return transformNode(cloned) as T;
+}
+
+/**
+ * テキストに `mermaid` フェンスらしき記法が含まれているか軽量に判定する。
+ * `MarkdownPasteExtension` で「Mermaid 変換を試みるべきか」のショートカット判定に使う。
+ *
+ * Lightweight predicate that tells whether a string contains a fenced
+ * code block whose info string starts with `mermaid` (case-insensitive). Used
+ * by `MarkdownPasteExtension` as a fast pre-check before running the full
+ * post-parse transform.
+ *
+ * @param text - 判定対象のテキスト / Text to inspect.
+ * @returns Mermaid フェンスが含まれていれば true / true if a mermaid fence is present.
+ */
+export function containsMermaidFence(text: string): boolean {
+  return /^[\t ]{0,3}```[\t ]*mermaid\b/im.test(text);
+}

--- a/src/lib/markdownExport.test.ts
+++ b/src/lib/markdownExport.test.ts
@@ -143,6 +143,38 @@ describe("tiptapToMarkdown", () => {
     expect(md).toContain("---");
   });
 
+  // `mermaid` ノードは ` ```mermaid ` フェンスとして出力し、ペースト時の正規化
+  // (`transformMermaidCodeBlocksInContent`) と round-trip が取れるようにする (Issue #945)。
+  // Mermaid nodes must round-trip back to ` ```mermaid ` fences so paste-side
+  // normalisation (`transformMermaidCodeBlocksInContent`) is reversible.
+  it("converts mermaid node back to a ```mermaid fence", () => {
+    const content = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "mermaid",
+          attrs: { code: "graph TD\n  A-->B" },
+        },
+      ],
+    });
+    const md = tiptapToMarkdown(content);
+    expect(md).toContain("```mermaid");
+    expect(md).toContain("graph TD");
+    expect(md).toContain("A-->B");
+    // フェンス開始の直後に空行が入らないこと（読みやすさ）
+    // Source code starts on the line immediately after the opening fence.
+    expect(md).toMatch(/```mermaid\ngraph TD/);
+  });
+
+  it("emits an empty mermaid fence when code attribute is missing", () => {
+    const content = JSON.stringify({
+      type: "doc",
+      content: [{ type: "mermaid" }],
+    });
+    const md = tiptapToMarkdown(content);
+    expect(md).toMatch(/```mermaid\n\n```/);
+  });
+
   it("handles bold, italic, strike, code marks", () => {
     const content = JSON.stringify({
       type: "doc",

--- a/src/lib/markdownExport.ts
+++ b/src/lib/markdownExport.ts
@@ -70,6 +70,17 @@ Object.assign(nodeHandlers, {
     const code = convertChildren(n).trim();
     return `\`\`\`${language}\n${code}\n\`\`\`\n\n`;
   },
+  mermaid: (n) => {
+    // `mermaid` ノードは Markdown 上では ``` ```mermaid ``` ``` フェンスへ戻す。
+    // ハンドラ未登録のままだと `code` 属性が落ちて空エクスポートになるため、
+    // ここで往復対称性を担保する（Issue #945）。
+    // Serialize a `mermaid` node back to a ``` ```mermaid ``` ``` fence so the
+    // Markdown export round-trips with the paste-side normalisation. Without a
+    // handler the `code` attribute would be silently dropped (Issue #945).
+    const code = typeof n.attrs?.code === "string" ? n.attrs.code : "";
+    const trimmed = code.replace(/\n+$/u, "");
+    return `\`\`\`mermaid\n${trimmed}\n\`\`\`\n\n`;
+  },
   horizontalRule: () => "---\n\n",
   hardBreak: () => "\n",
   text: (n) => applyMarks(n.text || "", n.marks || []),

--- a/src/lib/markdownToTiptap.ts
+++ b/src/lib/markdownToTiptap.ts
@@ -30,6 +30,7 @@
  */
 
 import { parseInlineContent, type TiptapTextNode } from "./markdownToTiptapHelpers";
+import { transformMermaidCodeBlocksInContent } from "@/components/editor/extensions/transformMermaidCodeBlocksInContent";
 
 type TiptapBlockNode = {
   type: string;
@@ -183,5 +184,14 @@ export function convertMarkdownToTiptapContent(
     });
   }
 
-  return JSON.stringify(doc);
+  // `codeBlock` + `language: "mermaid"` を `mermaid` ノードに正規化する。
+  // 現状この変換器は codeBlock を出さないが、将来 fenced code 対応を入れた際の
+  // 取りこぼし防止と、外部経由で同形の JSON が渡るケースの一貫性のために通す。
+  // Normalise any `codeBlock` + `language: "mermaid"` into a dedicated `mermaid`
+  // node. The current converter doesn't emit code blocks, but running the
+  // transform keeps the output consistent if fenced-code support is added
+  // later or if an external caller hands us a doc containing them.
+  const normalised = transformMermaidCodeBlocksInContent(doc);
+
+  return JSON.stringify(normalised);
 }

--- a/src/lib/tiptapToHtml.test.ts
+++ b/src/lib/tiptapToHtml.test.ts
@@ -127,6 +127,43 @@ describe("tiptapToHtml", () => {
     expect(html).not.toContain("<script>alert(1)</script>");
   });
 
+  // PDF エクスポートは同期的にレンダリングするため、`mermaid` ノードは Mermaid の
+  // 非同期 API を呼ばずに「ソースをコードブロック相当のプレースホルダー」として
+  // 残す。図のソースが PDF 上で失われないことだけ保証する (Issue #945)。
+  // The PDF exporter is synchronous, so `mermaid` nodes are rendered as a
+  // placeholder code block that preserves the diagram source instead of a real
+  // SVG (Issue #945).
+  it("renders mermaid node as a language-mermaid code block placeholder", () => {
+    const json = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "mermaid",
+          attrs: { code: "graph TD\n  A-->B" },
+        },
+      ],
+    });
+    const html = tiptapToHtml(json);
+    expect(html).toContain('<pre><code class="language-mermaid">');
+    expect(html).toContain("graph TD");
+    expect(html).toContain("A--&gt;B");
+  });
+
+  it("escapes mermaid source when it contains HTML-significant characters", () => {
+    const json = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "mermaid",
+          attrs: { code: "<script>alert(1)</script>" },
+        },
+      ],
+    });
+    const html = tiptapToHtml(json);
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+
   it("applies bold, italic, strike, inline-code, and link marks", () => {
     const json = JSON.stringify({
       type: "doc",

--- a/src/lib/tiptapToHtml.ts
+++ b/src/lib/tiptapToHtml.ts
@@ -117,6 +117,22 @@ Object.assign(nodeHandlers, {
     const langAttr = language ? ` class="language-${escapeHtmlAttr(language)}"` : "";
     return `<pre><code${langAttr}>${escapeHtml(codeText)}</code></pre>`;
   },
+  mermaid: (n) => {
+    // PDF エクスポートは html2pdf.js / html2canvas で静的レンダリングするため、
+    // 実際の SVG を生成するには Mermaid の非同期 API を呼ぶ必要がある。エクスポート
+    // 経路を同期に保つ目的で、ここでは Mermaid ソースをコードブロック相当の
+    // プレースホルダー (`<pre><code class="language-mermaid">…</code></pre>`) として
+    // 出力する。少なくとも図のソースが PDF 上で失われず、必要に応じて後続パスで
+    // 事前レンダリングへ差し替えやすい形にしておく（Issue #945）。
+    // Render `mermaid` nodes as a `<pre><code class="language-mermaid">` block.
+    // Generating a real SVG would require an async call into Mermaid; this
+    // exporter is synchronous (html2pdf.js consumes the DOM immediately) so we
+    // emit the source verbatim as a placeholder. The diagram source is then
+    // preserved in the PDF and can be upgraded to pre-rendered SVG later
+    // without touching call sites (Issue #945).
+    const code = typeof n.attrs?.code === "string" ? n.attrs.code : "";
+    return `<pre><code class="language-mermaid">${escapeHtml(code)}</code></pre>`;
+  },
   horizontalRule: () => "<hr />",
   hardBreak: () => "<br />",
   text: (n) => applyMarks(escapeHtml(n.text || ""), n.marks || []),


### PR DESCRIPTION
## 概要

Markdown ペースト時に ` ```mermaid ``` ` フェンスで書かれたコードブロックを、専用の `mermaid` ノードに正規化する機能を追加します。これにより、Mermaid 図がエディタ内で SVG として正しくレンダリングされるようになります。

## 変更点

- **`transformMermaidCodeBlocksInContent.ts`** (新規)
  - `codeBlock` + `language: "mermaid"` を `mermaid` ノードに変換するユーティリティ関数を実装
  - `containsMermaidFence()`: テキストに Mermaid フェンスが含まれているかを軽量判定
  - `transformMermaidCodeBlocksInContent()`: ProseMirror JSON を走査して変換

- **`mermaidCodeBlockNormalizeExtension.ts`** (新規)
  - Tiptap 拡張として、エディタロード時と実行時の言語変更時に自動正規化
  - `appendTransaction` で動的な言語変更にも対応

- **`MarkdownPasteExtension.ts`** (修正)
  - ペースト時に Mermaid フェンスを検出して `transformMermaidCodeBlocksInContent()` を適用
  - Wiki リンク変換と組み合わせて動作

- **`markdownToTiptap.ts`** (修正)
  - Markdown → Tiptap 変換時に Mermaid コードブロックを正規化

- **`markdownExport.ts`** (修正)
  - `mermaid` ノードを ` ```mermaid ``` ` フェンスに逆変換（round-trip 対応）

- **`tiptapToHtml.ts`** (修正)
  - PDF エクスポート時に `mermaid` ノードをコードブロック相当のプレースホルダーとして出力

- **`editorConfig.ts`** (修正)
  - `MermaidCodeBlockNormalize` 拡張をエディタに登録

- **テスト** (新規)
  - `transformMermaidCodeBlocksInContent.test.ts`: ユーティリティ関数の単体テスト
  - `mermaidCodeBlockNormalizeExtension.test.ts`: 拡張の統合テスト
  - `MarkdownPasteExtension.test.ts`: ペースト時の Mermaid ブロック処理テスト
  - `markdownExport.test.ts`: Markdown エクスポート時の Mermaid ノード処理テスト
  - `tiptapToHtml.test.ts`: HTML エクスポート時の Mermaid ノード処理テスト

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. **ユニットテスト実行**: `npm test` で全テストが通ることを確認
   - `transformMermaidCodeBlocksInContent.test.ts`: 変換ロジックの正確性
   - `mermaidCodeBlockNormalizeExtension.test.ts`: エディタ統合時の動作
   - `MarkdownPasteExtension.test.ts`: ペースト時の Mermaid 処理
   - `markdownExport.test.ts`: Markdown エクスポート時の round-trip
   - `tiptapToHtml.test.ts`: HTML エクスポート時のプレースホルダー出力

2

https://claude.ai/code/session_012B5oJNw6xupLUyQCK9E4Ax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native Mermaid diagram support in the editor
  * Automatic conversion of legacy Mermaid code fences into diagram nodes on load and paste
  * Pasted Mermaid fences are converted while mixed content and wiki-links are preserved
  * Mermaid nodes export as fenced ```mermaid``` in Markdown and as escaped <pre><code class="language-mermaid"> in HTML

* **Bug Fixes**
  * Migration/normalization runs without adding entries to undo history

* **Tests**
  * Expanded test coverage and regression tests for Mermaid handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/946?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->