### PR TITLE
feat(layout): navigate mobile Me tab to /account page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import ExtensionAuthCallback from "./pages/ExtensionAuthCallback";
 import McpAuthorize from "./pages/McpAuthorize";
 import PdfReaderPage from "./pages/pdfKnowledge/PdfReaderPage";
 import Settings from "./pages/Settings";
+import Account from "./pages/Account";
 import WikiSchemaPage from "./pages/WikiSchemaPage";
 import IndexPage from "./pages/IndexPage";
 import Pricing from "./pages/Pricing";
@@ -255,6 +256,7 @@ const App = () => (
                           desktop-only placeholder. */}
                       <Route path="/sources/:sourceId/pdf" element={<PdfReaderPage />} />
                       <Route path="/settings" element={<Settings />} />
+                      <Route path="/account" element={<Account />} />
                       <Route path="/wiki-schema" element={<WikiSchemaPage />} />
                       <Route path="/index" element={<IndexPage />} />
                       <Route path="/pricing" element={<Pricing />} />

--- a/src/components/layout/BottomNav/BottomNav.test.tsx
+++ b/src/components/layout/BottomNav/BottomNav.test.tsx
@@ -1,13 +1,13 @@
 /**
  * BottomNav: 4 tabs (My Note / Notes / AI / Me), aria-current on active tab,
- * safe-area padding, and Me tab opens a Sheet with the account menu content.
+ * safe-area padding, and Me tab links to `/account`.
  *
  * ボトムナビ: 4 タブ（マイノート / ノート / AI / Me）、アクティブタブの aria-current、
- * safe-area padding、Me タブの Sheet 表示を検証する。
+ * safe-area padding、Me タブの `/account` リンクを検証する。
  */
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { BottomNav } from "./index";
 
@@ -78,7 +78,7 @@ describe("BottomNav", () => {
     // Use exact match for "Notes" since "My Note" also contains "Note".
     expect(screen.getByRole("link", { name: /^notes$/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /^ai$/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /account/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /account/i })).toBeInTheDocument();
   });
 
   it("marks the My Note tab as aria-current when on /notes/me", () => {
@@ -124,10 +124,19 @@ describe("BottomNav", () => {
     expect(nav?.getAttribute("style") ?? "").toContain("env(safe-area-inset-bottom)");
   });
 
-  it("opens the Me sheet when the Me tab is clicked", async () => {
+  it("links the Me tab to /account", () => {
     renderAt("/notes/me");
-    const meButton = screen.getByRole("button", { name: /account/i });
-    fireEvent.click(meButton);
-    expect(await screen.findByTestId("bottom-nav-me-content")).toBeInTheDocument();
+    const meLink = screen.getByRole("link", { name: /account/i });
+    expect(meLink).toHaveAttribute("href", "/account");
+  });
+
+  it("marks the Me tab as aria-current when on /account", () => {
+    renderAt("/account");
+    const meLink = screen.getByRole("link", { name: /account/i });
+    expect(meLink).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: /my note/i })).not.toHaveAttribute(
+      "aria-current",
+      "page",
+    );
   });
 });

