### PR TITLE
feat(wiki-compose): Wiki生成時に設定画面のAIプロバイダーを自動選択

### DIFF
--- a/src/hooks/useInitialComposeBackend.ts
+++ b/src/hooks/useInitialComposeBackend.ts
@@ -58,23 +58,28 @@ export function useInitialComposeBackend(
     if (!enabled || userOverrode) return;
 
     let cancelled = false;
-    void loadComposeBackendFromSettings().then((resolved) => {
-      if (!cancelled) {
+    let loadGeneration = 0;
+
+    const applyFromSettings = (markSynced: boolean) => {
+      const generation = ++loadGeneration;
+      void loadComposeBackendFromSettings().then((resolved) => {
+        if (cancelled || generation !== loadGeneration) return;
         setBackend(resolved);
-        setSettingsSynced(true);
-      }
-    });
+        if (markSynced) setSettingsSynced(true);
+      });
+    };
+
+    applyFromSettings(true);
 
     const onSettingsChanged = () => {
       if (userOverrode) return;
-      void loadComposeBackendFromSettings().then((resolved) => {
-        if (!cancelled) setBackend(resolved);
-      });
+      applyFromSettings(false);
     };
 
     window.addEventListener(AI_SETTINGS_CHANGED_EVENT, onSettingsChanged);
     return () => {
       cancelled = true;
+      loadGeneration += 1;
       window.removeEventListener(AI_SETTINGS_CHANGED_EVENT, onSettingsChanged);
     };
   }, [enabled, userOverrode]);

--- a/src/hooks/useInitialComposeBackend.ts
+++ b/src/hooks/useInitialComposeBackend.ts
@@ -1,0 +1,89 @@
+/**
+ * Initializes Wiki Compose backend from AI settings (#951).
+ * Wiki Compose の backend を設定画面の AI 設定から初期化する。
+ */
+import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
+import { loadAISettings, AI_SETTINGS_CHANGED_EVENT } from "@/lib/aiSettings";
+import { fetchUserAiCredentialsStatus } from "@/lib/userAiCredentials";
+import { resolveComposeBackendFromAiSettings } from "@/lib/wikiCompose/resolveComposeBackend";
+import type { ComposeExecutionBackend } from "@/lib/wikiCompose/backends";
+import { DEFAULT_AI_SETTINGS } from "@/types/ai";
+
+const EMPTY_CREDENTIALS = {
+  storageEnabled: false,
+  providers: [
+    { provider: "anthropic" as const, configured: false },
+    { provider: "openai" as const, configured: false },
+    { provider: "google" as const, configured: false },
+  ],
+};
+
+/**
+ * Load compose backend from persisted AI settings and BYOK credential status.
+ * 永続化された AI 設定と BYOK credential 状態から compose backend を読み込む。
+ */
+async function loadComposeBackendFromSettings(): Promise<ComposeExecutionBackend> {
+  const settings = (await loadAISettings()) ?? DEFAULT_AI_SETTINGS;
+  const credentials = await fetchUserAiCredentialsStatus().catch(() => EMPTY_CREDENTIALS);
+  return resolveComposeBackendFromAiSettings(settings, credentials);
+}
+
+export interface UseInitialComposeBackendOptions {
+  /** When false, skips loading (e.g. session already started). */
+  enabled?: boolean;
+}
+
+export interface UseInitialComposeBackendResult {
+  backend: ComposeExecutionBackend;
+  setBackend: Dispatch<SetStateAction<ComposeExecutionBackend>>;
+  /** False until the first settings-based resolution finishes (when `enabled`). */
+  isResolved: boolean;
+}
+
+/**
+ * Returns backend state synced from AI settings until the user changes it or `enabled` is false.
+ * AI 設定と同期した backend。ユーザーが変更するか `enabled` が false になるまで追従する。
+ */
+export function useInitialComposeBackend(
+  options: UseInitialComposeBackendOptions = {},
+): UseInitialComposeBackendResult {
+  const { enabled = true } = options;
+  const [backend, setBackend] = useState<ComposeExecutionBackend>("zedi_managed");
+  const [userOverrode, setUserOverrode] = useState(false);
+  const [settingsSynced, setSettingsSynced] = useState(!enabled);
+
+  const isResolved = !enabled || userOverrode || settingsSynced;
+
+  useEffect(() => {
+    if (!enabled || userOverrode) return;
+
+    let cancelled = false;
+    void loadComposeBackendFromSettings().then((resolved) => {
+      if (!cancelled) {
+        setBackend(resolved);
+        setSettingsSynced(true);
+      }
+    });
+
+    const onSettingsChanged = () => {
+      if (userOverrode) return;
+      void loadComposeBackendFromSettings().then((resolved) => {
+        if (!cancelled) setBackend(resolved);
+      });
+    };
+
+    window.addEventListener(AI_SETTINGS_CHANGED_EVENT, onSettingsChanged);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(AI_SETTINGS_CHANGED_EVENT, onSettingsChanged);
+    };
+  }, [enabled, userOverrode]);
+
+  const setBackendWithOverride: Dispatch<SetStateAction<ComposeExecutionBackend>> = (value) => {
+    setUserOverrode(true);
+    setSettingsSynced(true);
+    setBackend(value);
+  };
+
+  return { backend, setBackend: setBackendWithOverride, isResolved };
+}

