### PR TITLE
refactor(wiki-compose): apply thermo-nuclear code quality review fixes

### DIFF
--- a/server/api/src/__tests__/routes/composeSessionRunLocale.test.ts
+++ b/server/api/src/__tests__/routes/composeSessionRunLocale.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for compose session locale preparation helper.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+  prepareComposeRunFromRequest,
+  resolveComposeSessionContentLocale,
+} from "../../routes/composeSessionRunLocale.js";
+
+describe("prepareComposeRunFromRequest", () => {
+  it("strips contentLocale from graph input and builds metadata patch on first run", () => {
+    const prep = prepareComposeRunFromRequest(
+      { composeSeed: { outline: "a", conversationText: "b" } },
+      { contentLocale: "en", chatSeed: { outline: "a", conversationText: "b" } },
+      "ja-JP",
+      "ja",
+    );
+    expect(prep.contentLocale).toBe("en");
+    expect(prep.graphInput).toEqual({ chatSeed: { outline: "a", conversationText: "b" } });
+    expect(prep.metadataUpdate).toEqual({
+      composeSeed: { outline: "a", conversationText: "b" },
+      contentLocale: "en",
+    });
+  });
+
+  it("skips metadata patch when locale is already persisted", () => {
+    const prep = prepareComposeRunFromRequest(
+      { contentLocale: "ja" },
+      { contentLocale: "en" },
+      null,
+      "ja",
+    );
+    expect(prep.contentLocale).toBe("ja");
+    expect(prep.metadataUpdate).toBeUndefined();
+  });
+});
+
+describe("resolveComposeSessionContentLocale", () => {
+  it("delegates to session metadata when present", () => {
+    expect(resolveComposeSessionContentLocale({ contentLocale: "en" }, null, "ja", "ja")).toBe(
+      "en",
+    );
+  });
+});

--- a/server/api/src/routes/composeSessionRunLocale.ts
+++ b/server/api/src/routes/composeSessionRunLocale.ts
@@ -9,11 +9,17 @@ import {
   type ComposeContentLocale,
 } from "../agents/core/composeLocale.js";
 
-/** Result of preparing a `POST /run` request for LangGraph execution. */
+/**
+ * Result of preparing a `POST /run` request for LangGraph execution.
+ * LangGraph 実行向け `POST /run` リクエスト前処理の結果。
+ */
 export type ComposeRunLocalePrep = {
   contentLocale: ComposeContentLocale;
   graphInput: unknown;
-  /** Metadata blob to persist on claim when locale is not yet stored. */
+  /**
+   * Metadata blob to persist on claim when locale is not yet stored.
+   * ロケール未保存時に claim 更新で永続化するメタデータ。
+   */
   metadataUpdate: Record<string, unknown> | undefined;
 };
 

--- a/server/api/src/routes/composeSessionRunLocale.ts
+++ b/server/api/src/routes/composeSessionRunLocale.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared locale preparation for compose session run / projection routes.
+ * compose セッション run / projection ルート向けのロケール準備を共通化する。
+ */
+import {
+  readContentLocaleFromSessionMetadata,
+  resolveSessionContentLocale,
+  stripContentLocaleFromGraphInput,
+  type ComposeContentLocale,
+} from "../agents/core/composeLocale.js";
+
+/** Result of preparing a `POST /run` request for LangGraph execution. */
+export type ComposeRunLocalePrep = {
+  contentLocale: ComposeContentLocale;
+  graphInput: unknown;
+  /** Metadata blob to persist on claim when locale is not yet stored. */
+  metadataUpdate: Record<string, unknown> | undefined;
+};
+
+function mergeSessionMetadataWithLocale(
+  metadata: unknown,
+  contentLocale: ComposeContentLocale,
+): Record<string, unknown> {
+  const base =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? { ...(metadata as Record<string, unknown>) }
+      : {};
+  return { ...base, contentLocale };
+}
+
+/**
+ * Resolve content locale, strip it from graph input, and build metadata patch for first run.
+ * contentLocale を解決し graph input から除去、初回 run 用 metadata 更新を組み立てる。
+ */
+export function prepareComposeRunFromRequest(
+  sessionMetadata: unknown,
+  rawInput: unknown,
+  acceptLanguage: string | undefined | null,
+  fallback: ComposeContentLocale = "ja",
+): ComposeRunLocalePrep {
+  const contentLocale = resolveSessionContentLocale(
+    sessionMetadata,
+    rawInput,
+    acceptLanguage,
+    fallback,
+  );
+  const shouldPersistLocale = !readContentLocaleFromSessionMetadata(sessionMetadata);
+  const metadataUpdate = shouldPersistLocale
+    ? mergeSessionMetadataWithLocale(sessionMetadata, contentLocale)
+    : undefined;
+  const graphInput = stripContentLocaleFromGraphInput(rawInput ?? {});
+  return { contentLocale, graphInput, metadataUpdate };
+}
+
+/**
+ * Resolve content locale for read / resume paths (no graph input or metadata patch).
+ * GET / resume 向けに contentLocale のみ解決する。
+ */
+export function resolveComposeSessionContentLocale(
+  sessionMetadata: unknown,
+  rawInput: unknown | null,
+  acceptLanguage: string | undefined | null,
+  fallback: ComposeContentLocale = "ja",
+): ComposeContentLocale {
+  return resolveSessionContentLocale(sessionMetadata, rawInput, acceptLanguage, fallback);
+}

--- a/server/api/src/routes/composeSessions.ts
+++ b/server/api/src/routes/composeSessions.ts
@@ -61,15 +61,14 @@ import { resolveCheckpointerForRun } from "../agents/core/checkpoint/index.js";
 import { RESEARCH_GRAPH_ID } from "../agents/subgraphs/research/index.js";
 import { WIKI_COMPOSE_GRAPH_ID } from "../agents/graphs/wikiCompose/index.js";
 import { WIKI_MAINTENANCE_GRAPH_ID } from "../agents/graphs/wikiMaintenance/index.js";
-import {
-  readContentLocaleFromSessionMetadata,
-  resolveSessionContentLocale,
-  stripContentLocaleFromGraphInput,
-  type ComposeContentLocale,
-} from "../agents/core/composeLocale.js";
+import type { ComposeContentLocale } from "../agents/core/composeLocale.js";
 import type { AppEnv } from "../types/index.js";
 import { persistOutcomeIfStillRunning } from "./composeSessionPersistence.js";
 import { loadComposeSessionProjection } from "./composeSessionProjection.js";
