### PR TITLE
fix(notes): make note settings layout responsive on mobile

### DIFF
--- a/src/pages/NoteMembers/NoteInviteLinksSection.tsx
+++ b/src/pages/NoteMembers/NoteInviteLinksSection.tsx
@@ -347,13 +347,13 @@ export const NoteInviteLinksSection: React.FC<NoteInviteLinksSectionProps> = ({
   const nowMs = (now ?? Date.now)();
 
   return (
-    <section className="border-border/60 mt-6 rounded-lg border p-4">
+    <section className="border-border/60 mt-6 rounded-lg border p-3 sm:p-4">
       <h2 className="mb-1 text-sm font-semibold">{t("notes.inviteLinksTitle")}</h2>
       <p className="text-muted-foreground mb-4 text-xs">{t("notes.inviteLinksPhase5Hint")}</p>
 
       {!readOnly ? (
         <>
-          <div className="grid gap-3 md:grid-cols-[1fr_140px_160px_160px_auto]">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-[1fr_140px_160px_160px_auto]">
             <Input
               value={label}
               onChange={(e) => setLabel(e.target.value)}
@@ -402,7 +402,7 @@ export const NoteInviteLinksSection: React.FC<NoteInviteLinksSectionProps> = ({
             <Button
               onClick={handleCreate}
               disabled={createMutation.isPending || needsEditorAck}
-              className="gap-1"
+              className="w-full gap-1 sm:col-span-2 lg:col-span-1 lg:w-auto"
             >
               {createMutation.isPending ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -550,7 +550,7 @@ const InviteLinkRowView: React.FC<InviteLinkRowViewProps> = ({
     );
 
   return (
-    <div className="border-border/60 flex flex-wrap items-center justify-between gap-3 border-b pb-2">
+    <div className="border-border/60 flex flex-col gap-3 border-b pb-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
       <div className="min-w-0 flex-1 space-y-1">
         <div className="flex flex-wrap items-center gap-2">
           <span className="text-sm font-medium">{link.label ?? t("notes.inviteLinksUnnamed")}</span>
@@ -561,7 +561,7 @@ const InviteLinkRowView: React.FC<InviteLinkRowViewProps> = ({
           {usageLabel} · {expiresLabel}
         </p>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center justify-end gap-2 sm:shrink-0">
         <Button
           variant="ghost"
           size="icon"

--- a/src/pages/NoteMembers/NoteMembersManageSection.tsx
+++ b/src/pages/NoteMembers/NoteMembersManageSection.tsx
@@ -8,6 +8,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  cn,
 } from "@zedi/ui";
 import { useTranslation } from "react-i18next";
 import type { NoteMemberInvitation, NoteMemberRole, NoteMemberStatus } from "@/types/note";
@@ -153,13 +154,13 @@ export function NoteMembersManageSection({
   const { t } = useTranslation();
   const nowMs = (now ?? Date.now)();
   return (
-    <section className="border-border/60 mt-6 rounded-lg border p-4">
+    <section className="border-border/60 mt-6 rounded-lg border p-3 sm:p-4">
       {readOnly ? (
         <h2 className="mb-4 text-sm font-semibold">{t("notes.members")}</h2>
       ) : (
         <>
           <h2 className="mb-4 text-sm font-semibold">{t("notes.inviteMember")}</h2>
-          <div className="grid gap-3 md:grid-cols-[1fr_200px_auto]">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_200px] md:grid-cols-[1fr_200px_auto]">
             <Input
               value={memberEmail}
               onChange={(event) => setMemberEmail(event.target.value)}
@@ -180,7 +181,9 @@ export function NoteMembersManageSection({
                 ))}
               </SelectContent>
             </Select>
-            <Button onClick={onAddMember}>{t("notes.add")}</Button>
+            <Button className="w-full sm:col-span-2 md:col-span-1 md:w-auto" onClick={onAddMember}>
+              {t("notes.add")}
+            </Button>
           </div>
         </>
       )}
@@ -213,13 +216,15 @@ export function NoteMembersManageSection({
             return (
               <div
                 key={member.memberEmail}
-                className="border-border/60 flex flex-wrap items-center justify-between gap-3 border-b pb-2"
+                className="border-border/60 flex flex-col gap-3 border-b pb-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between"
               >
-                <div className="flex items-center gap-2">
-                  <span className="text-sm">{member.memberEmail}</span>
-                  <Badge className={badgeStyles[variant]}>{badgeText}</Badge>
+                <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:gap-2">
+                  <span className="truncate text-sm">{member.memberEmail}</span>
+                  <Badge className={cn(badgeStyles[variant], "w-fit max-w-full shrink-0")}>
+                    {badgeText}
+                  </Badge>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex items-center justify-end gap-2 sm:shrink-0">
                   <Select
                     value={member.role}
                     onValueChange={(value) =>

--- a/src/pages/NoteSettings/NoteSettings.test.tsx
+++ b/src/pages/NoteSettings/NoteSettings.test.tsx
@@ -201,6 +201,13 @@ describe("NoteSettings layout", () => {
     expect(screen.getByRole("link", { name: /settingsNav\.members/i })).toBeInTheDocument();
   });
 
+  it("renders the settings nav as a horizontal scroll strip below md breakpoint", () => {
+    renderSettings("/notes/note-1/settings/general");
+    const nav = screen.getByRole("navigation", { name: /settingsNav\.ariaLabel/i });
+    expect(nav).toHaveClass("overflow-x-auto");
+    expect(nav).toHaveClass("md:flex-col");
+  });
+
   it("shows only the Visibility entry for viewers", () => {
     vi.mocked(useNote).mockReturnValue({
       note: baseNote,

--- a/src/pages/NoteSettings/NoteSettingsSidebar.tsx
+++ b/src/pages/NoteSettings/NoteSettingsSidebar.tsx
@@ -120,7 +120,7 @@ export const NoteSettingsSidebar: React.FC<NoteSettingsSidebarProps> = ({
   return (
     <nav
       aria-label={t("notes.settingsNav.ariaLabel")}
-      className="-mx-2 flex gap-1 overflow-x-auto px-2 py-1 md:mx-0 md:flex-col md:gap-0.5 md:overflow-visible md:px-0 md:py-0"
+      className="flex gap-1 overflow-x-auto overscroll-x-contain py-1 [-ms-overflow-style:none] [scrollbar-width:none] md:flex-col md:gap-0.5 md:overflow-visible md:py-0 [&::-webkit-scrollbar]:hidden"
     >
       {visible.map(({ key, labelI18nKey, Icon, variant }) => (
         <NavLink

--- a/src/pages/NoteSettings/index.tsx
+++ b/src/pages/NoteSettings/index.tsx
@@ -79,28 +79,27 @@ const NoteSettings: React.FC = () => {
 
   return (
     <NoteSettingsContext.Provider value={contextValue}>
-      <div className="min-h-0 flex-1 py-8">
+      <div className="min-h-0 flex-1 py-4 sm:py-6 md:py-8">
         <Container>
-          <header className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-            {/* タイトル → ノート切替 → 公開バッジ を 1 行に並べる。長いノート名は
-                NoteTitleSwitcher 側で whitespace-nowrap、外側は flex-wrap で
-                次の行に逃がす。
-                Lay out "Settings → [Note switcher] → [Visibility badge]" on a
-                single row. Long note titles stay on one line inside the
-                switcher; the wrapper flex-wraps to keep things readable on
-                narrow viewports. */}
+          <header className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-x-4 sm:gap-y-2">
+            {/* タイトル → ノート切替 → 公開バッジ。狭い画面では折り返し、
+                「ノートへ戻る」は全幅ボタンにしてタップしやすくする。
+                Title row wraps on narrow viewports; the back link becomes a
+                full-width button on mobile for a larger tap target. */}
             <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
-              <h1 className="text-xl font-semibold whitespace-nowrap">{t("notes.noteSettings")}</h1>
+              <h1 className="text-lg font-semibold whitespace-nowrap sm:text-xl">
+                {t("notes.noteSettings")}
+              </h1>
               <NoteTitleSwitcher noteId={note.id} noteTitle={note.title} variant="subtitle" />
               <NoteVisibilityBadge visibility={note.visibility} />
             </div>
-            <Button asChild variant="outline" size="sm">
+            <Button asChild variant="outline" size="sm" className="w-full shrink-0 sm:w-auto">
               <Link to={`/notes/${note.id}`}>{t("notes.backToNote")}</Link>
             </Button>
           </header>
 
-          <div className="mt-6 grid gap-6 md:grid-cols-[200px_1fr] md:gap-8">
-            <aside className="md:sticky md:top-24 md:self-start">
+          <div className="mt-4 grid gap-4 sm:mt-6 sm:gap-6 md:grid-cols-[minmax(0,12rem)_1fr] md:gap-8 lg:grid-cols-[minmax(0,13.5rem)_1fr]">
+            <aside className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-10 -mx-4 border-b px-4 pb-2 backdrop-blur-sm sm:-mx-6 sm:px-6 md:static md:top-24 md:z-auto md:mx-0 md:self-start md:border-b-0 md:bg-transparent md:px-0 md:pb-0 md:backdrop-blur-none">
               <NoteSettingsSidebar noteId={note.id} sidebarRole={sidebarRole} />
             </aside>
             <main className="min-w-0">

--- a/src/pages/NoteSettings/index.tsx
+++ b/src/pages/NoteSettings/index.tsx
@@ -99,7 +99,7 @@ const NoteSettings: React.FC = () => {
           </header>
 
           <div className="mt-4 grid gap-4 sm:mt-6 sm:gap-6 md:grid-cols-[minmax(0,12rem)_1fr] md:gap-8 lg:grid-cols-[minmax(0,13.5rem)_1fr]">
-            <aside className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-10 -mx-4 border-b px-4 pb-2 backdrop-blur-sm sm:-mx-6 sm:px-6 md:static md:top-24 md:z-auto md:mx-0 md:self-start md:border-b-0 md:bg-transparent md:px-0 md:pb-0 md:backdrop-blur-none">
+            <aside className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-10 -mx-4 border-b px-4 pb-2 backdrop-blur-sm sm:-mx-6 sm:px-6 md:top-24 md:z-auto md:mx-0 md:self-start md:border-b-0 md:bg-transparent md:px-0 md:pb-0 md:backdrop-blur-none">
               <NoteSettingsSidebar noteId={note.id} sidebarRole={sidebarRole} />
             </aside>
             <main className="min-w-0">

--- a/src/pages/NoteSettings/sections/DangerZoneSection.tsx
+++ b/src/pages/NoteSettings/sections/DangerZoneSection.tsx
@@ -58,13 +58,17 @@ const DangerZoneSection: React.FC = () => {
 
   return (
     <>
-      <section className="border-destructive/40 space-y-3 rounded-lg border p-4">
+      <section className="border-destructive/40 space-y-3 rounded-lg border p-3 sm:p-4">
         <header className="space-y-1">
           <h2 className="text-destructive text-base font-semibold">{t("notes.deleteSection")}</h2>
           <p className="text-muted-foreground text-sm">{t("notes.deleteSectionDescription")}</p>
         </header>
-        <div className="flex justify-end">
-          <Button variant="destructive" onClick={() => setIsDeleteDialogOpen(true)}>
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button
+            className="w-full sm:w-auto"
+            variant="destructive"
+            onClick={() => setIsDeleteDialogOpen(true)}
+          >
             {t("notes.deleteNote")}
           </Button>
         </div>

--- a/src/pages/NoteSettings/sections/DangerZoneSection.tsx
+++ b/src/pages/NoteSettings/sections/DangerZoneSection.tsx
@@ -63,7 +63,7 @@ const DangerZoneSection: React.FC = () => {
           <h2 className="text-destructive text-base font-semibold">{t("notes.deleteSection")}</h2>
           <p className="text-muted-foreground text-sm">{t("notes.deleteSectionDescription")}</p>
         </header>
-        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        <div className="flex sm:justify-end">
           <Button
             className="w-full sm:w-auto"
             variant="destructive"

--- a/src/pages/NoteSettings/sections/DomainsSection.tsx
+++ b/src/pages/NoteSettings/sections/DomainsSection.tsx
@@ -76,9 +76,9 @@ function DomainAccessAddForm({
     return t("notes.domainTabCreateFailedFreeEmail", { domain: inputError.domain });
   })();
   return (
-    <section className="border-border/60 space-y-3 rounded-lg border p-4">
+    <section className="border-border/60 space-y-3 rounded-lg border p-3 sm:p-4">
       <h3 className="text-sm font-semibold">{t("notes.domainTabAddHeading")}</h3>
-      <div className="grid gap-3 md:grid-cols-[1fr_180px_auto]">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_180px] md:grid-cols-[1fr_180px_auto]">
         <div className="flex flex-col gap-1">
           <Input
             value={domainInput}
@@ -102,7 +102,11 @@ function DomainAccessAddForm({
             <SelectItem value="editor">{t("notes.domainTabRoleEditor")}</SelectItem>
           </SelectContent>
         </Select>
-        <Button onClick={onAdd} disabled={isPending || !isValid}>
+        <Button
+          className="w-full sm:col-span-2 md:col-span-1 md:w-auto"
+          onClick={onAdd}
+          disabled={isPending || !isValid}
+        >
           {t("notes.domainTabAdd")}
         </Button>
       </div>

--- a/src/pages/NoteSettings/sections/GeneralSection.tsx
+++ b/src/pages/NoteSettings/sections/GeneralSection.tsx
@@ -52,7 +52,7 @@ const GeneralSection: React.FC = () => {
   };
 
   return (
-    <section className="border-border/60 rounded-lg border p-4">
+    <section className="border-border/60 rounded-lg border p-3 sm:p-4">
       <header className="mb-4 space-y-1">
         <h2 className="text-base font-semibold">{t("notes.settingsNav.general")}</h2>
         <p className="text-muted-foreground text-xs">{t("notes.generalSectionDescription")}</p>
@@ -71,8 +71,12 @@ const GeneralSection: React.FC = () => {
       </div>
 
       {canManage ? (
-        <div className="mt-4 flex justify-end">
-          <Button onClick={handleSave} disabled={updateNoteMutation.isPending || !isDirty}>
+        <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button
+            className="w-full sm:w-auto"
+            onClick={handleSave}
+            disabled={updateNoteMutation.isPending || !isDirty}
+          >
             {updateNoteMutation.isPending ? t("common.saving") : t("common.save")}
           </Button>
         </div>

--- a/src/pages/NoteSettings/sections/GeneralSection.tsx
+++ b/src/pages/NoteSettings/sections/GeneralSection.tsx
@@ -71,7 +71,7 @@ const GeneralSection: React.FC = () => {
       </div>
 
       {canManage ? (
-        <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        <div className="mt-4 flex sm:justify-end">
           <Button
             className="w-full sm:w-auto"
             onClick={handleSave}

--- a/src/pages/NoteSettings/sections/TagFilterBarSection.tsx
+++ b/src/pages/NoteSettings/sections/TagFilterBarSection.tsx
@@ -89,7 +89,7 @@ const TagFilterBarSection: React.FC = () => {
       </p>
 
       {canManage ? (
-        <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        <div className="mt-4 flex sm:justify-end">
           <Button
             className="w-full sm:w-auto"
             onClick={handleSave}

--- a/src/pages/NoteSettings/sections/TagFilterBarSection.tsx
+++ b/src/pages/NoteSettings/sections/TagFilterBarSection.tsx
@@ -60,14 +60,14 @@ const TagFilterBarSection: React.FC = () => {
   };
 
   return (
-    <section className="border-border/60 rounded-lg border p-4">
+    <section className="border-border/60 rounded-lg border p-3 sm:p-4">
       <header className="mb-4 space-y-1">
         <h2 className="text-base font-semibold">{t("notes.filterBarSettings.title")}</h2>
         <p className="text-muted-foreground text-xs">{t("notes.filterBarSettings.description")}</p>
       </header>
 
-      <div className="flex items-start justify-between gap-4">
-        <div className="space-y-1">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+        <div className="min-w-0 flex-1 space-y-1">
           <Label htmlFor="tag-filter-bar-show-default" className="text-sm font-medium">
             {t("notes.filterBarSettings.showByDefault")}
           </Label>
@@ -80,6 +80,7 @@ const TagFilterBarSection: React.FC = () => {
           checked={showByDefault}
           onCheckedChange={setShowByDefault}
           disabled={!canManage}
+          className="shrink-0 self-start sm:self-center"
         />
       </div>
 
@@ -88,8 +89,12 @@ const TagFilterBarSection: React.FC = () => {
       </p>
 
       {canManage ? (
-        <div className="mt-4 flex justify-end">
-          <Button onClick={handleSave} disabled={updateNoteMutation.isPending || !isDirty}>
+        <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button
+            className="w-full sm:w-auto"
+            onClick={handleSave}
+            disabled={updateNoteMutation.isPending || !isDirty}
+          >
             {updateNoteMutation.isPending ? t("common.saving") : t("common.save")}
           </Button>
         </div>

--- a/src/pages/NoteSettings/sections/VisibilitySection.tsx
+++ b/src/pages/NoteSettings/sections/VisibilitySection.tsx
@@ -61,9 +61,9 @@ function VisibilityOptionRow({
   const { t } = useTranslation();
   const inputId = `visibility-section-${value}`;
   return (
-    <div className="border-border/60 flex gap-3 rounded-md border p-3">
-      <RadioGroupItem value={value} id={inputId} disabled={!canEdit} className="mt-1" />
-      <div className="flex-1 space-y-1">
+    <div className="border-border/60 flex min-w-0 gap-3 rounded-md border p-3 sm:p-4">
+      <RadioGroupItem value={value} id={inputId} disabled={!canEdit} className="mt-1 shrink-0" />
+      <div className="min-w-0 flex-1 space-y-1">
         <Label htmlFor={inputId} className="text-sm font-medium">
           {t(visibilityKeys[value])}
         </Label>
@@ -78,7 +78,13 @@ function VisibilityOptionRow({
                 readOnly
                 className="text-xs"
               />
-              <Button type="button" variant="outline" size="sm" onClick={onCopyNoteUrl}>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="w-full shrink-0 sm:w-auto"
+                onClick={onCopyNoteUrl}
+              >
                 <Copy className="mr-2 h-4 w-4" />
                 {t("notes.copy")}
               </Button>
@@ -106,11 +112,16 @@ function EditPermissionOptionRow({
   const enabled = allowedEditOptions.includes(value);
   return (
     <div
-      className="border-border/60 flex gap-3 rounded-md border p-3 data-[disabled=true]:opacity-60"
+      className="border-border/60 flex min-w-0 gap-3 rounded-md border p-3 data-[disabled=true]:opacity-60 sm:p-4"
       data-disabled={!enabled || !canEdit}
     >
-      <RadioGroupItem value={value} id={inputId} disabled={!enabled || !canEdit} className="mt-1" />
-      <div className="flex-1 space-y-1">
+      <RadioGroupItem
+        value={value}
+        id={inputId}
+        disabled={!enabled || !canEdit}
+        className="mt-1 shrink-0"
+      />
+      <div className="min-w-0 flex-1 space-y-1">
         <Label htmlFor={inputId} className="text-sm font-medium">
           {t(editPermissionLabelKeys[value])}
         </Label>
@@ -185,7 +196,7 @@ const VisibilitySection: React.FC = () => {
 
   return (
     <div className="space-y-6">
-      <section className="border-border/60 space-y-3 rounded-lg border p-4">
+      <section className="border-border/60 space-y-3 rounded-lg border p-3 sm:p-4">
         <header className="space-y-1">
           <h2 className="text-base font-semibold">{t("notes.shareVisibilityHeading")}</h2>
           <p className="text-muted-foreground text-xs">{t("notes.visibilitySectionDescription")}</p>
@@ -217,7 +228,7 @@ const VisibilitySection: React.FC = () => {
         </RadioGroup>
       </section>
 
-      <section className="border-border/60 space-y-3 rounded-lg border p-4">
+      <section className="border-border/60 space-y-3 rounded-lg border p-3 sm:p-4">
         <header className="space-y-1">
           <h2 className="text-base font-semibold">{t("notes.shareEditPermissionHeading")}</h2>
         </header>
@@ -242,8 +253,12 @@ const VisibilitySection: React.FC = () => {
       </section>
 
       {canEdit ? (
-        <div className="flex justify-end">
-          <Button onClick={handleSaveNote} disabled={isSaving || !isDirty}>
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button
+            className="w-full sm:w-auto"
+            onClick={handleSaveNote}
+            disabled={isSaving || !isDirty}
+          >
             {isSaving ? t("common.saving") : t("notes.shareSaveChanges")}
           </Button>
         </div>

--- a/src/pages/NoteSettings/sections/VisibilitySection.tsx
+++ b/src/pages/NoteSettings/sections/VisibilitySection.tsx
@@ -253,7 +253,7 @@ const VisibilitySection: React.FC = () => {
       </section>
 
       {canEdit ? (
-        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        <div className="flex sm:justify-end">
           <Button
             className="w-full sm:w-auto"
             onClick={handleSaveNote}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

ノート設定画面（`/notes/:noteId/settings/*`）を狭い画面でも使いやすくするため、レイアウト・ナビ・フォーム・一覧行のレスポンシブ対応を行いました。

## 変更点

- **レイアウト**: ヘッダーを縦積みにし「ノートへ戻る」をモバイルで全幅ボタン化。セクションタブをスクロール時も見えるよう sticky + 下線区切り
- **サイドナビ**: 横スクロールタブのスクロールバーを非表示にし、`overflow-x-auto` を維持（テスト追加）
- **各セクション**: 保存・削除ボタンをモバイルで全幅、カードの余白を `p-3 sm:p-4` に調整
- **メンバー / 招待リンク / ドメイン**: 追加フォームを 1 列 → `sm`/`md`/`lg` で段階的に多列化。一覧行は狭い画面で縦積み、メールは `truncate`

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)

## テスト方法

1. ビューポート幅 &lt; 768px で `/notes/:noteId/settings` を開く
2. ヘッダー・横スクロールタブ・各セクション（一般 / 公開 / メンバー / リンク / ドメイン）の表示と操作を確認
3. `bun run test:run` または `npx vitest run src/pages/NoteSettings src/pages/NoteMembers`

## チェックリスト

- [x] テストがすべてパスする（対象スイート 38 件）
- [x] Lint エラーがない（変更ファイル）
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

（なし）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-724394ff-ebcb-4dd0-bb3f-8491dea1a248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-724394ff-ebcb-4dd0-bb3f-8491dea1a248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive layouts across note settings and member/invite sections for better mobile, tablet, and desktop behavior.
  * Adjusted spacing, padding, grid behavior, and button sizing to improve alignment and usability at small breakpoints.
  * Refined sidebar, header, and section arrangements to enhance navigation and stable sticky/overflow behavior.

* **Tests**
  * Added a test verifying responsive navigation renders as a horizontally scrollable strip below the md breakpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/994?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->