### PR TITLE
feat(ai): add system default model with admin config and fallback

### DIFF
--- a/admin/src/api/admin.ts
+++ b/admin/src/api/admin.ts
@@ -52,6 +52,7 @@ export interface AiModelAdmin {
   inputCostUnits: number;
   outputCostUnits: number;
   isActive: boolean;
+  isSystemDefault: boolean;
   sortOrder: number;
   createdAt: string;
 }
@@ -104,6 +105,7 @@ export async function patchAiModel(
       | "inputCostUnits"
       | "outputCostUnits"
       | "isActive"
+      | "isSystemDefault"
       | "sortOrder"
     >
   >,

--- a/admin/src/i18n/locales/en/aiModels.json
+++ b/admin/src/i18n/locales/en/aiModels.json
@@ -11,8 +11,11 @@
     "displayName": "Display name",
     "tier": "Tier",
     "active": "Active",
+    "systemDefault": "System default",
     "sortOrder": "Order"
   },
+  "systemDefaultBadge": "Default",
+  "setSystemDefault": "Set as default",
   "summary": "{{total}} models (active: {{active}})",
   "dragHint": "Drag to reorder",
   "displayNameAriaLabel": "Display name for {{modelId}}",

--- a/admin/src/i18n/locales/ja/aiModels.json
+++ b/admin/src/i18n/locales/ja/aiModels.json
@@ -11,8 +11,11 @@
     "displayName": "表示名",
     "tier": "ティア",
     "active": "有効",
+    "systemDefault": "システム既定",
     "sortOrder": "並び順"
   },
+  "systemDefaultBadge": "既定",
+  "setSystemDefault": "既定に設定",
   "summary": "{{total}} 件（有効: {{active}}）",
   "dragHint": "ドラッグで並び替え",
   "displayNameAriaLabel": "{{modelId}} の表示名",