+import {
+  prepareComposeRunFromRequest,
+  resolveComposeSessionContentLocale,
+} from "./composeSessionRunLocale.js";
 
 /**
  * Translate the documented `body.input.kind === "additional_research"` shape
@@ -251,7 +250,7 @@ app.get("/:pageId/compose-sessions/:id", authRequired, async (c) => {
   if (!row) throw new HTTPException(404, { message: "Session not found" });
 
   const tier = await getUserTier(userId, db);
-  const contentLocale = resolveSessionContentLocale(
+  const contentLocale = resolveComposeSessionContentLocale(
     row.metadata,
     null,
     c.req.header("accept-language"),
@@ -343,24 +342,16 @@ app.post("/:pageId/compose-sessions/:id/run", authRequired, rateLimit(), async (
     throw err;
   }
 
-  const acceptLanguage = c.req.header("accept-language");
-  const contentLocale = resolveSessionContentLocale(
+  const {
+    contentLocale,
+    graphInput,
+    metadataUpdate: metadataWithLocale,
+  } = prepareComposeRunFromRequest(
     session.metadata,
     body.input,
-    acceptLanguage,
+    c.req.header("accept-language"),
     "ja",
   );
-  const shouldPersistLocale = !readContentLocaleFromSessionMetadata(session.metadata);
-  const metadataWithLocale = shouldPersistLocale
-    ? {
-        ...(session.metadata &&
-        typeof session.metadata === "object" &&
-        !Array.isArray(session.metadata)
-          ? { ...(session.metadata as Record<string, unknown>) }
-          : {}),
-        contentLocale,
-      }
-    : undefined;
 
   // Atomically claim the session (and persist `contentLocale` when needed) so
   // concurrent POST /run cannot double-bill and a failed follow-up write cannot
@@ -421,7 +412,6 @@ app.post("/:pageId/compose-sessions/:id/run", authRequired, rateLimit(), async (
     // checkpoint 保存・再開を有効化する。テスト / CI では未設定なので `false`
     // を返し、LangGraph の checkpoint 機構を無効化したまま smoke-test で走る。
     const checkpointer = await resolveCheckpointerForRun();
-    const graphInput = stripContentLocaleFromGraphInput(body.input ?? {});
 
     try {
       await send(startedEvent(id, session.graphId, session.phase));
@@ -556,7 +546,7 @@ app.patch("/:pageId/compose-sessions/:id/resume", authRequired, rateLimit(), asy
   // Resume relies on the checkpointer to fetch the suspended thread; production
   // routes load `PostgresSaver` here, tests/smoke runs get `false`.
   const checkpointer = await resolveCheckpointerForRun();
-  const contentLocale = resolveSessionContentLocale(
+  const contentLocale = resolveComposeSessionContentLocale(
     session.metadata,
     null,
     c.req.header("accept-language"),

--- a/src/hooks/useWikiComposeSession.test.ts
+++ b/src/hooks/useWikiComposeSession.test.ts
@@ -31,6 +31,13 @@ vi.mock("@/lib/wikiCompose/resolveComposeContentLocale", () => ({
   resolveComposeContentLocale: () => "ja" as const,
 }));
 
+vi.mock("@/hooks/useInitialComposeBackend", () => ({
+  useInitialComposeBackend: () => ({
+    backend: "zedi_managed" as const,
+    isResolved: true,
+  }),
+}));
+
 import { useWikiComposeSession } from "./useWikiComposeSession";
 import type { ComposeSseEvent } from "@/lib/wikiCompose/types";
 

--- a/src/hooks/useWikiComposeSession.test.ts
+++ b/src/hooks/useWikiComposeSession.test.ts
@@ -76,6 +76,19 @@ describe("useWikiComposeSession", () => {
     mocks.createSession.mockResolvedValue(SESSION);
   });
 
+  it("exposes canRetryStart after auto-start fails for fresh compose / 新規 Compose の自動開始失敗後に canRetryStart になる", async () => {
+    mocks.createSession.mockRejectedValue(new Error("network"));
+    const { result } = renderHook(() =>
+      useWikiComposeSession({
+        pageId: "page-1",
+        sessionId: null,
+        startPolicy: "when-backend-ready",
+      }),
+    );
+    await waitFor(() => expect(result.current.canRetryStart).toBe(true));
+    expect(result.current.error).toBe("network");
+  });
+
   it("reduces a Brief interrupt into briefQuestions + pageSnapshot", async () => {
     arrangeRun([
       { type: "started", sessionId: SESSION.id, graphId: SESSION.graphId },

--- a/src/hooks/useWikiComposeSession.ts
+++ b/src/hooks/useWikiComposeSession.ts
@@ -1,15 +1,5 @@
 /**
- * `useWikiComposeSession` — React state machine for one Wiki Compose session
- * (#950).
- *
- * Compose 1 セッションのフロント側 state machine。SSE で来るイベントを
- * pattern match し、Brief 質問 / 調査バッチ / アウトライン / セクション本文
- * といったフェーズ固有の slice を再アセンブルする。`WikiComposePage` は本
- * フックの戻り値を読みつつ、`submitBrief` / `submitResearchApproval` /
- * `submitOutline` を呼ぶことで graph を次フェーズへ進める。
- *
- * Owns the wire-level wiring; UI components stay pure. Critically, the hook
- * does NOT navigate or persist — it only reflects what the SSE stream says.
+ * `useWikiComposeSession` — React state machine for one Wiki Compose session (#950).
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -19,539 +9,77 @@ import {
   resumeSession,
   runSession,
 } from "@/lib/wikiCompose/composeService";
-import i18n from "@/i18n";
 import type { ComposeExecutionBackend } from "@/lib/wikiCompose/backends";
-import { resolveComposeContentLocale } from "@/lib/wikiCompose/resolveComposeContentLocale";
 import type { ComposeNavigationSeed } from "@/lib/wikiCompose/navigation";
+import {
+  hydrateComposeFromProjection,
+  INITIAL_WIKI_COMPOSE_SESSION_STATE,
+  parseComposeSeedFromMetadata,
+  reduceComposeResumeOutput,
+  reduceComposeSseEvent,
+  withContentLocale,
+  type ComposeActivity,
+  type ComposePhase,
+  type WikiComposeSessionState,
+} from "@/lib/wikiCompose/wikiComposeSessionReducer";
+import { useInitialComposeBackend } from "@/hooks/useInitialComposeBackend";
 import type {
   BriefAnswer,
-  BriefQuestion,
-  ComposeInterruptPayload,
   ComposeSession,
-  ComposeSessionStatus,
-  ComposeSessionUiProjection,
-  ComposeSseEvent,
   DraftedSection,
   OutlineSection,
-  PageSnapshot,
-  ResearchBatch,
-  ResearchConflictSummary,
-  ResearchSource,
 } from "@/lib/wikiCompose/types";
+import type { ComposeSseEvent } from "@/lib/wikiCompose/types";
+
+export type { ComposeActivity, ComposePhase, WikiComposeSessionState };
 
 /**
- * UI phase for Wiki Compose session progression.
- * Wiki Compose セッション進行を表す UI フェーズ。
+ * When the hook should call `start()` automatically.
+ * `start()` を自動実行するタイミング。
  */
-export type ComposePhase = "brief" | "research" | "conflict" | "structure" | "draft" | "completed";
-
-/** Activity log entry surfaced in the right pane's ActivitySection. */
-export interface ComposeActivity {
-  id: string;
-  /** ISO timestamp. */
-  at: string;
-  /** Human-readable label for the activity row. */
-  label: string;
-  /** Optional secondary line (status, tool name, etc.). */
-  detail?: string;
-  /** Lifecycle hint so the UI can render spinners / checkmarks. */
-  status?: "started" | "completed" | "info" | "error";
-}
-
-/** Aggregate state surfaced to the UI. */
-export interface WikiComposeSessionState {
-  session: ComposeSession | null;
-  status: ComposeSessionStatus | "idle";
-  phase: ComposePhase;
-  /** Brief phase question cards (from interrupt). */
-  briefQuestions: BriefQuestion[];
-  /** Page snapshot (loaded at session start). */
-  pageSnapshot: PageSnapshot | null;
-  /** Latest research batch from the human-review interrupt. */
-  latestBatch: ResearchBatch | null;
-  /** Pending sources at the research interrupt. */
-  pendingSources: ResearchSource[];
-  /** Approved sources after research resume. */
-  approvedSources: ResearchSource[];
-  /** P5 conflict-resolution interrupt payload (#953). */
-  researchConflictSummary: ResearchConflictSummary | null;
-  /** Proposed outline from the structure interrupt. */
-  outlineProposal: OutlineSection[];
-  /** Drafted section bodies — keyed by sectionId. */
-  draftedSections: Record<string, DraftedSection>;
-  /** While streaming a section, this id is set; null between sections. */
-  streamingSectionId: string | null;
-  /** Per-section running token buffer while the section is mid-stream. */
-  sectionBuffers: Record<string, string>;
-  /** Activity timeline (newest last). */
-  activity: ComposeActivity[];
-  /** Final markdown if the session completed. */
-  completedMarkdown: string | null;
-  /** Last error message (set on failure). */
-  error: string | null;
-  /** True while an SSE stream is open. */
-  isStreaming: boolean;
-}
-
-const INITIAL_STATE: WikiComposeSessionState = {
-  session: null,
-  status: "idle",
-  phase: "brief",
-  briefQuestions: [],
-  pageSnapshot: null,
-  latestBatch: null,
-  pendingSources: [],
-  approvedSources: [],
-  researchConflictSummary: null,
-  outlineProposal: [],
-  draftedSections: {},
-  streamingSectionId: null,
-  sectionBuffers: {},
-  activity: [],
-  completedMarkdown: null,
-  error: null,
-  isStreaming: false,
-};
+export type ComposeStartPolicy = "never" | "on-mount" | "when-backend-ready";
 
 /** Args accepted by the hook. */
 export interface UseWikiComposeSessionArgs {
   pageId: string;
-  /** Existing session to resume; pass `null` to create a fresh session on start. */
   sessionId: string | null;
-  /**
-   * 初回 `POST /run` に渡す graph input（例: `chatSeed`）。
-   * Initial graph input for the first `POST /run` (e.g. `{ chatSeed }`).
-   */
   initialInput?: Record<string, unknown>;
-  /**
-   * チャット由来 seed。セッション行 `metadata` にも保存する。
-   * Chat-origin seed; also persisted on the session row metadata.
-   */
   composeSeed?: ComposeNavigationSeed;
-  /** Auto-start the first `run` when the session is created. Default `true`. */
-  autoStart?: boolean;
   /**
-   * 実行 backend（セッション作成時に固定）。省略時は `zedi_managed`。
-   * Execution backend fixed at session create; defaults to `zedi_managed`.
+   * @deprecated Prefer {@link startPolicy}. When set without `startPolicy`, `false` → `never`, `true` → `on-mount`.
    */
+  autoStart?: boolean;
+  /** When to auto-invoke `start()`. Default `on-mount`. */
+  startPolicy?: ComposeStartPolicy;
   backend?: ComposeExecutionBackend;
 }
 
 /** Hook return shape. */
 export interface UseWikiComposeSessionReturn extends WikiComposeSessionState {
-  /** Start a new session (or resume the existing one) and begin streaming. */
   start: () => Promise<void>;
-  /** Submit Brief answers and continue streaming. */
   submitBrief: (input: {
     answers: BriefAnswer[];
     appendToExisting?: boolean;
     researchMaxIterations?: number;
   }) => Promise<void>;
-  /** Submit research source approval (Approve/Reject) and continue streaming. */
   submitResearchApproval: (input: {
     approvedSourceIds: string[];
     rejectedSourceIds?: string[];
     note?: string;
   }) => Promise<void>;
-  /** Submit outline approval and continue streaming. */
   submitOutline: (input: { sections: OutlineSection[] }) => Promise<void>;
-  /**
-   * Acknowledge research conflicts and continue to Structure (#953).
-   * 調査の矛盾を確認し Structure へ進む（#953）。
-   */
   submitConflictAck: (input?: { note?: string }) => Promise<void>;
-  /** Cancel the session (DELETE). */
   cancel: () => Promise<void>;
+  /** True when a failed fresh-compose auto-start can be retried from the UI. */
+  canRetryStart: boolean;
 }
 
