### PR TITLE
feat(api): wiki compose P3 BYOK execution backends (#951)

### DIFF
--- a/e2e/wiki-compose.spec.ts
+++ b/e2e/wiki-compose.spec.ts
@@ -274,6 +274,8 @@ test.describe("Wiki Compose P2 happy path", () => {
 
     await page.goto(`/notes/${NOTE_ID}/${PAGE_ID}/compose`);
 
+    await page.getByTestId("compose-start").click();
+
     // Brief interrupt — question card appears.
     const briefCard = page.getByTestId(`brief-card-${BRIEF_QUESTION_ID}`);
     await expect(briefCard).toBeVisible();

--- a/server/api/.env.example
+++ b/server/api/.env.example
@@ -46,3 +46,8 @@ GITHUB_DISPATCH_REPOSITORY=
 #   内部 URL を設定してはいけない。未設定時はリンク行を省略する。
 ADMIN_BASE_URL=
 MONITORING_NOTIFY_EMAIL=
+
+# Wiki Compose BYOK — AES-256-GCM key for `user_ai_credentials` (#951).
+# 32 raw bytes as Base64 or 64-char hex. Never commit the real value.
+# Wiki Compose BYOK 用。`user_ai_credentials` の at-rest 暗号化鍵（32 バイト）。
+USER_AI_CREDENTIALS_ENCRYPTION_KEY=

--- a/server/api/drizzle/0032_add_user_ai_credentials.sql
+++ b/server/api/drizzle/0032_add_user_ai_credentials.sql
@@ -1,0 +1,35 @@
+-- 0032: Encrypted BYOK API credentials for Wiki Compose (#951).
+-- Wiki Compose BYOK 用のユーザー API キー（サーバー側暗号化保管）。
+--
+-- Plaintext keys are never stored. See `userAiCredentials` schema TSDoc.
+-- 平文キーは保存しない。`user_ai_credentials` の TSDoc を参照。
+--
+-- Issue: otomatty/zedi#951
+
+CREATE TABLE IF NOT EXISTS "user_ai_credentials" (
+    "id" text PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL,
+    "provider" text NOT NULL,
+    "encrypted_api_key" text NOT NULL,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+    ALTER TABLE "user_ai_credentials"
+        ADD CONSTRAINT "user_ai_credentials_user_id_users_id_fk"
+        FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+    ALTER TABLE "user_ai_credentials"
+        ADD CONSTRAINT "user_ai_credentials_provider_valid"
+        CHECK ("provider" IN ('anthropic', 'openai', 'google'));
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_user_ai_credentials_user_provider"
+    ON "user_ai_credentials" ("user_id", "provider");

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1779926400000,
       "tag": "0031_add_wiki_compose_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1780012800000,
+      "tag": "0032_add_user_ai_credentials",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/src/__tests__/agents/core/composeBackendValidation.test.ts
+++ b/server/api/src/__tests__/agents/core/composeBackendValidation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { HTTPException } from "hono/http-exception";
+import { assertComposeBackendReady } from "../../../agents/core/composeBackendValidation.js";
+
+const mockValidateModelAccess = vi.fn();
+const mockGetUserAiCredentialPlaintext = vi.fn();
+
+vi.mock("../../../services/usageService.js", () => ({
+  validateModelAccess: (...args: unknown[]) => mockValidateModelAccess(...args),
+}));
+
+vi.mock("../../../services/userAiCredentialService.js", () => ({
+  getUserAiCredentialPlaintext: (...args: unknown[]) => mockGetUserAiCredentialPlaintext(...args),
+}));
+
+describe("assertComposeBackendReady", () => {
+  const db = {} as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateModelAccess.mockResolvedValue({
+      provider: "anthropic",
+      apiModelId: "claude-3-5-haiku",
+      inputCostUnits: 1,
+      outputCostUnits: 2,
+    });
+    mockGetUserAiCredentialPlaintext.mockResolvedValue("sk-user");
+  });
+
+  it("no-ops for zedi_managed", async () => {
+    await assertComposeBackendReady({
+      backend: "zedi_managed",
+      graphId: "wiki-compose",
+      userId: "u1",
+      tier: "free",
+      db,
+    });
+    expect(mockValidateModelAccess).not.toHaveBeenCalled();
+  });
+
+  it("throws 400 when model provider mismatches BYOK backend", async () => {
+    mockValidateModelAccess.mockResolvedValue({
+      provider: "openai",
+      apiModelId: "gpt-4o-mini",
+      inputCostUnits: 1,
+      outputCostUnits: 2,
+    });
+    await expect(
+      assertComposeBackendReady({
+        backend: "user_anthropic",
+        graphId: "wiki-compose-research",
+        userId: "u1",
+        tier: "free",
+        db,
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("throws 400 when credential is missing", async () => {
+    mockGetUserAiCredentialPlaintext.mockResolvedValue(null);
+    await expect(
+      assertComposeBackendReady({
+        backend: "user_anthropic",
+        graphId: "wiki-compose-research",
+        userId: "u1",
+        tier: "free",
+        db,
+      }),
+    ).rejects.toBeInstanceOf(HTTPException);
+  });
+});

--- a/server/api/src/__tests__/agents/core/llm/modelFactory.test.ts
+++ b/server/api/src/__tests__/agents/core/llm/modelFactory.test.ts
@@ -1,36 +1,111 @@
 /**
- * `modelFactory` のテスト。`assertSupportedBackendP0` の挙動と `UnsupportedBackendError`
- * の型を固定する。`createZediChatModel` の DB / 環境変数まわりは統合テスト範囲
- * (route テスト) で見るため、ここは backend ガードに集中する。
- *
- * Tests for {@link assertSupportedBackendP0} and {@link UnsupportedBackendError}.
- * Full `createZediChatModel` is exercised through route tests (out of scope for
- * P0 unit tests); here we pin the backend whitelist so #951 cannot accidentally
- * widen it without a deliberate change.
+ * Tests for compose backend validation and BYOK API key resolution (#951).
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
+  assertSupportedComposeBackend,
   assertSupportedBackendP0,
+  createZediChatModel,
   UnsupportedBackendError,
+  MissingUserCredentialError,
+  BackendProviderMismatchError,
 } from "../../../../agents/core/llm/modelFactory.js";
 
-describe("assertSupportedBackendP0", () => {
-  it("accepts 'zedi_managed'", () => {
-    expect(assertSupportedBackendP0("zedi_managed")).toBe("zedi_managed");
-  });
+const mockValidateModelAccess = vi.fn();
+const mockGetUserAiCredentialPlaintext = vi.fn();
+
+vi.mock("../../../../services/usageService.js", () => ({
+  validateModelAccess: (...args: unknown[]) => mockValidateModelAccess(...args),
+}));
+
+vi.mock("../../../../services/userAiCredentialService.js", () => ({
+  getUserAiCredentialPlaintext: (...args: unknown[]) => mockGetUserAiCredentialPlaintext(...args),
+}));
+
+describe("assertSupportedComposeBackend", () => {
+  it.each(["zedi_managed", "user_anthropic", "user_openai", "user_google"] as const)(
+    "accepts %s",
+    (backend) => {
+      expect(assertSupportedComposeBackend(backend)).toBe(backend);
+      expect(assertSupportedBackendP0(backend)).toBe(backend);
+    },
+  );
 
   it.each(["byok", "byo_runner", "unknown", "", "ZEDI_MANAGED"])(
     "throws UnsupportedBackendError for %s",
     (backend) => {
-      let caught: unknown;
-      try {
-        assertSupportedBackendP0(backend);
-      } catch (err) {
-        caught = err;
-      }
-      expect(caught).toBeInstanceOf(UnsupportedBackendError);
-      expect((caught as UnsupportedBackendError).backend).toBe(backend);
-      expect((caught as UnsupportedBackendError).code).toBe("UNSUPPORTED_BACKEND");
+      expect(() => assertSupportedComposeBackend(backend)).toThrow(UnsupportedBackendError);
     },
   );
+});
+
+describe("createZediChatModel backend resolution", () => {
+  const db = {} as never;
+  const baseInput = {
+    modelId: "openai:gpt-4o-mini",
+    userId: "user-1",
+    tier: "free" as const,
+    db,
+    feature: "wiki_compose:test",
+    temperature: 0.2,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateModelAccess.mockResolvedValue({
+      provider: "openai",
+      apiModelId: "gpt-4o-mini",
+      inputCostUnits: 1,
+      outputCostUnits: 2,
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it("resolves zedi_managed from process.env", async () => {
+    process.env.OPENAI_API_KEY = "sk-system";
+    const model = await createZediChatModel({
+      ...baseInput,
+      backend: "zedi_managed",
+    });
+    expect(model).toBeDefined();
+    expect(mockGetUserAiCredentialPlaintext).not.toHaveBeenCalled();
+  });
+
+  it("resolves user_openai from stored credential", async () => {
+    mockGetUserAiCredentialPlaintext.mockResolvedValue("sk-user");
+    const model = await createZediChatModel({
+      ...baseInput,
+      backend: "user_openai",
+    });
+    expect(model).toBeDefined();
+    expect(mockGetUserAiCredentialPlaintext).toHaveBeenCalledWith("user-1", "openai", db);
+  });
+
+  it("throws MissingUserCredentialError when BYOK key is absent", async () => {
+    mockGetUserAiCredentialPlaintext.mockResolvedValue(null);
+    await expect(
+      createZediChatModel({
+        ...baseInput,
+        backend: "user_openai",
+      }),
+    ).rejects.toThrow(MissingUserCredentialError);
+  });
+
+  it("throws BackendProviderMismatchError when model provider differs from backend", async () => {
+    mockValidateModelAccess.mockResolvedValue({
+      provider: "anthropic",
+      apiModelId: "claude-3-5-sonnet-20241022",
+      inputCostUnits: 1,
+      outputCostUnits: 2,
+    });
+    await expect(
+      createZediChatModel({
+        ...baseInput,
+        backend: "user_openai",
+      }),
+    ).rejects.toThrow(BackendProviderMismatchError);
+  });
 });

--- a/server/api/src/__tests__/agents/core/llm/usageCallback.test.ts
+++ b/server/api/src/__tests__/agents/core/llm/usageCallback.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { recordZediUsage } from "../../../../agents/core/llm/usageCallback.js";
+
+const mockRecordUsage = vi.fn();
+const mockCalculateCost = vi.fn();
+
+vi.mock("../../../../services/usageService.js", () => ({
+  calculateCost: (...args: unknown[]) => mockCalculateCost(...args),
+  recordUsage: (...args: unknown[]) => mockRecordUsage(...args),
+}));
+
+describe("recordZediUsage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCalculateCost.mockReturnValue(42);
+  });
+
+  it("records zero costUnits for user_key (BYOK audit only)", async () => {
+    const db = {} as never;
+    const result = await recordZediUsage({
+      db,
+      userId: "u1",
+      modelId: "openai:gpt-4o-mini",
+      feature: "wiki_compose:test",
+      usage: { inputTokens: 100, outputTokens: 50 },
+      inputCostUnits: 10,
+      outputCostUnits: 20,
+      apiMode: "user_key",
+    });
+    expect(result.costUnits).toBe(0);
+    expect(mockRecordUsage).toHaveBeenCalledWith(
+      "u1",
+      "openai:gpt-4o-mini",
+      "wiki_compose:test",
+      { inputTokens: 100, outputTokens: 50 },
+      0,
+      "user_key",
+      db,
+    );
+  });
+
+  it("records calculated costUnits for system mode", async () => {
+    const db = {} as never;
+    const result = await recordZediUsage({
+      db,
+      userId: "u1",
+      modelId: "openai:gpt-4o-mini",
+      feature: "wiki_compose:test",
+      usage: { inputTokens: 100, outputTokens: 50 },
+      inputCostUnits: 10,
+      outputCostUnits: 20,
+      apiMode: "system",
+    });
+    expect(result.costUnits).toBe(42);
+    expect(mockRecordUsage).toHaveBeenCalledWith(
+      "u1",
+      "openai:gpt-4o-mini",
+      "wiki_compose:test",
+      { inputTokens: 100, outputTokens: 50 },
+      42,
+      "system",
+      db,
+    );
+  });
+});

--- a/server/api/src/__tests__/routes/composeSessions.test.ts
+++ b/server/api/src/__tests__/routes/composeSessions.test.ts
@@ -35,6 +35,12 @@ vi.mock("../../services/subscriptionService.js", () => ({
 
 const mockGetUserAiCredentialPlaintext = vi.fn();
 
+const mockValidateModelAccess = vi.fn();
+
+vi.mock("../../services/usageService.js", () => ({
+  validateModelAccess: (...args: unknown[]) => mockValidateModelAccess(...args),
+}));
+
 vi.mock("../../services/userAiCredentialService.js", () => ({
   getUserAiCredentialPlaintext: (...args: unknown[]) => mockGetUserAiCredentialPlaintext(...args),
 }));
@@ -99,6 +105,13 @@ function createComposeApp(dbResults: unknown[]) {
 
 beforeEach(() => {
   mockGetUserAiCredentialPlaintext.mockReset();
+  mockValidateModelAccess.mockReset();
+  mockValidateModelAccess.mockResolvedValue({
+    provider: "anthropic",
+    apiModelId: "claude-3-5-haiku",
+    inputCostUnits: 1,
+    outputCostUnits: 2,
+  });
   __resetRegistryForTests();
   // Register a graph the routes can resolve. Body is irrelevant for CRUD tests.
   registerGraph({
@@ -160,6 +173,12 @@ describe("POST /api/pages/:pageId/compose-sessions", () => {
 
   it("returns 400 for user_openai when credential is missing", async () => {
     mockGetUserAiCredentialPlaintext.mockResolvedValue(null);
+    mockValidateModelAccess.mockResolvedValue({
+      provider: "openai",
+      apiModelId: "gpt-4o-mini",
+      inputCostUnits: 1,
+      outputCostUnits: 2,
+    });
     const { app } = createComposeApp([...pageAccessPrefix()]);
     const res = await app.request(`/api/pages/${PAGE_ID}/compose-sessions`, {
       method: "POST",
@@ -176,6 +195,12 @@ describe("POST /api/pages/:pageId/compose-sessions", () => {
 
   it("creates a session with user_openai when credential exists", async () => {
     mockGetUserAiCredentialPlaintext.mockResolvedValue("sk-user");
+    mockValidateModelAccess.mockResolvedValue({
+      provider: "openai",
+      apiModelId: "gpt-4o-mini",
+      inputCostUnits: 1,
+      outputCostUnits: 2,
+    });
     const createdRow = {
       id: "sess-byok",
       pageId: PAGE_ID,

--- a/server/api/src/__tests__/routes/composeSessions.test.ts
+++ b/server/api/src/__tests__/routes/composeSessions.test.ts
@@ -33,6 +33,12 @@ vi.mock("../../services/subscriptionService.js", () => ({
   getUserTier: async () => "free" as const,
 }));
 
+const mockGetUserAiCredentialPlaintext = vi.fn();
+
+vi.mock("../../services/userAiCredentialService.js", () => ({
+  getUserAiCredentialPlaintext: (...args: unknown[]) => mockGetUserAiCredentialPlaintext(...args),
+}));
+
 import { Hono } from "hono";
 import composeSessionRoutes from "../../routes/composeSessions.js";
 import { errorHandler } from "../../middleware/errorHandler.js";
@@ -92,6 +98,7 @@ function createComposeApp(dbResults: unknown[]) {
 }
 
 beforeEach(() => {
+  mockGetUserAiCredentialPlaintext.mockReset();
   __resetRegistryForTests();
   // Register a graph the routes can resolve. Body is irrelevant for CRUD tests.
   registerGraph({
@@ -141,7 +148,7 @@ describe("POST /api/pages/:pageId/compose-sessions", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns 400 for unsupported backend (BYOK forward-compat)", async () => {
+  it("returns 400 for unsupported backend (legacy byok name)", async () => {
     const { app } = createComposeApp([...pageAccessPrefix()]);
     const res = await app.request(`/api/pages/${PAGE_ID}/compose-sessions`, {
       method: "POST",
@@ -149,6 +156,49 @@ describe("POST /api/pages/:pageId/compose-sessions", () => {
       body: JSON.stringify({ graphId: GRAPH_ID, backend: "byok" }),
     });
     expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for user_openai when credential is missing", async () => {
+    mockGetUserAiCredentialPlaintext.mockResolvedValue(null);
+    const { app } = createComposeApp([...pageAccessPrefix()]);
+    const res = await app.request(`/api/pages/${PAGE_ID}/compose-sessions`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ graphId: GRAPH_ID, backend: "user_openai" }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockGetUserAiCredentialPlaintext).toHaveBeenCalledWith(
+      OWNER_ID,
+      "openai",
+      expect.anything(),
+    );
+  });
+
+  it("creates a session with user_openai when credential exists", async () => {
+    mockGetUserAiCredentialPlaintext.mockResolvedValue("sk-user");
+    const createdRow = {
+      id: "sess-byok",
+      pageId: PAGE_ID,
+      userId: OWNER_ID,
+      graphId: GRAPH_ID,
+      phase: "init",
+      backend: "user_openai",
+      status: "pending",
+      metadata: null,
+      lastError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      closedAt: null,
+    };
+    const { app } = createComposeApp([...pageAccessPrefix(), [createdRow]]);
+    const res = await app.request(`/api/pages/${PAGE_ID}/compose-sessions`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ graphId: GRAPH_ID, backend: "user_openai" }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { session: { backend: string } };
+    expect(body.session.backend).toBe("user_openai");
   });
 
   it("creates a session row with the resolved backend defaulting to zedi_managed", async () => {
@@ -296,7 +346,7 @@ describe("DELETE /api/pages/:pageId/compose-sessions/:id", () => {
       ...pageAccessPrefix(),
       [interruptedRow],
       [interruptedRow], // atomic claim → running
-      undefined, // GraphNotRegisteredError recovery → failed update
+      [], // GraphNotRegisteredError recovery → failed update (no row if already terminal)
     ]);
 
     const res = await app.request(

--- a/server/api/src/__tests__/services/userAiCredentialCrypto.test.ts
+++ b/server/api/src/__tests__/services/userAiCredentialCrypto.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import {
+  decryptUserAiCredential,
+  encryptUserAiCredential,
+  resetUserAiCredentialEncryptionKeyCache,
+} from "../../services/userAiCredentialCrypto.js";
+
+/** 32-byte test key (hex). */
+const TEST_KEY_HEX = "a".repeat(64);
+
+describe("userAiCredentialCrypto", () => {
+  beforeEach(() => {
+    resetUserAiCredentialEncryptionKeyCache();
+    process.env.USER_AI_CREDENTIALS_ENCRYPTION_KEY = TEST_KEY_HEX;
+  });
+
+  afterEach(() => {
+    delete process.env.USER_AI_CREDENTIALS_ENCRYPTION_KEY;
+    resetUserAiCredentialEncryptionKeyCache();
+  });
+
+  it("round-trips encrypt and decrypt", () => {
+    const plain = "sk-test-key-12345";
+    const blob = encryptUserAiCredential(plain);
+    expect(blob).not.toContain(plain);
+    expect(decryptUserAiCredential(blob)).toBe(plain);
+  });
+
+  it("produces distinct ciphertext for the same plaintext", () => {
+    const a = encryptUserAiCredential("same");
+    const b = encryptUserAiCredential("same");
+    expect(a).not.toBe(b);
+    expect(decryptUserAiCredential(a)).toBe("same");
+    expect(decryptUserAiCredential(b)).toBe("same");
+  });
+});

--- a/server/api/src/agents/core/composeBackendValidation.ts
+++ b/server/api/src/agents/core/composeBackendValidation.ts
@@ -1,0 +1,47 @@
+/**
+ * Validate BYOK backend against compose graph model providers (#951).
+ * Compose グラフのモデル provider と BYOK backend の整合を検証する。
+ */
+import { HTTPException } from "hono/http-exception";
+import { validateModelAccess } from "../../services/usageService.js";
+import type { Database, UserTier } from "../../types/index.js";
+import { getComposeModelIdsForGraph } from "./composeModelConfig.js";
+import {
+  backendToCredentialProvider,
+  isUserByokBackend,
+  type ExecutionBackend,
+} from "./types/executionBackend.js";
+import { getUserAiCredentialPlaintext } from "../../services/userAiCredentialService.js";
+
+/**
+ * Ensure BYOK backend matches configured compose models and credentials exist.
+ * BYOK backend が compose モデルと credential と整合するか検証する。
+ */
+export async function assertComposeBackendReady(input: {
+  backend: ExecutionBackend;
+  graphId: string;
+  userId: string;
+  tier: UserTier;
+  db: Database;
+}): Promise<void> {
+  if (!isUserByokBackend(input.backend)) return;
+
+  const expectedProvider = backendToCredentialProvider(input.backend);
+  const modelIds = getComposeModelIdsForGraph(input.graphId);
+
+  for (const modelId of modelIds) {
+    const modelInfo = await validateModelAccess(modelId, input.tier, input.db);
+    if (modelInfo.provider !== expectedProvider) {
+      throw new HTTPException(400, {
+        message: `Backend "${input.backend}" does not match compose model "${modelId}" (provider ${modelInfo.provider})`,
+      });
+    }
+  }
+
+  const key = await getUserAiCredentialPlaintext(input.userId, expectedProvider, input.db);
+  if (!key?.trim()) {
+    throw new HTTPException(400, {
+      message: `No API credential configured for backend "${input.backend}"`,
+    });
+  }
+}

--- a/server/api/src/agents/core/composeModelConfig.ts
+++ b/server/api/src/agents/core/composeModelConfig.ts
@@ -1,0 +1,30 @@
+/**
+ * Resolve LLM model row ids used by Wiki Compose graphs (for BYOK validation).
+ * Wiki Compose グラフが使うモデル行 ID を解決する（BYOK 検証用）。
+ */
+import { WIKI_COMPOSE_GRAPH_ID } from "../graphs/wikiCompose/index.js";
+import { getOrchestratorModelId } from "../subgraphs/research/nodes/planQueries.js";
+import { RESEARCH_GRAPH_ID } from "../subgraphs/research/index.js";
+
+const DRAFT_MODEL_ENV = "WIKI_COMPOSE_DRAFT_MODEL_ID";
+const DRAFT_MODEL_FALLBACK = "claude-3-5-sonnet";
+
+function getDraftModelId(): string {
+  return process.env[DRAFT_MODEL_ENV]?.trim() || DRAFT_MODEL_FALLBACK;
+}
+
+/**
+ * Model row ids (`ai_models.id`) that a compose graph run will call via `createZediChatModel`.
+ * `createZediChatModel` 経由で呼ばれるモデル行 ID 一覧。
+ */
+export function getComposeModelIdsForGraph(graphId: string): string[] {
+  if (graphId === WIKI_COMPOSE_GRAPH_ID) {
+    const orchestrator = getOrchestratorModelId();
+    const draft = getDraftModelId();
+    return orchestrator === draft ? [orchestrator] : [orchestrator, draft];
+  }
+  if (graphId === RESEARCH_GRAPH_ID) {
+    return [getOrchestratorModelId()];
+  }
+  return [getOrchestratorModelId()];
+}

--- a/server/api/src/agents/core/llm/modelFactory.ts
+++ b/server/api/src/agents/core/llm/modelFactory.ts
@@ -2,20 +2,22 @@
  * Build a {@link ZediChatModel} for a Wiki Compose run.
  *
  * 1 つの compose セッションぶんの `ZediChatModel` を組み立てるファクトリ。
- * `validateModelAccess` で tier ゲートと cost 単価を解決し、`process.env` から
- * provider API キーを引いて `ZediChatModel` に注入する。BYOK (#951) で
- * `backend === "byok"` が来た場合の経路もこのファクトリで分岐する想定。
+ * `validateModelAccess` で tier ゲートと cost 単価を解決し、backend に応じて
+ * API キーを解決して `ZediChatModel` に注入する。
  *
  * Resolves model access (tier check + cost units) and provider credentials,
- * then constructs a `ZediChatModel`. Centralising this lets future BYOK paths
- * branch in one place instead of every subgraph.
+ * then constructs a `ZediChatModel`. Centralising this lets BYOK paths branch in
+ * one place instead of every subgraph.
  */
 import { getProviderApiKeyName } from "../../../services/aiProviders.js";
+import { getUserAiCredentialPlaintext } from "../../../services/userAiCredentialService.js";
 import { validateModelAccess } from "../../../services/usageService.js";
 import type { AIProviderType, ApiMode, Database, UserTier } from "../../../types/index.js";
 import {
+  backendToCredentialProvider,
   isExecutionBackend,
-  SUPPORTED_BACKENDS_P0,
+  isUserByokBackend,
+  SUPPORTED_COMPOSE_BACKENDS,
   type ExecutionBackend,
 } from "../types/executionBackend.js";
 import { ZediChatModel, type ExtraProviderOptions } from "./zediChatModel.js";
@@ -23,20 +25,6 @@ import { ZediChatModel, type ExtraProviderOptions } from "./zediChatModel.js";
 /**
  * `createZediChatModel` の入力。
  * Input for {@link createZediChatModel}.
- *
- * @property modelId  `ai_models.id`。`validateModelAccess` の入力と同じ。
- *                    `ai_models.id` (matches `validateModelAccess`).
- * @property userId   実行ユーザー ID。Executing user id.
- * @property tier     ユーザー tier。先に `getUserTier` で解決済みのものを渡す。
- *                    User tier (pre-resolved via `getUserTier`).
- * @property db       Drizzle DB ハンドル。Drizzle DB handle.
- * @property feature  `recordUsage` の feature ラベル。`recordUsage` feature label.
- * @property backend  実行 backend。P0 では `zedi_managed` のみ受理。
- *                    Execution backend; P0 only accepts `zedi_managed`.
- * @property apiKey   BYOK 用の上書き API キー（任意）。`backend === "byok"` の時必須。
- *                    Override API key for BYOK; required when `backend === "byok"`.
- * @property temperature  Provider オプション。Provider option.
- * @property maxTokens    Provider オプション。Provider option.
  */
 export interface CreateZediChatModelInput {
   modelId: string;
@@ -48,60 +36,89 @@ export interface CreateZediChatModelInput {
   apiKey?: string;
   temperature?: number;
   maxTokens?: number;
-  /** プロバイダ固有 pass-through。`useWebSearch` 等。Optional provider knobs. */
   extraProviderOptions?: ExtraProviderOptions;
 }
 
 /**
- * 未サポート backend を投げる時のエラー。route 層が 4xx に変換できるよう
- * 専用クラスにしておく。
- *
- * Thrown when a caller hands in a backend that is not yet wired up. Carries a
- * machine-readable code so the route layer can map to a 4xx without sniffing
- * the message string.
+ * Thrown when a caller hands in a backend that is not yet wired up.
  */
 export class UnsupportedBackendError extends Error {
-  /** Machine-readable code. */
   readonly code = "UNSUPPORTED_BACKEND";
-  /** The backend value that triggered the error. */
   readonly backend: string;
   constructor(backend: string) {
-    super(`Execution backend "${backend}" is not supported in P0 (zedi_managed only).`);
+    super(`Execution backend "${backend}" is not supported for Wiki Compose.`);
     this.name = "UnsupportedBackendError";
     this.backend = backend;
   }
 }
 
 /**
- * Validate that the requested `backend` is a P0-supported value and return it
- * narrowed to {@link ExecutionBackend}.
- *
- * P0 でサポートされる backend かを検証する。`byok` / `byo_runner` は #951 以降。
+ * Thrown when BYOK backend is selected but no credential is stored.
  */
-export function assertSupportedBackendP0(backend: string): ExecutionBackend {
-  if (!isExecutionBackend(backend) || !SUPPORTED_BACKENDS_P0.includes(backend)) {
+export class MissingUserCredentialError extends Error {
+  readonly code = "MISSING_USER_CREDENTIAL";
+  readonly backend: ExecutionBackend;
+  constructor(backend: ExecutionBackend) {
+    super(`No API credential configured for backend "${backend}"`);
+    this.name = "MissingUserCredentialError";
+    this.backend = backend;
+  }
+}
+
+/**
+ * Thrown when the model's provider does not match the BYOK backend.
+ */
+export class BackendProviderMismatchError extends Error {
+  readonly code = "BACKEND_PROVIDER_MISMATCH";
+  readonly backend: ExecutionBackend;
+  readonly provider: AIProviderType;
+  constructor(backend: ExecutionBackend, provider: AIProviderType) {
+    super(`Backend "${backend}" does not match model provider "${provider}"`);
+    this.name = "BackendProviderMismatchError";
+    this.backend = backend;
+    this.provider = provider;
+  }
+}
+
+/**
+ * Validate that the requested `backend` is supported for Wiki Compose (#951).
+ */
+export function assertSupportedComposeBackend(backend: string): ExecutionBackend {
+  if (!isExecutionBackend(backend) || !SUPPORTED_COMPOSE_BACKENDS.includes(backend)) {
     throw new UnsupportedBackendError(backend);
   }
   return backend;
 }
 
 /**
+ * @deprecated Use {@link assertSupportedComposeBackend}. Kept for barrel exports.
+ */
+export const assertSupportedBackendP0 = assertSupportedComposeBackend;
+
+/**
  * Build a {@link ZediChatModel} ready to be plugged into a LangGraph node.
- * LangGraph ノードへ差し込む `ZediChatModel` を組み立てて返す。
- *
- * 1. backend を検証（P0 は `zedi_managed` のみ）。
- * 2. `validateModelAccess` で tier ゲート + cost 単価を解決。
- * 3. provider API キーを backend に応じて解決
- *    （`zedi_managed` → `process.env[apiKeyName]`、`byok` → 入力の `apiKey`）。
  */
 export async function createZediChatModel(input: CreateZediChatModelInput): Promise<ZediChatModel> {
-  const backend = assertSupportedBackendP0(input.backend);
+  const backend = assertSupportedComposeBackend(input.backend);
 
   const modelInfo = await validateModelAccess(input.modelId, input.tier, input.db);
   const provider = modelInfo.provider as AIProviderType;
 
-  const apiKey = resolveApiKey(backend, provider, input.apiKey);
-  const apiMode: ApiMode = backend === "byok" ? "user_key" : "system";
+  if (isUserByokBackend(backend)) {
+    const expected = backendToCredentialProvider(backend);
+    if (provider !== expected) {
+      throw new BackendProviderMismatchError(backend, provider);
+    }
+  }
+
+  const apiKey = await resolveApiKey({
+    backend,
+    provider,
+    userId: input.userId,
+    db: input.db,
+    overrideKey: input.apiKey,
+  });
+  const apiMode: ApiMode = isUserByokBackend(backend) ? "user_key" : "system";
 
   return new ZediChatModel({
     provider,
@@ -121,18 +138,17 @@ export async function createZediChatModel(input: CreateZediChatModelInput): Prom
   });
 }
 
-/**
- * Backend + provider に応じた API キー解決。`zedi_managed` は `process.env` を
- * 引き、`byok` は呼び出し側からの注入キーを必須にする。
- *
- * Resolve the provider API key per backend. `zedi_managed` reads `process.env`;
- * `byok` requires an explicitly injected key.
- */
-function resolveApiKey(
-  backend: ExecutionBackend,
-  provider: AIProviderType,
-  overrideKey: string | undefined,
-): string {
+interface ResolveApiKeyInput {
+  backend: ExecutionBackend;
+  provider: AIProviderType;
+  userId: string;
+  db: Database;
+  overrideKey: string | undefined;
+}
+
+async function resolveApiKey(input: ResolveApiKeyInput): Promise<string> {
+  const { backend, provider, userId, db, overrideKey } = input;
+
   if (backend === "zedi_managed") {
     const envName = getProviderApiKeyName(provider);
     const key = process.env[envName];
@@ -141,8 +157,18 @@ function resolveApiKey(
     }
     return key;
   }
-  if (!overrideKey || !overrideKey.trim()) {
-    throw new Error(`apiKey is required for backend="${backend}"`);
+
+  if (isUserByokBackend(backend)) {
+    if (overrideKey?.trim()) {
+      return overrideKey.trim();
+    }
+    const credentialProvider = backendToCredentialProvider(backend);
+    const stored = await getUserAiCredentialPlaintext(userId, credentialProvider, db);
+    if (!stored?.trim()) {
+      throw new MissingUserCredentialError(backend);
+    }
+    return stored.trim();
   }
-  return overrideKey;
+
+  throw new UnsupportedBackendError(backend);
 }

--- a/server/api/src/agents/core/llm/modelFactory.ts
+++ b/server/api/src/agents/core/llm/modelFactory.ts
@@ -41,6 +41,7 @@ export interface CreateZediChatModelInput {
 
 /**
  * Thrown when a caller hands in a backend that is not yet wired up.
+ * 未対応 backend が渡されたときに投げる。
  */
 export class UnsupportedBackendError extends Error {
   readonly code = "UNSUPPORTED_BACKEND";
@@ -54,6 +55,7 @@ export class UnsupportedBackendError extends Error {
 
 /**
  * Thrown when BYOK backend is selected but no credential is stored.
+ * BYOK だが credential 未登録のときに投げる。
  */
 export class MissingUserCredentialError extends Error {
   readonly code = "MISSING_USER_CREDENTIAL";
@@ -67,6 +69,7 @@ export class MissingUserCredentialError extends Error {
 
 /**
  * Thrown when the model's provider does not match the BYOK backend.
+ * モデル provider と BYOK backend が一致しないときに投げる。
  */
 export class BackendProviderMismatchError extends Error {
   readonly code = "BACKEND_PROVIDER_MISMATCH";

--- a/server/api/src/agents/core/llm/usageCallback.ts
+++ b/server/api/src/agents/core/llm/usageCallback.ts
@@ -66,7 +66,9 @@ export interface RecordZediUsageResult {
  * `recordUsage`. Used by `ZediChatModel` after each provider call.
  */
 export async function recordZediUsage(input: RecordZediUsageInput): Promise<RecordZediUsageResult> {
-  const costUnits = calculateCost(input.usage, input.inputCostUnits, input.outputCostUnits);
+  const rawCostUnits = calculateCost(input.usage, input.inputCostUnits, input.outputCostUnits);
+  // BYOK (#951): audit usage in logs but do not consume Zedi monthly CU.
+  const costUnits = input.apiMode === "user_key" ? 0 : rawCostUnits;
   await recordUsage(
     input.userId,
     input.modelId,

--- a/server/api/src/agents/core/types/executionBackend.ts
+++ b/server/api/src/agents/core/types/executionBackend.ts
@@ -1,3 +1,5 @@
+import type { UserAiCredentialProvider } from "../../../schema/userAiCredentials.js";
+
 /**
  * Execution backend identifies where the LangGraph agent runs and which
  * credential mode applies.
@@ -5,29 +7,91 @@
  * 実行バックエンド。LangGraph エージェントが「どこで・誰の鍵で」走るかを表す。
  *
  * - `zedi_managed` — Zedi がプロビジョニングしたシステム API キーで API
- *   ホスト内で実行する。月次予算・利用記録は `recordUsage` を通る。これが
- *   P0 (#948) で唯一サポートされる backend。
- * - `byok` — ユーザーが自分の API キーを持ち込んで API ホスト内で実行する。
- *   P0 では未対応 (#951 で導入)。
- * - `byo_runner` — ユーザー所有のランナー（将来の self-host 想定）。P0 では
- *   未対応で予約済み。
+ *   ホスト内で実行。月次 CU は `recordUsage` で消費する。
+ * - `user_anthropic` / `user_openai` / `user_google` — ユーザーがサーバーに
+ *   登録した暗号化 API キーで実行（BYOK, #951）。Zedi CU は消費しない。
+ * - `byo_runner` — ユーザー所有ランナー（将来）。未対応で予約。
  *
- * `zedi_managed` is the only backend supported in P0 (#948). `byok` and
- * `byo_runner` are reserved for follow-ups (#951 and later) so the column
- * shape can stabilise before behaviour is wired up.
+ * `byok` は P0 スケッチ名；P3 では provider 別 backend に分割した。
  */
-export type ExecutionBackend = "zedi_managed" | "byok" | "byo_runner";
+export type ExecutionBackend =
+  | "zedi_managed"
+  | "user_anthropic"
+  | "user_openai"
+  | "user_google"
+  | "byo_runner";
+
+/** BYOK backends that map 1:1 to a stored credential provider. */
+export type UserByokExecutionBackend = "user_anthropic" | "user_openai" | "user_google";
 
 /**
- * P0 で受け入れる backend のホワイトリスト。
- * Whitelist of backends accepted in P0.
+ * Backends accepted for Wiki Compose session create / run (#951).
+ * Wiki Compose で受け入れる backend 一覧。
  */
-export const SUPPORTED_BACKENDS_P0: ReadonlyArray<ExecutionBackend> = ["zedi_managed"];
+export const SUPPORTED_COMPOSE_BACKENDS: ReadonlyArray<ExecutionBackend> = [
+  "zedi_managed",
+  "user_anthropic",
+  "user_openai",
+  "user_google",
+];
+
+/**
+ * @deprecated P0 名。`SUPPORTED_COMPOSE_BACKENDS` を使用すること。
+ * Alias kept for imports that still reference the P0 symbol.
+ */
+export const SUPPORTED_BACKENDS_P0: ReadonlyArray<ExecutionBackend> = SUPPORTED_COMPOSE_BACKENDS;
 
 /**
  * 与えられた値が `ExecutionBackend` の文字列かどうかを判定する。
  * Type guard for `ExecutionBackend`.
  */
 export function isExecutionBackend(value: unknown): value is ExecutionBackend {
-  return value === "zedi_managed" || value === "byok" || value === "byo_runner";
+  return (
+    value === "zedi_managed" ||
+    value === "user_anthropic" ||
+    value === "user_openai" ||
+    value === "user_google" ||
+    value === "byo_runner"
+  );
+}
+
+/**
+ * True when the backend uses a user-supplied API key (BYOK).
+ * ユーザー API キー backend かどうか。
+ */
+export function isUserByokBackend(backend: ExecutionBackend): backend is UserByokExecutionBackend {
+  return backend === "user_anthropic" || backend === "user_openai" || backend === "user_google";
+}
+
+/**
+ * Map a BYOK execution backend to the credential provider id.
+ * BYOK backend から credential provider へ変換。
+ */
+export function backendToCredentialProvider(
+  backend: UserByokExecutionBackend,
+): UserAiCredentialProvider {
+  switch (backend) {
+    case "user_anthropic":
+      return "anthropic";
+    case "user_openai":
+      return "openai";
+    case "user_google":
+      return "google";
+  }
+}
+
+/**
+ * Map credential provider to the compose execution backend id.
+ */
+export function credentialProviderToBackend(
+  provider: UserAiCredentialProvider,
+): UserByokExecutionBackend {
+  switch (provider) {
+    case "anthropic":
+      return "user_anthropic";
+    case "openai":
+      return "user_openai";
+    case "google":
+      return "user_google";
+  }
 }

--- a/server/api/src/agents/core/types/index.ts
+++ b/server/api/src/agents/core/types/index.ts
@@ -8,7 +8,12 @@
  */
 export {
   type ExecutionBackend,
+  type UserByokExecutionBackend,
   isExecutionBackend,
+  isUserByokBackend,
+  backendToCredentialProvider,
+  credentialProviderToBackend,
+  SUPPORTED_COMPOSE_BACKENDS,
   SUPPORTED_BACKENDS_P0,
 } from "./executionBackend.js";
 export { type GraphContext, GRAPH_CONTEXT_CONFIG_KEY } from "./graphContext.js";

--- a/server/api/src/agents/index.ts
+++ b/server/api/src/agents/index.ts
@@ -19,7 +19,10 @@ export {
 } from "./core/llm/zediChatModel.js";
 export {
   createZediChatModel,
+  assertSupportedComposeBackend,
   assertSupportedBackendP0,
+  MissingUserCredentialError,
+  BackendProviderMismatchError,
   UnsupportedBackendError,
   type CreateZediChatModelInput,
 } from "./core/llm/modelFactory.js";

--- a/server/api/src/app.ts
+++ b/server/api/src/app.ts
@@ -44,6 +44,7 @@ import activityRoutes from "./routes/activity.js";
 import onboardingRoutes from "./routes/onboarding.js";
 import internalRoutes from "./routes/internal.js";
 import composeSessionRoutes from "./routes/composeSessions.js";
+import userAiCredentialRoutes from "./routes/userAiCredentials.js";
 import { registerStubGraph } from "./agents/registry/stubGraph.js";
 import { registerResearchLoopGraph } from "./agents/subgraphs/research/index.js";
 import { registerWikiComposeGraph } from "./agents/graphs/wikiCompose/index.js";
@@ -136,6 +137,9 @@ export function createApp(): Hono<AppEnv> {
 
   // Users
   app.route("/api/users", userRoutes);
+
+  // BYOK credentials for Wiki Compose (#951)
+  app.route("/api/user/ai-credentials", userAiCredentialRoutes);
 
   // Onboarding wizard completion + status
   // セットアップウィザード完了・状況取得

--- a/server/api/src/routes/composeSessions.ts
+++ b/server/api/src/routes/composeSessions.ts
@@ -51,9 +51,14 @@ import {
 } from "../agents/runner/sseMapper.js";
 import { GraphNotRegisteredError, getRegisteredGraph } from "../agents/registry/graphRegistry.js";
 import {
-  assertSupportedBackendP0,
+  assertSupportedComposeBackend,
   UnsupportedBackendError,
 } from "../agents/core/llm/modelFactory.js";
+import {
+  backendToCredentialProvider,
+  isUserByokBackend,
+} from "../agents/core/types/executionBackend.js";
+import { getUserAiCredentialPlaintext } from "../services/userAiCredentialService.js";
 import { SSE_EVENT_NAMES, type SseEvent } from "../agents/core/types/sseEvents.js";
 import { GRAPH_CONTEXT_CONFIG_KEY } from "../agents/core/types/graphContext.js";
 import { resolveCheckpointerForRun } from "../agents/core/checkpoint/index.js";
@@ -169,14 +174,24 @@ app.post("/:pageId/compose-sessions", authRequired, rateLimit(), async (c) => {
     throw new HTTPException(400, { message: `Unknown graphId: ${graphId}` });
   }
 
-  let backend: ReturnType<typeof assertSupportedBackendP0>;
+  let backend: ReturnType<typeof assertSupportedComposeBackend>;
   try {
-    backend = assertSupportedBackendP0(body.backend ?? "zedi_managed");
+    backend = assertSupportedComposeBackend(body.backend ?? "zedi_managed");
   } catch (err) {
     if (err instanceof UnsupportedBackendError) {
       throw new HTTPException(400, { message: err.message });
     }
     throw err;
+  }
+
+  if (isUserByokBackend(backend)) {
+    const provider = backendToCredentialProvider(backend);
+    const key = await getUserAiCredentialPlaintext(userId, provider, db);
+    if (!key?.trim()) {
+      throw new HTTPException(400, {
+        message: `No API credential configured for backend "${backend}"`,
+      });
+    }
   }
 
   const [row] = await db
@@ -218,7 +233,7 @@ app.get("/:pageId/compose-sessions/:id", authRequired, async (c) => {
   // 古い backend 行でもセッション行は返し、projection だけ省略する。
   let projection = null;
   try {
-    const backend = assertSupportedBackendP0(row.backend);
+    const backend = assertSupportedComposeBackend(row.backend);
     projection = await loadComposeSessionProjection({
       sessionId: row.id,
       pageId: row.pageId,
@@ -282,7 +297,7 @@ app.post("/:pageId/compose-sessions/:id/run", authRequired, rateLimit(), async (
   // no longer permitted (future BYOK downgrade scenarios). Fail fast here.
   // 行作成後に backend サポートが変わった場合への保険。
   try {
-    assertSupportedBackendP0(session.backend);
+    assertSupportedComposeBackend(session.backend);
   } catch (err) {
     if (err instanceof UnsupportedBackendError) {
       throw new HTTPException(400, { message: err.message });
@@ -361,7 +376,7 @@ app.post("/:pageId/compose-sessions/:id/run", authRequired, rateLimit(), async (
             userEmail,
             pageId,
             graphId: session.graphId,
-            backend: assertSupportedBackendP0(session.backend),
+            backend: assertSupportedComposeBackend(session.backend),
             tier,
             db,
             feature: `wiki_compose:${session.graphId}`,
@@ -453,7 +468,7 @@ app.patch("/:pageId/compose-sessions/:id/resume", authRequired, rateLimit(), asy
   const runner = new GraphRunner();
 
   try {
-    assertSupportedBackendP0(session.backend);
+    assertSupportedComposeBackend(session.backend);
   } catch (err) {
     if (err instanceof UnsupportedBackendError) {
       throw new HTTPException(400, { message: err.message });
@@ -495,7 +510,7 @@ app.patch("/:pageId/compose-sessions/:id/resume", authRequired, rateLimit(), asy
           userEmail,
           pageId,
           graphId: session.graphId,
-          backend: assertSupportedBackendP0(session.backend),
+          backend: assertSupportedComposeBackend(session.backend),
           tier,
           db,
           feature: `wiki_compose:${session.graphId}`,

--- a/server/api/src/routes/composeSessions.ts
+++ b/server/api/src/routes/composeSessions.ts
@@ -54,11 +54,7 @@ import {
   assertSupportedComposeBackend,
   UnsupportedBackendError,
 } from "../agents/core/llm/modelFactory.js";
-import {
-  backendToCredentialProvider,
-  isUserByokBackend,
-} from "../agents/core/types/executionBackend.js";
-import { getUserAiCredentialPlaintext } from "../services/userAiCredentialService.js";
+import { assertComposeBackendReady } from "../agents/core/composeBackendValidation.js";
 import { SSE_EVENT_NAMES, type SseEvent } from "../agents/core/types/sseEvents.js";
 import { GRAPH_CONTEXT_CONFIG_KEY } from "../agents/core/types/graphContext.js";
 import { resolveCheckpointerForRun } from "../agents/core/checkpoint/index.js";
@@ -184,15 +180,8 @@ app.post("/:pageId/compose-sessions", authRequired, rateLimit(), async (c) => {
     throw err;
   }
 
-  if (isUserByokBackend(backend)) {
-    const provider = backendToCredentialProvider(backend);
-    const key = await getUserAiCredentialPlaintext(userId, provider, db);
-    if (!key?.trim()) {
-      throw new HTTPException(400, {
-        message: `No API credential configured for backend "${backend}"`,
-      });
-    }
-  }
+  const tier = await getUserTier(userId, db);
+  await assertComposeBackendReady({ backend, graphId, userId, tier, db });
 
   const [row] = await db
     .insert(wikiComposeSessions)

--- a/server/api/src/routes/userAiCredentials.ts
+++ b/server/api/src/routes/userAiCredentials.ts
@@ -61,8 +61,10 @@ app.put("/:provider", authRequired, rateLimit(), async (c) => {
   try {
     await upsertUserAiCredential(userId, provider, apiKey, db);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new HTTPException(400, { message });
+    if (err instanceof Error && err.message === "API key is required") {
+      throw new HTTPException(400, { message: err.message });
+    }
+    throw err;
   }
   return c.json({ ok: true, provider });
 });

--- a/server/api/src/routes/userAiCredentials.ts
+++ b/server/api/src/routes/userAiCredentials.ts
@@ -1,0 +1,79 @@
+/**
+ * `/api/user/ai-credentials` — BYOK credential registration (#951).
+ *
+ * 平文 API キーはレスポンスに含めない。POST body で受け取り暗号化して保存する。
+ * Plaintext keys are never returned; POST accepts a key and stores ciphertext only.
+ */
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { authRequired } from "../middleware/auth.js";
+import { rateLimit } from "../middleware/rateLimit.js";
+import type { AppEnv } from "../types/index.js";
+import type { UserAiCredentialProvider } from "../schema/userAiCredentials.js";
+import {
+  deleteUserAiCredential,
+  isUserAiCredentialStorageEnabled,
+  listUserAiCredentialAvailability,
+  upsertUserAiCredential,
+} from "../services/userAiCredentialService.js";
+
+const PROVIDERS: readonly UserAiCredentialProvider[] = ["anthropic", "openai", "google"];
+
+function parseProvider(value: unknown): UserAiCredentialProvider {
+  if (typeof value !== "string" || !PROVIDERS.includes(value as UserAiCredentialProvider)) {
+    throw new HTTPException(400, {
+      message: `provider must be one of: ${PROVIDERS.join(", ")}`,
+    });
+  }
+  return value as UserAiCredentialProvider;
+}
+
+const app = new Hono<AppEnv>();
+
+/** GET — list configured providers (no secrets). */
+app.get("/", authRequired, async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+  const storageEnabled = isUserAiCredentialStorageEnabled();
+  const providers = storageEnabled
+    ? await listUserAiCredentialAvailability(userId, db)
+    : PROVIDERS.map((provider) => ({ provider, configured: false }));
+  return c.json({ storageEnabled, providers });
+});
+
+/** PUT — upsert encrypted credential for a provider. */
+app.put("/:provider", authRequired, rateLimit(), async (c) => {
+  if (!isUserAiCredentialStorageEnabled()) {
+    throw new HTTPException(503, {
+      message: "Server-side credential storage is not configured",
+    });
+  }
+  const userId = c.get("userId");
+  const db = c.get("db");
+  const provider = parseProvider(c.req.param("provider"));
+  let body: { apiKey?: string };
+  try {
+    body = await c.req.json<{ apiKey?: string }>();
+  } catch {
+    throw new HTTPException(400, { message: "Invalid JSON body" });
+  }
+  const apiKey = typeof body.apiKey === "string" ? body.apiKey : "";
+  try {
+    await upsertUserAiCredential(userId, provider, apiKey, db);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new HTTPException(400, { message });
+  }
+  return c.json({ ok: true, provider });
+});
+
+/** DELETE — remove a stored credential. */
+app.delete("/:provider", authRequired, rateLimit(), async (c) => {
+  const userId = c.get("userId");
+  const db = c.get("db");
+  const provider = parseProvider(c.req.param("provider"));
+  const removed = await deleteUserAiCredential(userId, provider, db);
+  return c.json({ ok: true, provider, removed });
+});
+
+export default app;

--- a/server/api/src/schema/index.ts
+++ b/server/api/src/schema/index.ts
@@ -109,6 +109,12 @@ export {
   type NewWikiComposeSession,
   type WikiComposeSessionStatus,
 } from "./wikiComposeSessions.js";
+export {
+  userAiCredentials,
+  type UserAiCredential,
+  type NewUserAiCredential,
+  type UserAiCredentialProvider,
+} from "./userAiCredentials.js";
 
 export {
   usersRelations,

--- a/server/api/src/schema/userAiCredentials.ts
+++ b/server/api/src/schema/userAiCredentials.ts
@@ -1,0 +1,42 @@
+import { pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { users } from "./users.js";
+
+/**
+ * Provider ids stored for BYOK credentials (matches {@link AIProviderType} subset).
+ * BYOK 用 credential の provider 識別子（`AIProviderType` のサブセット）。
+ */
+export type UserAiCredentialProvider = "anthropic" | "openai" | "google";
+
+/**
+ * Server-side encrypted user API keys for Wiki Compose BYOK (#951).
+ *
+ * 平文 API キーは保存しない。`encrypted_api_key` は AES-256-GCM で暗号化した
+ * blob（IV + auth tag + ciphertext）を Base64 で格納する。復号鍵は環境変数
+ * `USER_AI_CREDENTIALS_ENCRYPTION_KEY`（32 バイト）のみが保持する。
+ *
+ * Plaintext API keys are never stored. `encrypted_api_key` holds a Base64 blob
+ * (IV + auth tag + ciphertext) from AES-256-GCM. Only
+ * `USER_AI_CREDENTIALS_ENCRYPTION_KEY` (32 bytes) can decrypt at runtime.
+ *
+ * @see {@link encryptUserAiCredential} / {@link decryptUserAiCredential}
+ */
+export const userAiCredentials = pgTable(
+  "user_ai_credentials",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    provider: text("provider", { enum: ["anthropic", "openai", "google"] }).notNull(),
+    /** AES-256-GCM encrypted secret (never plaintext). 平文ではない暗号化 blob。 */
+    encryptedApiKey: text("encrypted_api_key").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("idx_user_ai_credentials_user_provider").on(table.userId, table.provider),
+  ],
+);
+
+export type UserAiCredential = typeof userAiCredentials.$inferSelect;
+export type NewUserAiCredential = typeof userAiCredentials.$inferInsert;

--- a/server/api/src/schema/userAiCredentials.ts
+++ b/server/api/src/schema/userAiCredentials.ts
@@ -38,5 +38,7 @@ export const userAiCredentials = pgTable(
   ],
 );
 
+/** Selected row type for `user_ai_credentials`. `user_ai_credentials` の取得行型。 */
 export type UserAiCredential = typeof userAiCredentials.$inferSelect;
+/** Insert type for `user_ai_credentials`. `user_ai_credentials` の挿入型。 */
 export type NewUserAiCredential = typeof userAiCredentials.$inferInsert;

--- a/server/api/src/schema/wikiComposeSessions.ts
+++ b/server/api/src/schema/wikiComposeSessions.ts
@@ -71,8 +71,8 @@ export const wikiComposeSessions = pgTable(
      */
     phase: text("phase").notNull().default("init"),
     /**
-     * 実行 backend。P0 では常に `zedi_managed`。BYOK 対応 (#951) で拡張。
-     * Execution backend; `zedi_managed` only in P0.
+     * 実行 backend。`zedi_managed` または `user_*`（#951 BYOK）。セッション作成時に固定。
+     * Execution backend; `zedi_managed` or `user_*` BYOK backends (#951), fixed at create.
      */
     backend: text("backend").notNull().default("zedi_managed"),
     /**

--- a/server/api/src/services/userAiCredentialCrypto.ts
+++ b/server/api/src/services/userAiCredentialCrypto.ts
@@ -1,0 +1,91 @@
+/**
+ * AES-256-GCM encryption for `user_ai_credentials.encrypted_api_key` (#951).
+ *
+ * `user_ai_credentials` 用の at-rest 暗号化。鍵管理方針:
+ *
+ * - **鍵の所在**: 本番・開発とも `USER_AI_CREDENTIALS_ENCRYPTION_KEY` 環境変数
+ *   のみ（32 バイト raw、Base64 または hex で指定）。DB・ログ・クライアントへ
+ *   鍵を書き込まない。
+ * - **ローテーション**: 新鍵を設定したうえで既存行を再保存（upsert）する運用。
+ *   旧鍵での復号に失敗した行は利用者がキーを再登録する。
+ * - **形式**: `base64(iv[12] || authTag[16] || ciphertext)` — クライアント
+ *   `src/lib/encryption.ts` とは別鍵・別用途（ブラウザ localStorage 用）。
+ *
+ * Key management:
+ * - **Source of truth**: env `USER_AI_CREDENTIALS_ENCRYPTION_KEY` only (32 raw
+ *   bytes as Base64 or hex). Never persist the key in DB, logs, or the client.
+ * - **Rotation**: set a new env key and re-upsert credentials; rows that fail
+ *   decrypt require the user to re-register.
+ * - **Wire format**: `base64(iv[12] || authTag[16] || ciphertext)` — distinct
+ *   from browser `src/lib/encryption.ts` (localStorage, per-device key).
+ */
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+const KEY_LENGTH = 32;
+
+let cachedKey: Buffer | null = null;
+
+/**
+ * Load the 32-byte encryption key from the environment (memoized).
+ * 環境変数から 32 バイト鍵を読み込む（メモ化）。
+ */
+export function getUserAiCredentialEncryptionKey(): Buffer {
+  if (cachedKey) return cachedKey;
+  const raw = process.env.USER_AI_CREDENTIALS_ENCRYPTION_KEY?.trim();
+  if (!raw) {
+    throw new Error("USER_AI_CREDENTIALS_ENCRYPTION_KEY is not configured");
+  }
+  let key: Buffer;
+  if (/^[0-9a-fA-F]{64}$/.test(raw)) {
+    key = Buffer.from(raw, "hex");
+  } else {
+    key = Buffer.from(raw, "base64");
+  }
+  if (key.length !== KEY_LENGTH) {
+    throw new Error(
+      `USER_AI_CREDENTIALS_ENCRYPTION_KEY must decode to ${KEY_LENGTH} bytes (got ${key.length})`,
+    );
+  }
+  cachedKey = key;
+  return key;
+}
+
+/** Reset cached key (tests only). テスト用にキャッシュをクリア。 */
+export function resetUserAiCredentialEncryptionKeyCache(): void {
+  cachedKey = null;
+}
+
+/**
+ * Encrypt a plaintext API key for storage.
+ * 平文 API キーを DB 保存用に暗号化する。
+ */
+export function encryptUserAiCredential(plaintext: string): string {
+  const key = getUserAiCredentialEncryptionKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  const combined = Buffer.concat([iv, authTag, encrypted]);
+  return combined.toString("base64");
+}
+
+/**
+ * Decrypt a stored credential blob.
+ * 保存済み blob を復号する。
+ */
+export function decryptUserAiCredential(ciphertext: string): string {
+  const key = getUserAiCredentialEncryptionKey();
+  const combined = Buffer.from(ciphertext, "base64");
+  if (combined.length < IV_LENGTH + AUTH_TAG_LENGTH + 1) {
+    throw new Error("Invalid encrypted credential blob");
+  }
+  const iv = combined.subarray(0, IV_LENGTH);
+  const authTag = combined.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const encrypted = combined.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString("utf8");
+}

--- a/server/api/src/services/userAiCredentialService.ts
+++ b/server/api/src/services/userAiCredentialService.ts
@@ -115,11 +115,19 @@ export async function getUserAiCredentialPlaintext(
   provider: UserAiCredentialProvider,
   db: Database,
 ): Promise<string | null> {
+  if (!isUserAiCredentialStorageEnabled()) return null;
+
   const [row] = await db
     .select()
     .from(userAiCredentials)
     .where(and(eq(userAiCredentials.userId, userId), eq(userAiCredentials.provider, provider)))
     .limit(1);
   if (!row) return null;
-  return decryptUserAiCredential(row.encryptedApiKey);
+  try {
+    return decryptUserAiCredential(row.encryptedApiKey);
+  } catch {
+    // Master key rotated or corrupted blob — treat as missing so callers return 400.
+    // マスター鍵ローテーション等で復号不能な行は未設定扱い。
+    return null;
+  }
 }

--- a/server/api/src/services/userAiCredentialService.ts
+++ b/server/api/src/services/userAiCredentialService.ts
@@ -1,0 +1,125 @@
+/**
+ * CRUD for encrypted user AI credentials (#951).
+ * 暗号化されたユーザー AI 認証情報の CRUD。
+ */
+import { and, eq } from "drizzle-orm";
+import { userAiCredentials, type UserAiCredentialProvider } from "../schema/userAiCredentials.js";
+import type { Database } from "../types/index.js";
+import {
+  decryptUserAiCredential,
+  encryptUserAiCredential,
+  getUserAiCredentialEncryptionKey,
+} from "./userAiCredentialCrypto.js";
+
+/** Public availability shape (no secrets). 秘密情報を含まない利用可否。 */
+export interface UserAiCredentialAvailability {
+  provider: UserAiCredentialProvider;
+  configured: boolean;
+}
+
+const ALL_PROVIDERS: readonly UserAiCredentialProvider[] = ["anthropic", "openai", "google"];
+
+/**
+ * Whether server-side credential storage is configured (encryption key present).
+ * サーバー側 credential 保管が有効か（暗号化鍵が設定されているか）。
+ */
+export function isUserAiCredentialStorageEnabled(): boolean {
+  try {
+    getUserAiCredentialEncryptionKey();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * List which providers have a stored credential for the user.
+ * ユーザーが登録済みの provider 一覧（キー本体は返さない）。
+ */
+export async function listUserAiCredentialAvailability(
+  userId: string,
+  db: Database,
+): Promise<UserAiCredentialAvailability[]> {
+  if (!isUserAiCredentialStorageEnabled()) {
+    return ALL_PROVIDERS.map((provider) => ({ provider, configured: false }));
+  }
+  const rows = await db
+    .select({ provider: userAiCredentials.provider })
+    .from(userAiCredentials)
+    .where(eq(userAiCredentials.userId, userId));
+  const configured = new Set(rows.map((r) => r.provider));
+  return ALL_PROVIDERS.map((provider) => ({
+    provider,
+    configured: configured.has(provider),
+  }));
+}
+
+/**
+ * Upsert an encrypted API key for a provider.
+ * provider 向け API キーを暗号化して upsert する。
+ */
+export async function upsertUserAiCredential(
+  userId: string,
+  provider: UserAiCredentialProvider,
+  apiKey: string,
+  db: Database,
+): Promise<void> {
+  const trimmed = apiKey.trim();
+  if (!trimmed) {
+    throw new Error("API key is required");
+  }
+  const encryptedApiKey = encryptUserAiCredential(trimmed);
+  const id = `${userId}:${provider}`;
+  const now = new Date();
+  await db
+    .insert(userAiCredentials)
+    .values({
+      id,
+      userId,
+      provider,
+      encryptedApiKey,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [userAiCredentials.userId, userAiCredentials.provider],
+      set: {
+        encryptedApiKey,
+        updatedAt: now,
+      },
+    });
+}
+
+/**
+ * Remove a stored credential.
+ * 保存済み credential を削除する。
+ */
+export async function deleteUserAiCredential(
+  userId: string,
+  provider: UserAiCredentialProvider,
+  db: Database,
+): Promise<boolean> {
+  const result = await db
+    .delete(userAiCredentials)
+    .where(and(eq(userAiCredentials.userId, userId), eq(userAiCredentials.provider, provider)))
+    .returning({ id: userAiCredentials.id });
+  return result.length > 0;
+}
+
+/**
+ * Decrypt the stored API key for a provider (server-only).
+ * provider の API キーを復号する（サーバー内部専用）。
+ */
+export async function getUserAiCredentialPlaintext(
+  userId: string,
+  provider: UserAiCredentialProvider,
+  db: Database,
+): Promise<string | null> {
+  const [row] = await db
+    .select()
+    .from(userAiCredentials)
+    .where(and(eq(userAiCredentials.userId, userId), eq(userAiCredentials.provider, provider)))
+    .limit(1);
+  if (!row) return null;
+  return decryptUserAiCredential(row.encryptedApiKey);
+}

--- a/src/components/settings/AISettingsForm.tsx
+++ b/src/components/settings/AISettingsForm.tsx
@@ -22,6 +22,7 @@ import { ProviderSelector } from "./ProviderSelector";
 import { SectionSaveStatus } from "./SectionSaveStatus";
 import { ClaudeCodePrerequisites } from "./ClaudeCodePrerequisites";
 import { McpServerSettings } from "./McpServerSettings";
+import { ComposeByokCredentialsSection } from "./ComposeByokCredentialsSection";
 import { getProviderById, type AIInteractionMode } from "@/types/ai";
 import { isTauriDesktop } from "@/lib/platform";
 import { useTranslation } from "react-i18next";
@@ -141,6 +142,11 @@ export const AISettingsForm: React.FC<AISettingsFormProps> = ({ embedded = false
 
         {isClaudeCode && <ClaudeCodePrerequisites />}
         {isClaudeCode && <McpServerSettings />}
+
+        <div className="border-border space-y-3 border-t pt-6">
+          <h3 className="text-sm font-medium">{t("wikiCompose.credentials.title")}</h3>
+          <ComposeByokCredentialsSection />
+        </div>
       </CardContent>
 
       <CardFooter className="flex justify-between">

--- a/src/components/settings/ComposeByokCredentialsSection.tsx
+++ b/src/components/settings/ComposeByokCredentialsSection.tsx
@@ -1,0 +1,188 @@
+/**
+ * Settings section to register server-side BYOK API keys (#951).
+ * 設定画面: Wiki Compose BYOK 用 API キー登録。
+ */
+import React, { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
+import { Button, Input, Label, Alert, AlertDescription } from "@zedi/ui";
+import {
+  deleteUserAiCredential,
+  fetchUserAiCredentialsStatus,
+  upsertUserAiCredential,
+  type UserAiCredentialProvider,
+} from "@/lib/userAiCredentials";
+
+const PROVIDERS: readonly { id: UserAiCredentialProvider; labelKey: string }[] = [
+  { id: "anthropic", labelKey: "wikiCompose.credentials.anthropic" },
+  { id: "openai", labelKey: "wikiCompose.credentials.openai" },
+  { id: "google", labelKey: "wikiCompose.credentials.google" },
+];
+
+/**
+ * Per-provider API key inputs backed by `/api/user/ai-credentials`.
+ */
+export const ComposeByokCredentialsSection: React.FC = () => {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(true);
+  const [storageEnabled, setStorageEnabled] = useState(false);
+  const [configured, setConfigured] = useState<Record<UserAiCredentialProvider, boolean>>({
+    anthropic: false,
+    openai: false,
+    google: false,
+  });
+  const [draftKeys, setDraftKeys] = useState<Record<UserAiCredentialProvider, string>>({
+    anthropic: "",
+    openai: "",
+    google: "",
+  });
+  const [showKey, setShowKey] = useState<Record<UserAiCredentialProvider, boolean>>({
+    anthropic: false,
+    openai: false,
+    google: false,
+  });
+  const [saving, setSaving] = useState<UserAiCredentialProvider | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const status = await fetchUserAiCredentialsStatus();
+      setStorageEnabled(status.storageEnabled);
+      const next: Record<UserAiCredentialProvider, boolean> = {
+        anthropic: false,
+        openai: false,
+        google: false,
+      };
+      for (const p of status.providers) {
+        next[p.provider] = p.configured;
+      }
+      setConfigured(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const handleSave = async (provider: UserAiCredentialProvider) => {
+    setSaving(provider);
+    setError(null);
+    try {
+      await upsertUserAiCredential(provider, draftKeys[provider]);
+      setDraftKeys((prev) => ({ ...prev, [provider]: "" }));
+      await reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const handleRemove = async (provider: UserAiCredentialProvider) => {
+    setSaving(provider);
+    setError(null);
+    try {
+      await deleteUserAiCredential(provider);
+      await reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-6">
+        <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+      </div>
+    );
+  }
+
+  if (!storageEnabled) {
+    return (
+      <Alert>
+        <AlertDescription>{t("wikiCompose.credentials.storageDisabled")}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="space-y-6" data-testid="compose-byok-credentials">
+      <p className="text-muted-foreground text-sm">{t("wikiCompose.credentials.description")}</p>
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      {PROVIDERS.map(({ id, labelKey }) => (
+        <div key={id} className="space-y-2 rounded-lg border p-4">
+          <div className="flex items-center justify-between gap-2">
+            <Label htmlFor={`byok-${id}`}>{t(labelKey)}</Label>
+            {configured[id] && (
+              <span className="text-muted-foreground text-xs">
+                {t("wikiCompose.credentials.configured")}
+              </span>
+            )}
+          </div>
+          <div className="relative">
+            <Input
+              id={`byok-${id}`}
+              type={showKey[id] ? "text" : "password"}
+              value={draftKeys[id]}
+              onChange={(e) => setDraftKeys((prev) => ({ ...prev, [id]: e.target.value }))}
+              placeholder={t("wikiCompose.credentials.placeholder")}
+              disabled={saving === id}
+              className="pr-10"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="absolute top-0 right-0 h-full px-3 hover:bg-transparent"
+              onClick={() => setShowKey((prev) => ({ ...prev, [id]: !prev[id] }))}
+              disabled={saving === id}
+              aria-label={showKey[id] ? t("aiSettings.hideApiKey") : t("aiSettings.showApiKey")}
+            >
+              {showKey[id] ? (
+                <EyeOff className="text-muted-foreground h-4 w-4" />
+              ) : (
+                <Eye className="text-muted-foreground h-4 w-4" />
+              )}
+            </Button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => void handleSave(id)}
+              disabled={saving === id || !draftKeys[id].trim()}
+            >
+              {saving === id ? <Loader2 className="h-4 w-4 animate-spin" /> : t("common.save")}
+            </Button>
+            {configured[id] && (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => void handleRemove(id)}
+                disabled={saving === id}
+              >
+                {t("wikiCompose.credentials.remove")}
+              </Button>
+            )}
+          </div>
+        </div>
+      ))}
+      <p className="text-muted-foreground text-xs">
+        {t("wikiCompose.credentials.localStorageNote")}
+      </p>
+    </div>
+  );
+};

--- a/src/components/settings/ComposeByokCredentialsSection.tsx
+++ b/src/components/settings/ComposeByokCredentialsSection.tsx
@@ -74,7 +74,7 @@ export const ComposeByokCredentialsSection: React.FC = () => {
     setSaving(provider);
     setError(null);
     try {
-      await upsertUserAiCredential(provider, draftKeys[provider]);
+      await upsertUserAiCredential(provider, draftKeys[provider].trim());
       setDraftKeys((prev) => ({ ...prev, [provider]: "" }));
       await reload();
     } catch (err) {

--- a/src/components/wikiCompose/ComposeBackendSelector.tsx
+++ b/src/components/wikiCompose/ComposeBackendSelector.tsx
@@ -1,0 +1,120 @@
+/**
+ * Execution backend picker for Wiki Compose (#951).
+ * Wiki Compose 用の実行 backend 選択 UI。
+ */
+import React, { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Label, RadioGroup, RadioGroupItem } from "@zedi/ui";
+import {
+  COMPOSE_BACKEND_META,
+  type ComposeExecutionBackend,
+  usesZediCu,
+} from "@/lib/wikiCompose/backends";
+import {
+  fetchUserAiCredentialsStatus,
+  type UserAiCredentialProvider,
+} from "@/lib/userAiCredentials";
+
+export interface ComposeBackendSelectorProps {
+  value: ComposeExecutionBackend;
+  onChange: (backend: ComposeExecutionBackend) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Renders backend options; grays out BYOK choices without a stored credential.
+ */
+export const ComposeBackendSelector: React.FC<ComposeBackendSelectorProps> = ({
+  value,
+  onChange,
+  disabled = false,
+}) => {
+  const { t } = useTranslation();
+  const [configuredProviders, setConfiguredProviders] = useState<Set<UserAiCredentialProvider>>(
+    new Set(),
+  );
+  const [storageEnabled, setStorageEnabled] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchUserAiCredentialsStatus()
+      .then((status) => {
+        if (cancelled) return;
+        setStorageEnabled(status.storageEnabled);
+        const set = new Set<UserAiCredentialProvider>();
+        for (const p of status.providers) {
+          if (p.configured) set.add(p.provider);
+        }
+        setConfiguredProviders(set);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setStorageEnabled(false);
+          setConfiguredProviders(new Set());
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const availability = useMemo(() => {
+    const map = new Map<ComposeExecutionBackend, boolean>();
+    for (const meta of COMPOSE_BACKEND_META) {
+      if (meta.provider === null) {
+        map.set(meta.id, true);
+      } else {
+        map.set(meta.id, storageEnabled && configuredProviders.has(meta.provider));
+      }
+    }
+    return map;
+  }, [configuredProviders, storageEnabled]);
+
+  return (
+    <div className="space-y-2" data-testid="compose-backend-selector">
+      <Label>{t("wikiCompose.backend.label")}</Label>
+      <RadioGroup
+        value={value}
+        onValueChange={(v) => onChange(v as ComposeExecutionBackend)}
+        className="flex flex-col gap-2"
+        disabled={disabled}
+      >
+        {COMPOSE_BACKEND_META.map((meta) => {
+          const available = availability.get(meta.id) ?? false;
+          const itemDisabled = disabled || !available;
+          return (
+            <div
+              key={meta.id}
+              className={`flex items-start gap-2 rounded-md border p-3 ${
+                itemDisabled ? "opacity-50" : ""
+              }`}
+            >
+              <RadioGroupItem
+                value={meta.id}
+                id={`compose-backend-${meta.id}`}
+                disabled={itemDisabled}
+              />
+              <label
+                htmlFor={`compose-backend-${meta.id}`}
+                className={`flex flex-1 cursor-pointer flex-col gap-0.5 ${itemDisabled ? "cursor-not-allowed" : ""}`}
+              >
+                <span className="text-sm font-medium">{t(meta.labelKey)}</span>
+                <span className="text-muted-foreground text-xs">{t(meta.descriptionKey)}</span>
+                {usesZediCu(meta.id) && (
+                  <span className="text-muted-foreground text-xs">
+                    {t("wikiCompose.backend.usesCu")}
+                  </span>
+                )}
+                {!available && meta.provider !== null && (
+                  <span className="text-destructive text-xs">
+                    {t("wikiCompose.backend.credentialRequired")}
+                  </span>
+                )}
+              </label>
+            </div>
+          );
+        })}
+      </RadioGroup>
+    </div>
+  );
+};

--- a/src/hooks/useWikiComposeSession.ts
+++ b/src/hooks/useWikiComposeSession.ts
@@ -119,6 +119,11 @@ export interface UseWikiComposeSessionArgs {
   composeSeed?: ComposeNavigationSeed;
   /** Auto-start the first `run` when the session is created. Default `true`. */
   autoStart?: boolean;
+  /**
+   * 実行 backend（セッション作成時に固定）。省略時は `zedi_managed`。
+   * Execution backend fixed at session create; defaults to `zedi_managed`.
+   */
+  backend?: string;
 }
 
 /** Hook return shape. */
@@ -475,7 +480,14 @@ function reduceInterrupt(
 export function useWikiComposeSession(
   args: UseWikiComposeSessionArgs,
 ): UseWikiComposeSessionReturn {
-  const { pageId, sessionId: initialSessionId, initialInput, composeSeed, autoStart = true } = args;
+  const {
+    pageId,
+    sessionId: initialSessionId,
+    initialInput,
+    composeSeed,
+    autoStart = true,
+    backend = "zedi_managed",
+  } = args;
   const [state, setState] = useState<WikiComposeSessionState>(INITIAL_STATE);
   const sessionRef = useRef<ComposeSession | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -529,6 +541,7 @@ export function useWikiComposeSession(
         loaded?.session ??
         (await createSession({
           pageId,
+          backend,
           metadata: composeSeed
             ? {
                 composeSeed: {
@@ -566,7 +579,7 @@ export function useWikiComposeSession(
       const message = err instanceof Error ? err.message : String(err);
       update({ error: message });
     }
-  }, [pageId, initialSessionId, initialInput, composeSeed, streamRun, update]);
+  }, [pageId, initialSessionId, initialInput, composeSeed, backend, streamRun, update]);
 
   const submitBrief = useCallback<UseWikiComposeSessionReturn["submitBrief"]>(
     async (input) => {

--- a/src/hooks/useWikiComposeSession.ts
+++ b/src/hooks/useWikiComposeSession.ts
@@ -19,6 +19,7 @@ import {
   resumeSession,
   runSession,
 } from "@/lib/wikiCompose/composeService";
+import type { ComposeExecutionBackend } from "@/lib/wikiCompose/backends";
 import type { ComposeNavigationSeed } from "@/lib/wikiCompose/navigation";
 import type {
   BriefAnswer,
@@ -123,7 +124,7 @@ export interface UseWikiComposeSessionArgs {
    * 実行 backend（セッション作成時に固定）。省略時は `zedi_managed`。
    * Execution backend fixed at session create; defaults to `zedi_managed`.
    */
-  backend?: string;
+  backend?: ComposeExecutionBackend;
 }
 
 /** Hook return shape. */

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -26,6 +26,7 @@ import jaShortcuts from "./locales/ja/shortcuts.json";
 import jaSeedData from "./locales/ja/seedData.json";
 import jaMermaid from "./locales/ja/mermaid.json";
 import jaAiPrompt from "./locales/ja/aiPrompt.json";
+import jaWikiCompose from "./locales/ja/wikiCompose.json";
 import enCommon from "./locales/en/common.json";
 import enSettings from "./locales/en/settings.json";
 import enGeneralSettings from "./locales/en/generalSettings.json";
@@ -48,6 +49,7 @@ import enShortcuts from "./locales/en/shortcuts.json";
 import enSeedData from "./locales/en/seedData.json";
 import enMermaid from "./locales/en/mermaid.json";
 import enAiPrompt from "./locales/en/aiPrompt.json";
+import enWikiCompose from "./locales/en/wikiCompose.json";
 
 const ja = {
   common: jaCommon,
@@ -72,6 +74,7 @@ const ja = {
   seedData: jaSeedData,
   mermaid: jaMermaid,
   aiPrompt: jaAiPrompt,
+  wikiCompose: jaWikiCompose,
 };
 
 const en = {
@@ -97,6 +100,7 @@ const en = {
   seedData: enSeedData,
   mermaid: enMermaid,
   aiPrompt: enAiPrompt,
+  wikiCompose: enWikiCompose,
 };
 
 // localStorage の設定から初期言語を取得

--- a/src/i18n/locales/en/wikiCompose.json
+++ b/src/i18n/locales/en/wikiCompose.json
@@ -1,0 +1,27 @@
+{
+  "backend": {
+    "label": "Execution backend",
+    "zediManaged": "Zedi managed",
+    "zediManagedDesc": "Uses Zedi API keys; consumes monthly CU.",
+    "userAnthropic": "Your Anthropic key",
+    "userAnthropicDesc": "Runs with your Anthropic API key stored on the server (encrypted).",
+    "userOpenai": "Your OpenAI key",
+    "userOpenaiDesc": "Runs with your OpenAI API key stored on the server (encrypted).",
+    "userGoogle": "Your Google key",
+    "userGoogleDesc": "Runs with your Google API key stored on the server (encrypted).",
+    "usesCu": "Uses Zedi monthly CU.",
+    "credentialRequired": "Register this provider's API key in Settings → AI first."
+  },
+  "credentials": {
+    "title": "Wiki Compose API keys (BYOK)",
+    "description": "Store provider API keys on the server for Wiki Compose. Keys are encrypted at rest and never returned in API responses.",
+    "anthropic": "Anthropic",
+    "openai": "OpenAI",
+    "google": "Google",
+    "placeholder": "Paste API key",
+    "configured": "Configured",
+    "remove": "Remove",
+    "storageDisabled": "Server-side credential storage is not enabled on this environment.",
+    "localStorageNote": "General AI chat may still use browser-local keys; Wiki Compose BYOK uses the credentials above when you pick a user_* backend."
+  }
+}

--- a/src/i18n/locales/ja/wikiCompose.json
+++ b/src/i18n/locales/ja/wikiCompose.json
@@ -1,0 +1,27 @@
+{
+  "backend": {
+    "label": "実行バックエンド",
+    "zediManaged": "Zedi 管理",
+    "zediManagedDesc": "Zedi の API キーで実行。月次 CU を消費します。",
+    "userAnthropic": "自分の Anthropic キー",
+    "userAnthropicDesc": "サーバーに保存した Anthropic API キーで実行（暗号化保管）。",
+    "userOpenai": "自分の OpenAI キー",
+    "userOpenaiDesc": "サーバーに保存した OpenAI API キーで実行（暗号化保管）。",
+    "userGoogle": "自分の Google キー",
+    "userGoogleDesc": "サーバーに保存した Google API キーで実行（暗号化保管）。",
+    "usesCu": "Zedi の月次 CU を使用します。",
+    "credentialRequired": "先に 設定 → AI でこのプロバイダの API キーを登録してください。"
+  },
+  "credentials": {
+    "title": "Wiki Compose 用 API キー（BYOK）",
+    "description": "Wiki Compose で使うプロバイダ API キーをサーバーに保存します。キーは暗号化され、API レスポンスでは返しません。",
+    "anthropic": "Anthropic",
+    "openai": "OpenAI",
+    "google": "Google",
+    "placeholder": "API キーを貼り付け",
+    "configured": "登録済み",
+    "remove": "削除",
+    "storageDisabled": "この環境ではサーバー側の credential 保管が有効になっていません。",
+    "localStorageNote": "通常の AI チャットはブラウザ localStorage のキーを使う場合があります。Wiki Compose で user_* バックエンドを選んだときは、上記の登録キーを使います。"
+  }
+}

--- a/src/lib/userAiCredentials.ts
+++ b/src/lib/userAiCredentials.ts
@@ -1,0 +1,58 @@
+/**
+ * Client for `/api/user/ai-credentials` (#951).
+ */
+
+export type UserAiCredentialProvider = "anthropic" | "openai" | "google";
+
+export interface UserAiCredentialAvailability {
+  provider: UserAiCredentialProvider;
+  configured: boolean;
+}
+
+export interface UserAiCredentialsStatus {
+  storageEnabled: boolean;
+  providers: UserAiCredentialAvailability[];
+}
+
+const getApiBaseUrl = () => (import.meta.env.VITE_API_BASE_URL as string) ?? "";
+
+const REST_OPTS: RequestInit = { credentials: "include" };
+
+async function jsonOrThrow<T>(res: Response, hint: string): Promise<T> {
+  if (res.ok) return (await res.json()) as T;
+  const body = await res.json().catch(() => null);
+  const message =
+    (body && typeof body === "object" && "message" in body && typeof body.message === "string"
+      ? body.message
+      : null) ?? `${hint} failed: ${res.status}`;
+  throw new Error(message);
+}
+
+/** Fetch which BYOK providers have server-stored credentials. */
+export async function fetchUserAiCredentialsStatus(): Promise<UserAiCredentialsStatus> {
+  const res = await fetch(`${getApiBaseUrl()}/api/user/ai-credentials`, REST_OPTS);
+  return jsonOrThrow<UserAiCredentialsStatus>(res, "fetchUserAiCredentialsStatus");
+}
+
+/** Store an encrypted credential for a provider. */
+export async function upsertUserAiCredential(
+  provider: UserAiCredentialProvider,
+  apiKey: string,
+): Promise<void> {
+  const res = await fetch(`${getApiBaseUrl()}/api/user/ai-credentials/${provider}`, {
+    ...REST_OPTS,
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ apiKey }),
+  });
+  await jsonOrThrow(res, "upsertUserAiCredential");
+}
+
+/** Remove a stored credential. */
+export async function deleteUserAiCredential(provider: UserAiCredentialProvider): Promise<void> {
+  const res = await fetch(`${getApiBaseUrl()}/api/user/ai-credentials/${provider}`, {
+    ...REST_OPTS,
+    method: "DELETE",
+  });
+  await jsonOrThrow(res, "deleteUserAiCredential");
+}

--- a/src/lib/wikiCompose/backends.ts
+++ b/src/lib/wikiCompose/backends.ts
@@ -1,0 +1,64 @@
+/**
+ * Wiki Compose execution backends (#951) — mirrors server `ExecutionBackend`.
+ */
+
+/** Zedi-managed or BYOK provider-specific backends. */
+export type ComposeExecutionBackend =
+  | "zedi_managed"
+  | "user_anthropic"
+  | "user_openai"
+  | "user_google";
+
+export const COMPOSE_BACKEND_OPTIONS: readonly ComposeExecutionBackend[] = [
+  "zedi_managed",
+  "user_anthropic",
+  "user_openai",
+  "user_google",
+] as const;
+
+export type ComposeBackendProvider = "anthropic" | "openai" | "google";
+
+/** UI metadata for each backend option. */
+export interface ComposeBackendOptionMeta {
+  id: ComposeExecutionBackend;
+  provider: ComposeBackendProvider | null;
+  labelKey: string;
+  descriptionKey: string;
+}
+
+export const COMPOSE_BACKEND_META: readonly ComposeBackendOptionMeta[] = [
+  {
+    id: "zedi_managed",
+    provider: null,
+    labelKey: "wikiCompose.backend.zediManaged",
+    descriptionKey: "wikiCompose.backend.zediManagedDesc",
+  },
+  {
+    id: "user_anthropic",
+    provider: "anthropic",
+    labelKey: "wikiCompose.backend.userAnthropic",
+    descriptionKey: "wikiCompose.backend.userAnthropicDesc",
+  },
+  {
+    id: "user_openai",
+    provider: "openai",
+    labelKey: "wikiCompose.backend.userOpenai",
+    descriptionKey: "wikiCompose.backend.userOpenaiDesc",
+  },
+  {
+    id: "user_google",
+    provider: "google",
+    labelKey: "wikiCompose.backend.userGoogle",
+    descriptionKey: "wikiCompose.backend.userGoogleDesc",
+  },
+];
+
+export function isUserByokComposeBackend(
+  backend: ComposeExecutionBackend,
+): backend is Exclude<ComposeExecutionBackend, "zedi_managed"> {
+  return backend !== "zedi_managed";
+}
+
+export function usesZediCu(backend: ComposeExecutionBackend): boolean {
+  return backend === "zedi_managed";
+}

--- a/src/pages/WikiComposePage.tsx
+++ b/src/pages/WikiComposePage.tsx
@@ -28,6 +28,8 @@ import { COMPOSE_SEED_STATE_KEY, type ComposeNavigationSeed } from "@/lib/wikiCo
 import type { DraftedSection } from "@/lib/wikiCompose/types";
 import { EditorPane } from "@/components/wikiCompose/EditorPane";
 import { ComposePanel } from "@/components/wikiCompose/ComposePanel";
+import { ComposeBackendSelector } from "@/components/wikiCompose/ComposeBackendSelector";
+import type { ComposeExecutionBackend } from "@/lib/wikiCompose/backends";
 
 /** Map drafted section list to a quick lookup. */
 function indexById(items: DraftedSection[]): Record<string, DraftedSection> {
@@ -46,6 +48,7 @@ const WikiComposePage: React.FC = () => {
   const noteId = params.noteId ?? "";
   const pageId = params.pageId ?? "";
   const sessionId = params.sessionId ?? null;
+  const [composeBackend, setComposeBackend] = useState<ComposeExecutionBackend>("zedi_managed");
 
   // チャット seed は mount 時に 1 回だけ保持。`location.state` を消しても hook 側に残す。
   // Capture chat seed once on mount; survives clearing `location.state` for the hook.
@@ -78,7 +81,10 @@ const WikiComposePage: React.FC = () => {
     autoStart: Boolean(pageId),
     composeSeed,
     initialInput,
+    backend: composeBackend,
   });
+
+  const showBackendSelector = !sessionId && session.status === "idle" && !session.isStreaming;
 
   // Clear history seed only after the session row left `pending` (first run claimed).
   // `pending` のまま state を消すと失敗時リロードで chatSeed が届かなくなる (#950)。
@@ -222,6 +228,11 @@ const WikiComposePage: React.FC = () => {
       {header}
       {session.error ? (
         <div className="bg-destructive/10 text-destructive px-4 py-2 text-xs">{session.error}</div>
+      ) : null}
+      {showBackendSelector ? (
+        <div className="border-border border-b px-4 py-3">
+          <ComposeBackendSelector value={composeBackend} onChange={setComposeBackend} />
+        </div>
       ) : null}
       <div className="min-h-0 flex-1">
         <ResizablePanelGroup direction={isMobile ? "vertical" : "horizontal"} className="h-full">

--- a/src/pages/WikiComposePage.tsx
+++ b/src/pages/WikiComposePage.tsx
@@ -78,13 +78,16 @@ const WikiComposePage: React.FC = () => {
   const session = useWikiComposeSession({
     pageId,
     sessionId,
-    autoStart: Boolean(pageId),
+    // Fresh compose: user picks backend then clicks Start (#951).
+    autoStart: Boolean(sessionId && pageId),
     composeSeed,
     initialInput,
     backend: composeBackend,
   });
 
-  const showBackendSelector = !sessionId && session.status === "idle" && !session.isStreaming;
+  const awaitingComposeStart =
+    !sessionId && session.status === "idle" && !session.session && !session.isStreaming;
+  const showBackendSelector = awaitingComposeStart;
 
   // Clear history seed only after the session row left `pending` (first run claimed).
   // `pending` のまま state を消すと失敗時リロードで chatSeed が届かなくなる (#950)。
@@ -230,8 +233,21 @@ const WikiComposePage: React.FC = () => {
         <div className="bg-destructive/10 text-destructive px-4 py-2 text-xs">{session.error}</div>
       ) : null}
       {showBackendSelector ? (
-        <div className="border-border border-b px-4 py-3">
-          <ComposeBackendSelector value={composeBackend} onChange={setComposeBackend} />
+        <div className="border-border space-y-3 border-b px-4 py-3">
+          <ComposeBackendSelector
+            value={composeBackend}
+            onChange={setComposeBackend}
+            disabled={session.isStreaming}
+          />
+          <Button
+            type="button"
+            size="sm"
+            data-testid="compose-start"
+            onClick={() => void session.start()}
+            disabled={session.isStreaming}
+          >
+            Start compose
+          </Button>
         </div>
       ) : null}
       <div className="min-h-0 flex-1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Wiki Compose P3: ユーザー自身の LLM API キー（BYOK）で Compose セッションを実行できるようにする。`user_anthropic` / `user_openai` / `user_google` の 3 backend を追加し、サーバー側で暗号化保管した鍵を `modelFactory` が解決する。

## 変更点

- `user_ai_credentials` テーブル + Drizzle マイグレーション `0032`（AES-256-GCM、鍵は `USER_AI_CREDENTIALS_ENCRYPTION_KEY`）
- `ExecutionBackend` を provider 別 BYOK に拡張し、`createZediChatModel` で DB から鍵解決
- BYOK 時は `recordZediUsage` が `costUnits: 0`（監査ログのみ、`apiMode: user_key`）
- `/api/user/ai-credentials` CRUD（平文キーはレスポンスに含めない）
- Compose 開始前の backend 選択 UI + 設定 → AI の BYOK キー登録セクション
- Vitest: backend 解決・暗号化 round-trip・compose session 作成ガード

## 変更の種類

- [x] 新機能 (New feature)
- [x] テスト (Tests)

## テスト方法

1. `server/api` で `USER_AI_CREDENTIALS_ENCRYPTION_KEY`（32 バイト hex/base64）を設定
2. 設定 → AI で各プロバイダの API キーを保存
3. Wiki Compose 画面で BYOK backend を選択してセッション開始
4. `cd server/api && bun run test` / ルートで `bunx vitest run src/hooks/useWikiComposeSession.test.ts`

## チェックリスト

- [x] テストがすべてパスする（API 1362、フロント compose hook 7）
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した（`.env.example` のみ）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Closes #951
Parent: #947
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57a84050-3469-4adf-9356-8c568e0307e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57a84050-3469-4adf-9356-8c568e0307e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can register/manage encrypted API keys (OpenAI, Anthropic, Google) for Wiki Compose in Settings.
  * New backend selector lets users choose Zedi-managed or their own provider-backed execution when starting a compose session.
  * UI and localization added for credential management and backend options.

* **Tests**
  * Added end-to-end and unit tests covering credential encryption, backend selection/resolution, and compose session flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->