--- a/src/components/layout/BottomNav/BottomNavAccountTab.tsx
+++ b/src/components/layout/BottomNav/BottomNavAccountTab.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Avatar, AvatarFallback, AvatarImage, cn } from "@zedi/ui";
+import { useTranslation } from "react-i18next";
+import { SignedIn, SignedOut, useAuth, useUser } from "@/hooks/useAuth";
+import { useProfile } from "@/hooks/useProfile";
+import { useSyncStatusDotColor } from "../Header/UnifiedMenuSyncStatus";
+
+interface BottomNavAccountTabProps {
+  active: boolean;
+}
+
+/**
+ * Bottom-nav "Me" tab linking to `/account`. Mirrors {@link BottomNavTab}
+ * structure but renders the user avatar (and sync dot) instead of a Lucide icon.
+ *
+ * ボトムナビの「Me」タブ。`/account` へ遷移し、Lucide アイコンの代わりに
+ * アバター（と同期ドット）を表示する。
+ */
+export const BottomNavAccountTab: React.FC<BottomNavAccountTabProps> = ({ active }) => {
+  const { t } = useTranslation();
+  const { isSignedIn } = useAuth();
+  const { user } = useUser();
+  const { displayName, avatarUrl } = useProfile();
+  const dotColor = useSyncStatusDotColor();
+  const label = t("nav.account", "Account");
+
+  return (
+    <li className="flex-1">
+      <Link
+        to="/account"
+        aria-current={active ? "page" : undefined}
+        className={cn(
+          "flex h-full w-full flex-col items-center justify-center gap-1 py-2 text-[10px] font-medium transition-colors",
+          active ? "text-primary" : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        <span className="relative">
+          <SignedIn>
+            <Avatar className="h-6 w-6">
+              <AvatarImage
+                src={avatarUrl || user?.imageUrl}
+                alt={displayName || user?.fullName || "User"}
+              />
+              <AvatarFallback className="text-[10px]">
+                {(displayName || user?.firstName)?.charAt(0) ?? "U"}
+              </AvatarFallback>
+            </Avatar>
+          </SignedIn>
+          <SignedOut>
+            <Avatar className="h-6 w-6">
+              <AvatarFallback className="text-[10px]">{label.charAt(0)}</AvatarFallback>
+            </Avatar>
+          </SignedOut>
+          {isSignedIn && dotColor && (
+            <span
+              className={cn(
+                "border-background absolute right-0 bottom-0 h-2 w-2 rounded-full border",
+                dotColor,
+              )}
+            />
+          )}
+        </span>
+        <span>{label}</span>
+      </Link>
+    </li>
+  );
+};

--- a/src/components/layout/BottomNav/BottomNavMeContent.tsx
+++ b/src/components/layout/BottomNav/BottomNavMeContent.tsx
@@ -1,10 +1,10 @@
 /**
- * Thin re-export module so the bottom-nav Me tab and the desktop avatar
+ * Thin re-export module so the `/account` page and the desktop avatar
  * dropdown share the exact same menu content. This keeps the UnifiedMenu
  * surface the single source of truth for account actions, sync status and
  * sign-in / sign-out.
  *
- * ボトムナビ Me タブとデスクトップのアバタードロップダウンで同じメニュー内容を
+ * `/account` ページとデスクトップのアバタードロップダウンで同じメニュー内容を
  * 共有するための薄い再エクスポート。アカウント操作・同期ステータス・サインイン/
  * サインアウトの単一ソースを {@link UnifiedMenu} に保つ。
  */

--- a/src/components/layout/BottomNav/index.tsx
+++ b/src/components/layout/BottomNav/index.tsx
@@ -1,34 +1,25 @@
-import React, { useCallback, useState } from "react";
+import React from "react";
 import { useLocation } from "react-router-dom";
-import { Sheet, SheetContent, SheetDescription, SheetTitle, cn } from "@zedi/ui";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-import { Avatar, AvatarFallback, AvatarImage } from "@zedi/ui";
+import { cn } from "@zedi/ui";
 import { useTranslation } from "react-i18next";
-import { SignedIn, SignedOut, useAuth, useUser } from "@/hooks/useAuth";
-import { useProfile } from "@/hooks/useProfile";
-import { useSyncStatusDotColor } from "../Header/UnifiedMenuSyncStatus";
 import { PRIMARY_NAV_ITEMS, isPrimaryNavActive } from "../navigationItems";
-import { SignedInMenuContent, SignedOutMenuContent } from "./BottomNavMeContent";
+import { BottomNavAccountTab } from "./BottomNavAccountTab";
 import { BottomNavTab } from "./BottomNavTab";
 
 /**
  * Mobile bottom navigation. Renders the shared {@link PRIMARY_NAV_ITEMS} as
- * tabs followed by a Me tab. The Me tab opens a sheet that reuses the
- * signed-in / signed-out menu content from {@link UnifiedMenu}, so the
- * account surfaces stay in sync; the primary tabs stay in sync with the
+ * tabs followed by a Me tab that links to `/account`. The account page reuses
+ * menu content from {@link UnifiedMenu}; primary tabs stay in sync with the
  * header dropdown because both read from the same config.
  *
  * モバイル用のボトムナビゲーション。共通の {@link PRIMARY_NAV_ITEMS} をタブとして描画し、
- * 末尾に Me タブを追加する。Me タブは {@link UnifiedMenu} と同じメニュー内容を Sheet で
- * 表示しアカウント UI の二重実装を避ける。プライマリタブはヘッダーのドロップダウンと
- * 同じ配列を参照するので表示項目が常に一致する。
+ * 末尾の Me タブは `/account` へ遷移する。アカウント画面は {@link UnifiedMenu} と同じ
+ * メニュー内容を表示する。プライマリタブはヘッダーのドロップダウンと同じ配列を参照する。
  */
 export const BottomNav: React.FC = () => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
-  const [meOpen, setMeOpen] = useState(false);
-  const closeMe = useCallback(() => setMeOpen(false), []);
-  const sheetTitle = t("nav.account", "Account");
+  const accountActive = pathname === "/account";
 
   return (
     <nav
@@ -49,83 +40,9 @@ export const BottomNav: React.FC = () => {
             active={isPrimaryNavActive(item, pathname)}
           />
         ))}
-        <li className="flex-1">
-          <MeTab open={meOpen} onOpenChange={setMeOpen} />
-        </li>
+        <BottomNavAccountTab active={accountActive} />
       </ul>
-
-      <Sheet open={meOpen} onOpenChange={setMeOpen}>
-        <SheetContent side="right" className="w-3/4 max-w-sm p-4">
-          <VisuallyHidden>
-            <SheetTitle>{sheetTitle}</SheetTitle>
-            <SheetDescription>{t("nav.account", "Account")}</SheetDescription>
-          </VisuallyHidden>
-          <div data-testid="bottom-nav-me-content">
-            <SignedIn>
-              <SignedInMenuContent onClose={closeMe} />
-            </SignedIn>
-            <SignedOut>
-              <SignedOutMenuContent onClose={closeMe} />
-            </SignedOut>
-          </div>
-        </SheetContent>
-      </Sheet>
     </nav>
-  );
-};
-
-interface MeTabProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}
-
-const MeTab: React.FC<MeTabProps> = ({ open, onOpenChange }) => {
-  const { t } = useTranslation();
-  const { isSignedIn } = useAuth();
-  const { user } = useUser();
-  const { displayName, avatarUrl } = useProfile();
-  const dotColor = useSyncStatusDotColor();
-
-  return (
-    <button
-      type="button"
-      aria-label={t("nav.account", "Account")}
-      aria-haspopup="dialog"
-      aria-expanded={open}
-      onClick={() => onOpenChange(true)}
-      className={cn(
-        "text-muted-foreground hover:text-foreground flex h-full w-full flex-col items-center justify-center gap-1 py-2 text-[10px] font-medium transition-colors",
-      )}
-    >
-      <span className="relative">
-        {isSignedIn ? (
-          <Avatar className="h-6 w-6">
-            <AvatarImage
-              src={avatarUrl || user?.imageUrl}
-              alt={displayName || user?.fullName || "User"}
-            />
-            <AvatarFallback className="text-[10px]">
-              {(displayName || user?.firstName)?.charAt(0) ?? "U"}
-            </AvatarFallback>
-          </Avatar>
-        ) : (
-          <Avatar className="h-6 w-6">
-            <AvatarFallback className="text-[10px]">
-              {t("nav.account", "Account").charAt(0)}
-            </AvatarFallback>
-          </Avatar>
-        )}
-        {dotColor && (
-          <span
-            className={cn(
-              "border-background absolute right-0 bottom-0 h-2 w-2 rounded-full border",
-              dotColor,
-            )}
-          />
-        )}
-      </span>
-      <span>{t("nav.account", "Account")}</span>
-    </button>
   );
 };
 