-/** First interrupt kind on a LangGraph checkpoint output, if any. */
-function interruptKindFromOutput(output: unknown): string | undefined {
-  if (!output || typeof output !== "object") return undefined;
-  const interrupts = (output as { __interrupt__?: unknown }).__interrupt__;
-  if (!Array.isArray(interrupts) || interrupts.length === 0) return undefined;
-  const entry = interrupts[0];
-  const value =
-    entry && typeof entry === "object" ? (entry as { value?: unknown }).value : undefined;
-  if (value && typeof value === "object" && "kind" in value) {
-    const kind = (value as { kind?: unknown }).kind;
-    return typeof kind === "string" ? kind : undefined;
-  }
-  return undefined;
+function resolveStartPolicy(args: UseWikiComposeSessionArgs): ComposeStartPolicy {
+  if (args.startPolicy) return args.startPolicy;
+  if (args.autoStart === false) return "never";
+  return "on-mount";
 }
 
-/**
- * Returns a unique id for an activity row. Uses crypto.randomUUID when
- * available (modern browsers); falls back to a coarse fallback for old
- * environments and SSR.
- */
-/**
- * `session.metadata.composeSeed` を型検証して graph input 用 seed にする。
- * Validate persisted `metadata.composeSeed` before sending `/run` input.
- */
-function parseComposeSeedFromMetadata(metadata: Record<string, unknown> | null | undefined):
-  | {
-      outline: string;
-      conversationText: string;
-      userSchema?: string;
-      conversationId?: string;
-    }
-  | undefined {
-  if (!metadata || typeof metadata !== "object") return undefined;
-  const raw = metadata.composeSeed;
-  if (!raw || typeof raw !== "object") return undefined;
-  const seed = raw as Record<string, unknown>;
-  if (typeof seed.outline !== "string" || typeof seed.conversationText !== "string") {
-    return undefined;
-  }
-  const out: {
-    outline: string;
-    conversationText: string;
-    userSchema?: string;
-    conversationId?: string;
-  } = {
-    outline: seed.outline,
-    conversationText: seed.conversationText,
-  };
-  if (typeof seed.userSchema === "string" && seed.userSchema.trim()) {
-    out.userSchema = seed.userSchema;
-  }
-  if (typeof seed.conversationId === "string" && seed.conversationId.trim()) {
-    out.conversationId = seed.conversationId;
-  }
-  return out;
-}
-
-function activityId(): string {
-  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
-  return `act-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-}
-
-/** Merge graph run input with the active UI content locale. */
-function withContentLocale(input?: Record<string, unknown>): Record<string, unknown> {
-  return { ...(input ?? {}), contentLocale: resolveComposeContentLocale() };
-}
-
-/** Human-readable phase label for activity log entries. */
-function phaseDisplayLabel(phase: string): string {
-  const key = `wikiCompose.phaseDisplay.${phase}` as const;
-  const translated = i18n.t(key);
-  return translated === key ? phase : translated;
-}
-
-/**
- * Map an SSE event into a state update. Returns a partial state to merge.
- */
-function reduceEvent(
-  prev: WikiComposeSessionState,
-  event: ComposeSseEvent,
-): Partial<WikiComposeSessionState> {
-  switch (event.type) {
-    case "started":
-      return {
-        activity: appendActivity(prev.activity, {
-          label: i18n.t("wikiCompose.activity.runStarted"),
-          detail: event.graphId,
-          status: "info",
-        }),
-      };
-    case "compose_phase":
-      return {
-        phase: event.phase,
-        activity: appendActivity(prev.activity, {
-          label: i18n.t("wikiCompose.activity.phase", { phase: phaseDisplayLabel(event.phase) }),
-          detail: event.status,
-          status: event.status === "entered" ? "started" : "completed",
-        }),
-      };
-    case "status":
-      // Server-side `status` events use a colon-namespaced phase string
-      // (e.g. "brief:await_user"); we don't surface those as the top-level
-      // phase, only as activity log entries for debug.
-      return {
-        activity: appendActivity(prev.activity, {
-          label: event.phase,
-          detail: event.message,
-          status: "info",
-        }),
-      };
-    case "tool_start":
-      return {
-        activity: appendActivity(prev.activity, {
-          label: i18n.t("wikiCompose.activity.toolStarted", { tool: event.tool }),
-          detail: event.input ? "running" : undefined,
-          status: "started",
-        }),
-      };
-    case "tool_end":
-      return {
-        activity: appendActivity(prev.activity, {
-          label: i18n.t("wikiCompose.activity.toolDone", { tool: event.tool }),
-          detail: event.error ?? (event.outputLength ? `${event.outputLength} chars` : "ok"),
-          status: event.error ? "error" : "completed",
-        }),
-      };
-    case "research_iteration":
-      return {
-        activity: appendActivity(prev.activity, {
-          label: i18n.t("wikiCompose.activity.researchIteration", {
-            count: event.iteration + 1,
-          }),
-          detail: `${event.status} · ${event.queryCount} queries`,
-          status: "info",
-        }),
-      };
-    case "research_evaluation":
-      return {
-        activity: appendActivity(prev.activity, {
-          label: i18n.t("wikiCompose.activity.sufficiency", {
-            score: event.score.toFixed(2),
-          }),
-          detail: event.rationale,
-          status: "info",
-        }),
-      };
-    case "research_batch":
-      return {
-        activity: appendActivity(prev.activity, {
-          label: i18n.t("wikiCompose.activity.researchBatch", {
-            iteration: event.iteration,
-          }),
-          detail: `${event.sourceCount} sources · ${event.exitReason}`,
-          status: "completed",
-        }),
-      };
-    case "compose_section":
-      if (event.status === "started") {
-        return {
-          streamingSectionId: event.sectionId,
-          sectionBuffers: { ...prev.sectionBuffers, [event.sectionId]: "" },
-          activity: appendActivity(prev.activity, {
-            label: i18n.t("wikiCompose.activity.drafting", { heading: event.heading }),
-            detail: `${event.index} / ${event.total}`,
-            status: "started",
-          }),
-        };
-      }
-      return {
-        streamingSectionId:
-          prev.streamingSectionId === event.sectionId ? null : prev.streamingSectionId,
-        activity: appendActivity(prev.activity, {
-          label: i18n.t("wikiCompose.activity.drafted", { heading: event.heading }),
-          detail: `${event.index} / ${event.total}`,
-          status: "completed",
-        }),
-      };
-    case "token": {
-      const id = prev.streamingSectionId;
-      if (!id) return {};
-      const prior = prev.sectionBuffers[id] ?? "";
-      return {
-        sectionBuffers: { ...prev.sectionBuffers, [id]: prior + event.content },
-      };
-    }
-    case "interrupt":
-      return reduceInterrupt(prev, event.payload);
-    case "done":
-      return {
-        isStreaming: false,
-        status: event.status,
-        activity: appendActivity(prev.activity, {
-          label: i18n.t("wikiCompose.activity.runStatus", { status: event.status }),
-          status: event.status === "completed" ? "completed" : "info",
-        }),
-      };
-    case "error":
-      return {
-        error: event.message,
-        activity: appendActivity(prev.activity, {
-          label: i18n.t("wikiCompose.activity.error"),
-          detail: event.message,
-          status: "error",
-        }),
-      };
-    case "usage":
-      // Usage doesn't change UI state directly, but log it for debug.
-      return {
-        activity: appendActivity(prev.activity, {
-          label: i18n.t("wikiCompose.activity.usage"),
-          detail: `in=${event.inputTokens} out=${event.outputTokens} cu=${event.costUnits}`,
-          status: "info",
-        }),
-      };
-    default:
-      return {};
-  }
-}
-
-function appendActivity(
-  prev: ComposeActivity[],
-  next: Omit<ComposeActivity, "id" | "at">,
-): ComposeActivity[] {
-  const entry: ComposeActivity = {
-    id: activityId(),
-    at: new Date().toISOString(),
-    ...next,
-  };
-  // Cap the activity log so a long-running session does not grow unbounded.
-  // 直近 200 件のみ保持する（DOM 描画コスト対策）。
-  const merged = [...prev, entry];
-  return merged.length > 200 ? merged.slice(merged.length - 200) : merged;
-}
-
-/**
- * Extract UI state from a non-streaming `PATCH /resume` response body.
- *
- * Resume runs the graph via `invoke`, so tokens and interrupts are returned in
- * `output` rather than over SSE. The hook must hydrate phase slices from that
- * payload; relying on a follow-up `POST /run` would pass fresh `input` to an
- * interrupted checkpoint (invalid for LangGraph) and drop `completion` on the
- * final outline approve path.
- */
-/**
- * Merge `GET /compose-sessions/:id` checkpoint projection into hook state (#950).
- * `GET` の projection をフック state にマージする（リロード再開用）。
- */
-function hydrateFromProjection(
-  projection: ComposeSessionUiProjection,
-): Partial<WikiComposeSessionState> {
-  const partial: Partial<WikiComposeSessionState> = {};
-  if (projection.phase) partial.phase = projection.phase;
-  if (projection.briefQuestions?.length) partial.briefQuestions = projection.briefQuestions;
-  if (projection.pageSnapshot) partial.pageSnapshot = projection.pageSnapshot;
-  if (projection.latestBatch !== undefined) partial.latestBatch = projection.latestBatch;
-  if (projection.pendingSources?.length) partial.pendingSources = projection.pendingSources;
-  if (projection.approvedSources?.length) partial.approvedSources = projection.approvedSources;
-  if (projection.researchConflictSummary) {
-    partial.researchConflictSummary = projection.researchConflictSummary;
-  }
-  if (projection.outlineProposal?.length) partial.outlineProposal = projection.outlineProposal;
-  if (projection.completedMarkdown) partial.completedMarkdown = projection.completedMarkdown;
-  if (projection.draftedSections?.length) {
-    const draftedSections: Record<string, DraftedSection> = {};
-    for (const section of projection.draftedSections) {
-      if (section?.sectionId) draftedSections[section.sectionId] = section;
-    }
-    partial.draftedSections = draftedSections;
-  }
-  return partial;
-}
-
-/**
- * Build hook state context for resume-time interrupt projection.
- * resume 時の interrupt 投影用に、チェックポイント上の approvedResearch を引き継ぐ。
- */
-function interruptContextFromCheckpoint(state: Record<string, unknown>): WikiComposeSessionState {
-  const approved = Array.isArray(state.approvedResearch)
-    ? (state.approvedResearch as ResearchSource[])
-    : [];
-  return { ...INITIAL_STATE, approvedSources: approved };
-}
-
-function reduceResumeOutput(
-  output: unknown,
-  status: ComposeSessionStatus,
-): Partial<WikiComposeSessionState> {
-  if (!output || typeof output !== "object") {
-    return status === "completed" ? { phase: "completed" } : {};
-  }
-  const state = output as Record<string, unknown>;
-  const partial: Partial<WikiComposeSessionState> = {};
-
-  const interrupts = state.__interrupt__;
-  if (Array.isArray(interrupts) && interrupts.length > 0) {
-    const entry = interrupts[0];
-    const value =
-      entry && typeof entry === "object" ? (entry as { value?: unknown }).value : undefined;
-    if (value && typeof value === "object" && "kind" in value) {
-      Object.assign(
-        partial,
-        reduceInterrupt(interruptContextFromCheckpoint(state), value as ComposeInterruptPayload),
-      );
-    }
-  }
-
-  const completion = state.completion;
-  if (completion && typeof completion === "object") {
-    const c = completion as {
-      markdown?: string;
-      sections?: DraftedSection[];
-    };
-    if (typeof c.markdown === "string" && c.markdown.length > 0) {
-      partial.completedMarkdown = c.markdown;
-    }
-    if (Array.isArray(c.sections)) {
-      const draftedSections: Record<string, DraftedSection> = {};
-      for (const section of c.sections) {
-        if (!section || typeof section !== "object") continue;
-        const s = section as DraftedSection;
-        if (typeof s.sectionId === "string") draftedSections[s.sectionId] = s;
-      }
-      partial.draftedSections = draftedSections;
-      partial.phase = "completed";
-      const approvedOutline = state.approvedOutline as { sections?: OutlineSection[] } | undefined;
-      if (approvedOutline?.sections?.length) {
-        partial.outlineProposal = approvedOutline.sections;
-      } else if (c.sections.length > 0) {
-        partial.outlineProposal = c.sections.map((s) => ({
-          id: s.sectionId,
-          heading: s.heading,
-          depth: 1,
-          intent: "",
-        }));
-      }
-    }
-  }
-
-  if (status === "completed" && partial.phase !== "completed") {
-    partial.phase = "completed";
-  }
-
-  return partial;
-}
-
-function reduceInterrupt(
-  prev: WikiComposeSessionState,
-  payload: ComposeInterruptPayload | undefined,
-): Partial<WikiComposeSessionState> {
-  if (!payload) return {};
-  switch (payload.kind) {
-    case "human_review_brief":
-      return {
-        briefQuestions: payload.questions,
-        pageSnapshot: payload.pageSnapshot,
-        phase: "brief",
-      };
-    case "human_review_research":
-      return {
-        latestBatch: payload.batch,
-        pendingSources: payload.pendingSources,
-        phase: "research",
-      };
-    case "human_review_outline":
-      return {
-        outlineProposal: payload.outline,
-        approvedSources: payload.approvedSources,
-        researchConflictSummary: null,
-        phase: "structure",
-      };
-    case "conflict_resolution":
-      return {
-        researchConflictSummary: payload.conflicts,
-        phase: "conflict",
-        // Keep approvals from `prev` (SSE) or checkpoint context (resume); do not
-        // overwrite with an empty array when `reduceResumeOutput` seeds context.
-        ...(prev.approvedSources.length > 0 ? { approvedSources: prev.approvedSources } : {}),
-      };
-    default:
-      return {};
-  }
-}
-
-/**
- * `useWikiComposeSession` — owns SSE wiring and state reduction for one
- * compose session. The page component reads the returned state and calls the
- * submit functions to advance phases.
- */
 export function useWikiComposeSession(
   args: UseWikiComposeSessionArgs,
 ): UseWikiComposeSessionReturn {
@@ -560,24 +88,29 @@ export function useWikiComposeSession(
     sessionId: initialSessionId,
     initialInput,
     composeSeed,
-    autoStart = true,
-    backend = "zedi_managed",
+    backend: backendOverride = "zedi_managed",
   } = args;
-  const [state, setState] = useState<WikiComposeSessionState>(INITIAL_STATE);
+
+  const startPolicy = resolveStartPolicy(args);
+  const loadBackendFromSettings = startPolicy === "when-backend-ready";
+  const { backend: settingsBackend, isResolved: isBackendResolved } = useInitialComposeBackend({
+    enabled: loadBackendFromSettings,
+  });
+  const backend = loadBackendFromSettings ? settingsBackend : backendOverride;
+
+  const [state, setState] = useState<WikiComposeSessionState>(INITIAL_WIKI_COMPOSE_SESSION_STATE);
   const sessionRef = useRef<ComposeSession | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const autoStartRequestedRef = useRef(false);
 
-  /** Merge a partial update into state. */
   const update = useCallback((partial: Partial<WikiComposeSessionState>) => {
     setState((prev) => ({ ...prev, ...partial }));
   }, []);
 
-  /** Consume an SSE event by reducing it into state. */
   const onEvent = useCallback((event: ComposeSseEvent) => {
-    setState((prev) => ({ ...prev, ...reduceEvent(prev, event) }));
+    setState((prev) => ({ ...prev, ...reduceComposeSseEvent(prev, event) }));
   }, []);
 
-  /** Stream a `runSession` call and update state from events. */
   const streamRun = useCallback(
     async (session: ComposeSession, body?: Record<string, unknown>) => {
       abortRef.current?.abort();
@@ -593,11 +126,7 @@ export function useWikiComposeSession(
           signal: controller.signal,
         });
       } catch (err) {
-        if ((err as { name?: string }).name === "AbortError") {
-          // Caller aborted; do not surface as an error.
-          // ユーザー操作による abort は error として扱わない。
-          return;
-        }
+        if ((err as { name?: string }).name === "AbortError") return;
         const message = err instanceof Error ? err.message : String(err);
         update({ error: message, isStreaming: false });
       } finally {
@@ -608,7 +137,6 @@ export function useWikiComposeSession(
     [pageId, onEvent, update],
   );
 
-  /** Create or resume the session, then begin streaming. */
   const start = useCallback(async () => {
     try {
       const loaded = initialSessionId ? await getSession(pageId, initialSessionId) : null;
@@ -629,7 +157,7 @@ export function useWikiComposeSession(
             : undefined,
         }));
       const projectionHydration = loaded?.projection
-        ? hydrateFromProjection(loaded.projection)
+        ? hydrateComposeFromProjection(loaded.projection)
         : {};
 
       sessionRef.current = session;
@@ -644,9 +172,6 @@ export function useWikiComposeSession(
             }
           : undefined);
 
-      // Only fresh / retriable rows may call `POST /run` with graph input.
-      // Interrupted checkpoints require `Command({ resume })`; replaying input
-      // would restart or error, and resume payloads are not stored on the row.
       if (session.status === "pending" || session.status === "failed") {
         await streamRun(session, withContentLocale(runInput));
       }
@@ -661,7 +186,7 @@ export function useWikiComposeSession(
       const session = sessionRef.current;
       if (!session) throw new Error("Session not initialised");
       const result = await resumeSession({ pageId, sessionId: session.id, resume: input });
-      const fromResume = reduceResumeOutput(result.output, result.status);
+      const fromResume = reduceComposeResumeOutput(result.output, result.status);
       update({ status: result.status, ...fromResume });
     },
     [pageId, update],
@@ -671,18 +196,10 @@ export function useWikiComposeSession(
     async (input) => {
       const session = sessionRef.current;
       if (!session) throw new Error("Session not initialised");
-      // Mirror the approved sources into state immediately so the UI can show
-      // the user's choice without waiting for the server's projection.
-      // resume 直後に approvedSources を仮反映してフロントの追随を早める。
       const approved = state.pendingSources.filter((s) => input.approvedSourceIds.includes(s.id));
       update({ approvedSources: approved });
       const result = await resumeSession({ pageId, sessionId: session.id, resume: input });
-      if (interruptKindFromOutput(result.output) === "conflict_resolution") {
-        const fromResume = reduceResumeOutput(result.output, result.status);
-        update({ status: result.status, ...fromResume });
-        return;
-      }
-      const fromResume = reduceResumeOutput(result.output, result.status);
+      const fromResume = reduceComposeResumeOutput(result.output, result.status);
       update({ status: result.status, ...fromResume });
     },
     [pageId, state.pendingSources, update],
@@ -697,7 +214,7 @@ export function useWikiComposeSession(
         sessionId: session.id,
         resume: { acknowledged: true as const, ...(input?.note ? { note: input.note } : {}) },
       });
-      const fromResume = reduceResumeOutput(result.output, result.status);
+      const fromResume = reduceComposeResumeOutput(result.output, result.status);
       update({
         status: result.status,
         researchConflictSummary: null,
@@ -712,7 +229,7 @@ export function useWikiComposeSession(
       const session = sessionRef.current;
       if (!session) throw new Error("Session not initialised");
       const result = await resumeSession({ pageId, sessionId: session.id, resume: input });
-      const fromResume = reduceResumeOutput(result.output, result.status);
+      const fromResume = reduceComposeResumeOutput(result.output, result.status);
       update({ status: result.status, ...fromResume });
     },
     [pageId, update],
@@ -726,11 +243,25 @@ export function useWikiComposeSession(
     update({ status: "cancelled" });
   }, [pageId, update]);
 
-  // Auto-start on mount when requested. The dependency list is intentionally
-  // narrow so we don't double-start on prop changes.
-  // 自動開始は mount 時のみ。引数変更で再起動しないよう依存を意図的に絞る。
+  const awaitingFreshStart =
+    !initialSessionId && state.status === "idle" && !state.session && !state.isStreaming;
+
+  const canRetryStart =
+    startPolicy === "when-backend-ready" &&
+    !initialSessionId &&
+    Boolean(state.error) &&
+    !state.session &&
+    !state.isStreaming &&
+    (state.status === "idle" || state.status === "failed");
+
   useEffect(() => {
-    if (!autoStart) return;
+    if (startPolicy === "never") return;
+    if (startPolicy === "when-backend-ready") {
+      if (!isBackendResolved || !awaitingFreshStart) return;
+    }
+    if (autoStartRequestedRef.current) return;
+    autoStartRequestedRef.current = true;
+
     let cancelled = false;
     void start().catch((err) => {
       if (cancelled) return;
@@ -741,12 +272,14 @@ export function useWikiComposeSession(
       cancelled = true;
       abortRef.current?.abort();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [startPolicy, isBackendResolved, awaitingFreshStart, start, update]);
 
-  // Derive completion markdown from drafted sections when status flips.
-  // 完了時に Markdown を組み立てるロジックは backend `completed` ノードと別系統
-  // でも UI 側で再構築できるよう、フックでも軽量に持つ。
+  useEffect(() => {
+    if (startPolicy !== "when-backend-ready") return;
+    if (initialSessionId || state.session || !state.error) return;
+    autoStartRequestedRef.current = false;
+  }, [startPolicy, initialSessionId, state.session, state.error]);
+
   const completedMarkdown = useMemo(() => {
     if (state.status !== "completed") return state.completedMarkdown;
     if (state.completedMarkdown) return state.completedMarkdown;
@@ -765,7 +298,7 @@ export function useWikiComposeSession(
     submitResearchApproval,
     submitConflictAck,
     submitOutline,
-    submitConflictAck,
     cancel,
+    canRetryStart,
   };
 }

--- a/src/hooks/useWikiComposeSession.ts
+++ b/src/hooks/useWikiComposeSession.ts
@@ -243,21 +243,25 @@ export function useWikiComposeSession(
     update({ status: "cancelled" });
   }, [pageId, update]);
 
-  const awaitingFreshStart =
-    !initialSessionId && state.status === "idle" && !state.session && !state.isStreaming;
-
   const canRetryStart =
-    startPolicy === "when-backend-ready" &&
     !initialSessionId &&
     Boolean(state.error) &&
     !state.session &&
     !state.isStreaming &&
     (state.status === "idle" || state.status === "failed");
 
+  // Abort in-flight SSE only on unmount — not when `start()` sets `session` and
+  // re-renders (Codex P1: dependency churn must not cancel a fresh compose run).
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
   useEffect(() => {
     if (startPolicy === "never") return;
     if (startPolicy === "when-backend-ready") {
-      if (!isBackendResolved || !awaitingFreshStart) return;
+      if (!isBackendResolved || initialSessionId) return;
     }
     if (autoStartRequestedRef.current) return;
     autoStartRequestedRef.current = true;
@@ -270,9 +274,8 @@ export function useWikiComposeSession(
     });
     return () => {
       cancelled = true;
-      abortRef.current?.abort();
     };
-  }, [startPolicy, isBackendResolved, awaitingFreshStart, start, update]);
+  }, [startPolicy, isBackendResolved, initialSessionId, start, update]);
 
   useEffect(() => {
     if (startPolicy !== "when-backend-ready") return;

--- a/src/lib/wikiCompose/resolveComposeBackend.test.ts
+++ b/src/lib/wikiCompose/resolveComposeBackend.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import type { AISettings } from "@/types/ai";
 import {
+  coerceWikiComposeBackend,
   isComposeBackendAvailable,
+  isWikiComposeAllowedBackend,
   resolveComposeBackendFromAiSettings,
   resolvePreferredComposeBackend,
 } from "./resolveComposeBackend";
@@ -32,6 +34,15 @@ const credentialsOpenAi: UserAiCredentialsStatus = {
     { provider: "anthropic", configured: false },
     { provider: "openai", configured: true },
     { provider: "google", configured: false },
+  ],
+};
+
+const credentialsGoogle: UserAiCredentialsStatus = {
+  storageEnabled: true,
+  providers: [
+    { provider: "anthropic", configured: false },
+    { provider: "openai", configured: false },
+    { provider: "google", configured: true },
   ],
 };
 
@@ -76,6 +87,28 @@ describe("isComposeBackendAvailable", () => {
   });
 });
 
+describe("isWikiComposeAllowedBackend", () => {
+  it("allows zedi_managed and user_google only", () => {
+    expect(isWikiComposeAllowedBackend("zedi_managed")).toBe(true);
+    expect(isWikiComposeAllowedBackend("user_google")).toBe(true);
+    expect(isWikiComposeAllowedBackend("user_openai")).toBe(false);
+    expect(isWikiComposeAllowedBackend("user_anthropic")).toBe(false);
+  });
+});
+
+describe("coerceWikiComposeBackend", () => {
+  it("falls back to user_google when preferred non-Google BYOK but Google credential exists", () => {
+    expect(coerceWikiComposeBackend("user_openai", credentialsGoogle)).toBe("user_google");
+    expect(coerceWikiComposeBackend("user_anthropic", credentialsGoogle)).toBe("user_google");
+  });
+
+  it("falls back to zedi_managed when only non-Google BYOK credentials exist", () => {
+    expect(coerceWikiComposeBackend("user_openai", credentialsOpenAi)).toBe("zedi_managed");
+    expect(coerceWikiComposeBackend("user_anthropic", credentialsOpenAi)).toBe("zedi_managed");
+    expect(coerceWikiComposeBackend("user_openai", credentialsNone)).toBe("zedi_managed");
+  });
+});
+
 describe("resolveComposeBackendFromAiSettings", () => {
   it("falls back to zedi_managed when preferred BYOK is unavailable", () => {
     expect(
@@ -86,12 +119,21 @@ describe("resolveComposeBackendFromAiSettings", () => {
     ).toBe("zedi_managed");
   });
 
-  it("keeps user_* when credential exists", () => {
+  it("maps non-Google BYOK to user_google when Google credential exists (#990)", () => {
     expect(
       resolveComposeBackendFromAiSettings(
         baseSettings({ apiMode: "user_api_key", provider: "openai", isConfigured: true }),
-        credentialsOpenAi,
+        credentialsGoogle,
       ),
-    ).toBe("user_openai");
+    ).toBe("user_google");
+  });
+
+  it("keeps user_google when preferred and credential exists", () => {
+    expect(
+      resolveComposeBackendFromAiSettings(
+        baseSettings({ apiMode: "user_api_key", provider: "google", isConfigured: true }),
+        credentialsGoogle,
+      ),
+    ).toBe("user_google");
   });
 });

--- a/src/lib/wikiCompose/resolveComposeBackend.ts
+++ b/src/lib/wikiCompose/resolveComposeBackend.ts
@@ -45,16 +45,39 @@ export function isComposeBackendAvailable(
 }
 
 /**
- * Resolve compose backend from AI settings, falling back when BYOK is unavailable.
- * AI 設定から backend を決め、BYOK が使えない場合は zedi_managed にフォールバックする。
+ * Backends accepted by Wiki Compose while the graph pins LLM calls to a Google model (#990).
+ * Wiki Compose が Google 固定モデル運用中に受け付ける backend。
+ */
+export function isWikiComposeAllowedBackend(backend: ComposeExecutionBackend): boolean {
+  return backend === "zedi_managed" || backend === "user_google";
+}
+
+/**
+ * Map a settings-derived backend to one the Wiki Compose API accepts.
+ * 設定由来の backend を Wiki Compose API が受け付ける値に矯正する。
+ */
+export function coerceWikiComposeBackend(
+  preferred: ComposeExecutionBackend,
+  credentials: UserAiCredentialsStatus,
+): ComposeExecutionBackend {
+  if (isWikiComposeAllowedBackend(preferred) && isComposeBackendAvailable(preferred, credentials)) {
+    return preferred;
+  }
+  if (isComposeBackendAvailable("user_google", credentials)) {
+    return "user_google";
+  }
+  return "zedi_managed";
+}
+
+/**
+ * Resolve compose backend from AI settings, falling back when BYOK is unavailable
+ * or incompatible with the fixed Google Wiki Compose model (#990).
+ * AI 設定から backend を決め、BYOK 不可・非 Google BYOK は zedi_managed / user_google に落とす。
  */
 export function resolveComposeBackendFromAiSettings(
   settings: AISettings,
   credentials: UserAiCredentialsStatus,
 ): ComposeExecutionBackend {
   const preferred = resolvePreferredComposeBackend(settings);
-  if (isComposeBackendAvailable(preferred, credentials)) {
-    return preferred;
-  }
-  return "zedi_managed";
+  return coerceWikiComposeBackend(preferred, credentials);
 }

--- a/src/lib/wikiCompose/wikiComposeSessionReducer.ts
+++ b/src/lib/wikiCompose/wikiComposeSessionReducer.ts
@@ -406,12 +406,18 @@ export function reduceComposeResumeOutput(
       if (approvedOutline?.sections?.length) {
         partial.outlineProposal = approvedOutline.sections;
       } else if (c.sections.length > 0) {
-        partial.outlineProposal = c.sections.map((s) => ({
-          id: s.sectionId,
-          heading: s.heading,
-          depth: 1,
-          intent: "",
-        }));
+        partial.outlineProposal = c.sections
+          .filter((s): s is DraftedSection =>
+            Boolean(
+              s && typeof s === "object" && typeof (s as DraftedSection).sectionId === "string",
+            ),
+          )
+          .map((s) => ({
+            id: s.sectionId,
+            heading: s.heading ?? "",
+            depth: 1 as const,
+            intent: "",
+          }));
       }
     }
   }

--- a/src/lib/wikiCompose/wikiComposeSessionReducer.ts
+++ b/src/lib/wikiCompose/wikiComposeSessionReducer.ts
@@ -1,0 +1,424 @@
+/**
+ * Pure state reduction for {@link useWikiComposeSession} (#950).
+ * SSE / resume / projection → UI state。React 非依存。
+ */
+import i18n from "@/i18n";
+import { resolveComposeContentLocale } from "@/lib/wikiCompose/resolveComposeContentLocale";
+import type {
+  BriefQuestion,
+  ComposeInterruptPayload,
+  ComposeSession,
+  ComposeSessionStatus,
+  ComposeSessionUiProjection,
+  ComposeSseEvent,
+  DraftedSection,
+  OutlineSection,
+  PageSnapshot,
+  ResearchBatch,
+  ResearchConflictSummary,
+  ResearchSource,
+} from "@/lib/wikiCompose/types";
+
+/** UI phase for Wiki Compose session progression. */
+export type ComposePhase = "brief" | "research" | "conflict" | "structure" | "draft" | "completed";
+
+/** Activity log entry surfaced in the right pane's ActivitySection. */
+export interface ComposeActivity {
+  id: string;
+  at: string;
+  label: string;
+  detail?: string;
+  status?: "started" | "completed" | "info" | "error";
+}
+
+/** Aggregate state surfaced to the UI. */
+export interface WikiComposeSessionState {
+  session: ComposeSession | null;
+  status: ComposeSessionStatus | "idle";
+  phase: ComposePhase;
+  briefQuestions: BriefQuestion[];
+  pageSnapshot: PageSnapshot | null;
+  latestBatch: ResearchBatch | null;
+  pendingSources: ResearchSource[];
+  approvedSources: ResearchSource[];
+  researchConflictSummary: ResearchConflictSummary | null;
+  outlineProposal: OutlineSection[];
+  draftedSections: Record<string, DraftedSection>;
+  streamingSectionId: string | null;
+  sectionBuffers: Record<string, string>;
+  activity: ComposeActivity[];
+  completedMarkdown: string | null;
+  error: string | null;
+  isStreaming: boolean;
+}
+
+export const INITIAL_WIKI_COMPOSE_SESSION_STATE: WikiComposeSessionState = {
+  session: null,
+  status: "idle",
+  phase: "brief",
+  briefQuestions: [],
+  pageSnapshot: null,
+  latestBatch: null,
+  pendingSources: [],
+  approvedSources: [],
+  researchConflictSummary: null,
+  outlineProposal: [],
+  draftedSections: {},
+  streamingSectionId: null,
+  sectionBuffers: {},
+  activity: [],
+  completedMarkdown: null,
+  error: null,
+  isStreaming: false,
+};
+
+/** First interrupt kind on a LangGraph checkpoint output, if any. */
+export function interruptKindFromOutput(output: unknown): string | undefined {
+  if (!output || typeof output !== "object") return undefined;
+  const interrupts = (output as { __interrupt__?: unknown }).__interrupt__;
+  if (!Array.isArray(interrupts) || interrupts.length === 0) return undefined;
+  const entry = interrupts[0];
+  const value =
+    entry && typeof entry === "object" ? (entry as { value?: unknown }).value : undefined;
+  if (value && typeof value === "object" && "kind" in value) {
+    const kind = (value as { kind?: unknown }).kind;
+    return typeof kind === "string" ? kind : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Validate persisted `metadata.composeSeed` before sending `/run` input.
+ */
+export function parseComposeSeedFromMetadata(metadata: Record<string, unknown> | null | undefined):
+  | {
+      outline: string;
+      conversationText: string;
+      userSchema?: string;
+      conversationId?: string;
+    }
+  | undefined {
+  if (!metadata || typeof metadata !== "object") return undefined;
+  const raw = metadata.composeSeed;
+  if (!raw || typeof raw !== "object") return undefined;
+  const seed = raw as Record<string, unknown>;
+  if (typeof seed.outline !== "string" || typeof seed.conversationText !== "string") {
+    return undefined;
+  }
+  const out: {
+    outline: string;
+    conversationText: string;
+    userSchema?: string;
+    conversationId?: string;
+  } = {
+    outline: seed.outline,
+    conversationText: seed.conversationText,
+  };
+  if (typeof seed.userSchema === "string" && seed.userSchema.trim()) {
+    out.userSchema = seed.userSchema;
+  }
+  if (typeof seed.conversationId === "string" && seed.conversationId.trim()) {
+    out.conversationId = seed.conversationId;
+  }
+  return out;
+}
+
+/** Merge graph run input with the active UI content locale. */
+export function withContentLocale(input?: Record<string, unknown>): Record<string, unknown> {
+  return { ...(input ?? {}), contentLocale: resolveComposeContentLocale() };
+}
+
+function activityId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
+  return `act-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function phaseDisplayLabel(phase: string): string {
+  const key = `wikiCompose.phaseDisplay.${phase}` as const;
+  const translated = i18n.t(key);
+  return translated === key ? phase : translated;
+}
+
+function appendActivity(
+  prev: ComposeActivity[],
+  next: Omit<ComposeActivity, "id" | "at">,
+): ComposeActivity[] {
+  const entry: ComposeActivity = {
+    id: activityId(),
+    at: new Date().toISOString(),
+    ...next,
+  };
+  const merged = [...prev, entry];
+  return merged.length > 200 ? merged.slice(merged.length - 200) : merged;
+}
+
+function reduceInterrupt(
+  prev: WikiComposeSessionState,
+  payload: ComposeInterruptPayload | undefined,
+): Partial<WikiComposeSessionState> {
+  if (!payload) return {};
+  switch (payload.kind) {
+    case "human_review_brief":
+      return {
+        briefQuestions: payload.questions,
+        pageSnapshot: payload.pageSnapshot,
+        phase: "brief",
+      };
+    case "human_review_research":
+      return {
+        latestBatch: payload.batch,
+        pendingSources: payload.pendingSources,
+        phase: "research",
+      };
+    case "human_review_outline":
+      return {
+        outlineProposal: payload.outline,
+        approvedSources: payload.approvedSources,
+        researchConflictSummary: null,
+        phase: "structure",
+      };
+    case "conflict_resolution":
+      return {
+        researchConflictSummary: payload.conflicts,
+        phase: "conflict",
+        ...(prev.approvedSources.length > 0 ? { approvedSources: prev.approvedSources } : {}),
+      };
+    default:
+      return {};
+  }
+}
+
+/** Map an SSE event into a state update. */
+export function reduceComposeSseEvent(
+  prev: WikiComposeSessionState,
+  event: ComposeSseEvent,
+): Partial<WikiComposeSessionState> {
+  switch (event.type) {
+    case "started":
+      return {
+        activity: appendActivity(prev.activity, {
+          label: i18n.t("wikiCompose.activity.runStarted"),
+          detail: event.graphId,
+          status: "info",
+        }),
+      };
+    case "compose_phase":
+      return {
+        phase: event.phase,
+        activity: appendActivity(prev.activity, {
+          label: i18n.t("wikiCompose.activity.phase", { phase: phaseDisplayLabel(event.phase) }),
+          detail: event.status,
+          status: event.status === "entered" ? "started" : "completed",
+        }),
+      };
+    case "status":
+      return {
+        activity: appendActivity(prev.activity, {
+          label: event.phase,
+          detail: event.message,
+          status: "info",
+        }),
+      };
+    case "tool_start":
+      return {
+        activity: appendActivity(prev.activity, {
+          label: i18n.t("wikiCompose.activity.toolStarted", { tool: event.tool }),
+          detail: event.input ? "running" : undefined,
+          status: "started",
+        }),
+      };
+    case "tool_end":
+      return {
+        activity: appendActivity(prev.activity, {
+          label: i18n.t("wikiCompose.activity.toolDone", { tool: event.tool }),
+          detail: event.error ?? (event.outputLength ? `${event.outputLength} chars` : "ok"),
+          status: event.error ? "error" : "completed",
+        }),
+      };
+    case "research_iteration":
+      return {
+        activity: appendActivity(prev.activity, {
+          label: i18n.t("wikiCompose.activity.researchIteration", {
+            count: event.iteration + 1,
+          }),
+          detail: `${event.status} · ${event.queryCount} queries`,
+          status: "info",
+        }),
+      };
+    case "research_evaluation":
+      return {
+        activity: appendActivity(prev.activity, {
+          label: i18n.t("wikiCompose.activity.sufficiency", {
+            score: event.score.toFixed(2),
+          }),
+          detail: event.rationale,
+          status: "info",
+        }),
+      };
+    case "research_batch":
+      return {
+        activity: appendActivity(prev.activity, {
+          label: i18n.t("wikiCompose.activity.researchBatch", {
+            iteration: event.iteration,
+          }),
+          detail: `${event.sourceCount} sources · ${event.exitReason}`,
+          status: "completed",
+        }),
+      };
+    case "compose_section":
+      if (event.status === "started") {
+        return {
+          streamingSectionId: event.sectionId,
+          sectionBuffers: { ...prev.sectionBuffers, [event.sectionId]: "" },
+          activity: appendActivity(prev.activity, {
+            label: i18n.t("wikiCompose.activity.drafting", { heading: event.heading }),
+            detail: `${event.index} / ${event.total}`,
+            status: "started",
+          }),
+        };
+      }
+      return {
+        streamingSectionId:
+          prev.streamingSectionId === event.sectionId ? null : prev.streamingSectionId,
+        activity: appendActivity(prev.activity, {
+          label: i18n.t("wikiCompose.activity.drafted", { heading: event.heading }),
+          detail: `${event.index} / ${event.total}`,
+          status: "completed",
+        }),
+      };
+    case "token": {
+      const id = prev.streamingSectionId;
+      if (!id) return {};
+      const prior = prev.sectionBuffers[id] ?? "";
+      return {
+        sectionBuffers: { ...prev.sectionBuffers, [id]: prior + event.content },
+      };
+    }
+    case "interrupt":
+      return reduceInterrupt(prev, event.payload);
+    case "done":
+      return {
+        isStreaming: false,
+        status: event.status,
+        activity: appendActivity(prev.activity, {
+          label: i18n.t("wikiCompose.activity.runStatus", { status: event.status }),
+          status: event.status === "completed" ? "completed" : "info",
+        }),
+      };
+    case "error":
+      return {
+        error: event.message,
+        activity: appendActivity(prev.activity, {
+          label: i18n.t("wikiCompose.activity.error"),
+          detail: event.message,
+          status: "error",
+        }),
+      };
+    case "usage":
+      return {
+        activity: appendActivity(prev.activity, {
+          label: i18n.t("wikiCompose.activity.usage"),
+          detail: `in=${event.inputTokens} out=${event.outputTokens} cu=${event.costUnits}`,
+          status: "info",
+        }),
+      };
+    default:
+      return {};
+  }
+}
+
+/** Merge `GET` checkpoint projection into hook state. */
+export function hydrateComposeFromProjection(
+  projection: ComposeSessionUiProjection,
+): Partial<WikiComposeSessionState> {
+  const partial: Partial<WikiComposeSessionState> = {};
+  if (projection.phase) partial.phase = projection.phase;
+  if (projection.briefQuestions?.length) partial.briefQuestions = projection.briefQuestions;
+  if (projection.pageSnapshot) partial.pageSnapshot = projection.pageSnapshot;
+  if (projection.latestBatch !== undefined) partial.latestBatch = projection.latestBatch;
+  if (projection.pendingSources?.length) partial.pendingSources = projection.pendingSources;
+  if (projection.approvedSources?.length) partial.approvedSources = projection.approvedSources;
+  if (projection.researchConflictSummary) {
+    partial.researchConflictSummary = projection.researchConflictSummary;
+  }
+  if (projection.outlineProposal?.length) partial.outlineProposal = projection.outlineProposal;
+  if (projection.completedMarkdown) partial.completedMarkdown = projection.completedMarkdown;
+  if (projection.draftedSections?.length) {
+    const draftedSections: Record<string, DraftedSection> = {};
+    for (const section of projection.draftedSections) {
+      if (section?.sectionId) draftedSections[section.sectionId] = section;
+    }
+    partial.draftedSections = draftedSections;
+  }
+  return partial;
+}
+
+function interruptContextFromCheckpoint(state: Record<string, unknown>): WikiComposeSessionState {
+  const approved = Array.isArray(state.approvedResearch)
+    ? (state.approvedResearch as ResearchSource[])
+    : [];
+  return { ...INITIAL_WIKI_COMPOSE_SESSION_STATE, approvedSources: approved };
+}
+
+/** Extract UI state from a non-streaming `PATCH /resume` response body. */
+export function reduceComposeResumeOutput(
+  output: unknown,
+  status: ComposeSessionStatus,
+): Partial<WikiComposeSessionState> {
+  if (!output || typeof output !== "object") {
+    return status === "completed" ? { phase: "completed" } : {};
+  }
+  const state = output as Record<string, unknown>;
+  const partial: Partial<WikiComposeSessionState> = {};
+
+  const interrupts = state.__interrupt__;
+  if (Array.isArray(interrupts) && interrupts.length > 0) {
+    const entry = interrupts[0];
+    const value =
+      entry && typeof entry === "object" ? (entry as { value?: unknown }).value : undefined;
+    if (value && typeof value === "object" && "kind" in value) {
+      Object.assign(
+        partial,
+        reduceInterrupt(interruptContextFromCheckpoint(state), value as ComposeInterruptPayload),
+      );
+    }
+  }
+
+  const completion = state.completion;
+  if (completion && typeof completion === "object") {
+    const c = completion as {
+      markdown?: string;
+      sections?: DraftedSection[];
+    };
+    if (typeof c.markdown === "string" && c.markdown.length > 0) {
+      partial.completedMarkdown = c.markdown;
+    }
+    if (Array.isArray(c.sections)) {
+      const draftedSections: Record<string, DraftedSection> = {};
+      for (const section of c.sections) {
+        if (!section || typeof section !== "object") continue;
+        const s = section as DraftedSection;
+        if (typeof s.sectionId === "string") draftedSections[s.sectionId] = s;
+      }
+      partial.draftedSections = draftedSections;
+      partial.phase = "completed";
+      const approvedOutline = state.approvedOutline as { sections?: OutlineSection[] } | undefined;
+      if (approvedOutline?.sections?.length) {
+        partial.outlineProposal = approvedOutline.sections;
+      } else if (c.sections.length > 0) {
+        partial.outlineProposal = c.sections.map((s) => ({
+          id: s.sectionId,
+          heading: s.heading,
+          depth: 1,
+          intent: "",
+        }));
+      }
+    }
+  }
+
+  if (status === "completed" && partial.phase !== "completed") {
+    partial.phase = "completed";
+  }
+
+  return partial;
+}

--- a/src/pages/WikiComposePage.tsx
+++ b/src/pages/WikiComposePage.tsx
@@ -1,16 +1,7 @@
 /**
  * `WikiComposePage` — Wiki Compose split-screen UI (#950).
- *
- * `/notes/:noteId/:pageId/compose` (および `compose/:sessionId`) のルート要素。
- * 左ペイン = `EditorPane` (タイトル + 進捗中の本文プレビュー)、右ペイン =
- * `ComposePanel` (PhaseStepper + Dialogue + Research + Activity)。
- * モバイルでは縦分割、デスクトップでは横分割で表示する。Compose 完了 / 中断
- * 時はノートページに戻れる。
- *
- * Compose UI shell. The page reads the `useWikiComposeSession` hook for state
- * and routes user submissions back through the hook's mutator methods.
  */
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { ArrowLeft, X } from "lucide-react";
@@ -29,7 +20,6 @@ import { COMPOSE_SEED_STATE_KEY, type ComposeNavigationSeed } from "@/lib/wikiCo
 import type { DraftedSection } from "@/lib/wikiCompose/types";
 import { EditorPane } from "@/components/wikiCompose/EditorPane";
 import { ComposePanel } from "@/components/wikiCompose/ComposePanel";
-import { useInitialComposeBackend } from "@/hooks/useInitialComposeBackend";
 
 /** Map drafted section list to a quick lookup. */
 function indexById(items: DraftedSection[]): Record<string, DraftedSection> {
@@ -50,8 +40,6 @@ const WikiComposePage: React.FC = () => {
   const pageId = params.pageId ?? "";
   const sessionId = params.sessionId ?? null;
 
-  // チャット seed は mount 時に 1 回だけ保持。`location.state` を消しても hook 側に残す。
-  // Capture chat seed once on mount; survives clearing `location.state` for the hook.
   const [composeSeed] = useState((): ComposeNavigationSeed | undefined => {
     const raw = (location.state as Record<string, unknown> | null)?.[COMPOSE_SEED_STATE_KEY];
     if (!raw || typeof raw !== "object") return undefined;
@@ -59,11 +47,6 @@ const WikiComposePage: React.FC = () => {
     if (typeof s.outline !== "string" || typeof s.conversationText !== "string") return undefined;
     return s;
   });
-
-  const { backend: composeBackend, isResolved: isComposeBackendResolved } =
-    useInitialComposeBackend({
-      enabled: !sessionId,
-    });
 
   const initialInput = useMemo(
     () =>
@@ -83,43 +66,11 @@ const WikiComposePage: React.FC = () => {
   const session = useWikiComposeSession({
     pageId,
     sessionId,
-    // Resume existing session on mount; fresh compose starts after backend resolves.
-    autoStart: Boolean(sessionId && pageId),
+    startPolicy: sessionId ? "on-mount" : "when-backend-ready",
     composeSeed,
     initialInput,
-    backend: composeBackend,
   });
 
-  const awaitingComposeStart =
-    !sessionId && session.status === "idle" && !session.session && !session.isStreaming;
-  const autoStartRequestedRef = useRef(false);
-
-  const startComposeSession = session.start;
-
-  // Fresh compose: start automatically once AI settings yield a backend (#951).
-  useEffect(() => {
-    if (sessionId || !isComposeBackendResolved || !awaitingComposeStart) return;
-    if (autoStartRequestedRef.current) return;
-    autoStartRequestedRef.current = true;
-    void startComposeSession();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot auto-start when backend resolves
-  }, [sessionId, isComposeBackendResolved, awaitingComposeStart]);
-
-  // Allow manual retry after a failed auto-start (ref would otherwise block re-entry).
-  useEffect(() => {
-    if (sessionId || session.session || !session.error) return;
-    autoStartRequestedRef.current = false;
-  }, [sessionId, session.session, session.error]);
-
-  const canRetryComposeStart =
-    !sessionId &&
-    Boolean(session.error) &&
-    !session.session &&
-    !session.isStreaming &&
-    (session.status === "idle" || session.status === "failed");
-
-  // Clear history seed only after the session row left `pending` (first run claimed).
-  // `pending` のまま state を消すと失敗時リロードで chatSeed が届かなくなる (#950)。
   useEffect(() => {
     if (!composeSeed || !location.state) return;
     if (session.status === "idle" || session.status === "pending") return;
@@ -137,7 +88,6 @@ const WikiComposePage: React.FC = () => {
     session.status,
   ]);
 
-  // Persist the session id in the URL so refresh re-opens the same row.
   useEffect(() => {
     const id = session.session?.id;
     if (!id || sessionId || !noteId || !pageId) return;
@@ -148,14 +98,6 @@ const WikiComposePage: React.FC = () => {
     () => indexById(Object.values(session.draftedSections)),
     [session.draftedSections],
   );
-
-  // The displayed outline switches sources as the user progresses through
-  // phases: proposal during structure → final approved outline once approved.
-  // (For the editor pane preview, both are acceptable since they share `id`.)
-  const outlineForPreview =
-    session.phase === "completed" || session.phase === "draft"
-      ? session.outlineProposal
-      : session.outlineProposal;
 
   const handleBack = () => {
     if (noteId && pageId) {
@@ -236,7 +178,7 @@ const WikiComposePage: React.FC = () => {
   const left = (
     <EditorPane
       title={session.pageSnapshot?.title ?? ""}
-      outline={outlineForPreview}
+      outline={session.outlineProposal}
       draftedSections={draftedSectionsById}
       sectionBuffers={session.sectionBuffers}
       streamingSectionId={session.streamingSectionId}
@@ -260,7 +202,6 @@ const WikiComposePage: React.FC = () => {
       onSubmitResearchApproval={session.submitResearchApproval}
       onSubmitConflictAck={session.submitConflictAck}
       onSubmitOutline={session.submitOutline}
-      onSubmitConflictAck={session.submitConflictAck}
     />
   );
 
@@ -270,14 +211,14 @@ const WikiComposePage: React.FC = () => {
       {session.error ? (
         <div className="bg-destructive/10 text-destructive flex items-center justify-between gap-2 px-4 py-2 text-xs">
           <span className="min-w-0 flex-1">{session.error}</span>
-          {canRetryComposeStart ? (
+          {session.canRetryStart ? (
             <Button
               type="button"
               size="sm"
               variant="outline"
               className="h-7 shrink-0 px-2"
               data-testid="compose-retry"
-              onClick={() => void startComposeSession()}
+              onClick={() => void session.start()}
             >
               {t("common:retry")}
             </Button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Thermo-nuclear コード品質レビューで挙がった推奨アクションをすべて反映しました。Wiki Compose の backend 契約の整合、フックの分解、auto-start の一本化、API の locale 準備の共通化、コピペ残骸の削除です。

## 変更点

- **Frontend backend 契約**: `coerceWikiComposeBackend` / `isWikiComposeAllowedBackend` を追加し、非 Google BYOK 設定時は `user_google` または `zedi_managed` にフォールバック（サーバ `#990` と整合）
- **`wikiComposeSessionReducer.ts`**: SSE / resume / projection の純関数 reducer を切り出し（`useWikiComposeSession` は約 300 行に）
- **Auto-start 統合**: `startPolicy`（`on-mount` / `when-backend-ready` / `never`）と `canRetryStart` をフックに集約し、`WikiComposePage` の ref/effect を削除
- **API locale**: `composeSessionRunLocale.ts` で `POST /run` の locale 解決・metadata 更新・graph input 整形を共通化
- **バグ修正**: `submitConflictAck` / `onSubmitConflictAck` の重複、無意味な `outlineForPreview` 三項演算子を削除

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `bunx vitest run src/lib/wikiCompose/resolveComposeBackend.test.ts src/hooks/useWikiComposeSession.test.ts`
2. `cd server/api && bun test src/__tests__/routes/composeSessionRunLocale.test.ts`
3. Anthropic/OpenAI BYOK 設定で新規 Compose を開始し、セッション作成が 400 にならず `zedi_managed` または `user_google` で開始されること

## チェックリスト

- [x] テストがすべてパスする（上記ユニットテスト）
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した（英語正本 + 該当する場合は `.ja.md` ペア）
- [x] コミットメッセージが Conventional Commits に従っている

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff2ba18b-6643-453f-84c0-0fce55aae1bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff2ba18b-6643-453f-84c0-0fce55aae1bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * コンポーズの開始ポリシーを追加（on-mount / when-backend-ready 等）
  * 自動開始失敗時のリトライ可能状態を返すように改善

* **Refactor**
  * セッションのコンテンツロケール解決と入力整形を共通化してルーティング側を簡素化
  * セッション状態管理を純粋なリデューサ層に移譲し、SSE／再開出力の取り扱いを統一

* **Tests**
  * ロケール解決、バックエンド選定、起動リトライ挙動をカバーするテストを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->