--- a/admin/src/pages/ai-models/AiModelCard.tsx
+++ b/admin/src/pages/ai-models/AiModelCard.tsx
@@ -18,6 +18,7 @@ interface AiModelCardProps {
   onDisplayNameBlur: (value: string) => void;
   onTierChange: (tier: "free" | "pro") => void;
   onToggleActive: () => void;
+  onSetSystemDefault: () => void;
 }
 
 /**
@@ -30,6 +31,7 @@ export function AiModelCard({
   onDisplayNameBlur,
   onTierChange,
   onToggleActive,
+  onSetSystemDefault,
 }: AiModelCardProps) {
   const { t } = useTranslation();
   return (
@@ -82,6 +84,21 @@ export function AiModelCard({
           >
             {m.isActive ? "ON" : "OFF"}
           </Button>
+          {m.isSystemDefault ? (
+            <span className="text-primary text-xs font-medium">
+              {t("aiModels.systemDefaultBadge")}
+            </span>
+          ) : (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!m.isActive}
+              onClick={onSetSystemDefault}
+            >
+              {t("aiModels.setSystemDefault")}
+            </Button>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/admin/src/pages/ai-models/AiModelRow.tsx
+++ b/admin/src/pages/ai-models/AiModelRow.tsx
@@ -20,6 +20,7 @@ interface AiModelRowProps {
   onDisplayNameBlur: (value: string) => void;
   onTierChange: (tier: "free" | "pro") => void;
   onToggleActive: () => void;
+  onSetSystemDefault: () => void;
   onDragStart: (e: React.DragEvent, id: string) => void;
   onDragOver: (e: React.DragEvent, id: string) => void;
   onDragLeave: () => void;
@@ -39,6 +40,7 @@ export function AiModelRow({
   onDisplayNameBlur,
   onTierChange,
   onToggleActive,
+  onSetSystemDefault,
   onDragStart,
   onDragOver,
   onDragLeave,
@@ -101,6 +103,23 @@ export function AiModelRow({
         >
           {m.isActive ? "ON" : "OFF"}
         </Button>
+      </TableCell>
+      <TableCell className="px-3 py-2">
+        {m.isSystemDefault ? (
+          <span className="text-primary text-xs font-medium">
+            {t("aiModels.systemDefaultBadge")}
+          </span>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!m.isActive}
+            onClick={onSetSystemDefault}
+          >
+            {t("aiModels.setSystemDefault")}
+          </Button>
+        )}
       </TableCell>
       <TableCell className="text-muted-foreground px-3 py-2">{m.sortOrder}</TableCell>
     </TableRow>

--- a/admin/src/pages/ai-models/AiModelsContent.tsx
+++ b/admin/src/pages/ai-models/AiModelsContent.tsx
@@ -30,12 +30,14 @@ interface AiModelsContentProps {
         | "inputCostUnits"
         | "outputCostUnits"
         | "isActive"
+        | "isSystemDefault"
         | "sortOrder"
       >
     >,
   ) => Promise<void>;
   onTierChange: (m: AiModelAdmin, tier: "free" | "pro") => Promise<void>;
   onToggleActive: (m: AiModelAdmin) => Promise<void>;
+  onSetSystemDefault: (m: AiModelAdmin) => Promise<void>;
   onDragStart: (e: React.DragEvent, id: string) => void;
   onDragOver: (e: React.DragEvent, id: string) => void;
   onDragLeave: () => void;
@@ -68,6 +70,7 @@ export function AiModelsContent({
   onModelUpdate,
   onTierChange,
   onToggleActive,
+  onSetSystemDefault,
   onDragStart,
   onDragOver,
   onDragLeave,
@@ -148,6 +151,7 @@ export function AiModelsContent({
               <TableHead className="px-3 py-2">{t("aiModels.columns.displayName")}</TableHead>
               <TableHead className="px-3 py-2">{t("aiModels.columns.tier")}</TableHead>
               <TableHead className="px-3 py-2">{t("aiModels.columns.active")}</TableHead>
+              <TableHead className="px-3 py-2">{t("aiModels.columns.systemDefault")}</TableHead>
               <TableHead className="px-3 py-2">{t("aiModels.columns.sortOrder")}</TableHead>
             </TableRow>
           </TableHeader>
@@ -161,6 +165,7 @@ export function AiModelsContent({
                 {...createDisplayNameHandlers(m)}
                 onTierChange={(tier) => onTierChange(m, tier)}
                 onToggleActive={() => onToggleActive(m)}
+                onSetSystemDefault={() => onSetSystemDefault(m)}
                 onDragStart={onDragStart}
                 onDragOver={onDragOver}
                 onDragLeave={onDragLeave}
@@ -181,6 +186,7 @@ export function AiModelsContent({
             {...createDisplayNameHandlers(m)}
             onTierChange={(tier) => onTierChange(m, tier)}
             onToggleActive={() => onToggleActive(m)}
+            onSetSystemDefault={() => onSetSystemDefault(m)}
           />
         ))}
       </div>

--- a/admin/src/pages/ai-models/index.tsx
+++ b/admin/src/pages/ai-models/index.tsx
@@ -40,12 +40,13 @@ export default function AiModels() {
     }
   }, []);
 
-  const { handleModelUpdate, handleToggleActive, handleTierChange } = useAiModelActions({
-    setModels,
-    setError,
-    isMountedRef,
-    originalModelsRef,
-  });
+  const { handleModelUpdate, handleToggleActive, handleTierChange, handleSetSystemDefault } =
+    useAiModelActions({
+      setModels,
+      setError,
+      isMountedRef,
+      originalModelsRef,
+    });
 
   const dragReorder = useAiModelsDragReorder({
     models,
@@ -126,6 +127,7 @@ export default function AiModels() {
       onModelUpdate={handleModelUpdate}
       onTierChange={handleTierChange}
       onToggleActive={handleToggleActive}
+      onSetSystemDefault={handleSetSystemDefault}
       onDragStart={dragReorder.handleDragStart}
       onDragOver={dragReorder.handleDragOver}
       onDragLeave={dragReorder.handleDragLeave}

--- a/admin/src/pages/ai-models/useAiModelActions.test.ts
+++ b/admin/src/pages/ai-models/useAiModelActions.test.ts
@@ -29,6 +29,7 @@ const baseModel: AiModelAdmin = {
   inputCostUnits: 100,
   outputCostUnits: 100,
   isActive: true,
+  isSystemDefault: false,
   sortOrder: 0,
   createdAt: "2026-01-01T00:00:00Z",
 };

--- a/admin/src/pages/ai-models/useAiModelActions.ts
+++ b/admin/src/pages/ai-models/useAiModelActions.ts
@@ -12,7 +12,13 @@ interface UseAiModelActionsArgs {
 type ModelUpdates = Partial<
   Pick<
     AiModelAdmin,
-    "displayName" | "tierRequired" | "inputCostUnits" | "outputCostUnits" | "isActive" | "sortOrder"
+    | "displayName"
+    | "tierRequired"
+    | "inputCostUnits"
+    | "outputCostUnits"
+    | "isActive"
+    | "isSystemDefault"
+    | "sortOrder"
   >
 >;
 
@@ -68,5 +74,34 @@ export function useAiModelActions({
     [handleModelUpdate, originalModelsRef],
   );
 
-  return { handleModelUpdate, handleToggleActive, handleTierChange };
+  const handleSetSystemDefault = useCallback(
+    async (m: AiModelAdmin) => {
+      if (m.isSystemDefault || !m.isActive) return;
+      const originalModel = originalModelsRef.current.find((om) => om.id === m.id);
+      if (!originalModel) return;
+
+      if (!isMountedRef.current) return;
+      setError(null);
+      setModels((prevModels) =>
+        prevModels.map((x) => ({
+          ...x,
+          isSystemDefault: x.id === m.id,
+        })),
+      );
+      try {
+        await patchAiModel(m.id, { isSystemDefault: true });
+        originalModelsRef.current = originalModelsRef.current.map((x) => ({
+          ...x,
+          isSystemDefault: x.id === m.id,
+        }));
+      } catch (e) {
+        if (!isMountedRef.current) return;
+        setModels(originalModelsRef.current);
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [setModels, setError, isMountedRef, originalModelsRef],
+  );
+
+  return { handleModelUpdate, handleToggleActive, handleTierChange, handleSetSystemDefault };
 }

--- a/admin/src/pages/ai-models/useAiModelActions.ts
+++ b/admin/src/pages/ai-models/useAiModelActions.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import type { AiModelAdmin } from "@/api/admin";
 import { patchAiModel } from "@/api/admin";
 
@@ -28,6 +28,8 @@ export function useAiModelActions({
   isMountedRef,
   originalModelsRef,
 }: UseAiModelActionsArgs) {
+  const settingSystemDefaultRef = useRef(false);
+
   const handleModelUpdate = useCallback(
     async (model: AiModelAdmin, updates: ModelUpdates) => {
       const rollbackUpdates = Object.fromEntries(
@@ -59,7 +61,11 @@ export function useAiModelActions({
     async (m: AiModelAdmin) => {
       const originalModel = originalModelsRef.current.find((om) => om.id === m.id);
       if (!originalModel) return;
-      await handleModelUpdate(originalModel, { isActive: !m.isActive });
+      const nextActive = !m.isActive;
+      await handleModelUpdate(originalModel, {
+        isActive: nextActive,
+        ...(nextActive === false && m.isSystemDefault ? { isSystemDefault: false } : {}),
+      });
     },
     [handleModelUpdate, originalModelsRef],
   );
@@ -76,11 +82,12 @@ export function useAiModelActions({
 
   const handleSetSystemDefault = useCallback(
     async (m: AiModelAdmin) => {
-      if (m.isSystemDefault || !m.isActive) return;
+      if (settingSystemDefaultRef.current || m.isSystemDefault || !m.isActive) return;
       const originalModel = originalModelsRef.current.find((om) => om.id === m.id);
       if (!originalModel) return;
 
       if (!isMountedRef.current) return;
+      settingSystemDefaultRef.current = true;
       setError(null);
       setModels((prevModels) =>
         prevModels.map((x) => ({
@@ -98,6 +105,8 @@ export function useAiModelActions({
         if (!isMountedRef.current) return;
         setModels(originalModelsRef.current);
         setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        settingSystemDefaultRef.current = false;
       }
     },
     [setModels, setError, isMountedRef, originalModelsRef],

--- a/admin/src/pages/ai-models/useAiModelsDragReorder.test.ts
+++ b/admin/src/pages/ai-models/useAiModelsDragReorder.test.ts
@@ -29,6 +29,7 @@ const makeModel = (id: string, sortOrder: number): AiModelAdmin => ({
   inputCostUnits: 100,
   outputCostUnits: 100,
   isActive: true,
+  isSystemDefault: false,
   sortOrder,
   createdAt: "2026-01-01T00:00:00Z",
 });

--- a/server/api/drizzle/0033_add_ai_model_system_default.sql
+++ b/server/api/drizzle/0033_add_ai_model_system_default.sql
@@ -1,0 +1,7 @@
+-- Add system default flag to ai_models so admins can designate a fallback model.
+-- 管理者がシステム既定モデルを指定できるよう ai_models にフラグを追加する。
+ALTER TABLE "ai_models" ADD COLUMN IF NOT EXISTS "is_system_default" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_ai_models_system_default_unique"
+  ON "ai_models" ("is_system_default")
+  WHERE "is_system_default" = true;

--- a/server/api/drizzle/meta/_journal.json
+++ b/server/api/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1780012800000,
       "tag": "0032_add_user_ai_credentials",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1780099200000,
+      "tag": "0033_add_ai_model_system_default",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/src/__tests__/routes/ai/chat.test.ts
+++ b/server/api/src/__tests__/routes/ai/chat.test.ts
@@ -25,7 +25,7 @@ vi.mock("../../../middleware/rateLimit.js", () => ({
 
 const {
   mockGetUserTier,
-  mockValidateModelAccess,
+  mockResolveModelAccessWithFallback,
   mockCheckUsage,
   mockCalculateCost,
   mockRecordUsage,
@@ -34,7 +34,7 @@ const {
   mockGetProviderApiKeyName,
 } = vi.hoisted(() => ({
   mockGetUserTier: vi.fn(),
-  mockValidateModelAccess: vi.fn(),
+  mockResolveModelAccessWithFallback: vi.fn(),
   mockCheckUsage: vi.fn(),
   mockCalculateCost: vi.fn(),
   mockRecordUsage: vi.fn(),
@@ -49,9 +49,12 @@ vi.mock("../../../services/subscriptionService.js", () => ({
 
 vi.mock("../../../services/usageService.js", () => ({
   checkUsage: mockCheckUsage,
-  validateModelAccess: mockValidateModelAccess,
   calculateCost: mockCalculateCost,
   recordUsage: mockRecordUsage,
+}));
+
+vi.mock("../../../services/modelResolverService.js", () => ({
+  resolveModelAccessWithFallback: mockResolveModelAccessWithFallback,
 }));
 
 vi.mock("../../../services/aiProviders.js", () => ({
@@ -89,11 +92,13 @@ function authHeaders(): Record<string, string> {
 
 beforeEach(() => {
   mockGetUserTier.mockReset().mockResolvedValue("pro");
-  mockValidateModelAccess.mockReset().mockResolvedValue({
+  mockResolveModelAccessWithFallback.mockReset().mockResolvedValue({
+    modelId: "gpt-4o",
     provider: "openai",
     apiModelId: "gpt-4o",
     inputCostUnits: 5,
     outputCostUnits: 15,
+    didFallback: false,
   });
   mockCheckUsage.mockReset().mockResolvedValue({
     allowed: true,
@@ -203,10 +208,11 @@ describe("POST /api/chat — usage and API key gating", () => {
     expect(res.status).toBe(503);
   });
 
-  it("propagates 'Model not found or inactive' as a 500 by default", async () => {
+  it("returns 503 when no model is available for the tier", async () => {
     process.env.OPENAI_API_KEY = "sk-test";
-    mockValidateModelAccess.mockRejectedValueOnce(new Error("Model not found or inactive"));
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockResolveModelAccessWithFallback.mockRejectedValueOnce(
+      new Error("No available model for tier"),
+    );
     const app = createTestApp();
 
     const res = await app.request("/api/chat", {
@@ -215,24 +221,7 @@ describe("POST /api/chat — usage and API key gating", () => {
       body: JSON.stringify(validBody),
     });
 
-    expect(res.status).toBe(500);
-  });
-
-  it("maps a FORBIDDEN error from validateModelAccess to 403", async () => {
-    process.env.OPENAI_API_KEY = "sk-test";
-    mockValidateModelAccess.mockRejectedValueOnce(new Error("FORBIDDEN"));
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const app = createTestApp();
-
-    const res = await app.request("/api/chat", {
-      method: "POST",
-      headers: authHeaders(),
-      body: JSON.stringify(validBody),
-    });
-
-    // errorHandler の statusMap で FORBIDDEN → 403。
-    // statusMap in errorHandler maps the literal "FORBIDDEN" message to 403.
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(503);
   });
 });
 

--- a/server/api/src/__tests__/services/modelResolverService.test.ts
+++ b/server/api/src/__tests__/services/modelResolverService.test.ts
@@ -1,0 +1,153 @@
+/**
+ * modelResolverService.ts のテスト。
+ * Tests for modelResolverService.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  isModelTierAccessible,
+  isModelUsable,
+  resolveSystemDefaultModelId,
+  resolveModelAccessWithFallback,
+} from "../../services/modelResolverService.js";
+import { createMockDb } from "../createMockDb.js";
+import type { Database } from "../../types/index.js";
+
+function asDb(results: unknown[]) {
+  const { db } = createMockDb(results);
+  return db as unknown as Database;
+}
+
+const baseModel = {
+  id: "google:gemini-flash",
+  provider: "google",
+  modelId: "gemini-flash",
+  displayName: "Gemini Flash",
+  tierRequired: "free" as const,
+  inputCostUnits: 1,
+  outputCostUnits: 1,
+  isActive: true,
+  isSystemDefault: false,
+  sortOrder: 1,
+  createdAt: new Date(),
+};
+
+describe("isModelTierAccessible", () => {
+  it("allows free models for free tier", () => {
+    expect(isModelTierAccessible({ tierRequired: "free" }, "free")).toBe(true);
+  });
+
+  it("blocks pro models for free tier", () => {
+    expect(isModelTierAccessible({ tierRequired: "pro" }, "free")).toBe(false);
+  });
+
+  it("allows pro models for pro tier", () => {
+    expect(isModelTierAccessible({ tierRequired: "pro" }, "pro")).toBe(true);
+  });
+});
+
+describe("resolveSystemDefaultModelId", () => {
+  it("returns configured system default when active and tier-accessible", async () => {
+    const db = asDb([
+      [
+        { ...baseModel, id: "openai:gpt", sortOrder: 0 },
+        { ...baseModel, id: "google:default", isSystemDefault: true, sortOrder: 1 },
+      ],
+    ]);
+
+    const id = await resolveSystemDefaultModelId("free", db);
+    expect(id).toBe("google:default");
+  });
+
+  it("falls back to first sortOrder model when configured default is pro-only for free tier", async () => {
+    const db = asDb([
+      [
+        { ...baseModel, id: "openai:free", sortOrder: 0 },
+        {
+          ...baseModel,
+          id: "openai:pro",
+          tierRequired: "pro" as const,
+          isSystemDefault: true,
+          sortOrder: 1,
+        },
+      ],
+    ]);
+
+    const id = await resolveSystemDefaultModelId("free", db);
+    expect(id).toBe("openai:free");
+  });
+
+  it("returns null when no active models exist", async () => {
+    const db = asDb([[]]);
+    const id = await resolveSystemDefaultModelId("free", db);
+    expect(id).toBeNull();
+  });
+});
+
+describe("resolveModelAccessWithFallback", () => {
+  it("uses requested model when active and accessible", async () => {
+    const db = asDb([
+      [
+        { ...baseModel, id: "openai:a" },
+        { ...baseModel, id: "google:b", isSystemDefault: true },
+      ],
+    ]);
+
+    const result = await resolveModelAccessWithFallback("openai:a", "free", db);
+    expect(result.modelId).toBe("openai:a");
+    expect(result.didFallback).toBe(false);
+  });
+
+  it("falls back to system default when requested model is inactive", async () => {
+    const db = asDb([[{ ...baseModel, id: "google:default", isSystemDefault: true }]]);
+
+    const result = await resolveModelAccessWithFallback("openai:missing", "free", db);
+    expect(result.modelId).toBe("google:default");
+    expect(result.didFallback).toBe(true);
+  });
+
+  it("falls back to system default when requested model requires pro tier", async () => {
+    const db = asDb([
+      [
+        {
+          ...baseModel,
+          id: "openai:pro-only",
+          tierRequired: "pro" as const,
+        },
+        { ...baseModel, id: "google:default", isSystemDefault: true },
+      ],
+    ]);
+
+    const result = await resolveModelAccessWithFallback("openai:pro-only", "free", db);
+    expect(result.modelId).toBe("google:default");
+    expect(result.didFallback).toBe(true);
+  });
+
+  it("uses first available model when no system default is configured", async () => {
+    const db = asDb([
+      [
+        { ...baseModel, id: "openai:first", sortOrder: 0 },
+        { ...baseModel, id: "google:second", sortOrder: 1 },
+      ],
+    ]);
+
+    const result = await resolveModelAccessWithFallback(null, "free", db);
+    expect(result.modelId).toBe("openai:first");
+    expect(result.didFallback).toBe(false);
+  });
+
+  it("throws when no models are available for tier", async () => {
+    const db = asDb([[{ ...baseModel, tierRequired: "pro" as const }]]);
+
+    await expect(resolveModelAccessWithFallback(null, "free", db)).rejects.toThrow(
+      /No available model/i,
+    );
+  });
+});
+
+describe("isModelUsable", () => {
+  it("requires active and tier-accessible", () => {
+    expect(isModelUsable({ isActive: true, tierRequired: "free" }, "free")).toBe(true);
+    expect(isModelUsable({ isActive: false, tierRequired: "free" }, "free")).toBe(false);
+    expect(isModelUsable({ isActive: true, tierRequired: "pro" }, "free")).toBe(false);
+  });
+});

--- a/server/api/src/routes/ai/admin.ts
+++ b/server/api/src/routes/ai/admin.ts
@@ -12,6 +12,7 @@ import { adminRequired } from "../../middleware/adminAuth.js";
 import { aiModels, type NewAiModel } from "../../schema/index.js";
 import { users } from "../../schema/users.js";
 import { syncAiModels, previewSyncAiModels } from "../../services/syncAiModels.js";
+import { setSystemDefaultModel } from "../../services/modelResolverService.js";
 import type { AppEnv } from "../../types/index.js";
 
 const SYNC_SECRET = process.env.SYNC_AI_MODELS_SECRET ?? "";
@@ -44,6 +45,7 @@ adminApp.get("/models", async (c) => {
       inputCostUnits: m.inputCostUnits,
       outputCostUnits: m.outputCostUnits,
       isActive: m.isActive,
+      isSystemDefault: m.isSystemDefault,
       sortOrder: m.sortOrder,
       createdAt: m.createdAt,
     })),
@@ -61,6 +63,7 @@ adminApp.patch("/models/:id", async (c) => {
     inputCostUnits: number;
     outputCostUnits: number;
     isActive: boolean;
+    isSystemDefault: boolean;
     sortOrder: number;
   }> = {};
 
@@ -93,6 +96,24 @@ adminApp.patch("/models/:id", async (c) => {
     if (typeof body.sortOrder !== "number")
       return c.json({ error: "sortOrder must be a number" }, 400);
     updates.sortOrder = body.sortOrder;
+  }
+
+  if (body.isSystemDefault !== undefined) {
+    if (typeof body.isSystemDefault !== "boolean")
+      return c.json({ error: "isSystemDefault must be a boolean" }, 400);
+    if (body.isSystemDefault) {
+      try {
+        const model = await setSystemDefaultModel(id, db);
+        return c.json({ model });
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg === "NOT_FOUND") return c.json({ error: "Not found", id }, 404);
+        if (msg === "INACTIVE")
+          return c.json({ error: "Cannot set inactive model as system default" }, 400);
+        throw e;
+      }
+    }
+    updates.isSystemDefault = false;
   }
 
   if (Object.keys(updates).length === 0) {

--- a/server/api/src/routes/ai/admin.ts
+++ b/server/api/src/routes/ai/admin.ts
@@ -91,6 +91,9 @@ adminApp.patch("/models/:id", async (c) => {
     if (typeof body.isActive !== "boolean")
       return c.json({ error: "isActive must be a boolean" }, 400);
     updates.isActive = body.isActive;
+    if (body.isActive === false) {
+      updates.isSystemDefault = false;
+    }
   }
   if (body.sortOrder !== undefined) {
     if (typeof body.sortOrder !== "number")
@@ -102,6 +105,9 @@ adminApp.patch("/models/:id", async (c) => {
     if (typeof body.isSystemDefault !== "boolean")
       return c.json({ error: "isSystemDefault must be a boolean" }, 400);
     if (body.isSystemDefault) {
+      if (Object.keys(updates).length > 0) {
+        return c.json({ error: "isSystemDefault=true cannot be combined with other fields" }, 400);
+      }
       try {
         const model = await setSystemDefaultModel(id, db);
         return c.json({ model });

--- a/server/api/src/routes/ai/chat.ts
+++ b/server/api/src/routes/ai/chat.ts
@@ -25,8 +25,12 @@ app.post("/", authRequired, rateLimit(), async (c) => {
   let modelInfo;
   try {
     modelInfo = await resolveModelAccessWithFallback(body.model, tier, db);
-  } catch {
-    throw new HTTPException(503, { message: "No available model for tier" });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/No available model for tier/i.test(msg)) {
+      throw new HTTPException(503, { message: "No available model for tier" });
+    }
+    throw e;
   }
   const usageCheck = await checkUsage(userId, tier, db);
   if (!usageCheck.allowed) {
@@ -80,6 +84,8 @@ app.post("/", authRequired, rateLimit(), async (c) => {
             const donePayload: SSEPayload = {
               done: true,
               finishReason: chunk.finishReason,
+              modelId: modelInfo.modelId,
+              didFallback: modelInfo.didFallback,
               usage: {
                 inputTokens,
                 outputTokens,
@@ -129,6 +135,8 @@ app.post("/", authRequired, rateLimit(), async (c) => {
   return c.json({
     content: result.content,
     finishReason: result.finishReason,
+    modelId: modelInfo.modelId,
+    didFallback: modelInfo.didFallback,
     usage: {
       inputTokens: result.usage.inputTokens,
       outputTokens: result.usage.outputTokens,

--- a/server/api/src/routes/ai/chat.ts
+++ b/server/api/src/routes/ai/chat.ts
@@ -4,12 +4,8 @@ import { HTTPException } from "hono/http-exception";
 import { authRequired } from "../../middleware/auth.js";
 import { rateLimit } from "../../middleware/rateLimit.js";
 import { getUserTier } from "../../services/subscriptionService.js";
-import {
-  checkUsage,
-  validateModelAccess,
-  calculateCost,
-  recordUsage,
-} from "../../services/usageService.js";
+import { checkUsage, calculateCost, recordUsage } from "../../services/usageService.js";
+import { resolveModelAccessWithFallback } from "../../services/modelResolverService.js";
 import { callProvider, streamProvider, getProviderApiKeyName } from "../../services/aiProviders.js";
 import type { AppEnv, AIChatRequest, SSEPayload, AIProviderType } from "../../types/index.js";
 
@@ -26,13 +22,18 @@ app.post("/", authRequired, rateLimit(), async (c) => {
   }
 
   const tier = await getUserTier(userId, db);
-  const modelInfo = await validateModelAccess(body.model, tier, db);
+  let modelInfo;
+  try {
+    modelInfo = await resolveModelAccessWithFallback(body.model, tier, db);
+  } catch {
+    throw new HTTPException(503, { message: "No available model for tier" });
+  }
   const usageCheck = await checkUsage(userId, tier, db);
   if (!usageCheck.allowed) {
     throw new HTTPException(429, { message: "Monthly budget exceeded" });
   }
 
-  const apiKeyName = getProviderApiKeyName(body.provider);
+  const apiKeyName = getProviderApiKeyName(modelInfo.provider as AIProviderType);
   const apiKey = process.env[apiKeyName];
   if (!apiKey) {
     throw new HTTPException(503, { message: `API key not configured: ${apiKeyName}` });
@@ -90,7 +91,7 @@ app.post("/", authRequired, rateLimit(), async (c) => {
 
             await recordUsage(
               userId,
-              body.model,
+              modelInfo.modelId,
               feature,
               { inputTokens, outputTokens },
               costUnits,
@@ -122,7 +123,7 @@ app.post("/", authRequired, rateLimit(), async (c) => {
     modelInfo.inputCostUnits,
     modelInfo.outputCostUnits,
   );
-  await recordUsage(userId, body.model, feature, result.usage, costUnits, "system", db);
+  await recordUsage(userId, modelInfo.modelId, feature, result.usage, costUnits, "system", db);
   const updatedUsage = await checkUsage(userId, tier, db);
 
   return c.json({

--- a/server/api/src/routes/ai/models.ts
+++ b/server/api/src/routes/ai/models.ts
@@ -3,6 +3,7 @@ import { eq, asc } from "drizzle-orm";
 import { aiModels } from "../../schema/index.js";
 import { authOptional } from "../../middleware/auth.js";
 import { getUserTier } from "../../services/subscriptionService.js";
+import { resolveSystemDefaultModelId } from "../../services/modelResolverService.js";
 import type { AppEnv, UserTier } from "../../types/index.js";
 
 const app = new Hono<AppEnv>();
@@ -44,6 +45,7 @@ app.get("/", authOptional, async (c) => {
   const toModelTier = (v: string | undefined): "free" | "pro" => (v === "free" ? "free" : "pro");
 
   const clientTier = toClientTier(tier);
+  const systemDefaultModelId = await resolveSystemDefaultModelId(clientTier, db);
   const models = rows.map((m) => {
     const tierRequired = toModelTier(m.tierRequired);
     return {
@@ -58,7 +60,7 @@ app.get("/", authOptional, async (c) => {
     };
   });
 
-  return c.json({ models, tier: clientTier });
+  return c.json({ models, tier: clientTier, systemDefaultModelId });
 });
 
 export default app;

--- a/server/api/src/schema/aiModels.ts
+++ b/server/api/src/schema/aiModels.ts
@@ -25,6 +25,8 @@ export const aiModels = pgTable(
     inputCostUnits: integer("input_cost_units").notNull(),
     outputCostUnits: integer("output_cost_units").notNull(),
     isActive: boolean("is_active").notNull().default(true),
+    /** Admin-designated system default; at most one row may be true. / 管理者指定のシステム既定（最大1件） */
+    isSystemDefault: boolean("is_system_default").notNull().default(false),
     sortOrder: integer("sort_order").notNull().default(0),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },

