### PR TITLE
feat(api): Wiki Compose P4 — Ingest への research subgraph 共有 (#952)

### DIFF
--- a/server/api/src/__tests__/agents/graphs/ingest/formatResearchForIngest.test.ts
+++ b/server/api/src/__tests__/agents/graphs/ingest/formatResearchForIngest.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { formatResearchForIngest } from "../../../../agents/graphs/ingest/nodes/formatResearchForIngest.js";
+import type { IngestPlannerStateType } from "../../../../agents/graphs/ingest/state.js";
+
+function baseState(): IngestPlannerStateType {
+  return {
+    messages: [],
+    phase: "ingest:prepare",
+    pageId: "",
+    userId: "u1",
+    article: { title: "T", url: "https://a/", excerpt: "body" },
+    candidates: [],
+    userSchema: null,
+    ingestPlan: null,
+    iteration: 1,
+    maxIterations: 3,
+    queries: [],
+    pendingSources: [],
+    lastEvaluation: null,
+    exitReason: null,
+    batches: [
+      {
+        id: "b1",
+        iteration: 1,
+        queries: [],
+        sources: [],
+        evaluation: { score: 0.9, rationale: "ok", missingAspects: [] },
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+    approvedResearch: [
+      {
+        id: "src:1",
+        kind: "fetched",
+        title: "Research hit",
+        url: "https://hit/",
+        excerpt: "Details from web",
+      },
+    ],
+    rejectedResearch: [],
+    additionalRequest: null,
+  };
+}
+
+describe("formatResearchForIngest", () => {
+  it("includes approved sources and evaluation in the prompt block", () => {
+    const block = formatResearchForIngest(baseState());
+    expect(block).toContain("APPROVED RESEARCH SOURCES");
+    expect(block).toContain("src:1");
+    expect(block).toContain("Research hit");
+    expect(block).toContain("RESEARCH EVALUATION");
+    expect(block).toContain("score: 0.9");
+  });
+
+  it("returns empty string when no research output exists", () => {
+    const state = baseState();
+    state.approvedResearch = [];
+    state.batches = [];
+    expect(formatResearchForIngest(state)).toBe("");
+  });
+});

--- a/server/api/src/__tests__/agents/graphs/ingest/ingestPlannerGraph.test.ts
+++ b/server/api/src/__tests__/agents/graphs/ingest/ingestPlannerGraph.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Ingest planner graph (#952) — research subgraph wiring + routing tests.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  prepareIngest,
+  planIngest,
+  planQueries,
+  webSearch,
+  wikiSearch,
+  fetchArticles,
+  evaluateSufficiency,
+  refineQueries,
+  compileBatch,
+} = vi.hoisted(() => ({
+  prepareIngest: vi.fn(),
+  planIngest: vi.fn(),
+  planQueries: vi.fn(),
+  webSearch: vi.fn(),
+  wikiSearch: vi.fn(),
+  fetchArticles: vi.fn(),
+  evaluateSufficiency: vi.fn(),
+  refineQueries: vi.fn(),
+  compileBatch: vi.fn(),
+}));
+
+vi.mock("../../../../agents/graphs/ingest/nodes/index.js", async () => {
+  const real = await vi.importActual<
+    typeof import("../../../../agents/graphs/ingest/nodes/index.js")
+  >("../../../../agents/graphs/ingest/nodes/index.js");
+  return { ...real, prepareIngest, planIngest };
+});
+
+vi.mock("../../../../agents/subgraphs/research/nodes/index.js", async () => {
+  const real = await vi.importActual<
+    typeof import("../../../../agents/subgraphs/research/nodes/index.js")
+  >("../../../../agents/subgraphs/research/nodes/index.js");
+  return {
+    ...real,
+    planQueries,
+    webSearch,
+    wikiSearch,
+    fetchArticles,
+    evaluateSufficiency,
+    refineQueries,
+    compileBatch,
+  };
+});
+
+import { GraphRunner } from "../../../../agents/runner/graphRunner.js";
+import { __resetRegistryForTests } from "../../../../agents/registry/graphRegistry.js";
+import {
+  INGEST_PLANNER_GRAPH_ID,
+  registerIngestPlannerGraph,
+} from "../../../../agents/graphs/ingest/index.js";
+import type { GraphContext } from "../../../../agents/core/types/graphContext.js";
+import type { Database } from "../../../../types/index.js";
+import { MemorySaver } from "@langchain/langgraph";
+
+function fakeContext(threadId: string): GraphContext {
+  return {
+    threadId,
+    sessionId: threadId,
+    userId: "user-1",
+    pageId: "",
+    graphId: INGEST_PLANNER_GRAPH_ID,
+    backend: "zedi_managed",
+    tier: "free",
+    db: {} as Database,
+    feature: "ingest_graph:test",
+    userEmail: null,
+  };
+}
+
+const articleInput = {
+  title: "Test Article",
+  url: "https://example.com/a",
+  excerpt: "Body text about testing.",
+};
+
+const candidatesInput = [{ id: "page-1", title: "Existing", excerpt: "Old content" }];
+
+function defaultMocks() {
+  prepareIngest.mockImplementation(async () => ({
+    article: articleInput,
+    candidates: candidatesInput,
+    phase: "ingest:prepare",
+  }));
+
+  planQueries.mockImplementation(async () => ({
+    queries: [{ id: "q1", query: "topic", channels: ["web"] }],
+    maxIterations: 3,
+    iteration: 0,
+    phase: "research:plan",
+  }));
+  webSearch.mockImplementation(async () => ({
+    pendingSources: [{ id: "src:1", kind: "web", title: "Hit", url: "https://hit/" }],
+  }));
+  wikiSearch.mockImplementation(async () => ({ pendingSources: [] }));
+  fetchArticles.mockImplementation(async () => ({ pendingSources: [] }));
+  evaluateSufficiency.mockImplementation(async (state: { iteration: number }) => ({
+    lastEvaluation: { score: 0.9, rationale: "ok", missingAspects: [] },
+    iteration: state.iteration + 1,
+    phase: "research:evaluated",
+  }));
+  compileBatch.mockImplementation(
+    async (state: {
+      iteration: number;
+      queries: unknown[];
+      pendingSources: unknown[];
+      lastEvaluation: unknown;
+    }) => ({
+      batches: [
+        {
+          id: "batch-1",
+          iteration: state.iteration,
+          queries: state.queries,
+          sources: state.pendingSources,
+          evaluation: state.lastEvaluation,
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      exitReason: "score_threshold",
+      phase: "research:compile",
+    }),
+  );
+
+  planIngest.mockImplementation(async () => ({
+    ingestPlan: {
+      action: "merge",
+      reason: "Same topic",
+      targetPageId: "page-1",
+    },
+    phase: "ingest:planned",
+  }));
+}
+
+describe("ingestPlannerGraph — research subgraph connection", () => {
+  beforeEach(() => {
+    __resetRegistryForTests();
+    registerIngestPlannerGraph();
+    prepareIngest.mockReset();
+    planIngest.mockReset();
+    planQueries.mockReset();
+    webSearch.mockReset();
+    wikiSearch.mockReset();
+    fetchArticles.mockReset();
+    evaluateSufficiency.mockReset();
+    refineQueries.mockReset();
+    compileBatch.mockReset();
+    defaultMocks();
+  });
+
+  afterEach(() => {
+    __resetRegistryForTests();
+  });
+
+  it("runs prepare_ingest then research nodes before halting at human_review_research", async () => {
+    const runner = new GraphRunner();
+    const result = await runner.invoke(
+      {
+        graphId: INGEST_PLANNER_GRAPH_ID,
+        context: fakeContext("thread-ingest-1"),
+        checkpointer: new MemorySaver(),
+        recursionLimit: 60,
+      },
+      {
+        kind: "input",
+        value: { article: articleInput, candidates: candidatesInput },
+      },
+    );
+
+    expect(result.status).toBe("interrupted");
+    expect(prepareIngest).toHaveBeenCalledTimes(1);
+    expect(planQueries).toHaveBeenCalledTimes(1);
+    expect(compileBatch).toHaveBeenCalledTimes(1);
+    expect(planIngest).not.toHaveBeenCalled();
+  });
+
+  it("reaches plan_ingest after research HITL resume", async () => {
+    const checkpointer = new MemorySaver();
+    const runner = new GraphRunner();
+    const ctx = fakeContext("thread-ingest-2");
+
+    await runner.invoke(
+      {
+        graphId: INGEST_PLANNER_GRAPH_ID,
+        context: ctx,
+        checkpointer,
+        recursionLimit: 60,
+      },
+      { kind: "input", value: { article: articleInput, candidates: candidatesInput } },
+    );
+
+    const resumed = await runner.resume(
+      {
+        graphId: INGEST_PLANNER_GRAPH_ID,
+        context: ctx,
+        checkpointer,
+        recursionLimit: 60,
+      },
+      { approvedSourceIds: ["src:1"] },
+    );
+
+    expect(resumed.status).toBe("completed");
+    expect(planIngest).toHaveBeenCalledTimes(1);
+    const output = resumed.output as { ingestPlan?: { action?: string } };
+    expect(output.ingestPlan?.action).toBe("merge");
+  });
+});

--- a/server/api/src/__tests__/agents/graphs/ingest/ingestPlannerGraph.test.ts
+++ b/server/api/src/__tests__/agents/graphs/ingest/ingestPlannerGraph.test.ts
@@ -1,5 +1,6 @@
 /**
  * Ingest planner graph (#952) — research subgraph wiring + routing tests.
+ * ingest プランナーグラフ — 調査 subgraph 配線とルーティングのテスト。
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/server/api/src/__tests__/services/ingestPlanner.test.ts
+++ b/server/api/src/__tests__/services/ingestPlanner.test.ts
@@ -9,6 +9,7 @@ import {
   extractJsonFromResponse,
   IngestPlanParseError,
   parseIngestPlanResponse,
+  parseIngestPlanValue,
   planIngest,
   type CallProviderAdapter,
   type CandidatePage,
@@ -54,6 +55,16 @@ describe("extractJsonFromResponse", () => {
   it("falls back to first { .. last } when there is surrounding prose", () => {
     const raw = `Here is the plan:\n{"a":1, "b":2}\nThanks!`;
     expect(extractJsonFromResponse(raw)).toBe(`{"a":1, "b":2}`);
+  });
+});
+
+describe("parseIngestPlanValue", () => {
+  it("validates structured objects without JSON round-trip", () => {
+    const plan = parseIngestPlanValue({
+      action: "skip",
+      reason: "no value",
+    });
+    expect(plan.action).toBe("skip");
   });
 });
 

--- a/server/api/src/agents/core/composeModelConfig.ts
+++ b/server/api/src/agents/core/composeModelConfig.ts
@@ -5,6 +5,7 @@
 import { WIKI_COMPOSE_GRAPH_ID } from "../graphs/wikiCompose/index.js";
 import { getOrchestratorModelId } from "../subgraphs/research/nodes/planQueries.js";
 import { RESEARCH_GRAPH_ID } from "../subgraphs/research/index.js";
+import { INGEST_PLANNER_GRAPH_ID } from "../graphs/ingest/index.js";
 
 const DRAFT_MODEL_ENV = "WIKI_COMPOSE_DRAFT_MODEL_ID";
 const DRAFT_MODEL_FALLBACK = "claude-3-5-sonnet";
@@ -23,7 +24,7 @@ export function getComposeModelIdsForGraph(graphId: string): string[] {
     const draft = getDraftModelId();
     return orchestrator === draft ? [orchestrator] : [orchestrator, draft];
   }
-  if (graphId === RESEARCH_GRAPH_ID) {
+  if (graphId === RESEARCH_GRAPH_ID || graphId === INGEST_PLANNER_GRAPH_ID) {
     return [getOrchestratorModelId()];
   }
   return [getOrchestratorModelId()];

--- a/server/api/src/agents/graphs/ingest/index.ts
+++ b/server/api/src/agents/graphs/ingest/index.ts
@@ -1,0 +1,17 @@
+export {
+  INGEST_PLANNER_GRAPH_ID,
+  INGEST_PLANNER_GRAPH_VERSION,
+  registerIngestPlannerGraph,
+} from "./ingestPlannerGraph.js";
+export {
+  IngestPlannerState,
+  type IngestPlannerStateType,
+  type IngestPlannerStateUpdate,
+} from "./state.js";
+export type {
+  IngestAction,
+  IngestPlan,
+  IngestConflict,
+  CandidatePage,
+  IngestArticleSummary,
+} from "./types.js";

--- a/server/api/src/agents/graphs/ingest/ingestPlannerGraph.ts
+++ b/server/api/src/agents/graphs/ingest/ingestPlannerGraph.ts
@@ -24,9 +24,9 @@ import {
 import { IngestPlannerState } from "./state.js";
 import { prepareIngest, planIngest } from "./nodes/index.js";
 
-/** Registered graph id. */
+/** Registered graph id. / 登録グラフ ID。 */
 export const INGEST_PLANNER_GRAPH_ID = "ingest-planner" as const;
-/** Registered graph version. */
+/** Registered graph version. / 登録グラフのバージョン。 */
 export const INGEST_PLANNER_GRAPH_VERSION = "1.0.0";
 
 const factory: GraphFactory = ({ checkpointer }) => {
@@ -64,6 +64,7 @@ const factory: GraphFactory = ({ checkpointer }) => {
 
 /**
  * Register the ingest planner graph. Idempotent; call from `app.ts` bootstrap.
+ * ingest プランナーグラフを登録する。`app.ts` 起動時に呼ぶ（冪等）。
  */
 export function registerIngestPlannerGraph(): void {
   registerGraph({

--- a/server/api/src/agents/graphs/ingest/ingestPlannerGraph.ts
+++ b/server/api/src/agents/graphs/ingest/ingestPlannerGraph.ts
@@ -1,0 +1,79 @@
+/**
+ * Wiki Compose P4 — `ingestPlannerGraph` (issue #952).
+ *
+ * 記事クリップ ingest フロー。`prepare_ingest` の後に P1 調査ループ
+ * （`researchLoopSubgraph` と同じノード / tools / `shouldRefine`）を組み込み、
+ * `human_review_research` のあと `plan_ingest` で merge / create / skip を決定する。
+ *
+ * Ingest planner graph: seeds clip context, runs the shared research loop
+ * (same nodes/tools as Compose), then emits an ingest plan via ZediChatModel.
+ */
+import { END, START, StateGraph } from "@langchain/langgraph";
+import { registerGraph, type GraphFactory } from "../../registry/graphRegistry.js";
+import { shouldRefine } from "../../subgraphs/research/researchGraph.js";
+import {
+  planQueries,
+  webSearch,
+  wikiSearch,
+  fetchArticles,
+  evaluateSufficiency,
+  refineQueries,
+  compileBatch,
+  humanReviewResearch,
+} from "../../subgraphs/research/nodes/index.js";
+import { IngestPlannerState } from "./state.js";
+import { prepareIngest, planIngest } from "./nodes/index.js";
+
+/** Registered graph id. */
+export const INGEST_PLANNER_GRAPH_ID = "ingest-planner" as const;
+/** Registered graph version. */
+export const INGEST_PLANNER_GRAPH_VERSION = "1.0.0";
+
+const factory: GraphFactory = ({ checkpointer }) => {
+  const builder = new StateGraph(IngestPlannerState)
+    .addNode("prepare_ingest", prepareIngest)
+    .addNode("plan_ingest", planIngest)
+    .addEdge(START, "prepare_ingest")
+    // Research loop (same wiring as `researchLoopSubgraph` / `wireResearchLoopSubgraph`).
+    .addNode("plan_queries", planQueries)
+    .addNode("web_search", webSearch)
+    .addNode("wiki_search", wikiSearch)
+    .addNode("fetch_articles", fetchArticles)
+    .addNode("evaluate_sufficiency", evaluateSufficiency)
+    .addNode("refine_queries", refineQueries)
+    .addNode("compile_batch", compileBatch)
+    .addNode("human_review_research", humanReviewResearch)
+    .addEdge("prepare_ingest", "plan_queries")
+    .addEdge("plan_queries", "web_search")
+    .addEdge("plan_queries", "wiki_search")
+    .addEdge("web_search", "fetch_articles")
+    .addEdge("wiki_search", "fetch_articles")
+    .addEdge("fetch_articles", "evaluate_sufficiency")
+    .addConditionalEdges("evaluate_sufficiency", shouldRefine, {
+      refine: "refine_queries",
+      compile: "compile_batch",
+    })
+    .addEdge("refine_queries", "web_search")
+    .addEdge("refine_queries", "wiki_search")
+    .addEdge("compile_batch", "human_review_research")
+    .addEdge("human_review_research", "plan_ingest")
+    .addEdge("plan_ingest", END);
+
+  return checkpointer ? builder.compile({ checkpointer }) : builder.compile();
+};
+
+/**
+ * Register the ingest planner graph. Idempotent; call from `app.ts` bootstrap.
+ */
+export function registerIngestPlannerGraph(): void {
+  registerGraph({
+    id: INGEST_PLANNER_GRAPH_ID,
+    version: INGEST_PLANNER_GRAPH_VERSION,
+    phase: "ingest",
+    description:
+      "Wiki Compose P4: ingest clip planner. Runs the P1 research loop (shared nodes/tools) " +
+      "then plans merge/create/skip via ZediChatModel. Interrupt at human_review_research; " +
+      "resume payload matches wiki-compose-research. Coexists with POST /api/ingest/plan (#595).",
+    factory,
+  });
+}

--- a/server/api/src/agents/graphs/ingest/nodes/formatResearchForIngest.ts
+++ b/server/api/src/agents/graphs/ingest/nodes/formatResearchForIngest.ts
@@ -1,10 +1,12 @@
 /**
  * Formats approved research + latest batch evaluation for the ingest planner prompt.
+ * 採用調査ソースと最新 batch 評価を ingest プランナープロンプト用に整形する。
  */
 import type { IngestPlannerStateType } from "../state.js";
 
 /**
  * Build a markdown block summarizing research loop output for `plan_ingest`.
+ * `plan_ingest` 向けに調査ループ出力を markdown ブロックにまとめる。
  */
 export function formatResearchForIngest(state: IngestPlannerStateType): string {
   const lines: string[] = [];

--- a/server/api/src/agents/graphs/ingest/nodes/formatResearchForIngest.ts
+++ b/server/api/src/agents/graphs/ingest/nodes/formatResearchForIngest.ts
@@ -1,0 +1,36 @@
+/**
+ * Formats approved research + latest batch evaluation for the ingest planner prompt.
+ */
+import type { IngestPlannerStateType } from "../state.js";
+
+/**
+ * Build a markdown block summarizing research loop output for `plan_ingest`.
+ */
+export function formatResearchForIngest(state: IngestPlannerStateType): string {
+  const lines: string[] = [];
+
+  if (state.approvedResearch.length > 0) {
+    lines.push("## APPROVED RESEARCH SOURCES");
+    for (const s of state.approvedResearch) {
+      const loc = s.url ?? s.finalUrl ?? (s.pageId ? `wiki:${s.pageId}` : s.id);
+      lines.push(`- [${s.id}] ${s.title} (${s.kind}) ${loc}`);
+      const preview = s.excerpt ?? s.snippet;
+      if (preview) {
+        lines.push(`  preview: ${preview.slice(0, 400)}`);
+      }
+    }
+  }
+
+  const latest = state.batches[state.batches.length - 1];
+  if (latest?.evaluation) {
+    lines.push("", "## RESEARCH EVALUATION (latest batch)");
+    lines.push(`score: ${latest.evaluation.score}`);
+    lines.push(`rationale: ${latest.evaluation.rationale}`);
+    if (latest.evaluation.missingAspects?.length) {
+      lines.push(`missing: ${latest.evaluation.missingAspects.join("; ")}`);
+    }
+  }
+
+  if (lines.length === 0) return "";
+  return `\n\n${lines.join("\n")}`;
+}

--- a/server/api/src/agents/graphs/ingest/nodes/index.ts
+++ b/server/api/src/agents/graphs/ingest/nodes/index.ts
@@ -1,0 +1,2 @@
+export { prepareIngest } from "./prepareIngest.js";
+export { planIngest } from "./planIngest.js";

--- a/server/api/src/agents/graphs/ingest/nodes/planIngest.ts
+++ b/server/api/src/agents/graphs/ingest/nodes/planIngest.ts
@@ -1,0 +1,74 @@
+/**
+ * `plan_ingest` — structured ingest plan after the shared research loop (#952).
+ *
+ * 調査ループ完了後、クリップ記事と候補ページから merge / create / skip を決める。
+ * LLM 呼び出しは `createZediChatModel` 経由（`ingestPlanner.ts` のプロンプトを再利用）。
+ */
+import type { LangGraphRunnableConfig } from "@langchain/langgraph";
+import { z } from "zod";
+import { createZediChatModel } from "../../../core/llm/modelFactory.js";
+import { getOrchestratorModelId } from "../../../subgraphs/research/nodes/planQueries.js";
+import { getGraphContext } from "../../../subgraphs/research/nodes/shared/getGraphContext.js";
+import {
+  buildIngestPlannerPrompt,
+  parseIngestPlanResponse,
+} from "../../../../services/ingestPlanner.js";
+import type { IngestPlannerStateType, IngestPlannerStateUpdate } from "../state.js";
+
+const ingestPlanSchema = z.object({
+  action: z.enum(["merge", "create", "skip"]),
+  reason: z.string().min(1),
+  targetPageId: z.string().optional(),
+  title: z.string().optional(),
+  summary: z.string().optional(),
+  conflicts: z
+    .array(
+      z.object({
+        claim: z.string().min(1),
+        existing: z.string().min(1),
+        note: z.string().optional(),
+      }),
+    )
+    .optional(),
+});
+
+/**
+ * Produce {@link IngestPlan} via ZediChatModel after research completes.
+ */
+export async function planIngest(
+  state: IngestPlannerStateType,
+  config: LangGraphRunnableConfig,
+): Promise<IngestPlannerStateUpdate> {
+  const ctx = getGraphContext(config);
+  if (!state.article) {
+    throw new Error("plan_ingest: article is missing from state");
+  }
+
+  const messages = buildIngestPlannerPrompt({
+    article: state.article,
+    candidates: state.candidates,
+    userSchema: state.userSchema ?? undefined,
+  });
+
+  const model = await createZediChatModel({
+    modelId: getOrchestratorModelId(),
+    userId: ctx.userId,
+    tier: ctx.tier,
+    db: ctx.db,
+    feature: `${ctx.feature}:plan_ingest`,
+    backend: ctx.backend,
+    temperature: 0.2,
+    maxTokens: 1024,
+  });
+
+  const structured = model.withStructuredOutput(ingestPlanSchema, { name: "plan_ingest" });
+  const raw = await structured.invoke(messages.map((m) => ({ role: m.role, content: m.content })));
+
+  const validCandidateIds = new Set(state.candidates.map((c) => c.id));
+  const ingestPlan = parseIngestPlanResponse(JSON.stringify(raw), { validCandidateIds });
+
+  return {
+    ingestPlan,
+    phase: "ingest:planned",
+  };
+}

--- a/server/api/src/agents/graphs/ingest/nodes/planIngest.ts
+++ b/server/api/src/agents/graphs/ingest/nodes/planIngest.ts
@@ -11,9 +11,10 @@ import { getOrchestratorModelId } from "../../../subgraphs/research/nodes/planQu
 import { getGraphContext } from "../../../subgraphs/research/nodes/shared/getGraphContext.js";
 import {
   buildIngestPlannerPrompt,
-  parseIngestPlanResponse,
+  parseIngestPlanValue,
 } from "../../../../services/ingestPlanner.js";
 import type { IngestPlannerStateType, IngestPlannerStateUpdate } from "../state.js";
+import { formatResearchForIngest } from "./formatResearchForIngest.js";
 
 const ingestPlanSchema = z.object({
   action: z.enum(["merge", "create", "skip"]),
@@ -49,6 +50,15 @@ export async function planIngest(
     candidates: state.candidates,
     userSchema: state.userSchema ?? undefined,
   });
+  const researchBlock = formatResearchForIngest(state);
+  if (researchBlock.length > 0) {
+    const last = messages[messages.length - 1];
+    if (last?.role === "user") {
+      last.content = `${last.content}${researchBlock}`;
+    } else {
+      messages.push({ role: "user", content: researchBlock.trimStart() });
+    }
+  }
 
   const model = await createZediChatModel({
     modelId: getOrchestratorModelId(),
@@ -65,7 +75,7 @@ export async function planIngest(
   const raw = await structured.invoke(messages.map((m) => ({ role: m.role, content: m.content })));
 
   const validCandidateIds = new Set(state.candidates.map((c) => c.id));
-  const ingestPlan = parseIngestPlanResponse(JSON.stringify(raw), { validCandidateIds });
+  const ingestPlan = parseIngestPlanValue(raw, { validCandidateIds });
 
   return {
     ingestPlan,

--- a/server/api/src/agents/graphs/ingest/nodes/prepareIngest.ts
+++ b/server/api/src/agents/graphs/ingest/nodes/prepareIngest.ts
@@ -36,6 +36,15 @@ export async function prepareIngest(
   const userSchema = state.userSchema;
   const maxIterations = clampMaxIterations(state.maxIterations);
 
+  for (const [i, c] of candidates.entries()) {
+    if (!c?.id?.trim() || typeof c.title !== "string" || !c.title.trim()) {
+      throw new Error(`prepare_ingest: candidates[${i}] requires non-empty { id, title }`);
+    }
+    if (c.excerpt != null && typeof c.excerpt !== "string") {
+      throw new Error(`prepare_ingest: candidates[${i}].excerpt must be a string when provided`);
+    }
+  }
+
   const candidateBlock =
     candidates.length === 0
       ? "(no candidates)"

--- a/server/api/src/agents/graphs/ingest/nodes/prepareIngest.ts
+++ b/server/api/src/agents/graphs/ingest/nodes/prepareIngest.ts
@@ -1,0 +1,71 @@
+/**
+ * `prepare_ingest` — seeds article / candidates and messages for the research loop.
+ *
+ * `POST /api/ingest/graph/run` の input を state に投影し、続く
+ * `researchLoopSubgraph`（共有ノード配線）が参照する `messages` を組み立てる。
+ */
+import { HumanMessage } from "@langchain/core/messages";
+import type { LangGraphRunnableConfig } from "@langchain/langgraph";
+import { getGraphContext } from "../../../subgraphs/research/nodes/shared/getGraphContext.js";
+import type { IngestPlannerStateType, IngestPlannerStateUpdate } from "../state.js";
+
+function clampMaxIterations(raw: number): number {
+  if (!Number.isFinite(raw)) return 3;
+  const truncated = Math.trunc(raw);
+  return Math.min(Math.max(truncated, 1), 5);
+}
+
+/**
+ * Project graph run input into ingest + research seed state.
+ *
+ * LangGraph merges `POST /run` input keys that match state annotations (`article`,
+ * `candidates`, `userSchema`, `maxIterations`) before this node runs.
+ */
+export async function prepareIngest(
+  state: IngestPlannerStateType,
+  config: LangGraphRunnableConfig,
+): Promise<IngestPlannerStateUpdate> {
+  const ctx = getGraphContext(config);
+
+  const article = state.article;
+  if (!article?.title?.trim() || !article.url?.trim()) {
+    throw new Error("prepare_ingest: article { title, url, excerpt } is required");
+  }
+
+  const candidates = state.candidates;
+  const userSchema = state.userSchema;
+  const maxIterations = clampMaxIterations(state.maxIterations);
+
+  const candidateBlock =
+    candidates.length === 0
+      ? "(no candidates)"
+      : candidates
+          .map(
+            (c, i) =>
+              `[${i + 1}] id=${c.id}\n    title: ${c.title}\n    excerpt: ${c.excerpt.slice(0, 400)}`,
+          )
+          .join("\n\n");
+
+  const brief = [
+    "[Ingest clip]",
+    `title: ${article.title}`,
+    `url: ${article.url}`,
+    "",
+    "excerpt:",
+    article.excerpt.slice(0, 4000),
+    "",
+    "## CANDIDATES",
+    candidateBlock,
+  ].join("\n");
+
+  return {
+    article,
+    candidates,
+    userSchema,
+    maxIterations,
+    userId: ctx.userId,
+    pageId: ctx.pageId,
+    phase: "ingest:prepare",
+    messages: [new HumanMessage(brief)],
+  };
+}

--- a/server/api/src/agents/graphs/ingest/nodes/prepareIngest.ts
+++ b/server/api/src/agents/graphs/ingest/nodes/prepareIngest.ts
@@ -28,7 +28,7 @@ export async function prepareIngest(
   const ctx = getGraphContext(config);
 
   const article = state.article;
-  if (!article?.title?.trim() || !article.url?.trim()) {
+  if (!article?.title?.trim() || !article.url?.trim() || typeof article.excerpt !== "string") {
     throw new Error("prepare_ingest: article { title, url, excerpt } is required");
   }
 
@@ -42,7 +42,7 @@ export async function prepareIngest(
       : candidates
           .map(
             (c, i) =>
-              `[${i + 1}] id=${c.id}\n    title: ${c.title}\n    excerpt: ${c.excerpt.slice(0, 400)}`,
+              `[${i + 1}] id=${c.id}\n    title: ${c.title}\n    excerpt: ${(c.excerpt ?? "").slice(0, 400)}`,
           )
           .join("\n\n");
 

--- a/server/api/src/agents/graphs/ingest/state.ts
+++ b/server/api/src/agents/graphs/ingest/state.ts
@@ -1,0 +1,103 @@
+/**
+ * `IngestPlannerState` — LangGraph state for the Ingest planner graph (#952).
+ *
+ * `ResearchLoopState` の channel 群を superset として保持し、
+ * `wireResearchLoopSubgraph` で P1 調査ループを組み込む。記事クリップ用の
+ * `article` / `candidates` / `ingestPlan` を追加する。
+ *
+ * Extends research-loop channels so {@link wireResearchLoopSubgraph} can share
+ * nodes with Compose. Adds ingest-specific fields for clip planning.
+ */
+import { Annotation } from "@langchain/langgraph";
+import { BaseState } from "../../core/state/baseState.js";
+import type {
+  AdditionalResearchRequest,
+  Evaluation,
+  ExitReason,
+  PlannedQuery,
+  ResearchBatch,
+  Source,
+} from "../../subgraphs/research/types.js";
+import type { CandidatePage, IngestArticleSummary, IngestPlan } from "./types.js";
+
+function mergeSourcesById(prev: Source[], next: Source[] | undefined): Source[] {
+  if (!next || next.length === 0) return prev;
+  const order: string[] = [];
+  const map = new Map<string, Source>();
+  for (const s of prev) {
+    if (!map.has(s.id)) order.push(s.id);
+    map.set(s.id, s);
+  }
+  for (const s of next) {
+    if (!map.has(s.id)) order.push(s.id);
+    map.set(s.id, s);
+  }
+  return order.map((id) => map.get(id) as Source);
+}
+
+export const IngestPlannerState = Annotation.Root({
+  ...BaseState.spec,
+
+  // ── Ingest clip input ─────────────────────────────────────────────────────
+  article: Annotation<IngestArticleSummary | null>({
+    reducer: (prev, next) => (next === undefined ? prev : next),
+    default: () => null,
+  }),
+  candidates: Annotation<CandidatePage[]>({
+    reducer: (_prev, next) => next,
+    default: () => [],
+  }),
+  userSchema: Annotation<string | null>({
+    reducer: (prev, next) => (next === undefined ? prev : next),
+    default: () => null,
+  }),
+  ingestPlan: Annotation<IngestPlan | null>({
+    reducer: (prev, next) => (next === undefined ? prev : next),
+    default: () => null,
+  }),
+
+  // ── Research mirror (matches ResearchLoopState) ───────────────────────────
+  iteration: Annotation<number>({
+    reducer: (_prev, next) => next,
+    default: () => 0,
+  }),
+  maxIterations: Annotation<number>({
+    reducer: (prev, next) => next ?? prev,
+    default: () => 3,
+  }),
+  queries: Annotation<PlannedQuery[]>({
+    reducer: (_prev, next) => next,
+    default: () => [],
+  }),
+  pendingSources: Annotation<Source[]>({
+    reducer: mergeSourcesById,
+    default: () => [],
+  }),
+  lastEvaluation: Annotation<Evaluation | null>({
+    reducer: (_prev, next) => next,
+    default: () => null,
+  }),
+  exitReason: Annotation<ExitReason | null>({
+    reducer: (_prev, next) => next,
+    default: () => null,
+  }),
+  batches: Annotation<ResearchBatch[]>({
+    reducer: (prev, next) => (next === undefined ? prev : [...prev, ...next]),
+    default: () => [],
+  }),
+  approvedResearch: Annotation<Source[]>({
+    reducer: (_prev, next) => next,
+    default: () => [],
+  }),
+  rejectedResearch: Annotation<Source[]>({
+    reducer: (_prev, next) => next,
+    default: () => [],
+  }),
+  additionalRequest: Annotation<AdditionalResearchRequest | null>({
+    reducer: (prev, next) => (next === undefined ? prev : next),
+    default: () => null,
+  }),
+});
+
+export type IngestPlannerStateType = typeof IngestPlannerState.State;
+export type IngestPlannerStateUpdate = typeof IngestPlannerState.Update;

--- a/server/api/src/agents/graphs/ingest/types.ts
+++ b/server/api/src/agents/graphs/ingest/types.ts
@@ -1,0 +1,13 @@
+/**
+ * Ingest planner graph types (issue #952).
+ *
+ * `ingestPlanner.ts` サービス型の graph 用エイリアス。サービス層を正とし、
+ * graph state は同じ shape を参照する。
+ */
+export type {
+  IngestAction,
+  IngestPlan,
+  IngestConflict,
+  CandidatePage,
+  IngestArticleSummary,
+} from "../../../services/ingestPlanner.js";

--- a/server/api/src/agents/index.ts
+++ b/server/api/src/agents/index.ts
@@ -90,6 +90,14 @@ export {
   type HumanReviewInterruptPayload,
 } from "./subgraphs/research/index.js";
 export {
+  INGEST_PLANNER_GRAPH_ID,
+  INGEST_PLANNER_GRAPH_VERSION,
+  registerIngestPlannerGraph,
+  IngestPlannerState,
+  type IngestPlannerStateType,
+  type IngestPlannerStateUpdate,
+} from "./graphs/ingest/index.js";
+export {
   WIKI_COMPOSE_GRAPH_ID,
   WIKI_COMPOSE_GRAPH_VERSION,
   registerWikiComposeGraph,

--- a/server/api/src/agents/subgraphs/research/nodes/index.ts
+++ b/server/api/src/agents/subgraphs/research/nodes/index.ts
@@ -13,4 +13,4 @@ export { evaluateSufficiency } from "./evaluateSufficiency.js";
 export { refineQueries } from "./refineQueries.js";
 export { compileBatch } from "./compileBatch.js";
 export { humanReviewResearch } from "./humanReviewResearch.js";
-export { shouldRefine } from "../researchGraph.js";
+export { shouldRefine } from "../shouldRefine.js";

--- a/server/api/src/agents/subgraphs/research/researchGraph.ts
+++ b/server/api/src/agents/subgraphs/research/researchGraph.ts
@@ -14,7 +14,7 @@
  * node which projects it into `approvedResearch` / `rejectedResearch`.
  */
 import { END, START, StateGraph } from "@langchain/langgraph";
-import { ResearchLoopState, type ResearchLoopStateType } from "./state.js";
+import { ResearchLoopState } from "./state.js";
 import { registerGraph, type GraphFactory } from "../../registry/graphRegistry.js";
 import {
   planQueries,
@@ -27,32 +27,16 @@ import {
   humanReviewResearch,
 } from "./nodes/index.js";
 
+import { shouldRefine } from "./shouldRefine.js";
+
+export { shouldRefine };
+
 /** Registered graph id. */
 export const RESEARCH_GRAPH_ID = "wiki-compose-research" as const;
 /** Registered graph version. Bump when behaviour changes meaningfully. */
 export const RESEARCH_GRAPH_VERSION = "1.0.0";
 
-/**
- * 終了条件判定。`evaluate_sufficiency` の直後に呼ばれる。
- *
- * Conditional edge predicate:
- * - `score >= 0.75` → `"compile"` (exit loop)
- * - `iteration >= maxIterations` → `"compile"` (hard cap)
- * - otherwise → `"refine"` (loop back)
- *
- * Pure function; unit-tested directly in `researchGraph.conditional.test.ts`.
- */
-export function shouldRefine(state: ResearchLoopStateType): "refine" | "compile" {
-  const score = state.lastEvaluation?.score;
-  if (typeof score === "number" && score >= 0.75) return "compile";
-  if (state.iteration >= state.maxIterations) return "compile";
-  return "refine";
-}
-
 const factory: GraphFactory = ({ checkpointer }) => {
-  // LangGraph's `StateGraph` chaining is heavily typed; we let the inference
-  // flow naturally instead of pinning intermediate types, mirroring the stub
-  // graph (`registry/stubGraph.ts`).
   const builder = new StateGraph(ResearchLoopState)
     .addNode("plan_queries", planQueries)
     .addNode("web_search", webSearch)
@@ -63,10 +47,8 @@ const factory: GraphFactory = ({ checkpointer }) => {
     .addNode("compile_batch", compileBatch)
     .addNode("human_review_research", humanReviewResearch)
     .addEdge(START, "plan_queries")
-    // Parallel fan-out from plan_queries.
     .addEdge("plan_queries", "web_search")
     .addEdge("plan_queries", "wiki_search")
-    // Implicit join on fetch_articles (both fan-out branches feed into it).
     .addEdge("web_search", "fetch_articles")
     .addEdge("wiki_search", "fetch_articles")
     .addEdge("fetch_articles", "evaluate_sufficiency")
@@ -74,14 +56,11 @@ const factory: GraphFactory = ({ checkpointer }) => {
       refine: "refine_queries",
       compile: "compile_batch",
     })
-    // refine_queries kicks the next iteration (loop back via web_search).
     .addEdge("refine_queries", "web_search")
     .addEdge("refine_queries", "wiki_search")
     .addEdge("compile_batch", "human_review_research")
     .addEdge("human_review_research", END);
 
-  // `checkpointer === false` is honoured by LangGraph as "no persistence" (the
-  // test path), `BaseCheckpointSaver` enables resume in production.
   return checkpointer ? builder.compile({ checkpointer }) : builder.compile();
 };
 

--- a/server/api/src/agents/subgraphs/research/shouldRefine.ts
+++ b/server/api/src/agents/subgraphs/research/shouldRefine.ts
@@ -1,0 +1,18 @@
+/**
+ * Research loop exit predicate (`evaluate_sufficiency` → refine | compile).
+ */
+import type { ResearchLoopStateType } from "./state.js";
+
+/**
+ * 終了条件判定。`evaluate_sufficiency` の直後に呼ばれる。
+ *
+ * - `score >= 0.75` → `"compile"`
+ * - `iteration >= maxIterations` → `"compile"`
+ * - otherwise → `"refine"`
+ */
+export function shouldRefine(state: ResearchLoopStateType): "refine" | "compile" {
+  const score = state.lastEvaluation?.score;
+  if (typeof score === "number" && score >= 0.75) return "compile";
+  if (state.iteration >= state.maxIterations) return "compile";
+  return "refine";
+}

--- a/server/api/src/app.ts
+++ b/server/api/src/app.ts
@@ -48,6 +48,7 @@ import userAiCredentialRoutes from "./routes/userAiCredentials.js";
 import { registerStubGraph } from "./agents/registry/stubGraph.js";
 import { registerResearchLoopGraph } from "./agents/subgraphs/research/index.js";
 import { registerWikiComposeGraph } from "./agents/graphs/wikiCompose/index.js";
+import { registerIngestPlannerGraph } from "./agents/graphs/ingest/index.js";
 
 /**
  * Creates and configures the Hono API app (routes, CORS, etc.).
@@ -58,12 +59,14 @@ export function createApp(): Hono<AppEnv> {
   // - `wiki-compose-stub` — P0 smoke test (#948)
   // - `wiki-compose-research` — P1 自律調査ループ (#949)
   // - `wiki-compose` — P2 全体オーケストレータ (#950)
+  // - `ingest-planner` — P4 ingest + shared research loop (#952)
   //
   // Register all Wiki Compose graphs. Calls are idempotent across hot
   // reloads (registry uses `Map#set` so the latest registration wins).
   registerStubGraph();
   registerResearchLoopGraph();
   registerWikiComposeGraph();
+  registerIngestPlannerGraph();
 
   const app = new Hono<AppEnv>();
   const wildcard = isWildcardCors();

--- a/server/api/src/routes/ingest.ts
+++ b/server/api/src/routes/ingest.ts
@@ -54,6 +54,40 @@ const app = new Hono<AppEnv>();
 const INGEST_GRAPH_RECURSION_LIMIT = 60;
 
 /**
+ * Map graph runner failures caused by client/input validation to HTTP 4xx.
+ */
+function httpStatusForGraphFailure(error: string | undefined): 400 | 500 {
+  if (!error) return 500;
+  const clientish =
+    /prepare_ingest|plan_ingest|invalid|required|expected|approvedSourceIds|zod|resume/i.test(
+      error,
+    );
+  return clientish ? 400 : 500;
+}
+
+function assertGraphRunArticle(article: IngestArticleSummary): void {
+  if (!article.title?.trim() || !article.url?.trim() || typeof article.excerpt !== "string") {
+    throw new HTTPException(400, { message: "article { title, url, excerpt } is required" });
+  }
+}
+
+function normalizeGraphCandidates(raw: CandidatePage[] | undefined): CandidatePage[] {
+  if (!Array.isArray(raw)) return [];
+  const out: CandidatePage[] = [];
+  for (const entry of raw) {
+    if (typeof entry?.id !== "string" || !entry.id.trim()) continue;
+    if (typeof entry.title !== "string") continue;
+    if (typeof entry.excerpt !== "string") continue;
+    out.push({
+      id: entry.id.trim(),
+      title: entry.title,
+      excerpt: entry.excerpt,
+    });
+  }
+  return out;
+}
+
+/**
  * リクエストボディ。
  * Request body for POST /api/ingest/plan.
  */
@@ -340,11 +374,12 @@ app.post("/graph/run", authRequired, rateLimit(), async (c) => {
     throw new HTTPException(400, { message: "Invalid JSON body" });
   }
 
-  if (!body.article || typeof body.article.title !== "string" || !body.article.url?.trim()) {
+  if (!body.article) {
     throw new HTTPException(400, { message: "article { title, url, excerpt } is required" });
   }
+  assertGraphRunArticle(body.article);
 
-  const candidates = Array.isArray(body.candidates) ? body.candidates : [];
+  const candidates = normalizeGraphCandidates(body.candidates);
   const threadId =
     typeof body.threadId === "string" && body.threadId.trim() ? body.threadId.trim() : randomUUID();
 
@@ -397,7 +432,8 @@ app.post("/graph/run", authRequired, rateLimit(), async (c) => {
   );
 
   if (result.status === "failed") {
-    throw new HTTPException(500, { message: result.error ?? "Graph run failed" });
+    const status = httpStatusForGraphFailure(result.error);
+    throw new HTTPException(status, { message: result.error ?? "Graph run failed" });
   }
 
   const output = result.output as
@@ -483,7 +519,8 @@ app.post("/graph/resume", authRequired, rateLimit(), async (c) => {
   );
 
   if (result.status === "failed") {
-    throw new HTTPException(500, { message: result.error ?? "Graph resume failed" });
+    const status = httpStatusForGraphFailure(result.error);
+    throw new HTTPException(status, { message: result.error ?? "Graph resume failed" });
   }
 
   const output = result.output as { ingestPlan?: unknown } | undefined;

--- a/server/api/src/routes/ingest.ts
+++ b/server/api/src/routes/ingest.ts
@@ -1,16 +1,23 @@
 /**
- * /api/ingest — LLM Wiki ingest flow (P1, otomatty/zedi#595).
+ * /api/ingest — LLM Wiki ingest flow (P1 #595, graph P4 #952).
  *
  * POST /api/ingest/plan — dry-run: given a URL, propose how the article should
  * be merged / created / skipped in the user's existing Wiki. Does NOT write
  * to the database. The corresponding apply endpoint is tracked as a follow-up
  * and will reuse the plan shape returned here.
  *
+ * POST /api/ingest/graph/run — invoke graph `ingest-planner` (#952): shared
+ * research loop + structured ingest plan via ZediChatModel. See route TSDoc below.
+ *
+ * POST /api/ingest/graph/resume — resume an interrupted `ingest-planner` run
+ * (HITL at `human_review_research`) using the same `threadId`.
+ *
  * LLM Wiki の ingest フロー。プラン生成までの dry-run エンドポイント。
  * DB への書き込みは行わず、プレビュー用のプラン JSON を返す。
  * apply（実適用）エンドポイントは後続 PR で追加する。
  */
 import { Hono } from "hono";
+import { randomUUID } from "node:crypto";
 import { HTTPException } from "hono/http-exception";
 import { sql } from "drizzle-orm";
 import { authRequired } from "../middleware/auth.js";
@@ -34,8 +41,17 @@ import { pages } from "../schema/pages.js";
 import { pageContents } from "../schema/pageContents.js";
 import { recordActivity } from "../services/activityLogService.js";
 import type { AppEnv, AIProviderType } from "../types/index.js";
+import { GraphRunner } from "../agents/runner/graphRunner.js";
+import { INGEST_PLANNER_GRAPH_ID } from "../agents/graphs/ingest/index.js";
+import type { IngestArticleSummary } from "../services/ingestPlanner.js";
+import { assertSupportedComposeBackend } from "../agents/core/llm/modelFactory.js";
+import { assertComposeBackendReady } from "../agents/core/composeBackendValidation.js";
+import { resolveCheckpointerForRun } from "../agents/core/checkpoint/index.js";
+import type { ExecutionBackend } from "../agents/core/types/executionBackend.js";
 
 const app = new Hono<AppEnv>();
+
+const INGEST_GRAPH_RECURSION_LIMIT = 60;
 
 /**
  * リクエストボディ。
@@ -268,6 +284,216 @@ app.post("/plan", authRequired, rateLimit(), async (c) => {
       contentHash: article.contentHash,
     },
     candidates,
+  });
+});
+
+/**
+ * Request body for `POST /api/ingest/graph/run` (#952).
+ */
+interface IngestGraphRunBody {
+  /** Optional stable thread id for checkpoint resume (defaults to new UUID). */
+  threadId?: string;
+  backend?: ExecutionBackend;
+  article?: IngestArticleSummary;
+  candidates?: CandidatePage[];
+  userSchema?: string;
+  maxIterations?: number;
+}
+
+/**
+ * Request body for `POST /api/ingest/graph/resume` (#952).
+ */
+interface IngestGraphResumeBody {
+  threadId: string;
+  backend?: ExecutionBackend;
+  resume: unknown;
+}
+
+/**
+ * POST /api/ingest/graph/run — LangGraph `ingest-planner` execution (#952).
+ *
+ * **Integration with `POST /api/ingest/plan` (#595)**
+ *
+ * - `/plan` remains the URL-first production path: server-side article extraction,
+ *   candidate SQL search, and `callProvider` via `ingestPlanner.ts` (no research loop).
+ * - `/graph/run` expects the caller to supply `article` + `candidates` (typically the
+ *   same shapes `/plan` returns) and runs graph id {@link INGEST_PLANNER_GRAPH_ID}:
+ *   `prepare_ingest` → shared P1 research nodes → `plan_ingest` (ZediChatModel).
+ * - Both endpoints return the same {@link IngestPlan} JSON shape on success.
+ * - Apply persistence stays on `POST /api/ingest/apply` for either path.
+ *
+ * **Resume**
+ *
+ * When the graph halts at `human_review_research`, the response includes `threadId`.
+ * Call `POST /api/ingest/graph/resume` with the research resume payload
+ * (`{ approvedSourceIds, rejectedSourceIds?, note? }`, same as compose research).
+ */
+app.post("/graph/run", authRequired, rateLimit(), async (c) => {
+  const userId = c.get("userId");
+  const userEmail = c.get("userEmail") ?? null;
+  const db = c.get("db");
+
+  let body: IngestGraphRunBody;
+  try {
+    body = await c.req.json<IngestGraphRunBody>();
+  } catch {
+    throw new HTTPException(400, { message: "Invalid JSON body" });
+  }
+
+  if (!body.article || typeof body.article.title !== "string" || !body.article.url?.trim()) {
+    throw new HTTPException(400, { message: "article { title, url, excerpt } is required" });
+  }
+
+  const candidates = Array.isArray(body.candidates) ? body.candidates : [];
+  const threadId =
+    typeof body.threadId === "string" && body.threadId.trim() ? body.threadId.trim() : randomUUID();
+
+  let backend: ExecutionBackend;
+  try {
+    backend = assertSupportedComposeBackend(body.backend ?? "zedi_managed");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "unsupported backend";
+    throw new HTTPException(400, { message: msg });
+  }
+
+  const tier = await getUserTier(userId, db);
+  await assertComposeBackendReady({
+    backend,
+    graphId: INGEST_PLANNER_GRAPH_ID,
+    userId,
+    tier,
+    db,
+  });
+
+  const checkpointer = await resolveCheckpointerForRun();
+  const runner = new GraphRunner();
+  const result = await runner.invoke(
+    {
+      graphId: INGEST_PLANNER_GRAPH_ID,
+      checkpointer,
+      recursionLimit: INGEST_GRAPH_RECURSION_LIMIT,
+      context: {
+        threadId,
+        sessionId: threadId,
+        userId,
+        userEmail,
+        pageId: "",
+        graphId: INGEST_PLANNER_GRAPH_ID,
+        backend,
+        tier,
+        db,
+        feature: "ingest_graph:run",
+      },
+    },
+    {
+      kind: "input",
+      value: {
+        article: body.article,
+        candidates,
+        userSchema: body.userSchema ?? null,
+        maxIterations: body.maxIterations,
+      },
+    },
+  );
+
+  if (result.status === "failed") {
+    throw new HTTPException(500, { message: result.error ?? "Graph run failed" });
+  }
+
+  const output = result.output as
+    | {
+        ingestPlan?: unknown;
+        __interrupt__?: unknown[];
+      }
+    | undefined;
+
+  return c.json({
+    status: result.status,
+    threadId,
+    graphId: INGEST_PLANNER_GRAPH_ID,
+    plan: output?.ingestPlan ?? null,
+    output,
+  });
+});
+
+/**
+ * POST /api/ingest/graph/resume — resume `ingest-planner` after research HITL (#952).
+ */
+app.post("/graph/resume", authRequired, rateLimit(), async (c) => {
+  const userId = c.get("userId");
+  const userEmail = c.get("userEmail") ?? null;
+  const db = c.get("db");
+
+  let body: IngestGraphResumeBody;
+  try {
+    body = await c.req.json<IngestGraphResumeBody>();
+  } catch {
+    throw new HTTPException(400, { message: "Invalid JSON body" });
+  }
+
+  if (typeof body.threadId !== "string" || !body.threadId.trim()) {
+    throw new HTTPException(400, { message: "threadId is required" });
+  }
+  const threadId = body.threadId.trim();
+
+  let backend: ExecutionBackend;
+  try {
+    backend = assertSupportedComposeBackend(body.backend ?? "zedi_managed");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "unsupported backend";
+    throw new HTTPException(400, { message: msg });
+  }
+
+  const tier = await getUserTier(userId, db);
+  await assertComposeBackendReady({
+    backend,
+    graphId: INGEST_PLANNER_GRAPH_ID,
+    userId,
+    tier,
+    db,
+  });
+
+  const checkpointer = await resolveCheckpointerForRun();
+  if (checkpointer === false) {
+    throw new HTTPException(503, {
+      message: "Graph resume requires DATABASE_URL checkpointing",
+    });
+  }
+
+  const runner = new GraphRunner();
+  const result = await runner.resume(
+    {
+      graphId: INGEST_PLANNER_GRAPH_ID,
+      checkpointer,
+      recursionLimit: INGEST_GRAPH_RECURSION_LIMIT,
+      context: {
+        threadId,
+        sessionId: threadId,
+        userId,
+        userEmail,
+        pageId: "",
+        graphId: INGEST_PLANNER_GRAPH_ID,
+        backend,
+        tier,
+        db,
+        feature: "ingest_graph:resume",
+      },
+    },
+    body.resume,
+  );
+
+  if (result.status === "failed") {
+    throw new HTTPException(500, { message: result.error ?? "Graph resume failed" });
+  }
+
+  const output = result.output as { ingestPlan?: unknown } | undefined;
+
+  return c.json({
+    status: result.status,
+    threadId,
+    graphId: INGEST_PLANNER_GRAPH_ID,
+    plan: output?.ingestPlan ?? null,
+    output,
   });
 });
 

--- a/server/api/src/routes/ingest.ts
+++ b/server/api/src/routes/ingest.ts
@@ -71,6 +71,14 @@ function assertGraphRunArticle(article: IngestArticleSummary): void {
   }
 }
 
+/**
+ * LangGraph `thread_id` scoped per user so shared checkpoint storage cannot collide.
+ * 共有 checkpoint 上での thread_id 衝突を防ぐため userId でスコープする。
+ */
+function scopedIngestGraphThreadId(userId: string, clientThreadId: string): string {
+  return `${userId}:${clientThreadId}`;
+}
+
 function normalizeGraphCandidates(raw: CandidatePage[] | undefined): CandidatePage[] {
   if (!Array.isArray(raw)) return [];
   const out: CandidatePage[] = [];
@@ -358,8 +366,9 @@ interface IngestGraphResumeBody {
  *
  * **Resume**
  *
- * When the graph halts at `human_review_research`, the response includes `threadId`.
- * Call `POST /api/ingest/graph/resume` with the research resume payload
+ * When the graph halts at `human_review_research`, the response includes `threadId`
+ * (client-visible id; checkpoint `thread_id` is scoped as `{userId}:{threadId}`).
+ * Call `POST /api/ingest/graph/resume` with the same `threadId` and research resume payload
  * (`{ approvedSourceIds, rejectedSourceIds?, note? }`, same as compose research).
  */
 app.post("/graph/run", authRequired, rateLimit(), async (c) => {
@@ -380,8 +389,9 @@ app.post("/graph/run", authRequired, rateLimit(), async (c) => {
   assertGraphRunArticle(body.article);
 
   const candidates = normalizeGraphCandidates(body.candidates);
-  const threadId =
+  const clientThreadId =
     typeof body.threadId === "string" && body.threadId.trim() ? body.threadId.trim() : randomUUID();
+  const threadId = scopedIngestGraphThreadId(userId, clientThreadId);
 
   let backend: ExecutionBackend;
   try {
@@ -445,7 +455,7 @@ app.post("/graph/run", authRequired, rateLimit(), async (c) => {
 
   return c.json({
     status: result.status,
-    threadId,
+    threadId: clientThreadId,
     graphId: INGEST_PLANNER_GRAPH_ID,
     plan: output?.ingestPlan ?? null,
     output,
@@ -470,7 +480,11 @@ app.post("/graph/resume", authRequired, rateLimit(), async (c) => {
   if (typeof body.threadId !== "string" || !body.threadId.trim()) {
     throw new HTTPException(400, { message: "threadId is required" });
   }
-  const threadId = body.threadId.trim();
+  if (!Object.prototype.hasOwnProperty.call(body, "resume")) {
+    throw new HTTPException(400, { message: "resume is required" });
+  }
+  const clientThreadId = body.threadId.trim();
+  const threadId = scopedIngestGraphThreadId(userId, clientThreadId);
 
   let backend: ExecutionBackend;
   try {
@@ -527,7 +541,7 @@ app.post("/graph/resume", authRequired, rateLimit(), async (c) => {
 
   return c.json({
     status: result.status,
-    threadId,
+    threadId: clientThreadId,
     graphId: INGEST_PLANNER_GRAPH_ID,
     plan: output?.ingestPlan ?? null,
     output,

--- a/server/api/src/services/ingestPlanner.ts
+++ b/server/api/src/services/ingestPlanner.ts
@@ -265,10 +265,13 @@ function parseConflicts(value: unknown): IngestConflict[] | undefined {
 
 /**
  * Validates a parsed ingest plan object (structured LLM output or `JSON.parse` result).
+ * パース済み ingest プランオブジェクトを検証する（structured output または JSON.parse 結果）。
  *
- * @param parsed - Already-parsed plan object.
+ * @param parsed - Already-parsed plan object. / パース済みプランオブジェクト。
  * @param options - Optional candidate id set for merge target validation.
+ *                  / merge 先検証用の候補 ID 集合（任意）。
  * @throws {@link IngestPlanParseError} when fields are invalid.
+ *         / フィールドが不正な場合。
  */
 export function parseIngestPlanValue(
   parsed: unknown,

--- a/server/api/src/services/ingestPlanner.ts
+++ b/server/api/src/services/ingestPlanner.ts
@@ -264,27 +264,16 @@ function parseConflicts(value: unknown): IngestConflict[] | undefined {
 }
 
 /**
- * LLM の生応答を厳格にパース・バリデーションして {@link IngestPlan} を返す。
- * Strictly validates an LLM raw response and returns a typed {@link IngestPlan}.
+ * Validates a parsed ingest plan object (structured LLM output or `JSON.parse` result).
  *
- * @param raw - LLM の生テキスト応答。Raw LLM text response.
- * @param options - 候補ページ ID の集合（merge 時の整合性チェック用）。Set of candidate IDs.
- * @returns 検証済みプラン。Validated ingest plan.
- * @throws {@link IngestPlanParseError} when JSON is malformed or fields are invalid.
+ * @param parsed - Already-parsed plan object.
+ * @param options - Optional candidate id set for merge target validation.
+ * @throws {@link IngestPlanParseError} when fields are invalid.
  */
-export function parseIngestPlanResponse(
-  raw: string,
+export function parseIngestPlanValue(
+  parsed: unknown,
   options: { validCandidateIds?: ReadonlySet<string> } = {},
 ): IngestPlan {
-  const jsonText = extractJsonFromResponse(raw);
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(jsonText);
-  } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
-    throw new IngestPlanParseError(`Invalid JSON in LLM response: ${reason}`);
-  }
-
   if (!isRecord(parsed)) {
     throw new IngestPlanParseError("Plan must be a JSON object");
   }
@@ -330,6 +319,28 @@ export function parseIngestPlanResponse(
   }
 
   return plan;
+}
+
+/**
+ * LLM の生応答を厳格にパース・バリデーションして {@link IngestPlan} を返す。
+ *
+ * @param raw - LLM の生テキスト応答。Raw LLM text response.
+ * @param options - 候補ページ ID の集合（merge 時の整合性チェック用）。Set of candidate IDs.
+ * @throws {@link IngestPlanParseError} when JSON is malformed or fields are invalid.
+ */
+export function parseIngestPlanResponse(
+  raw: string,
+  options: { validCandidateIds?: ReadonlySet<string> } = {},
+): IngestPlan {
+  const jsonText = extractJsonFromResponse(raw);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new IngestPlanParseError(`Invalid JSON in LLM response: ${reason}`);
+  }
+  return parseIngestPlanValue(parsed, options);
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #952](https://github.com/otomatty/zedi/issues/952) (Wiki Compose P4): connect the P1 research loop to the article ingest workflow via a new LangGraph `ingest-planner`, without duplicating tools or LLM plumbing.

## Changes

- **`ingest-planner` graph** (`server/api/src/agents/graphs/ingest/`): `prepare_ingest` → shared P1 research nodes (`plan_queries`, `web_search`, `wiki_search`, `fetch_articles`, `evaluate_sufficiency`, …) → `plan_ingest` (ZediChatModel + existing `ingestPlanner` parse logic)
- **Registry**: `registerIngestPlannerGraph()` at app bootstrap; exported from `agents/index.ts`
- **API**: `POST /api/ingest/graph/run` and `POST /api/ingest/graph/resume` with TSDoc describing coexistence with `POST /api/ingest/plan` (#595)
- **`shouldRefine`**: extracted to `shouldRefine.ts` for shared conditional routing across graphs
- **Tests**: `ingestPlannerGraph.test.ts` (research wiring + HITL resume → `plan_ingest`); existing ingest service/route tests unchanged

## Acceptance criteria

- [x] Ingest graph runs shared research loop nodes (same imports as Compose)
- [x] No duplicate tool / ZediChatModel definitions for research
- [x] Vitest for ingest graph routing / subgraph connection
- [x] Existing ingest regression tests pass

## How to verify

```bash
cd server/api && bun install && bun run typecheck
bun run test:run -- src/__tests__/agents/graphs/ingest src/__tests__/services/ingestPlanner.test.ts src/__tests__/routes/ingest.test.ts
```

## Notes

- `POST /api/ingest/plan` remains the URL-first production path (`callProvider`); `/graph/run` expects client-supplied `article` + `candidates` (e.g. after `/plan`).
- Resume requires DB checkpointing (`DATABASE_URL`); same research HITL payload as `wiki-compose-research`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfa8a7a9-f7e2-4466-93d5-de4775b5acdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfa8a7a9-f7e2-4466-93d5-de4775b5acdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New ingest-planner graph for a resumable ingest workflow, including prepare/plan steps and research-loop decision logic.
  * New API endpoints to run and resume graph-based ingest workflows; responses may include a validated ingest plan.
  * Prompt/content formatting for including approved research in ingest planning and stronger ingest-plan validation.

* **Tests**
  * Added unit tests covering ingest planner wiring, research formatting, and ingest-plan parsing/validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->