--- a/src/lib/wikiCompose/resolveComposeBackend.test.ts
+++ b/src/lib/wikiCompose/resolveComposeBackend.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import type { AISettings } from "@/types/ai";
+import {
+  isComposeBackendAvailable,
+  resolveComposeBackendFromAiSettings,
+  resolvePreferredComposeBackend,
+} from "./resolveComposeBackend";
+import type { UserAiCredentialsStatus } from "@/lib/userAiCredentials";
+
+const baseSettings = (overrides: Partial<AISettings>): AISettings => ({
+  provider: "google",
+  apiKey: "",
+  apiMode: "api_server",
+  model: "gemini-3-flash-preview",
+  modelId: "google:gemini-3-flash-preview",
+  isConfigured: false,
+  ...overrides,
+});
+
+const credentialsNone: UserAiCredentialsStatus = {
+  storageEnabled: true,
+  providers: [
+    { provider: "anthropic", configured: false },
+    { provider: "openai", configured: false },
+    { provider: "google", configured: false },
+  ],
+};
+
+const credentialsOpenAi: UserAiCredentialsStatus = {
+  storageEnabled: true,
+  providers: [
+    { provider: "anthropic", configured: false },
+    { provider: "openai", configured: true },
+    { provider: "google", configured: false },
+  ],
+};
+
+describe("resolvePreferredComposeBackend", () => {
+  it("maps api_server mode to zedi_managed", () => {
+    expect(resolvePreferredComposeBackend(baseSettings({ provider: "openai" }))).toBe(
+      "zedi_managed",
+    );
+  });
+
+  it("maps user_api_key mode to matching user_* backend", () => {
+    expect(
+      resolvePreferredComposeBackend(
+        baseSettings({ apiMode: "user_api_key", provider: "anthropic", isConfigured: true }),
+      ),
+    ).toBe("user_anthropic");
+  });
+
+  it("maps claude-code to zedi_managed", () => {
+    expect(
+      resolvePreferredComposeBackend(
+        baseSettings({ provider: "claude-code", modelId: "claude-code:default" }),
+      ),
+    ).toBe("zedi_managed");
+  });
+});
+
+describe("isComposeBackendAvailable", () => {
+  it("treats zedi_managed as always available", () => {
+    expect(isComposeBackendAvailable("zedi_managed", credentialsNone)).toBe(true);
+  });
+
+  it("requires storage and configured credential for BYOK", () => {
+    expect(isComposeBackendAvailable("user_openai", credentialsOpenAi)).toBe(true);
+    expect(isComposeBackendAvailable("user_openai", credentialsNone)).toBe(false);
+    expect(
+      isComposeBackendAvailable("user_openai", {
+        storageEnabled: false,
+        providers: credentialsOpenAi.providers,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveComposeBackendFromAiSettings", () => {
+  it("falls back to zedi_managed when preferred BYOK is unavailable", () => {
+    expect(
+      resolveComposeBackendFromAiSettings(
+        baseSettings({ apiMode: "user_api_key", provider: "openai", isConfigured: true }),
+        credentialsNone,
+      ),
+    ).toBe("zedi_managed");
+  });
+
+  it("keeps user_* when credential exists", () => {
+    expect(
+      resolveComposeBackendFromAiSettings(
+        baseSettings({ apiMode: "user_api_key", provider: "openai", isConfigured: true }),
+        credentialsOpenAi,
+      ),
+    ).toBe("user_openai");
+  });
+});

--- a/src/lib/wikiCompose/resolveComposeBackend.ts
+++ b/src/lib/wikiCompose/resolveComposeBackend.ts
@@ -1,0 +1,60 @@
+/**
+ * Map persisted AI settings to Wiki Compose execution backends (#951).
+ * 設定画面の AI 設定から Wiki Compose の backend を導出する。
+ */
+import type { AISettings } from "@/types/ai";
+import { getInteractionMode, isAPIProvider } from "@/types/ai";
+import type { ComposeExecutionBackend } from "./backends";
+import type { UserAiCredentialProvider, UserAiCredentialsStatus } from "@/lib/userAiCredentials";
+
+/** Map API provider id to BYOK compose backend. */
+export function apiProviderToComposeBackend(
+  provider: UserAiCredentialProvider,
+): Exclude<ComposeExecutionBackend, "zedi_managed"> {
+  switch (provider) {
+    case "anthropic":
+      return "user_anthropic";
+    case "openai":
+      return "user_openai";
+    case "google":
+      return "user_google";
+  }
+}
+
+/**
+ * Preferred backend from settings alone (no credential availability check).
+ * 設定のみから見た希望 backend（credential 有無は未確認）。
+ */
+export function resolvePreferredComposeBackend(settings: AISettings): ComposeExecutionBackend {
+  const mode = getInteractionMode(settings);
+  if (mode === "user_api_key" && isAPIProvider(settings.provider)) {
+    return apiProviderToComposeBackend(settings.provider);
+  }
+  return "zedi_managed";
+}
+
+/** Whether the backend can be selected in Compose UI. */
+export function isComposeBackendAvailable(
+  backend: ComposeExecutionBackend,
+  credentials: UserAiCredentialsStatus,
+): boolean {
+  if (backend === "zedi_managed") return true;
+  if (!credentials.storageEnabled) return false;
+  const provider = backend.replace("user_", "") as UserAiCredentialProvider;
+  return credentials.providers.some((p) => p.provider === provider && p.configured);
+}
+
+/**
+ * Resolve compose backend from AI settings, falling back when BYOK is unavailable.
+ * AI 設定から backend を決め、BYOK が使えない場合は zedi_managed にフォールバックする。
+ */
+export function resolveComposeBackendFromAiSettings(
+  settings: AISettings,
+  credentials: UserAiCredentialsStatus,
+): ComposeExecutionBackend {
+  const preferred = resolvePreferredComposeBackend(settings);
+  if (isComposeBackendAvailable(preferred, credentials)) {
+    return preferred;
+  }
+  return "zedi_managed";
+}

--- a/src/pages/WikiComposePage.tsx
+++ b/src/pages/WikiComposePage.tsx
@@ -29,7 +29,7 @@ import type { DraftedSection } from "@/lib/wikiCompose/types";
 import { EditorPane } from "@/components/wikiCompose/EditorPane";
 import { ComposePanel } from "@/components/wikiCompose/ComposePanel";
 import { ComposeBackendSelector } from "@/components/wikiCompose/ComposeBackendSelector";
-import type { ComposeExecutionBackend } from "@/lib/wikiCompose/backends";
+import { useInitialComposeBackend } from "@/hooks/useInitialComposeBackend";
 
 /** Map drafted section list to a quick lookup. */
 function indexById(items: DraftedSection[]): Record<string, DraftedSection> {
@@ -48,7 +48,6 @@ const WikiComposePage: React.FC = () => {
   const noteId = params.noteId ?? "";
   const pageId = params.pageId ?? "";
   const sessionId = params.sessionId ?? null;
-  const [composeBackend, setComposeBackend] = useState<ComposeExecutionBackend>("zedi_managed");
 
   // チャット seed は mount 時に 1 回だけ保持。`location.state` を消しても hook 側に残す。
   // Capture chat seed once on mount; survives clearing `location.state` for the hook.
@@ -58,6 +57,14 @@ const WikiComposePage: React.FC = () => {
     const s = raw as ComposeNavigationSeed;
     if (typeof s.outline !== "string" || typeof s.conversationText !== "string") return undefined;
     return s;
+  });
+
+  const {
+    backend: composeBackend,
+    setBackend: setComposeBackend,
+    isResolved: isComposeBackendResolved,
+  } = useInitialComposeBackend({
+    enabled: !sessionId,
   });
 
   const initialInput = useMemo(
@@ -247,7 +254,7 @@ const WikiComposePage: React.FC = () => {
             size="sm"
             data-testid="compose-start"
             onClick={() => void session.start()}
-            disabled={session.isStreaming}
+            disabled={session.isStreaming || !isComposeBackendResolved}
           >
             Start compose
           </Button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Wiki生成ボタンから Wiki Compose 画面を開いたとき、実行 backend（プロバイダー）が常に `zedi_managed` 固定になっていた問題を修正し、設定画面（AI）で選択しているモード・プロバイダーに合わせて初期選択されるようにしました。

## 変更点

- `resolveComposeBackendFromAiSettings` を追加し、AI 設定と BYOK credential 状態から compose backend を導出
- `useInitialComposeBackend` フックで Compose 開始前の backend 初期値を設定画面と同期
- 設定読み込み完了まで「Start compose」を無効化し、誤った backend で開始しないようガード
- 単体テストを追加（api_server / user_api_key / BYOK 未登録時のフォールバック）

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## マッピング仕様

| 設定画面（AI） | Compose backend |
|---|---|
| デフォルト（Zedi サーバー / `api_server`） | `zedi_managed` |
| 自分の API キー + OpenAI / Anthropic / Google | `user_openai` 等（サーバーに BYOK 登録済みの場合） |
| 自分の API キーだが BYOK 未登録 | `zedi_managed` にフォールバック |
| Claude Code | `zedi_managed` |

## テスト方法

1. 設定 → AI でプロバイダー（例: Google）を選択し保存
2. 空の Wiki ページで「Wiki生成」をクリック
3. Compose 画面の backend 選択で `zedi_managed`（サーバー利用）が選ばれていることを確認
4. 設定を「自分の API キー」+ OpenAI に変更し、Settings の Wiki Compose BYOK に OpenAI キーを登録
5. 再度 Wiki生成 → `user_openai` が初期選択されることを確認

```bash
npx vitest run src/lib/wikiCompose/resolveComposeBackend.test.ts
```

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない（変更ファイル）
- [ ] 必要に応じてドキュメントを更新した（英語正本 + 該当する場合は `.ja.md` ペア）
- [x] コミットメッセージが Conventional Commits に従っている
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fe57805-75e4-4bec-81c3-02396d89adc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fe57805-75e4-4bec-81c3-02396d89adc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WikiCompose now automatically resolves and synchronizes its execution backend based on your AI settings and credential configuration. The "Start compose" button is disabled until the backend is ready for use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->