### PR TITLE
fix(api): pin Wiki Compose LLM to google:gemini-3.5-flash

### DIFF
--- a/server/api/src/__tests__/agents/core/composeBackendValidation.test.ts
+++ b/server/api/src/__tests__/agents/core/composeBackendValidation.test.ts
@@ -27,15 +27,31 @@ describe("assertComposeBackendReady", () => {
     expect(mockGetUserAiCredentialPlaintext).not.toHaveBeenCalled();
   });
 
-  it("allows BYOK backend without static env model provider mismatch (#972)", async () => {
+  it("rejects non-Google BYOK for wiki-compose-research (fixed Gemini model)", async () => {
+    await expect(
+      assertComposeBackendReady({
+        backend: "user_openai",
+        graphId: "wiki-compose-research",
+        userId: "u1",
+        tier: "free",
+        db,
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("user_google"),
+    });
+    expect(mockGetUserAiCredentialPlaintext).not.toHaveBeenCalled();
+  });
+
+  it("allows user_google BYOK for wiki-compose when credential exists", async () => {
     await assertComposeBackendReady({
-      backend: "user_openai",
-      graphId: "wiki-compose-research",
+      backend: "user_google",
+      graphId: "wiki-compose",
       userId: "u1",
       tier: "free",
       db,
     });
-    expect(mockGetUserAiCredentialPlaintext).toHaveBeenCalledWith("u1", "openai", db);
+    expect(mockGetUserAiCredentialPlaintext).toHaveBeenCalledWith("u1", "google", db);
   });
 
   it("skips credential check for model-less graphs (wiki-maintenance)", async () => {
@@ -53,7 +69,7 @@ describe("assertComposeBackendReady", () => {
     mockGetUserAiCredentialPlaintext.mockResolvedValue(null);
     await expect(
       assertComposeBackendReady({
-        backend: "user_anthropic",
+        backend: "user_google",
         graphId: "wiki-compose-research",
         userId: "u1",
         tier: "free",

--- a/server/api/src/__tests__/agents/core/llm/wikiComposeModelId.test.ts
+++ b/server/api/src/__tests__/agents/core/llm/wikiComposeModelId.test.ts
@@ -1,5 +1,6 @@
 /**
  * Tests for fixed Wiki Compose model id resolution.
+ * 固定 Wiki Compose モデル id 解決のテスト。
  */
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import {

--- a/server/api/src/__tests__/agents/core/llm/wikiComposeModelId.test.ts
+++ b/server/api/src/__tests__/agents/core/llm/wikiComposeModelId.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for fixed Wiki Compose model id resolution.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  resolveWikiComposeModelId,
+  WIKI_COMPOSE_MODEL_ID,
+} from "../../../../agents/core/llm/wikiComposeModelId.js";
+
+const mockDb = {
+  select: vi.fn(),
+};
+
+function chainLimit(rows: unknown[]) {
+  const chain = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  };
+  return chain;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveWikiComposeModelId", () => {
+  it("returns the fixed id when the row is active and tier-accessible", async () => {
+    mockDb.select.mockReturnValueOnce(chainLimit([{ id: WIKI_COMPOSE_MODEL_ID }]));
+    const id = await resolveWikiComposeModelId("orchestrator", "free", mockDb as never);
+    expect(id).toBe(WIKI_COMPOSE_MODEL_ID);
+  });
+
+  it("returns the fixed id even when no DB row matches", async () => {
+    mockDb.select.mockReturnValueOnce(chainLimit([]));
+    const id = await resolveWikiComposeModelId("draft", "pro", mockDb as never);
+    expect(id).toBe("google:gemini-3.5-flash");
+  });
+
+  it("uses the same id for orchestrator and draft roles", async () => {
+    mockDb.select.mockReturnValue(chainLimit([{ id: WIKI_COMPOSE_MODEL_ID }]));
+    const orchestrator = await resolveWikiComposeModelId("orchestrator", "free", mockDb as never);
+    const draft = await resolveWikiComposeModelId("draft", "free", mockDb as never);
+    expect(orchestrator).toBe(draft);
+  });
+});

--- a/server/api/src/__tests__/agents/subgraphs/research/nodes/planQueries.test.ts
+++ b/server/api/src/__tests__/agents/subgraphs/research/nodes/planQueries.test.ts
@@ -8,6 +8,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { createZediChatModel } = vi.hoisted(() => ({ createZediChatModel: vi.fn() }));
 
+vi.mock("../../../../../agents/core/llm/wikiComposeModelId.js", () => ({
+  WIKI_COMPOSE_MODEL_ID: "google:gemini-3.5-flash",
+  resolveWikiComposeModelId: vi.fn(async () => "google:gemini-3.5-flash"),
+}));
+
 vi.mock("../../../../../agents/core/llm/modelFactory.js", async () => {
   const actual = await vi.importActual<
     typeof import("../../../../../agents/core/llm/modelFactory.js")

--- a/server/api/src/__tests__/agents/subgraphs/research/researchGraph.modelGuard.test.ts
+++ b/server/api/src/__tests__/agents/subgraphs/research/researchGraph.modelGuard.test.ts
@@ -15,6 +15,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { createZediChatModel } = vi.hoisted(() => ({ createZediChatModel: vi.fn() }));
 
+vi.mock("../../../../agents/core/llm/wikiComposeModelId.js", () => ({
+  WIKI_COMPOSE_MODEL_ID: "google:gemini-3.5-flash",
+  resolveWikiComposeModelId: vi.fn(async () => "google:gemini-3.5-flash"),
+}));
+
 vi.mock("../../../../agents/core/llm/modelFactory.js", async () => {
   const actual = await vi.importActual<
     typeof import("../../../../agents/core/llm/modelFactory.js")

--- a/server/api/src/agents/core/composeBackendValidation.ts
+++ b/server/api/src/agents/core/composeBackendValidation.ts
@@ -3,15 +3,16 @@
  * Wiki Compose セッション作成前の BYOK 事前チェック（#951）。
  *
  * Wiki Compose uses a fixed Google model at runtime ({@link WIKI_COMPOSE_MODEL_ID}).
- * BYOK sessions still need a stored credential when the graph calls an LLM; provider
- * alignment with the fixed model is the caller's responsibility for now.
+ * Non-Google BYOK backends are rejected at session create to avoid runtime
+ * `BackendProviderMismatchError` in `createZediChatModel`.
  *
- * Wiki Compose は実行時に Google 固定モデルを使う。BYOK 時は LLM 呼び出し前に
- * credential の有無だけをここで確認する。
+ * Wiki Compose は Google 固定モデルを使う。`user_anthropic` / `user_openai` など
+ * provider が合わない BYOK はセッション作成時に 400 で弾く。
  */
 import { HTTPException } from "hono/http-exception";
 import type { Database, UserTier } from "../../types/index.js";
 import { getComposeModelIdsForGraph } from "./composeModelConfig.js";
+import { isFixedWikiComposeModelGraph, WIKI_COMPOSE_MODEL_ID } from "./llm/wikiComposeModelId.js";
 import {
   backendToCredentialProvider,
   isUserByokBackend,
@@ -36,6 +37,12 @@ export async function assertComposeBackendReady(input: {
   // Model-less graphs (e.g. wiki-maintenance) never call `createZediChatModel`.
   // LLM を呼ばないグラフ（wiki-maintenance 等）は credential 不要。
   if (modelIds.length === 0) return;
+
+  if (isFixedWikiComposeModelGraph(input.graphId) && input.backend !== "user_google") {
+    throw new HTTPException(400, {
+      message: `Wiki Compose requires zedi_managed or user_google backend (fixed model ${WIKI_COMPOSE_MODEL_ID})`,
+    });
+  }
 
   const expectedProvider = backendToCredentialProvider(input.backend);
   const key = await getUserAiCredentialPlaintext(input.userId, expectedProvider, input.db);

--- a/server/api/src/agents/core/composeBackendValidation.ts
+++ b/server/api/src/agents/core/composeBackendValidation.ts
@@ -2,13 +2,12 @@
  * Pre-flight BYOK checks for Wiki Compose session creation (#951).
  * Wiki Compose セッション作成前の BYOK 事前チェック（#951）。
  *
- * Static env model ids are not validated here — provider matching is enforced at
- * runtime via {@link resolveComposeModelId}. This function only verifies that
- * the user has a stored credential when the graph will call an LLM.
+ * Wiki Compose uses a fixed Google model at runtime ({@link WIKI_COMPOSE_MODEL_ID}).
+ * BYOK sessions still need a stored credential when the graph calls an LLM; provider
+ * alignment with the fixed model is the caller's responsibility for now.
  *
- * 静的 env モデル id との provider 照合は行わない。実行時の
- * `resolveComposeModelId` が provider 整合を担保する。本関数は LLM を呼ぶ
- * グラフで credential が存在するかだけを確認する。
+ * Wiki Compose は実行時に Google 固定モデルを使う。BYOK 時は LLM 呼び出し前に
+ * credential の有無だけをここで確認する。
  */
 import { HTTPException } from "hono/http-exception";
 import type { Database, UserTier } from "../../types/index.js";

--- a/server/api/src/agents/core/composeModelConfig.ts
+++ b/server/api/src/agents/core/composeModelConfig.ts
@@ -7,13 +7,7 @@ import { WIKI_MAINTENANCE_GRAPH_ID } from "../graphs/wikiMaintenance/index.js";
 import { getOrchestratorModelId } from "../subgraphs/research/nodes/planQueries.js";
 import { RESEARCH_GRAPH_ID } from "../subgraphs/research/index.js";
 import { INGEST_PLANNER_GRAPH_ID } from "../graphs/ingest/index.js";
-
-const DRAFT_MODEL_ENV = "WIKI_COMPOSE_DRAFT_MODEL_ID";
-const DRAFT_MODEL_FALLBACK = "claude-3-5-sonnet";
-
-function getDraftModelId(): string {
-  return process.env[DRAFT_MODEL_ENV]?.trim() || DRAFT_MODEL_FALLBACK;
-}
+import { WIKI_COMPOSE_MODEL_ID } from "./llm/wikiComposeModelId.js";
 
 /**
  * Model row ids (`ai_models.id`) that a compose graph run will call via `createZediChatModel`.
@@ -23,11 +17,12 @@ export function getComposeModelIdsForGraph(graphId: string): string[] {
   // Lint-only graph — no `createZediChatModel` calls; BYOK must not require orchestrator keys.
   if (graphId === WIKI_MAINTENANCE_GRAPH_ID) return [];
   if (graphId === WIKI_COMPOSE_GRAPH_ID) {
-    const orchestrator = getOrchestratorModelId();
-    const draft = getDraftModelId();
-    return orchestrator === draft ? [orchestrator] : [orchestrator, draft];
+    return [WIKI_COMPOSE_MODEL_ID];
   }
-  if (graphId === RESEARCH_GRAPH_ID || graphId === INGEST_PLANNER_GRAPH_ID) {
+  if (graphId === RESEARCH_GRAPH_ID) {
+    return [WIKI_COMPOSE_MODEL_ID];
+  }
+  if (graphId === INGEST_PLANNER_GRAPH_ID) {
     return [getOrchestratorModelId()];
   }
   return [getOrchestratorModelId()];

--- a/server/api/src/agents/core/llm/resolveComposeModelId.ts
+++ b/server/api/src/agents/core/llm/resolveComposeModelId.ts
@@ -1,8 +1,8 @@
 /**
- * Resolve `ai_models.id` for Wiki Compose nodes so BYOK backends use a matching provider.
+ * Resolve `ai_models.id` for non–Wiki Compose graphs (e.g. ingest planner).
+ * Wiki Compose uses {@link resolveWikiComposeModelId} instead.
  *
- * Wiki Compose の LLM ノード用 model id 解決。BYOK backend では provider が一致する
- * active モデルを選び、`BackendProviderMismatchError` でセッション全体が落ちるのを防ぐ。
+ * Wiki Compose 以外（ingest planner 等）向けの model id 解決。
  */
 import { and, asc, eq } from "drizzle-orm";
 import { aiModels } from "../../../schema/index.js";

--- a/server/api/src/agents/core/llm/wikiComposeModelId.ts
+++ b/server/api/src/agents/core/llm/wikiComposeModelId.ts
@@ -1,0 +1,54 @@
+/**
+ * Fixed Wiki Compose model id (temporary until per-role / per-backend selection returns).
+ * Wiki Compose 用の固定モデル id（将来ロール別選択に戻すまでの暫定）。
+ */
+import { and, eq } from "drizzle-orm";
+import { aiModels } from "../../../schema/index.js";
+import type { Database, UserTier } from "../../../types/index.js";
+import type { ComposeModelRole } from "./resolveComposeModelId.js";
+
+/**
+ * `ai_models.id` used by every Wiki Compose LLM node and the `web_search` tool.
+ * すべての Wiki Compose LLM ノードと `web_search` ツールが使う `ai_models.id`。
+ */
+export const WIKI_COMPOSE_MODEL_ID = "google:gemini-3.5-flash" as const;
+
+function tierFilter(tier: UserTier) {
+  if (tier === "pro") return undefined;
+  return eq(aiModels.tierRequired, "free");
+}
+
+/**
+ * When the fixed row exists and is accessible, return it; otherwise still return
+ * {@link WIKI_COMPOSE_MODEL_ID} so callers fail consistently in `validateModelAccess`.
+ * 行が active かつ tier 的に使えるときだけ DB 上の id を返し、それ以外は固定 id を返す。
+ */
+async function fixedModelIdIfAccessible(db: Database, tier: UserTier): Promise<string> {
+  const tierClause = tierFilter(tier);
+  const [row] = await db
+    .select({ id: aiModels.id })
+    .from(aiModels)
+    .where(
+      and(
+        eq(aiModels.id, WIKI_COMPOSE_MODEL_ID),
+        eq(aiModels.isActive, true),
+        ...(tierClause ? [tierClause] : []),
+      ),
+    )
+    .limit(1);
+  return row?.id ?? WIKI_COMPOSE_MODEL_ID;
+}
+
+/**
+ * Resolve the model row id for Wiki Compose orchestrator / draft / research nodes.
+ * `role` is accepted for API stability; all roles map to {@link WIKI_COMPOSE_MODEL_ID} for now.
+ *
+ * Wiki Compose の model id 解決。現時点では role に関わらず gemini-3.5-flash 固定。
+ */
+export async function resolveWikiComposeModelId(
+  _role: ComposeModelRole,
+  _tier: UserTier,
+  db: Database,
+): Promise<string> {
+  return fixedModelIdIfAccessible(db, _tier);
+}

--- a/server/api/src/agents/core/llm/wikiComposeModelId.ts
+++ b/server/api/src/agents/core/llm/wikiComposeModelId.ts
@@ -5,6 +5,8 @@
 import { and, eq } from "drizzle-orm";
 import { aiModels } from "../../../schema/index.js";
 import type { Database, UserTier } from "../../../types/index.js";
+import { WIKI_COMPOSE_GRAPH_ID } from "../../graphs/wikiCompose/index.js";
+import { RESEARCH_GRAPH_ID } from "../../subgraphs/research/index.js";
 import type { ComposeModelRole } from "./resolveComposeModelId.js";
 
 /**
@@ -13,17 +15,24 @@ import type { ComposeModelRole } from "./resolveComposeModelId.js";
  */
 export const WIKI_COMPOSE_MODEL_ID = "google:gemini-3.5-flash" as const;
 
+/** Graph ids that pin LLM calls to {@link WIKI_COMPOSE_MODEL_ID}. */
+export function isFixedWikiComposeModelGraph(graphId: string): boolean {
+  return graphId === WIKI_COMPOSE_GRAPH_ID || graphId === RESEARCH_GRAPH_ID;
+}
+
 function tierFilter(tier: UserTier) {
   if (tier === "pro") return undefined;
   return eq(aiModels.tierRequired, "free");
 }
 
 /**
- * When the fixed row exists and is accessible, return it; otherwise still return
- * {@link WIKI_COMPOSE_MODEL_ID} so callers fail consistently in `validateModelAccess`.
- * 行が active かつ tier 的に使えるときだけ DB 上の id を返し、それ以外は固定 id を返す。
+ * Returns the fixed model row id when active and tier-accessible; otherwise `null`.
+ * `null` のとき呼び出し側はフォールバック（web_search の cheapest 探索など）へ進める。
  */
-async function fixedModelIdIfAccessible(db: Database, tier: UserTier): Promise<string> {
+export async function resolveActiveWikiComposeModelId(
+  db: Database,
+  tier: UserTier,
+): Promise<string | null> {
   const tierClause = tierFilter(tier);
   const [row] = await db
     .select({ id: aiModels.id })
@@ -36,7 +45,7 @@ async function fixedModelIdIfAccessible(db: Database, tier: UserTier): Promise<s
       ),
     )
     .limit(1);
-  return row?.id ?? WIKI_COMPOSE_MODEL_ID;
+  return row?.id ?? null;
 }
 
 /**
@@ -50,5 +59,5 @@ export async function resolveWikiComposeModelId(
   _tier: UserTier,
   db: Database,
 ): Promise<string> {
-  return fixedModelIdIfAccessible(db, _tier);
+  return (await resolveActiveWikiComposeModelId(db, _tier)) ?? WIKI_COMPOSE_MODEL_ID;
 }

--- a/server/api/src/agents/core/tools/resolveWebSearchModel.ts
+++ b/server/api/src/agents/core/tools/resolveWebSearchModel.ts
@@ -26,7 +26,7 @@
 import { and, asc, eq, inArray } from "drizzle-orm";
 import { aiModels } from "../../../schema/index.js";
 import type { Database, UserTier } from "../../../types/index.js";
-import { WIKI_COMPOSE_MODEL_ID } from "../llm/wikiComposeModelId.js";
+import { resolveActiveWikiComposeModelId } from "../llm/wikiComposeModelId.js";
 
 const ENV_OVERRIDE = "WIKI_COMPOSE_WEB_SEARCH_MODEL_ID";
 
@@ -50,19 +50,8 @@ export async function resolveWebSearchModelId(
   db: Database,
   tier: UserTier,
 ): Promise<string | null> {
-  const tierClause = tierFilter(tier);
-  const [fixedRow] = await db
-    .select({ id: aiModels.id })
-    .from(aiModels)
-    .where(
-      and(
-        eq(aiModels.id, WIKI_COMPOSE_MODEL_ID),
-        eq(aiModels.isActive, true),
-        ...(tierClause ? [tierClause] : []),
-      ),
-    )
-    .limit(1);
-  if (fixedRow) return fixedRow.id;
+  const fixedId = await resolveActiveWikiComposeModelId(db, tier);
+  if (fixedId) return fixedId;
 
   const override = process.env[ENV_OVERRIDE]?.trim();
   if (override) {

--- a/server/api/src/agents/core/tools/resolveWebSearchModel.ts
+++ b/server/api/src/agents/core/tools/resolveWebSearchModel.ts
@@ -5,13 +5,14 @@
  * `useGoogleSearch` for Google) を呼ぶため、Anthropic-only な選択では成立しない。
  * 本ヘルパは次の優先順で model を選ぶ:
  *
- * 1. `process.env.WIKI_COMPOSE_WEB_SEARCH_MODEL_ID` (explicit override; `ai_models.id`)
+ * 1. {@link WIKI_COMPOSE_MODEL_ID} when active and tier-accessible
+ * 2. `process.env.WIKI_COMPOSE_WEB_SEARCH_MODEL_ID` (explicit override; `ai_models.id`)
  *    — 必ず active かつ tier 通過することを DB 側で確認する（coderabbit review #956:
  *    不正な override で `createZediChatModel` が失敗してエラー envelope になる
  *    のを防ぐ）。
- * 2. `ai_models` の active な OpenAI モデルで最安 (`input_cost_units` ASC, `output_cost_units` ASC)
- * 3. `ai_models` の active な Google モデルで最安
- * 4. 何も無ければ `null` を返す（ツール側は empty result + note を返す）。
+ * 3. `ai_models` の active な OpenAI モデルで最安 (`input_cost_units` ASC, `output_cost_units` ASC)
+ * 4. `ai_models` の active な Google モデルで最安
+ * 5. 何も無ければ `null` を返す（ツール側は empty result + note を返す）。
  *
  * Returns the `ai_models.id` so `createZediChatModel({ modelId })` can validate
  * tier access and resolve the API key uniformly. Centralising the choice in one
@@ -25,6 +26,7 @@
 import { and, asc, eq, inArray } from "drizzle-orm";
 import { aiModels } from "../../../schema/index.js";
 import type { Database, UserTier } from "../../../types/index.js";
+import { WIKI_COMPOSE_MODEL_ID } from "../llm/wikiComposeModelId.js";
 
 const ENV_OVERRIDE = "WIKI_COMPOSE_WEB_SEARCH_MODEL_ID";
 
@@ -48,6 +50,20 @@ export async function resolveWebSearchModelId(
   db: Database,
   tier: UserTier,
 ): Promise<string | null> {
+  const tierClause = tierFilter(tier);
+  const [fixedRow] = await db
+    .select({ id: aiModels.id })
+    .from(aiModels)
+    .where(
+      and(
+        eq(aiModels.id, WIKI_COMPOSE_MODEL_ID),
+        eq(aiModels.isActive, true),
+        ...(tierClause ? [tierClause] : []),
+      ),
+    )
+    .limit(1);
+  if (fixedRow) return fixedRow.id;
+
   const override = process.env[ENV_OVERRIDE]?.trim();
   if (override) {
     // Validate the override before returning: it must be active and
@@ -73,7 +89,6 @@ export async function resolveWebSearchModelId(
     // override が使えない場合は通常検索にフォールバックする。
   }
 
-  const tierClause = tierFilter(tier);
   const rows = await db
     .select({
       id: aiModels.id,

--- a/server/api/src/agents/core/tools/resolveWebSearchModel.ts
+++ b/server/api/src/agents/core/tools/resolveWebSearchModel.ts
@@ -78,6 +78,7 @@ export async function resolveWebSearchModelId(
     // override が使えない場合は通常検索にフォールバックする。
   }
 
+  const tierClause = tierFilter(tier);
   const rows = await db
     .select({
       id: aiModels.id,

--- a/server/api/src/agents/graphs/wikiCompose/nodes/briefDialogue.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/briefDialogue.ts
@@ -16,7 +16,7 @@ import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { composeContentLocaleInstruction } from "../../../core/composeLocale.js";
 import { createZediChatModel } from "../../../core/llm/modelFactory.js";
-import { resolveComposeModelId } from "../../../core/llm/resolveComposeModelId.js";
+import { resolveWikiComposeModelId } from "../../../core/llm/wikiComposeModelId.js";
 import { getGraphContext } from "../../../subgraphs/research/nodes/shared/getGraphContext.js";
 import { loadPageSnapshot } from "./shared/loadPageSnapshot.js";
 import { dispatchComposePhase } from "./shared/dispatch.js";
@@ -117,7 +117,7 @@ export async function briefDialogue(
   // セッション開始時に 1 度だけ読み、以後は state を参照する。
   const snapshot = state.pageSnapshot ?? (await loadPageSnapshot(ctx.db, ctx.pageId));
 
-  const modelId = await resolveComposeModelId("orchestrator", ctx.backend, ctx.tier, ctx.db);
+  const modelId = await resolveWikiComposeModelId("orchestrator", ctx.tier, ctx.db);
   const model = await createZediChatModel({
     modelId,
     userId: ctx.userId,

--- a/server/api/src/agents/graphs/wikiCompose/nodes/draftSections.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/draftSections.ts
@@ -15,7 +15,7 @@
 import type { LangGraphRunnableConfig } from "@langchain/langgraph";
 import { composeContentLocaleInstruction } from "../../../core/composeLocale.js";
 import { createZediChatModel } from "../../../core/llm/modelFactory.js";
-import { resolveComposeModelId } from "../../../core/llm/resolveComposeModelId.js";
+import { resolveWikiComposeModelId } from "../../../core/llm/wikiComposeModelId.js";
 import { getGraphContext } from "../../../subgraphs/research/nodes/shared/getGraphContext.js";
 import { dispatchComposePhase, dispatchComposeSection } from "./shared/dispatch.js";
 import type { WikiComposeStateType, WikiComposeStateUpdate } from "../state.js";
@@ -127,7 +127,7 @@ export async function draftSections(
     return { draftedSections: [], phase: "draft:completed" };
   }
 
-  const modelId = await resolveComposeModelId("draft", ctx.backend, ctx.tier, ctx.db);
+  const modelId = await resolveWikiComposeModelId("draft", ctx.tier, ctx.db);
   const model = await createZediChatModel({
     modelId,
     userId: ctx.userId,

--- a/server/api/src/agents/graphs/wikiCompose/nodes/structureDialogue.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/structureDialogue.ts
@@ -19,7 +19,7 @@ import {
   structureDialogueFallbackOutline,
 } from "../../../core/composeLocale.js";
 import { createZediChatModel } from "../../../core/llm/modelFactory.js";
-import { resolveComposeModelId } from "../../../core/llm/resolveComposeModelId.js";
+import { resolveWikiComposeModelId } from "../../../core/llm/wikiComposeModelId.js";
 import { getGraphContext } from "../../../subgraphs/research/nodes/shared/getGraphContext.js";
 import { dispatchComposePhase } from "./shared/dispatch.js";
 import type { WikiComposeStateType, WikiComposeStateUpdate } from "../state.js";
@@ -83,7 +83,7 @@ export async function structureDialogue(
 
   await dispatchComposePhase({ phase: "structure", status: "entered" }, config);
 
-  const modelId = await resolveComposeModelId("orchestrator", ctx.backend, ctx.tier, ctx.db);
+  const modelId = await resolveWikiComposeModelId("orchestrator", ctx.tier, ctx.db);
   const model = await createZediChatModel({
     modelId,
     userId: ctx.userId,

--- a/server/api/src/agents/subgraphs/research/nodes/evaluateSufficiency.ts
+++ b/server/api/src/agents/subgraphs/research/nodes/evaluateSufficiency.ts
@@ -12,7 +12,7 @@ import type { LangGraphRunnableConfig } from "@langchain/langgraph";
 import { z } from "zod";
 import { composeContentLocaleInstruction } from "../../../core/composeLocale.js";
 import { createZediChatModel } from "../../../core/llm/modelFactory.js";
-import { resolveComposeModelId } from "../../../core/llm/resolveComposeModelId.js";
+import { resolveWikiComposeModelId } from "../../../core/llm/wikiComposeModelId.js";
 import { getGraphContext } from "./shared/getGraphContext.js";
 import { dispatchResearchEvaluation } from "./shared/dispatchSseCustom.js";
 import type { ResearchLoopStateType, ResearchLoopStateUpdate } from "../state.js";
@@ -72,7 +72,7 @@ export async function evaluateSufficiency(
 ): Promise<ResearchLoopStateUpdate> {
   const ctx = getGraphContext(config);
 
-  const modelId = await resolveComposeModelId("orchestrator", ctx.backend, ctx.tier, ctx.db);
+  const modelId = await resolveWikiComposeModelId("orchestrator", ctx.tier, ctx.db);
   const model = await createZediChatModel({
     modelId,
     userId: ctx.userId,

--- a/server/api/src/agents/subgraphs/research/nodes/planQueries.ts
+++ b/server/api/src/agents/subgraphs/research/nodes/planQueries.ts
@@ -23,8 +23,8 @@ import type { ResearchLoopStateType, ResearchLoopStateUpdate } from "../state.js
 import type { PlannedQuery, Source } from "../types.js";
 
 /**
- * @deprecated Use {@link resolveWikiComposeModelId} for Wiki Compose graphs.
- * Kept for ingest planner BYOK preflight ({@link getComposeModelIdsForGraph}).
+ * @deprecated Use {@link resolveWikiComposeModelId} for Wiki Compose graphs; kept for ingest planner BYOK preflight ({@link getComposeModelIdsForGraph}).
+ * Wiki Compose では {@link resolveWikiComposeModelId} を使う。ingest BYOK 事前検証用。
  */
 export function getOrchestratorModelId(): string {
   return process.env.WIKI_COMPOSE_ORCHESTRATOR_MODEL_ID?.trim() || "claude-3-5-haiku";

--- a/server/api/src/agents/subgraphs/research/nodes/planQueries.ts
+++ b/server/api/src/agents/subgraphs/research/nodes/planQueries.ts
@@ -16,14 +16,15 @@ import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { composeContentLocaleInstruction } from "../../../core/composeLocale.js";
 import { createZediChatModel } from "../../../core/llm/modelFactory.js";
-import { resolveComposeModelId } from "../../../core/llm/resolveComposeModelId.js";
+import { resolveWikiComposeModelId } from "../../../core/llm/wikiComposeModelId.js";
 import { getGraphContext } from "./shared/getGraphContext.js";
 import { dispatchResearchIteration } from "./shared/dispatchSseCustom.js";
 import type { ResearchLoopStateType, ResearchLoopStateUpdate } from "../state.js";
 import type { PlannedQuery, Source } from "../types.js";
 
 /**
- * @deprecated Use {@link resolveComposeModelId} with graph context. Kept for tests importing the symbol.
+ * @deprecated Use {@link resolveWikiComposeModelId} for Wiki Compose graphs.
+ * Kept for ingest planner BYOK preflight ({@link getComposeModelIdsForGraph}).
  */
 export function getOrchestratorModelId(): string {
   return process.env.WIKI_COMPOSE_ORCHESTRATOR_MODEL_ID?.trim() || "claude-3-5-haiku";
@@ -100,7 +101,7 @@ export async function planQueries(
   // maxIterations は既存 state を優先しつつ 1..5 にクランプ。
   const maxIterations = clampMaxIterations(state.maxIterations ?? 3);
 
-  const modelId = await resolveComposeModelId("orchestrator", ctx.backend, ctx.tier, ctx.db);
+  const modelId = await resolveWikiComposeModelId("orchestrator", ctx.tier, ctx.db);
   const model = await createZediChatModel({
     modelId,
     userId: ctx.userId,

--- a/server/api/src/agents/subgraphs/research/nodes/refineQueries.ts
+++ b/server/api/src/agents/subgraphs/research/nodes/refineQueries.ts
@@ -10,7 +10,7 @@ import type { LangGraphRunnableConfig } from "@langchain/langgraph";
 import { randomUUID } from "node:crypto";
 import { composeContentLocaleInstruction } from "../../../core/composeLocale.js";
 import { createZediChatModel } from "../../../core/llm/modelFactory.js";
-import { resolveComposeModelId } from "../../../core/llm/resolveComposeModelId.js";
+import { resolveWikiComposeModelId } from "../../../core/llm/wikiComposeModelId.js";
 import { getGraphContext } from "./shared/getGraphContext.js";
 import { dispatchResearchIteration } from "./shared/dispatchSseCustom.js";
 import { planQueriesSchema } from "./planQueries.js";
@@ -62,7 +62,7 @@ export async function refineQueries(
 ): Promise<ResearchLoopStateUpdate> {
   const ctx = getGraphContext(config);
 
-  const modelId = await resolveComposeModelId("orchestrator", ctx.backend, ctx.tier, ctx.db);
+  const modelId = await resolveWikiComposeModelId("orchestrator", ctx.tier, ctx.db);
   const model = await createZediChatModel({
     modelId,
     userId: ctx.userId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wiki Compose のすべての LLM 呼び出し（Brief / 調査 / 構成 / 執筆）と `web_search` ツールが、固定の `ai_models.id` **`google:gemini-3.5-flash`** を使うように変更しました。ロール（orchestrator / draft）や実行 backend によるモデル切り替えは現時点では行いません。

## Changes

- 新規 `wikiComposeModelId.ts`: `WIKI_COMPOSE_MODEL_ID` と `resolveWikiComposeModelId()`
- Wiki Compose 各ノード・調査サブグラフを `resolveWikiComposeModelId` に切り替え
- `web_search` は固定モデルを最優先で解決
- `composeModelConfig` の wiki-compose / wiki-compose-research は単一モデル id のみ返す
- ingest planner は従来どおり `resolveComposeModelId`（変更なし）

## Ops note

本番・開発 DB の `ai_models` に **`google:gemini-3.5-flash`** が `is_active = true` で登録されている必要があります。未登録の場合は従来どおり `Model not found or inactive` になります。管理画面のモデル同期、または `GOOGLE_MODEL_IDS` に `gemini-3.5-flash` を含めて `sync:ai-models` を実行してください。

## Testing

- `server/api`: `wikiComposeModelId.test.ts`, wiki compose / research 関連 Vitest（42 tests）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88b6e7ee-371b-4e46-8e95-988240ec0d93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88b6e7ee-371b-4e46-8e95-988240ec0d93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wiki Compose and related research flows now consistently use a single fixed model at runtime.
  * Session validation now rejects non-Google BYOK backends for Wiki Compose graphs.

* **Removed**
  * Draft-model environment override for Wiki Compose selection.

* **Behavior Changes**
  * Web-search model selection now prioritizes the fixed Wiki Compose model when available.

* **Tests**
  * Added tests for model resolution, BYOK validation, and routing across compose/research flows.

* **Documentation**
  * Updated docs to describe the fixed model behavior and BYOK pre-flight checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->