--- a/src/components/layout/Header/UnifiedMenu.tsx
+++ b/src/components/layout/Header/UnifiedMenu.tsx
@@ -101,9 +101,9 @@ interface MenuContentProps {
 
 /**
  * User menu content for signed-in users. Exported so that other shell
- * elements (e.g. the mobile bottom nav Me tab) can reuse the same list.
+ * elements (e.g. the `/account` page) can reuse the same list.
  *
- * サインイン済みユーザー向けのメニュー内容。モバイルボトムナビの Me タブ等、
+ * サインイン済みユーザー向けのメニュー内容。`/account` ページ等、
  * 他のシェル要素からも同じリストを再利用できるよう export している。
  */
 export const SignedInMenuContent: React.FC<MenuContentProps> = ({ onClose }) => {
@@ -210,9 +210,9 @@ const DesktopSignedInMenuContent: React.FC<MenuContentProps> = ({ onClose }) => 
 
 /**
  * User menu content for signed-out (guest) users. Exported so that the
- * mobile bottom nav Me tab can reuse the same list.
+ * `/account` page can reuse the same list.
  *
- * 未サインインユーザー向けのメニュー内容。モバイルボトムナビの Me タブから
+ * 未サインインユーザー向けのメニュー内容。`/account` ページから
  * 再利用できるよう export している。
  */
 export const SignedOutMenuContent: React.FC<MenuContentProps> = ({ onClose }) => {

--- a/src/components/layout/navigationItems.ts
+++ b/src/components/layout/navigationItems.ts
@@ -6,11 +6,11 @@ import type React from "react";
  * One entry in the primary navigation. The header dropdown and the mobile
  * bottom navigation both render the same list so the two surfaces stay in
  * sync. User-menu / account entries are intentionally excluded; they live on
- * the header avatar and the bottom nav "Me" tab respectively.
+ * the header avatar and the bottom nav `/account` tab respectively.
  *
  * プライマリナビゲーションの 1 項目。ヘッダーのドロップダウンとモバイルのボトムナビが
  * 同じリストを参照するため、表示項目が常に一致する。ユーザーメニュー・アカウント関連は
- * ここには含めず、引き続きヘッダーのアバターとボトムナビの Me タブに分離する。
+ * ここには含めず、引き続きヘッダーのアバターとボトムナビの `/account` タブに分離する。
  */
 export interface PrimaryNavItem {
   /** Link target. 遷移先パス。*/

--- a/src/pages/Account.test.tsx
+++ b/src/pages/Account.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Account hub page: reuses signed-in / signed-out menu content.
+ *
+ * アカウントハブページ: サインイン済み・未サインインのメニュー内容を再利用する。
+ */
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Account from "./Account";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => {
+      const table: Record<string, string> = {
+        "nav.account": "Account",
+        "nav.settings": "Settings",
+        "nav.plan": "Plan",
+        "nav.signOut": "Sign out",
+      };
+      return table[key] ?? fallback ?? key;
+    },
+    i18n: { language: "ja" },
+  }),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({
+    isLoaded: true,
+    isSignedIn: true,
+    signOut: vi.fn(),
+  }),
+  SignedIn: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SignedOut: () => null,
+  useUser: () => ({
+    user: {
+      fullName: "Test User",
+      firstName: "Test",
+      primaryEmailAddress: { emailAddress: "test@example.com" },
+    },
+  }),
+}));
+
+vi.mock("@/hooks/useProfile", () => ({
+  useProfile: () => ({ displayName: "Test User", avatarUrl: "" }),
+}));
+
+vi.mock("@/hooks/usePageQueries", () => ({
+  useSyncStatus: () => "idle",
+  useSync: () => ({ sync: vi.fn(), isSyncing: false }),
+}));
+
+describe("Account page", () => {
+  it("renders the account title and menu content", () => {
+    render(
+      <MemoryRouter>
+        <Account />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: /account/i })).toBeInTheDocument();
+    expect(screen.getByTestId("account-page-content")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /settings/i })).toBeInTheDocument();
+  });
+});

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback } from "react";
+import Container from "@/components/layout/Container";
+import { PageHeader } from "@/components/layout/PageHeader";
+import {
+  SignedInMenuContent,
+  SignedOutMenuContent,
+} from "@/components/layout/BottomNav/BottomNavMeContent";
+import { SignedIn, SignedOut } from "@/hooks/useAuth";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Account hub for mobile bottom-nav "Me" and direct `/account` navigation.
+ * Reuses the same menu content as the desktop avatar dropdown so account
+ * actions, sync status, and sign-in/out stay in one place.
+ *
+ * モバイルボトムナビの「Me」および `/account` 直リンク向けのアカウントハブ。
+ * デスクトップのアバターメニューと同じ内容を再利用し、アカウント操作・同期・
+ * サインイン/アウトの単一ソースを保つ。
+ */
+const Account: React.FC = () => {
+  const { t } = useTranslation();
+  const noopClose = useCallback(() => {}, []);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PageHeader title={t("nav.account", "Account")} />
+
+      <div className="min-h-0 flex-1 py-6">
+        <Container>
+          <div
+            className="border-border bg-card mx-auto max-w-2xl overflow-hidden rounded-lg border shadow-sm"
+            data-testid="account-page-content"
+          >
+            <SignedIn>
+              <SignedInMenuContent onClose={noopClose} />
+            </SignedIn>
+            <SignedOut>
+              <SignedOutMenuContent onClose={noopClose} />
+            </SignedOut>
+          </div>
+        </Container>
+      </div>
+    </div>
+  );
+};
+
+export default Account;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

モバイルボトムナビの「Me」タブが開いていた右側 Sheet をやめ、`/account` ページへ遷移するようにしました。アカウントメニューの中身はデスクトップのアバターメニューと同じ `SignedInMenuContent` / `SignedOutMenuContent` を再利用しています。

## 変更点

- `/account` ルートと `Account` ページを新規追加（既存ページはなかった）
- ボトムナビの Me タブを `Link` に変更し、`/account` で `aria-current="page"` を付与
- Sheet 関連の state / UI を `BottomNav` から削除

## 変更の種類

- [x] ✨ 新機能 (New feature)

## テスト方法

1. モバイル幅でアプリを開く
2. ボトムナビの「Account」をタップ → `/account` に遷移し、プロフィール・設定・プラン・同期・サインアウトが表示されること
3. `/account` 表示中、Me タブがアクティブになること

## チェックリスト

- [x] 関連ユニットテストを追加・更新（`Account.test.tsx`, `BottomNav.test.tsx`）
- [x] コミットメッセージが Conventional Commits に従っている

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61612f3b-d5af-4481-9d1d-216d6379168f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61612f3b-d5af-4481-9d1d-216d6379168f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