--- a/server/api/src/services/modelResolverService.ts
+++ b/server/api/src/services/modelResolverService.ts
@@ -1,0 +1,145 @@
+/**
+ * AI モデル解決（システム既定・フォールバック）。
+ * AI model resolution (system default and fallback chain).
+ */
+import { eq, asc } from "drizzle-orm";
+import { aiModels, type AiModel } from "../schema/index.js";
+import type { Database, UserTier } from "../types/index.js";
+
+export type ResolvedModelAccess = {
+  modelId: string;
+  provider: string;
+  apiModelId: string;
+  inputCostUnits: number;
+  outputCostUnits: number;
+  /** True when a different model was chosen than requested. / 要求モデルと異なるモデルに解決した */
+  didFallback: boolean;
+};
+
+/** Whether the user's tier can use this model row. / ユーザーティアでモデル行が利用可能か */
+export function isModelTierAccessible(
+  model: Pick<AiModel, "tierRequired">,
+  tier: UserTier,
+): boolean {
+  return tier === "pro" || model.tierRequired === "free";
+}
+
+/** Whether an active model row is usable for the tier. / アクティブなモデル行がティアで使えるか */
+export function isModelUsable(
+  model: Pick<AiModel, "isActive" | "tierRequired">,
+  tier: UserTier,
+): boolean {
+  return model.isActive && isModelTierAccessible(model, tier);
+}
+
+/**
+ * Resolves the effective system default model id for a tier (configured default, then sort order).
+ * ティア向けの実効システム既定モデル ID を解決する（設定既定 → sortOrder 順）。
+ */
+export async function resolveSystemDefaultModelId(
+  tier: UserTier,
+  db: Database,
+): Promise<string | null> {
+  const rows = await db
+    .select()
+    .from(aiModels)
+    .where(eq(aiModels.isActive, true))
+    .orderBy(asc(aiModels.sortOrder), asc(aiModels.id));
+
+  const configured = rows.find((m) => m.isSystemDefault && isModelTierAccessible(m, tier));
+  if (configured) return configured.id;
+
+  const firstAvailable = rows.find((m) => isModelTierAccessible(m, tier));
+  return firstAvailable?.id ?? null;
+}
+
+/**
+ * Resolves model access with fallback: requested → system default → sort order.
+ * 要求モデル → システム既定 → sortOrder 順でモデルアクセスを解決する。
+ */
+export async function resolveModelAccessWithFallback(
+  requestedModelId: string | null | undefined,
+  tier: UserTier,
+  db: Database,
+): Promise<ResolvedModelAccess> {
+  const rows = await db
+    .select()
+    .from(aiModels)
+    .where(eq(aiModels.isActive, true))
+    .orderBy(asc(aiModels.sortOrder), asc(aiModels.id));
+
+  const usable = rows.filter((m) => isModelTierAccessible(m, tier));
+
+  if (requestedModelId) {
+    const requested = usable.find((m) => m.id === requestedModelId);
+    if (requested) {
+      return toResolvedAccess(requested, false);
+    }
+  }
+
+  const configuredDefault = usable.find((m) => m.isSystemDefault);
+  if (configuredDefault) {
+    return toResolvedAccess(configuredDefault, Boolean(requestedModelId));
+  }
+
+  const first = usable[0];
+  if (first) {
+    return toResolvedAccess(first, Boolean(requestedModelId));
+  }
+
+  throw new Error("No available model for tier");
+}
+
+function toResolvedAccess(model: AiModel, didFallback: boolean): ResolvedModelAccess {
+  return {
+    modelId: model.id,
+    provider: model.provider,
+    apiModelId: model.modelId,
+    inputCostUnits: model.inputCostUnits,
+    outputCostUnits: model.outputCostUnits,
+    didFallback,
+  };
+}
+
+/**
+ * Sets the system default model (clears other defaults in one transaction).
+ * システム既定モデルを設定する（他行の既定フラグをトランザクションで解除）。
+ */
+export async function setSystemDefaultModel(modelId: string, db: Database): Promise<AiModel> {
+  const [target] = await db.select().from(aiModels).where(eq(aiModels.id, modelId)).limit(1);
+  if (!target) {
+    throw new Error("NOT_FOUND");
+  }
+  if (!target.isActive) {
+    throw new Error("INACTIVE");
+  }
+
+  const result = await db.transaction(async (tx) => {
+    await tx
+      .update(aiModels)
+      .set({ isSystemDefault: false })
+      .where(eq(aiModels.isSystemDefault, true));
+    const updated = await tx
+      .update(aiModels)
+      .set({ isSystemDefault: true })
+      .where(eq(aiModels.id, modelId))
+      .returning();
+    return updated[0];
+  });
+
+  if (!result) {
+    throw new Error("NOT_FOUND");
+  }
+  return result;
+}
+
+/**
+ * Clears the system default flag from all models.
+ * 全モデルのシステム既定フラグを解除する。
+ */
+export async function clearSystemDefaultModel(db: Database): Promise<void> {
+  await db
+    .update(aiModels)
+    .set({ isSystemDefault: false })
+    .where(eq(aiModels.isSystemDefault, true));
+}

--- a/server/api/src/services/modelResolverService.ts
+++ b/server/api/src/services/modelResolverService.ts
@@ -106,15 +106,15 @@ function toResolvedAccess(model: AiModel, didFallback: boolean): ResolvedModelAc
  * システム既定モデルを設定する（他行の既定フラグをトランザクションで解除）。
  */
 export async function setSystemDefaultModel(modelId: string, db: Database): Promise<AiModel> {
-  const [target] = await db.select().from(aiModels).where(eq(aiModels.id, modelId)).limit(1);
-  if (!target) {
-    throw new Error("NOT_FOUND");
-  }
-  if (!target.isActive) {
-    throw new Error("INACTIVE");
-  }
-
   const result = await db.transaction(async (tx) => {
+    const [target] = await tx.select().from(aiModels).where(eq(aiModels.id, modelId)).limit(1);
+    if (!target) {
+      throw new Error("NOT_FOUND");
+    }
+    if (!target.isActive) {
+      throw new Error("INACTIVE");
+    }
+
     await tx
       .update(aiModels)
       .set({ isSystemDefault: false })

--- a/server/api/src/types/index.ts
+++ b/server/api/src/types/index.ts
@@ -55,6 +55,10 @@ export interface SSEPayload {
   done?: boolean;
   finishReason?: string;
   error?: string;
+  /** Resolved model id after fallback / フォールバック後に解決されたモデル ID */
+  modelId?: string;
+  /** True when a different model was used than requested / 要求と異なるモデルが使われた */
+  didFallback?: boolean;
   usage?: {
     inputTokens: number;
     outputTokens: number;

--- a/src/components/ai-chat/AIChatModelSelector.tsx
+++ b/src/components/ai-chat/AIChatModelSelector.tsx
@@ -9,6 +9,7 @@ import { isTauriDesktop } from "../../lib/platform";
 import type { AIModel, AIInteractionMode, AIProviderType } from "../../types/ai";
 import { getInteractionMode } from "../../types/ai";
 import { cn } from "@zedi/ui";
+import { resolveServerInitialSelection } from "../../lib/resolveServerModel";
 
 interface DisplayModel {
   id: string;
@@ -47,22 +48,6 @@ function resolveClaudeInitialSelection(
   if (matchedCurrent) return undefined;
   const matchedSaved = savedModelId ? claudeModels.find((m) => m.id === savedModelId) : undefined;
   return matchedSaved ?? claudeModels[0];
-}
-
-/**
- * Resolves which server model to select when the current store id is not in the list.
- * ストアの選択が一覧に無いときに選ぶサーバーモデルを解決する。
- */
-function resolveServerInitialSelection(
-  available: AIModel[],
-  current: { id: string } | null,
-  savedModelId: string | undefined,
-): AIModel | undefined {
-  if (available.length === 0) return undefined;
-  const matchedCurrent = current ? available.find((m) => m.id === current.id) : undefined;
-  if (matchedCurrent) return undefined;
-  const matched = savedModelId ? available.find((m) => m.id === savedModelId) : null;
-  return matched ?? available[0];
 }
 
 /**
@@ -126,7 +111,7 @@ export function AIChatModelSelector() {
         return;
       }
 
-      const { models: serverModels } = await fetchServerModels();
+      const { models: serverModels, systemDefaultModelId } = await fetchServerModels();
       let available = serverModels.filter((m) => m.available);
       if (currentMode === "user_api_key" && settings) {
         available = available.filter((m) => m.provider === settings.provider);
@@ -147,7 +132,12 @@ export function AIChatModelSelector() {
       if (available.length === 0) {
         setSelectedModel(null);
       } else {
-        const initial = resolveServerInitialSelection(available, current, settings?.modelId);
+        const initial = resolveServerInitialSelection(
+          available,
+          current,
+          settings?.modelId,
+          systemDefaultModelId,
+        );
         if (initial) {
           setSelectedModel({
             id: initial.id,

--- a/src/components/settings/useAISettingsForm.ts
+++ b/src/components/settings/useAISettingsForm.ts
@@ -7,6 +7,7 @@ import {
   useSavedIndicator,
   useClaudeCodeAvailability,
   useServerModels,
+  resolvePreferredForSettings,
 } from "./useAISettingsFormHelpers";
 import type { AIProviderType, AISettings, AIInteractionMode } from "@/types/ai";
 import { DEFAULT_AI_SETTINGS, getInteractionMode } from "@/types/ai";
@@ -124,6 +125,7 @@ export function useAISettingsForm() {
   const claudeCodeAvailable = useClaudeCodeAvailability();
   const {
     models: serverModels,
+    systemDefaultModelId,
     loading: serverModelsLoading,
     error: serverModelsError,
     load: loadServerModels,
@@ -141,6 +143,37 @@ export function useAISettingsForm() {
       loadServerModels();
     }
   }, [isServerMode, loadServerModels]);
+
+  useEffect(() => {
+    if (!isServerMode || serverModelsLoading) return;
+    const available = serverModels.filter((m) => m.available);
+    if (available.length === 0) return;
+
+    const savedStillAvailable =
+      settings.modelId !== "" && available.some((m) => m.id === settings.modelId);
+    if (savedStillAvailable) return;
+
+    const preferred = resolvePreferredForSettings(
+      available,
+      settings.modelId || undefined,
+      systemDefaultModelId,
+    );
+    if (!preferred) return;
+
+    updateSettingsBase({
+      provider: preferred.provider,
+      model: preferred.modelId,
+      modelId: preferred.id,
+    });
+  }, [
+    isServerMode,
+    serverModelsLoading,
+    serverModels,
+    systemDefaultModelId,
+    settings.modelId,
+    settings.provider,
+    updateSettingsBase,
+  ]);
 
   const runSave = useCallback(async () => {
     markSaved(await save());

--- a/src/components/settings/useAISettingsFormHelpers.ts
+++ b/src/components/settings/useAISettingsFormHelpers.ts
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { toast as sonnerToast } from "@zedi/ui/components/sonner";
 import { isTauriDesktop } from "@/lib/platform";
 import { fetchServerModels, FetchServerModelsError } from "@/lib/aiService";
+import { resolvePreferredServerModel } from "@/lib/resolveServerModel";
 import type { AIModel } from "@/types/ai";
 
 const SAVED_INDICATOR_MS = 3000;
@@ -94,6 +95,7 @@ export function useClaudeCodeAvailability(): boolean | null {
 export function useServerModels() {
   const { t } = useTranslation();
   const [models, setModels] = useState<AIModel[]>([]);
+  const [systemDefaultModelId, setSystemDefaultModelId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -102,8 +104,10 @@ export function useServerModels() {
       setError(null);
       setLoading(true);
       try {
-        const { models: fetched } = await fetchServerModels(forceRefresh);
+        const { models: fetched, systemDefaultModelId: defaultId } =
+          await fetchServerModels(forceRefresh);
         setModels(fetched ?? []);
+        setSystemDefaultModelId(defaultId);
         if (!fetched?.length) {
           setError(t("aiSettings.modelsEmpty"));
         }
@@ -116,6 +120,7 @@ export function useServerModels() {
               : String(e);
         setError(message);
         setModels([]);
+        setSystemDefaultModelId(null);
       } finally {
         setLoading(false);
       }
@@ -123,5 +128,17 @@ export function useServerModels() {
     [t],
   );
 
-  return { models, loading, error, load };
+  return { models, systemDefaultModelId, loading, error, load };
+}
+
+/**
+ * Resolves the settings model from available server models and system default.
+ * 利用可能なサーバーモデルとシステム既定から設定用モデルを解決する。
+ */
+export function resolvePreferredForSettings(
+  available: AIModel[],
+  savedModelId: string | undefined,
+  systemDefaultModelId: string | null,
+): AIModel | undefined {
+  return resolvePreferredServerModel(available, { savedModelId, systemDefaultModelId });
 }

--- a/src/lib/aiServiceModels.test.ts
+++ b/src/lib/aiServiceModels.test.ts
@@ -315,7 +315,11 @@ describe("aiServiceModels", () => {
         throw new Error("quota exceeded");
       });
 
-      await expect(fetchServerModels()).resolves.toEqual({ models: [], tier: "free" });
+      await expect(fetchServerModels()).resolves.toEqual({
+        models: [],
+        tier: "free",
+        systemDefaultModelId: null,
+      });
       expect(setItemSpy).toHaveBeenCalled();
     });
   });

--- a/src/lib/aiServiceModels.ts
+++ b/src/lib/aiServiceModels.ts
@@ -61,7 +61,7 @@ export class FetchServerModelsError extends Error {
 
 async function fetchModelsFromApi(
   apiBaseUrl: string,
-): Promise<{ models: AIModel[]; tier: UserTier }> {
+): Promise<{ models: AIModel[]; tier: UserTier; systemDefaultModelId: string | null }> {
   let response: Response;
   try {
     response = await fetch(`${apiBaseUrl}/api/ai/models`, {
@@ -111,9 +111,13 @@ async function fetchModelsFromApi(
     throw err;
   }
 
-  let data: { models?: unknown[]; tier?: UserTier };
+  let data: { models?: unknown[]; tier?: UserTier; systemDefaultModelId?: string | null };
   try {
-    data = JSON.parse(bodyText) as { models?: unknown[]; tier?: UserTier };
+    data = JSON.parse(bodyText) as {
+      models?: unknown[];
+      tier?: UserTier;
+      systemDefaultModelId?: string | null;
+    };
   } catch (_e) {
     const err = new FetchServerModelsError(
       i18n.t("errors.apiResponseNotJson"),
@@ -140,7 +144,9 @@ async function fetchModelsFromApi(
 
   const models = data.models.map((m) => normalizeToAIModel((m as Record<string, unknown>) ?? {}));
   const tier: UserTier = data.tier === "pro" ? "pro" : "free";
-  return { models, tier };
+  const systemDefaultModelId =
+    typeof data.systemDefaultModelId === "string" ? data.systemDefaultModelId : null;
+  return { models, tier, systemDefaultModelId };
 }
 
 /**
@@ -151,6 +157,7 @@ async function fetchModelsFromApi(
 export async function fetchServerModels(forceRefresh = false): Promise<{
   models: AIModel[];
   tier: UserTier;
+  systemDefaultModelId: string | null;
 }> {
   if (!forceRefresh) {
     try {
@@ -163,11 +170,14 @@ export async function fetchServerModels(forceRefresh = false): Promise<{
           );
           const rawTier = parsed.tier as string;
           const cachedTier: UserTier = rawTier === "pro" ? "pro" : "free";
+          const systemDefaultModelId =
+            typeof parsed.systemDefaultModelId === "string" ? parsed.systemDefaultModelId : null;
           console.debug("[fetchServerModels] cache hit", {
             count: models.length,
             tier: cachedTier,
+            systemDefaultModelId,
           });
-          return { models, tier: cachedTier };
+          return { models, tier: cachedTier, systemDefaultModelId };
         }
       }
     } catch (e) {
@@ -190,6 +200,7 @@ export async function fetchServerModels(forceRefresh = false): Promise<{
   console.debug("[fetchServerModels] API response", {
     count: result.models.length,
     tier: result.tier,
+    systemDefaultModelId: result.systemDefaultModelId,
   });
 
   try {
@@ -198,6 +209,7 @@ export async function fetchServerModels(forceRefresh = false): Promise<{
       JSON.stringify({
         models: result.models,
         tier: result.tier as UserTier,
+        systemDefaultModelId: result.systemDefaultModelId,
         cachedAt: Date.now(),
       } satisfies CachedServerModels),
     );

--- a/src/lib/resolveServerModel.test.ts
+++ b/src/lib/resolveServerModel.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { resolvePreferredServerModel, resolveServerInitialSelection } from "./resolveServerModel";
+import type { AIModel } from "@/types/ai";
+
+function model(id: string): AIModel {
+  return {
+    id,
+    provider: "google",
+    modelId: id.split(":")[1] ?? id,
+    displayName: id,
+    tierRequired: "free",
+    available: true,
+    inputCostUnits: 1,
+    outputCostUnits: 1,
+  };
+}
+
+describe("resolvePreferredServerModel", () => {
+  const available = [model("openai:a"), model("google:b"), model("google:default")];
+
+  it("prefers current selection when still available", () => {
+    const picked = resolvePreferredServerModel(available, {
+      currentId: "google:b",
+      savedModelId: "openai:a",
+      systemDefaultModelId: "google:default",
+    });
+    expect(picked?.id).toBe("google:b");
+  });
+
+  it("falls back to saved model when current is unavailable", () => {
+    const picked = resolvePreferredServerModel(available, {
+      currentId: "openai:removed",
+      savedModelId: "openai:a",
+      systemDefaultModelId: "google:default",
+    });
+    expect(picked?.id).toBe("openai:a");
+  });
+
+  it("uses system default when saved model is unavailable", () => {
+    const picked = resolvePreferredServerModel(available, {
+      savedModelId: "openai:removed",
+      systemDefaultModelId: "google:default",
+    });
+    expect(picked?.id).toBe("google:default");
+  });
+
+  it("uses first available when nothing else matches", () => {
+    const picked = resolvePreferredServerModel(available, {
+      savedModelId: "missing",
+      systemDefaultModelId: "also-missing",
+    });
+    expect(picked?.id).toBe("openai:a");
+  });
+});
+
+describe("resolveServerInitialSelection", () => {
+  const available = [model("openai:a"), model("google:default")];
+
+  it("returns undefined when current selection is still valid", () => {
+    expect(
+      resolveServerInitialSelection(
+        available,
+        { id: "openai:a" },
+        "google:default",
+        "google:default",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns fallback when current selection is missing", () => {
+    const picked = resolveServerInitialSelection(
+      available,
+      { id: "openai:removed" },
+      "openai:removed",
+      "google:default",
+    );
+    expect(picked?.id).toBe("google:default");
+  });
+});

--- a/src/lib/resolveServerModel.ts
+++ b/src/lib/resolveServerModel.ts
@@ -1,5 +1,9 @@
 import type { AIModel } from "@/types/ai";
 
+/**
+ * Options used to resolve the preferred server model.
+ * 優先サーバーモデルの解決に使うオプション。
+ */
 export type ResolvePreferredServerModelOptions = {
   /** Current chat-store selection id / チャットストアの選択 ID */
   currentId?: string | null;

--- a/src/lib/resolveServerModel.ts
+++ b/src/lib/resolveServerModel.ts
@@ -1,0 +1,58 @@
+import type { AIModel } from "@/types/ai";
+
+export type ResolvePreferredServerModelOptions = {
+  /** Current chat-store selection id / チャットストアの選択 ID */
+  currentId?: string | null;
+  /** Persisted settings model id / 設定に保存されたモデル ID */
+  savedModelId?: string | null;
+  /** Server-resolved default for the user's tier / サーバー解決済みの既定モデル ID */
+  systemDefaultModelId?: string | null;
+};
+
+/**
+ * Picks the best available server model: current → saved → system default → first.
+ * 利用可能なサーバーモデルを優先度順に選ぶ（現在 → 保存 → システム既定 → 先頭）。
+ */
+export function resolvePreferredServerModel(
+  available: AIModel[],
+  options: ResolvePreferredServerModelOptions,
+): AIModel | undefined {
+  if (available.length === 0) return undefined;
+
+  const { currentId, savedModelId, systemDefaultModelId } = options;
+
+  if (currentId) {
+    const matched = available.find((m) => m.id === currentId);
+    if (matched) return matched;
+  }
+
+  if (savedModelId) {
+    const matched = available.find((m) => m.id === savedModelId);
+    if (matched) return matched;
+  }
+
+  if (systemDefaultModelId) {
+    const matched = available.find((m) => m.id === systemDefaultModelId);
+    if (matched) return matched;
+  }
+
+  return available[0];
+}
+
+/**
+ * Returns a new selection when the current store id is absent from the available list.
+ * ストアの選択が一覧に無いときだけ新しい選択を返す（それ以外は undefined）。
+ */
+export function resolveServerInitialSelection(
+  available: AIModel[],
+  current: { id: string } | null,
+  savedModelId: string | undefined,
+  systemDefaultModelId: string | null | undefined,
+): AIModel | undefined {
+  if (available.length === 0) return undefined;
+  if (current && available.some((m) => m.id === current.id)) return undefined;
+  return resolvePreferredServerModel(available, {
+    savedModelId,
+    systemDefaultModelId,
+  });
+}

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -114,6 +114,7 @@ export interface CachedModels {
 export interface CachedServerModels {
   models: AIModel[];
   tier: UserTier;
+  systemDefaultModelId?: string | null;
   cachedAt: number;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

管理者がシステム既定の AI モデルを設定でき、ユーザーの選択モデルが非アクティブになった場合や未設定の場合に自動的にフォールバックする機能を追加しました。

## 変更点

- `ai_models` テーブルに `is_system_default` カラムを追加（マイグレーション `0033_add_ai_model_system_default.sql`）
- `modelResolverService` でモデル解決チェーンを実装（要求モデル → システム既定 → sortOrder 順）
- `GET /api/ai/models` に `systemDefaultModelId`（ティア向けに解決済み）を追加
- `POST /api/ai/chat` で非アクティブ／利用不可モデル要求時にサーバー側フォールバック
- チャット応答に解決済み `modelId` / `didFallback` を含める
- Admin 画面に「既定に設定」ボタンを追加
- クライアント（チャット・設定）で保存モデルが利用不可のときシステム既定を使用

## レビュー対応（babysit）

- Build 失敗: admin テストフィクスチャに `isSystemDefault` を追加
- `isSystemDefault=true` と他フィールドの混在 PATCH を 400 で拒否
- モデル非アクティブ化時に `isSystemDefault` フラグをクリア
- リゾルバーの未知エラーを 503 に丸めない（既知の no-model のみ 503）
- `setSystemDefaultModel` の検証をトランザクション内で実行
- Admin の「既定に設定」連打を in-flight ガードで直列化
- エクスポート型に TSDoc を追加

## 変更の種類

- [x] ✨ 新機能 (New feature)

## テスト方法

1. マイグレーション適用後、Admin の AI モデル管理でアクティブなモデルを「既定に設定」
2. `GET /api/ai/models` のレスポンスに `systemDefaultModelId` が含まれることを確認
3. ユーザー設定のモデルを非アクティブ化し、チャット送信がシステム既定モデルで成功することを確認
4. モデル未選択（または一覧にない ID）のユーザーがシステム既定で開始できることを確認

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint / Prettier 通過
- [x] CI green（mergeStateStatus: CLEAN）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f776018c-7ec7-4ea3-bbc6-ba9001f3eef9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f776018c-7ec7-4ea3-bbc6-ba9001f3eef9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can mark an AI model as the system default; admins can set/clear this in the UI.
  * Model lists and cards show a "Default" badge or a "Set as default" action.

* **Behavior**
  * Chat and selection flows fall back to the system default when a requested model is unavailable; responses include resolved model info and fallback indication.
  * Settings prefer the system default when saved models are missing.

* **Database**
  * Added a system-default flag with uniqueness enforced so only one model can be default.

* **Tests**
  * Updated and added tests to cover resolution and fallback behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->