### PR TITLE
feat(notes): refresh my notes list with sections and pin

### DIFF
--- a/src/components/note/NoteListRow.test.tsx
+++ b/src/components/note/NoteListRow.test.tsx
@@ -59,7 +59,7 @@ describe("NoteListRow", () => {
         </Routes>
       </MemoryRouter>,
     );
-    await user.click(screen.getByRole("button", { name: /Team wiki/i }));
+    await user.click(screen.getByRole("link", { name: "Team wiki" }));
     expect(screen.getByTestId("location")).toHaveTextContent("/notes/note-1");
   });
 
@@ -84,5 +84,18 @@ describe("NoteListRow", () => {
     await user.click(screen.getByRole("button", { name: "notes.list.pin" }));
     expect(onTogglePin).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("location")).toHaveTextContent("/notes");
+  });
+
+  it("handles null title without crashing", () => {
+    render(
+      <MemoryRouter>
+        <NoteListRow
+          note={{ ...note, title: null as unknown as string }}
+          showPinAction
+          onTogglePin={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("link", { name: "notes.untitledNote" })).toBeInTheDocument();
   });
 });

--- a/src/components/note/NoteListRow.test.tsx
+++ b/src/components/note/NoteListRow.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import type { NoteSummary } from "@/types/note";
+import { NoteListRow } from "./NoteListRow";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "ja" },
+  }),
+}));
+
+vi.mock("@/lib/dateUtils", () => ({
+  formatTimeAgo: () => "common.date.hoursAgo",
+}));
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+const note: NoteSummary = {
+  id: "note-1",
+  ownerUserId: "u1",
+  title: "Team wiki",
+  visibility: "private",
+  editPermission: "owner_only",
+  isOfficial: false,
+  isDefault: false,
+  viewCount: 0,
+  showTagFilterBar: false,
+  defaultFilterTags: [],
+  createdAt: 0,
+  updatedAt: Date.now() - 3600_000,
+  isDeleted: false,
+  role: "owner",
+  pageCount: 4,
+  memberCount: 2,
+};
+
+describe("NoteListRow", () => {
+  it("navigates to the note on row click", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/notes"]}>
+        <Routes>
+          <Route
+            path="/notes"
+            element={
+              <>
+                <NoteListRow note={note} showPinAction onTogglePin={vi.fn()} isPinned={false} />
+                <LocationProbe />
+              </>
+            }
+          />
+          <Route path="/notes/:noteId" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByRole("button", { name: /Team wiki/i }));
+    expect(screen.getByTestId("location")).toHaveTextContent("/notes/note-1");
+  });
+
+  it("calls onTogglePin without navigating", async () => {
+    const onTogglePin = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/notes"]}>
+        <Routes>
+          <Route
+            path="/notes"
+            element={
+              <>
+                <NoteListRow note={note} showPinAction onTogglePin={onTogglePin} isPinned={false} />
+                <LocationProbe />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByRole("button", { name: "notes.list.pin" }));
+    expect(onTogglePin).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("location")).toHaveTextContent("/notes");
+  });
+});

--- a/src/components/note/NoteListRow.tsx
+++ b/src/components/note/NoteListRow.tsx
@@ -1,0 +1,252 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { FileText, NotebookText, Pin, PinOff, Users } from "lucide-react";
+import type { NoteSummary } from "@/types/note";
+import type { NoteAccessRole } from "@/types/note";
+import { cn } from "@zedi/ui";
+import { NoteVisibilityBadge } from "./NoteVisibilityBadge";
+import { Badge } from "@zedi/ui";
+import { Button } from "@zedi/ui";
+import { useTranslation } from "react-i18next";
+import { formatTimeAgo } from "@/lib/dateUtils";
+
+const ROLE_I18N_KEYS: Record<NoteAccessRole, string> = {
+  owner: "common.note.owner",
+  editor: "common.note.editor",
+  viewer: "common.note.viewer",
+  guest: "common.note.guest",
+  none: "common.note.roleUnknown",
+};
+
+const ROLE_ACCENT_CLASS: Record<NoteAccessRole, string> = {
+  owner: "bg-primary",
+  editor: "bg-blue-500",
+  viewer: "bg-muted-foreground/50",
+  guest: "bg-muted-foreground/40",
+  none: "bg-border",
+};
+
+export type NoteListRowVariant = "compact" | "card";
+
+interface NoteListRowContentProps {
+  note: NoteSummary;
+  variant: NoteListRowVariant;
+  isDefault: boolean;
+  isActive?: boolean;
+  isPinned?: boolean;
+}
+
+/**
+ * Shared metadata layout for note list rows.
+ * ノート一覧行の共通メタデータレイアウト。
+ */
+export const NoteListRowContent: React.FC<NoteListRowContentProps> = ({
+  note,
+  variant,
+  isDefault,
+  isActive,
+  isPinned,
+}) => {
+  const { t } = useTranslation();
+  const title = note.title.trim().length > 0 ? note.title : t("notes.untitledNote");
+  const updatedLabel = formatTimeAgo(note.updatedAt);
+
+  return (
+    <>
+      <span
+        className={cn("w-1 shrink-0 self-stretch rounded-full", ROLE_ACCENT_CLASS[note.role])}
+        aria-hidden
+      />
+      <span
+        className={cn(
+          "bg-muted/60 text-muted-foreground flex shrink-0 items-center justify-center rounded-md",
+          variant === "card" ? "h-10 w-10" : "h-9 w-9",
+        )}
+      >
+        <NotebookText className="h-4 w-4" aria-hidden />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-start justify-between gap-2">
+          <span
+            className={cn(
+              "truncate",
+              variant === "card" ? "text-base font-medium" : "text-sm font-medium",
+              isActive ? "text-foreground" : "text-foreground",
+            )}
+          >
+            {title}
+          </span>
+          <span className="flex shrink-0 items-center gap-1">
+            {isPinned && <Pin className="text-muted-foreground h-3.5 w-3.5" aria-hidden />}
+            {note.isOfficial && (
+              <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+                {t("notes.officialBadge")}
+              </Badge>
+            )}
+            <NoteVisibilityBadge visibility={note.visibility} />
+          </span>
+        </span>
+        <span className="text-muted-foreground mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs">
+          <span>{updatedLabel}</span>
+          <span aria-hidden>·</span>
+          <span>{t(ROLE_I18N_KEYS[note.role])}</span>
+          {isDefault && (
+            <>
+              <span aria-hidden>·</span>
+              <Badge variant="outline" className="px-1.5 py-0 text-[10px] font-medium">
+                {t("notes.switcher.defaultBadge")}
+              </Badge>
+            </>
+          )}
+        </span>
+        <span className="text-muted-foreground mt-1.5 flex items-center gap-4 text-xs">
+          <span className="inline-flex items-center gap-1">
+            <FileText className="h-3.5 w-3.5" aria-hidden />
+            {note.pageCount}
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <Users className="h-3.5 w-3.5" aria-hidden />
+            {note.memberCount}
+          </span>
+        </span>
+      </span>
+    </>
+  );
+};
+
+export interface NoteListRowProps {
+  note: NoteSummary;
+  variant?: NoteListRowVariant;
+  index?: number;
+  isDefault?: boolean;
+  isActive?: boolean;
+  isPinned?: boolean;
+  showPinAction?: boolean;
+  onTogglePin?: () => void;
+}
+
+/**
+ * Note list / card row with metadata (no page previews).
+ * プレビューなしのメタデータ中心ノート行。
+ */
+export const NoteListRow: React.FC<NoteListRowProps> = ({
+  note,
+  variant = "compact",
+  index = 0,
+  isDefault = false,
+  isActive = false,
+  isPinned = false,
+  showPinAction = false,
+  onTogglePin,
+}) => {
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  const handleNavigate = () => {
+    navigate(`/notes/${note.id}`);
+  };
+
+  const pinLabel = isPinned ? t("notes.list.unpin") : t("notes.list.pin");
+
+  return (
+    <div
+      className={cn(
+        "group relative w-full",
+        variant === "card" && "h-full",
+        index <= 5 && "animate-fade-in opacity-0",
+        index <= 5 && `stagger-${Math.min(index + 1, 5)}`,
+      )}
+      style={
+        index <= 5
+          ? { animationFillMode: "forwards", animationDelay: `${index * 50}ms` }
+          : undefined
+      }
+    >
+      <button
+        type="button"
+        onClick={handleNavigate}
+        className={cn(
+          "border-border/50 bg-card hover:border-border hover:bg-muted/30 flex w-full items-center gap-3 rounded-lg border text-left transition-colors",
+          variant === "card" ? "h-full p-4" : "p-3",
+          isActive && "border-primary/40 bg-accent/30",
+        )}
+      >
+        <NoteListRowContent
+          note={note}
+          variant={variant}
+          isDefault={isDefault}
+          isActive={isActive}
+          isPinned={isPinned}
+        />
+      </button>
+      {showPinAction && onTogglePin && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={cn(
+            "absolute top-2 right-2 h-8 w-8 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100",
+            isPinned && "opacity-100",
+          )}
+          aria-label={pinLabel}
+          onClick={(e) => {
+            e.stopPropagation();
+            onTogglePin();
+          }}
+        >
+          {isPinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}
+        </Button>
+      )}
+    </div>
+  );
+};
+
+interface NoteSwitcherRowProps {
+  note: NoteSummary;
+  isDefault: boolean;
+  isActive: boolean;
+  isPinned: boolean;
+}
+
+/**
+ * Dropdown row for {@link NoteTitleSwitcher} (link + compact metadata).
+ * {@link NoteTitleSwitcher} 用のドロップダウン行。
+ */
+export const NoteSwitcherRow: React.FC<NoteSwitcherRowProps> = ({
+  note,
+  isDefault,
+  isActive,
+  isPinned,
+}) => {
+  const { t } = useTranslation();
+  const title = note.title.trim().length > 0 ? note.title : t("notes.untitledNote");
+  const updatedLabel = formatTimeAgo(note.updatedAt);
+
+  return (
+    <div
+      className={cn(
+        "flex w-full items-center gap-3 rounded-md px-2.5 py-2",
+        isActive && "bg-accent/60",
+      )}
+    >
+      <span
+        className={cn("w-1 shrink-0 self-stretch rounded-full", ROLE_ACCENT_CLASS[note.role])}
+        aria-hidden
+      />
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-2">
+          <span className={cn("truncate text-sm", isActive && "font-medium")}>{title}</span>
+          {isPinned && <Pin className="text-muted-foreground h-3 w-3 shrink-0" aria-hidden />}
+          {isDefault && (
+            <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">
+              {t("notes.switcher.defaultBadge")}
+            </Badge>
+          )}
+        </span>
+        <span className="text-muted-foreground mt-0.5 text-xs">
+          {updatedLabel} · {note.pageCount} {t("notes.list.pagesShort")}
+        </span>
+      </span>
+    </div>
+  );
+};

--- a/src/components/note/NoteListRow.tsx
+++ b/src/components/note/NoteListRow.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { FileText, NotebookText, Pin, PinOff, Users } from "lucide-react";
 import type { NoteSummary } from "@/types/note";
 import type { NoteAccessRole } from "@/types/note";
@@ -9,6 +9,7 @@ import { Badge } from "@zedi/ui";
 import { Button } from "@zedi/ui";
 import { useTranslation } from "react-i18next";
 import { formatTimeAgo } from "@/lib/dateUtils";
+import { resolveNoteDisplayTitle } from "@/lib/noteListSections";
 
 const ROLE_I18N_KEYS: Record<NoteAccessRole, string> = {
   owner: "common.note.owner",
@@ -48,7 +49,7 @@ export const NoteListRowContent: React.FC<NoteListRowContentProps> = ({
   isPinned,
 }) => {
   const { t } = useTranslation();
-  const title = note.title.trim().length > 0 ? note.title : t("notes.untitledNote");
+  const title = resolveNoteDisplayTitle(note.title, t("notes.untitledNote"));
   const updatedLabel = formatTimeAgo(note.updatedAt);
 
   return (
@@ -139,13 +140,8 @@ export const NoteListRow: React.FC<NoteListRowProps> = ({
   showPinAction = false,
   onTogglePin,
 }) => {
-  const navigate = useNavigate();
   const { t } = useTranslation();
-
-  const handleNavigate = () => {
-    navigate(`/notes/${note.id}`);
-  };
-
+  const displayTitle = resolveNoteDisplayTitle(note.title, t("notes.untitledNote"));
   const pinLabel = isPinned ? t("notes.list.unpin") : t("notes.list.pin");
 
   return (
@@ -162,9 +158,9 @@ export const NoteListRow: React.FC<NoteListRowProps> = ({
           : undefined
       }
     >
-      <button
-        type="button"
-        onClick={handleNavigate}
+      <Link
+        to={`/notes/${note.id}`}
+        aria-label={displayTitle}
         className={cn(
           "border-border/50 bg-card hover:border-border hover:bg-muted/30 flex w-full items-center gap-3 rounded-lg border text-left transition-colors",
           variant === "card" ? "h-full p-4" : "p-3",
@@ -178,7 +174,7 @@ export const NoteListRow: React.FC<NoteListRowProps> = ({
           isActive={isActive}
           isPinned={isPinned}
         />
-      </button>
+      </Link>
       {showPinAction && onTogglePin && (
         <Button
           type="button"
@@ -190,6 +186,7 @@ export const NoteListRow: React.FC<NoteListRowProps> = ({
           )}
           aria-label={pinLabel}
           onClick={(e) => {
+            e.preventDefault();
             e.stopPropagation();
             onTogglePin();
           }}
@@ -206,47 +203,49 @@ interface NoteSwitcherRowProps {
   isDefault: boolean;
   isActive: boolean;
   isPinned: boolean;
+  onSelect: () => void;
 }
 
 /**
  * Dropdown row for {@link NoteTitleSwitcher} (link + compact metadata).
  * {@link NoteTitleSwitcher} 用のドロップダウン行。
  */
-export const NoteSwitcherRow: React.FC<NoteSwitcherRowProps> = ({
-  note,
-  isDefault,
-  isActive,
-  isPinned,
-}) => {
-  const { t } = useTranslation();
-  const title = note.title.trim().length > 0 ? note.title : t("notes.untitledNote");
-  const updatedLabel = formatTimeAgo(note.updatedAt);
+export const NoteSwitcherRow = React.forwardRef<HTMLAnchorElement, NoteSwitcherRowProps>(
+  function NoteSwitcherRow({ note, isDefault, isActive, isPinned, onSelect }, ref) {
+    const { t } = useTranslation();
+    const title = resolveNoteDisplayTitle(note.title, t("notes.untitledNote"));
+    const updatedLabel = formatTimeAgo(note.updatedAt);
 
-  return (
-    <div
-      className={cn(
-        "flex w-full items-center gap-3 rounded-md px-2.5 py-2",
-        isActive && "bg-accent/60",
-      )}
-    >
-      <span
-        className={cn("w-1 shrink-0 self-stretch rounded-full", ROLE_ACCENT_CLASS[note.role])}
-        aria-hidden
-      />
-      <span className="min-w-0 flex-1">
-        <span className="flex items-center gap-2">
-          <span className={cn("truncate text-sm", isActive && "font-medium")}>{title}</span>
-          {isPinned && <Pin className="text-muted-foreground h-3 w-3 shrink-0" aria-hidden />}
-          {isDefault && (
-            <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">
-              {t("notes.switcher.defaultBadge")}
-            </Badge>
-          )}
+    return (
+      <Link
+        ref={ref}
+        to={`/notes/${note.id}`}
+        aria-current={isActive ? "true" : undefined}
+        onClick={onSelect}
+        className={cn(
+          "hover:bg-accent flex w-full items-center gap-3 rounded-md px-2.5 py-2",
+          isActive && "bg-accent/60",
+        )}
+      >
+        <span
+          className={cn("w-1 shrink-0 self-stretch rounded-full", ROLE_ACCENT_CLASS[note.role])}
+          aria-hidden
+        />
+        <span className="min-w-0 flex-1">
+          <span className="flex items-center gap-2">
+            <span className={cn("truncate text-sm", isActive && "font-medium")}>{title}</span>
+            {isPinned && <Pin className="text-muted-foreground h-3 w-3 shrink-0" aria-hidden />}
+            {isDefault && (
+              <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">
+                {t("notes.switcher.defaultBadge")}
+              </Badge>
+            )}
+          </span>
+          <span className="text-muted-foreground mt-0.5 text-xs">
+            {updatedLabel} · {note.pageCount} {t("notes.list.pagesShort")}
+          </span>
         </span>
-        <span className="text-muted-foreground mt-0.5 text-xs">
-          {updatedLabel} · {note.pageCount} {t("notes.list.pagesShort")}
-        </span>
-      </span>
-    </div>
-  );
-};
+      </Link>
+    );
+  },
+);

--- a/src/components/note/NoteListRow.tsx
+++ b/src/components/note/NoteListRow.tsx
@@ -27,6 +27,10 @@ const ROLE_ACCENT_CLASS: Record<NoteAccessRole, string> = {
   none: "bg-border",
 };
 
+/**
+ * Visual density for note list rows (`compact` = mobile list, `card` = desktop grid).
+ * ノート行の表示密度（`compact` = モバイルリスト、`card` = デスクトップグリッド）。
+ */
 export type NoteListRowVariant = "compact" | "card";
 
 interface NoteListRowContentProps {
@@ -115,6 +119,7 @@ export const NoteListRowContent: React.FC<NoteListRowContentProps> = ({
   );
 };
 
+/** Props for {@link NoteListRow}. / {@link NoteListRow} の props。 */
 export interface NoteListRowProps {
   note: NoteSummary;
   variant?: NoteListRowVariant;
@@ -181,7 +186,8 @@ export const NoteListRow: React.FC<NoteListRowProps> = ({
           variant="ghost"
           size="icon"
           className={cn(
-            "absolute top-2 right-2 h-8 w-8 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100",
+            "absolute top-2 right-2 h-8 w-8 transition-opacity focus-visible:opacity-100",
+            variant === "compact" ? "opacity-100" : "opacity-0 group-hover:opacity-100",
             isPinned && "opacity-100",
           )}
           aria-label={pinLabel}

--- a/src/components/note/NoteTitleSwitcher.test.tsx
+++ b/src/components/note/NoteTitleSwitcher.test.tsx
@@ -30,6 +30,10 @@ type UseAuthResult = {
   userId: string | null;
 };
 
+vi.mock("@/lib/dateUtils", () => ({
+  formatTimeAgo: () => "3時間前",
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, fallback?: string) => {
@@ -42,6 +46,7 @@ vi.mock("react-i18next", () => ({
         "notes.switcher.allNotes": "すべてのノートを見る",
         "notes.switcher.newNote": "新規ノートを作成",
         "notes.untitledNote": "無題のノート",
+        "notes.list.pagesShort": "ページ",
       };
       return table[key] ?? fallback ?? key;
     },
@@ -64,6 +69,16 @@ const useAuthMock: Mock<() => UseAuthResult> = vi.fn();
 vi.mock("@/hooks/useNoteQueries", () => ({
   useNotes: () => useNotesMock(),
   useMyNote: (options?: { enabled?: boolean }) => useMyNoteMock(options),
+}));
+
+const usePinnedNotesMock = vi.fn(() => ({
+  pinnedIds: [] as string[],
+  isPinned: () => false,
+  togglePin: vi.fn(),
+}));
+
+vi.mock("@/hooks/usePinnedNotes", () => ({
+  usePinnedNotes: () => usePinnedNotesMock(),
 }));
 
 vi.mock("@/hooks/useAuth", () => ({
@@ -198,10 +213,10 @@ describe("NoteTitleSwitcher", () => {
     await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
 
     const betaItem = await screen.findByRole("menuitem", { name: /Beta note/ });
-    expect(betaItem).toHaveAttribute("aria-current", "true");
+    expect(betaItem.querySelector(".font-medium")).toBeTruthy();
 
     const alphaItem = await screen.findByRole("menuitem", { name: /Alpha note/ });
-    expect(alphaItem).not.toHaveAttribute("aria-current", "true");
+    expect(alphaItem.querySelector(".font-medium")).toBeFalsy();
   });
 
   it("navigates to /notes/:noteId when a row is selected", async () => {
@@ -210,7 +225,6 @@ describe("NoteTitleSwitcher", () => {
     await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
 
     const betaItem = await screen.findByRole("menuitem", { name: /Beta note/ });
-    expect(betaItem).toHaveAttribute("href", "/notes/note-beta");
     await user.click(betaItem);
     expect(screen.getByTestId("location")).toHaveTextContent("/notes/note-beta");
   });
@@ -255,8 +269,8 @@ describe("NoteTitleSwitcher", () => {
     expect(await screen.findByText("読み込み中…")).toBeInTheDocument();
   });
 
-  it("caps the listed notes at 50 entries", async () => {
-    const many: NoteSummary[] = Array.from({ length: 80 }, (_, i) =>
+  it("lists pinned and recent notes only, not the full catalog", async () => {
+    const many: NoteSummary[] = Array.from({ length: 20 }, (_, i) =>
       makeNote({ id: `note-${i}`, title: `Note ${i}`, updatedAt: i }),
     );
     useNotesMock.mockReturnValue({ data: many, isLoading: false });
@@ -266,10 +280,11 @@ describe("NoteTitleSwitcher", () => {
     await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
 
     const rows = (await screen.findAllByRole("menuitem")).filter((el) =>
-      /^Note \d+$/.test((el.textContent ?? "").trim()),
+      /Note \d+/.test(el.textContent ?? ""),
     );
-    expect(rows.length).toBe(50);
-    expect(rows[0].textContent?.trim()).toBe("Note 79");
+    expect(rows.length).toBe(5);
+    expect(rows[0].textContent).toMatch(/Note 19/);
+    expect(screen.queryByRole("menuitem", { name: /^Note 0$/ })).not.toBeInTheDocument();
   });
 
   it("does not list soft-deleted notes", async () => {

--- a/src/components/note/NoteTitleSwitcher.test.tsx
+++ b/src/components/note/NoteTitleSwitcher.test.tsx
@@ -145,6 +145,11 @@ const noteBeta = makeNote({ id: "note-beta", title: "Beta note", updatedAt: 300 
 const noteGamma = makeNote({ id: "note-gamma", title: "Gamma note", updatedAt: 200 });
 const defaultNote = makeNote({ id: "note-default", title: "My default", updatedAt: 50 });
 
+async function noteSwitcherLinks() {
+  const links = await screen.findAllByRole("link");
+  return links.filter((el) => /^\/notes\/[^/?]+$/.test(el.getAttribute("href") ?? ""));
+}
+
 describe("NoteTitleSwitcher", () => {
   beforeEach(() => {
     useAuthMock.mockReturnValue({ isSignedIn: true, isLoaded: true, userId: "user-1" });
@@ -192,10 +197,8 @@ describe("NoteTitleSwitcher", () => {
 
     await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
 
-    const items = await screen.findAllByRole("menuitem");
-    const noteRowNames = items
-      .map((el) => el.textContent ?? "")
-      .filter((text) => /My default|Alpha note|Beta note|Gamma note/.test(text));
+    const links = await noteSwitcherLinks();
+    const noteRowNames = links.map((el) => el.textContent ?? "");
 
     expect(noteRowNames[0]).toMatch(/My default/);
     expect(noteRowNames[0]).toMatch(/既定/);
@@ -212,11 +215,11 @@ describe("NoteTitleSwitcher", () => {
     renderAt("/notes/note-beta/settings", { noteId: "note-beta", noteTitle: "Beta note" });
     await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
 
-    const betaItem = await screen.findByRole("menuitem", { name: /Beta note/ });
-    expect(betaItem.querySelector(".font-medium")).toBeTruthy();
+    const betaItem = await screen.findByRole("link", { name: /Beta note/ });
+    expect(betaItem).toHaveAttribute("aria-current", "true");
 
-    const alphaItem = await screen.findByRole("menuitem", { name: /Alpha note/ });
-    expect(alphaItem.querySelector(".font-medium")).toBeFalsy();
+    const alphaItem = await screen.findByRole("link", { name: /Alpha note/ });
+    expect(alphaItem).not.toHaveAttribute("aria-current", "true");
   });
 
   it("navigates to /notes/:noteId when a row is selected", async () => {
@@ -224,7 +227,8 @@ describe("NoteTitleSwitcher", () => {
     renderAt("/notes/note-alpha");
     await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
 
-    const betaItem = await screen.findByRole("menuitem", { name: /Beta note/ });
+    const betaItem = await screen.findByRole("link", { name: /Beta note/ });
+    expect(betaItem).toHaveAttribute("href", "/notes/note-beta");
     await user.click(betaItem);
     expect(screen.getByTestId("location")).toHaveTextContent("/notes/note-beta");
   });
@@ -279,12 +283,12 @@ describe("NoteTitleSwitcher", () => {
     renderAt("/notes/note-0", { noteId: "note-0", noteTitle: "Note 0" });
     await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
 
-    const rows = (await screen.findAllByRole("menuitem")).filter((el) =>
-      /Note \d+/.test(el.textContent ?? ""),
-    );
+    const rows = (await noteSwitcherLinks()).filter((el) => /Note \d+/.test(el.textContent ?? ""));
     expect(rows.length).toBe(5);
     expect(rows[0].textContent).toMatch(/Note 19/);
-    expect(screen.queryByRole("menuitem", { name: /^Note 0$/ })).not.toBeInTheDocument();
+    expect(
+      (await noteSwitcherLinks()).find((el) => el.getAttribute("href") === "/notes/note-0"),
+    ).toBeUndefined();
   });
 
   it("does not list soft-deleted notes", async () => {
@@ -300,8 +304,9 @@ describe("NoteTitleSwitcher", () => {
     renderAt("/notes/note-live", { noteId: "note-live", noteTitle: "Live note" });
     await user.click(screen.getByRole("button", { name: "ノートを切り替え" }));
 
-    expect(screen.queryByRole("menuitem", { name: /Dead note/ })).not.toBeInTheDocument();
-    expect(await screen.findByRole("menuitem", { name: /Live note/ })).toBeInTheDocument();
+    const links = await noteSwitcherLinks();
+    expect(links.some((el) => /Dead note/.test(el.textContent ?? ""))).toBe(false);
+    expect(links.some((el) => /Live note/.test(el.textContent ?? ""))).toBe(true);
   });
 
   it("applies subtitle text styling when variant=subtitle", () => {

--- a/src/components/note/NoteTitleSwitcher.tsx
+++ b/src/components/note/NoteTitleSwitcher.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { Link, matchPath, useLocation, useNavigate } from "react-router-dom";
+import { Link, matchPath, useLocation } from "react-router-dom";
 import { ChevronsUpDown, ListTree, Plus } from "lucide-react";
 import {
   cn,
@@ -85,7 +85,6 @@ export const NoteTitleSwitcher: React.FC<NoteTitleSwitcherProps> = ({
   const { isSignedIn } = useAuth();
   const isAuthed = isSignedIn === true;
   const [open, setOpen] = useState(false);
-  const navigate = useNavigate();
   const close = useCallback(() => setOpen(false), []);
 
   const notesQuery = useNotes();
@@ -165,18 +164,16 @@ export const NoteTitleSwitcher: React.FC<NoteTitleSwitcherProps> = ({
               {switcherNotes.map((note) => (
                 <DropdownMenuItem
                   key={note.id}
+                  asChild
+                  onSelect={close}
                   className="cursor-pointer p-0 focus:bg-transparent"
-                  onSelect={(event) => {
-                    event.preventDefault();
-                    close();
-                    navigate(`/notes/${note.id}`);
-                  }}
                 >
                   <NoteSwitcherRow
                     note={note}
                     isDefault={note.id === defaultNoteId}
                     isActive={note.id === activeNoteId}
                     isPinned={isNotePinned(note.id, pinnedIds) || note.id === defaultNoteId}
+                    onSelect={close}
                   />
                 </DropdownMenuItem>
               ))}

--- a/src/components/note/NoteTitleSwitcher.tsx
+++ b/src/components/note/NoteTitleSwitcher.tsx
@@ -90,7 +90,7 @@ export const NoteTitleSwitcher: React.FC<NoteTitleSwitcherProps> = ({
   const notesQuery = useNotes();
   const myNoteQuery = useMyNote({ enabled: isAuthed });
   const defaultNoteId = myNoteQuery.data?.id ?? null;
-  const { pinnedIds } = usePinnedNotes();
+  const { pinnedIds } = usePinnedNotes({ defaultNoteId });
 
   const location = useLocation();
   const activeNoteId = useMemo(

--- a/src/components/note/NoteTitleSwitcher.tsx
+++ b/src/components/note/NoteTitleSwitcher.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { Link, matchPath, useLocation } from "react-router-dom";
-import { Check, ChevronsUpDown, NotebookText, Plus, ListTree } from "lucide-react";
+import { Link, matchPath, useLocation, useNavigate } from "react-router-dom";
+import { ChevronsUpDown, ListTree, Plus } from "lucide-react";
 import {
-  Badge,
   cn,
   DropdownMenu,
   DropdownMenuContent,
@@ -15,18 +14,10 @@ import {
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/hooks/useAuth";
 import { useMyNote, useNotes } from "@/hooks/useNoteQueries";
-import type { NoteSummary } from "@/types/note";
-
-/**
- * ドロップダウンに直接並べる行数の上限。これを超える場合はフッターの
- * 「すべてのノートを見る」リンクから `/notes` に誘導し、メニューが肥大化
- * しないようにする（issue #827 を踏襲）。
- *
- * Hard cap on the number of rows the dropdown renders inline. Beyond this we
- * funnel users to `/notes` via the "see all" footer link rather than letting
- * the menu balloon (carried over from the former header switcher).
- */
-const MAX_ROWS = 50;
+import { buildSwitcherNotes } from "@/lib/noteListSections";
+import { isNotePinned } from "@/lib/notePinnedStorage";
+import { usePinnedNotes } from "@/hooks/usePinnedNotes";
+import { NoteSwitcherRow } from "./NoteListRow";
 
 /**
  * URL から現在開いているノートの id を解決する。`/notes/:noteId` 系のみが
@@ -46,72 +37,6 @@ function resolveActiveNoteId(pathname: string): string | null {
   if (reservedSegments.has(id)) return null;
   return id;
 }
-
-interface NoteRowProps {
-  note: NoteSummary;
-  isDefault: boolean;
-  isActive: boolean;
-  onSelect: () => void;
-}
-
-/**
- * スイッチャー内の 1 ノート行。デフォルトノートには `既定 / Default` バッジを
- * 付け、現在開いているノートには `aria-current=true` とチェックアイコンを
- * 付与する。リンク先は `NoteView` が解釈する `/notes/:noteId`。
- *
- * One note row inside the switcher dropdown. The default note keeps a
- * `既定 / Default` badge; the currently open note carries `aria-current=true`
- * and a leading check icon.
- */
-const NoteRow: React.FC<NoteRowProps> = ({ note, isDefault, isActive, onSelect }) => {
-  const { t } = useTranslation();
-  const title = note.title.trim().length > 0 ? note.title : t("notes.untitledNote");
-  return (
-    <DropdownMenuItem
-      asChild
-      onSelect={onSelect}
-      className={cn(
-        "cursor-pointer gap-3 rounded-md px-2.5 py-2",
-        isActive && "bg-accent/60 data-highlighted:bg-accent",
-      )}
-    >
-      <Link
-        to={`/notes/${note.id}`}
-        aria-current={isActive ? "true" : undefined}
-        className="flex w-full items-center gap-3"
-      >
-        <span
-          className={cn(
-            "flex h-5 w-5 shrink-0 items-center justify-center",
-            isActive ? "text-primary" : "text-muted-foreground",
-          )}
-        >
-          {isActive ? (
-            <Check aria-hidden="true" className="h-4 w-4" />
-          ) : (
-            <NotebookText aria-hidden="true" className="h-4 w-4" />
-          )}
-        </span>
-        <span
-          className={cn(
-            "min-w-0 flex-1 truncate text-sm",
-            isActive ? "text-foreground font-medium" : "text-foreground",
-          )}
-        >
-          {title}
-        </span>
-        {isDefault && (
-          <Badge
-            variant="secondary"
-            className="shrink-0 px-1.5 py-0 text-[10px] font-medium tracking-wide uppercase"
-          >
-            {t("notes.switcher.defaultBadge")}
-          </Badge>
-        )}
-      </Link>
-    </DropdownMenuItem>
-  );
-};
 
 /**
  * `NoteTitleSwitcher` のレイアウトバリアント。
@@ -137,16 +62,6 @@ interface NoteTitleSwitcherProps {
 
 /**
  * トリガーボタンの余白・タイポグラフィをバリアントごとに切り替える。
- * - `heading`: 本文タイトルとして使うため、左端のテキスト位置を保つよう
- *   負の左マージンを当てつつ、内側パディングでクリックターゲットを広くする。
- * - `subtitle`: 補助行・チップとして使うため、両側に同等のパディングを置く
- *   （タップ領域を十分に確保）。
- *
- * Variant-specific spacing/typography for the trigger button.
- * `heading` keeps the title text visually flush with the container's left
- * edge via a negative inline margin while still giving the click target
- * comfortable inner padding; `subtitle` is a balanced chip-style trigger with
- * enough padding for a comfortable tap target.
  */
 const triggerVariantClass: Record<NoteTitleSwitcherVariant, string> = {
   heading: "text-foreground text-xl font-semibold gap-2.5 -ml-2 px-3 py-1.5",
@@ -154,19 +69,11 @@ const triggerVariantClass: Record<NoteTitleSwitcherVariant, string> = {
 };
 
 /**
- * ノートのタイトル自体をクリックトリガーとするノート切替 UI。ヘッダーの
- * 旧 `NoteSwitcher` を廃止する代わりに、ノート詳細・設定・メンバーの
- * 各画面で同じ動作を提供する。
+ * ノートのタイトル自体をクリックトリガーとするノート切替 UI。ピン留めと
+ * 最近更新したノートのみを表示し、フル一覧は `/notes` に誘導する。
  *
- * - サインイン中: ドロップダウンを開き、所属ノートをデフォルト先頭・
- *   `updatedAt` 降順で表示。フッターから `/notes?new=1` と `/notes` に遷移。
- * - 未サインイン: 静的にタイトルを表示するだけにフォールバックする
- *   （公開ノートのゲスト閲覧で誤ってトリガー化しないため）。
- *
- * Note-title-as-switcher: replaces the legacy header `NoteSwitcher` and
- * appears on the note detail / settings / members pages. Signed-in users
- * get the dropdown; guests fall back to a static label so public notes
- * stay readable without exposing a no-op trigger.
+ * Note-title-as-switcher: shows pinned + recently updated notes only; full
+ * catalog lives on `/notes`.
  */
 export const NoteTitleSwitcher: React.FC<NoteTitleSwitcherProps> = ({
   noteId,
@@ -178,11 +85,13 @@ export const NoteTitleSwitcher: React.FC<NoteTitleSwitcherProps> = ({
   const { isSignedIn } = useAuth();
   const isAuthed = isSignedIn === true;
   const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
   const close = useCallback(() => setOpen(false), []);
 
   const notesQuery = useNotes();
   const myNoteQuery = useMyNote({ enabled: isAuthed });
-  const myNoteId = myNoteQuery.data?.id ?? null;
+  const defaultNoteId = myNoteQuery.data?.id ?? null;
+  const { pinnedIds } = usePinnedNotes();
 
   const location = useLocation();
   const activeNoteId = useMemo(
@@ -190,22 +99,14 @@ export const NoteTitleSwitcher: React.FC<NoteTitleSwitcherProps> = ({
     [location.pathname, noteId],
   );
 
-  const sortedNotes = useMemo<NoteSummary[]>(() => {
-    const list = notesQuery.data ?? [];
-    const live = list.filter((note) => !note.isDeleted);
-    const def = myNoteId ? (live.find((note) => note.id === myNoteId) ?? null) : null;
-    const others = live
-      .filter((note) => note.id !== def?.id)
-      .sort((a, b) => b.updatedAt - a.updatedAt);
-    const ordered = def ? [def, ...others] : others;
-    return ordered.slice(0, MAX_ROWS);
-  }, [notesQuery.data, myNoteId]);
+  const switcherNotes = useMemo(
+    () => buildSwitcherNotes(notesQuery.data ?? [], pinnedIds, defaultNoteId),
+    [notesQuery.data, pinnedIds, defaultNoteId],
+  );
 
   const displayTitle = noteTitle.trim().length > 0 ? noteTitle : t("notes.untitledNote");
   const variantClass = triggerVariantClass[variant];
 
-  // 未サインイン時はトリガー化せず、テキストとしてだけ描画する。
-  // Guests see the title as plain text — no dropdown is wired up.
   if (!isAuthed) {
     return (
       <span className={cn("inline-block whitespace-nowrap", variantClass, className)}>
@@ -215,7 +116,7 @@ export const NoteTitleSwitcher: React.FC<NoteTitleSwitcherProps> = ({
   }
 
   const isLoading = notesQuery.isLoading;
-  const isEmpty = !isLoading && sortedNotes.length === 0;
+  const isEmpty = !isLoading && switcherNotes.length === 0;
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -258,17 +159,26 @@ export const NoteTitleSwitcher: React.FC<NoteTitleSwitcherProps> = ({
           <p className="text-muted-foreground px-4 pb-3 text-sm">{t("notes.switcher.empty")}</p>
         )}
 
-        {!isLoading && sortedNotes.length > 0 && (
+        {!isLoading && switcherNotes.length > 0 && (
           <ScrollArea className="max-h-80">
             <div className="space-y-0.5 px-2 pb-2">
-              {sortedNotes.map((note) => (
-                <NoteRow
+              {switcherNotes.map((note) => (
+                <DropdownMenuItem
                   key={note.id}
-                  note={note}
-                  isDefault={note.id === myNoteId}
-                  isActive={note.id === activeNoteId}
-                  onSelect={close}
-                />
+                  className="cursor-pointer p-0 focus:bg-transparent"
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    close();
+                    navigate(`/notes/${note.id}`);
+                  }}
+                >
+                  <NoteSwitcherRow
+                    note={note}
+                    isDefault={note.id === defaultNoteId}
+                    isActive={note.id === activeNoteId}
+                    isPinned={isNotePinned(note.id, pinnedIds) || note.id === defaultNoteId}
+                  />
+                </DropdownMenuItem>
               ))}
             </div>
           </ScrollArea>

--- a/src/components/note/NotesListView.tsx
+++ b/src/components/note/NotesListView.tsx
@@ -1,0 +1,213 @@
+import React, { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { NoteSummary } from "@/types/note";
+import { Input } from "@zedi/ui";
+import { cn } from "@zedi/ui";
+import { NoteListRow } from "./NoteListRow";
+import {
+  buildNoteListSections,
+  filterNotesByTitle,
+  sortNotes,
+  type NoteListSort,
+} from "@/lib/noteListSections";
+import { isNotePinned } from "@/lib/notePinnedStorage";
+import { usePinnedNotes } from "@/hooks/usePinnedNotes";
+import { useMyNote } from "@/hooks/useNoteQueries";
+
+interface NotesListViewProps {
+  notes: NoteSummary[];
+  isLoading: boolean;
+}
+
+interface NoteSectionProps {
+  title: string;
+  notes: NoteSummary[];
+  defaultNoteId: string | null;
+  pinnedIds: string[];
+  showPinAction: boolean;
+  onTogglePin: (noteId: string) => void;
+  variant: "compact" | "card";
+  indexOffset?: number;
+}
+
+const NoteSection: React.FC<NoteSectionProps> = ({
+  title,
+  notes,
+  defaultNoteId,
+  pinnedIds,
+  showPinAction,
+  onTogglePin,
+  variant,
+  indexOffset = 0,
+}) => {
+  if (notes.length === 0) return null;
+
+  return (
+    <section className="mb-8">
+      <h2 className="text-foreground mb-3 text-lg font-medium">{title}</h2>
+      <div
+        className={cn(
+          variant === "compact"
+            ? "flex flex-col gap-2"
+            : "grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3",
+        )}
+      >
+        {notes.map((note, index) => (
+          <NoteListRow
+            key={note.id}
+            note={note}
+            variant={variant}
+            index={indexOffset + index}
+            isDefault={note.id === defaultNoteId}
+            isPinned={isNotePinned(note.id, pinnedIds) || note.id === defaultNoteId}
+            showPinAction={showPinAction && note.id !== defaultNoteId}
+            onTogglePin={() => onTogglePin(note.id)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+/**
+ * Sectioned, searchable notes list for `/notes` (pinned / recent / all).
+ * `/notes` 向けのセクション付き・検索可能なノート一覧。
+ */
+export const NotesListView: React.FC<NotesListViewProps> = ({ notes, isLoading }) => {
+  const { t } = useTranslation();
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<NoteListSort>("updated");
+  const { pinnedIds, togglePin } = usePinnedNotes();
+  const { data: myNote } = useMyNote();
+  const defaultNoteId = myNote?.id ?? null;
+
+  const filtered = useMemo(() => filterNotesByTitle(notes, search), [notes, search]);
+
+  const sections = useMemo(
+    () => buildNoteListSections(filtered, pinnedIds, defaultNoteId),
+    [filtered, pinnedIds, defaultNoteId],
+  );
+
+  const sortedAll = useMemo(() => sortNotes(sections.all, sort), [sections.all, sort]);
+
+  const hasAny = sections.pinned.length > 0 || sections.recent.length > 0 || sortedAll.length > 0;
+
+  if (isLoading) {
+    return <p className="text-muted-foreground text-sm">{t("common.loading")}</p>;
+  }
+
+  return (
+    <>
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder={t("notes.list.searchPlaceholder")}
+          aria-label={t("notes.list.searchPlaceholder")}
+          className="max-w-md"
+        />
+        <div className="border-border flex shrink-0 rounded-lg border p-0.5">
+          <button
+            type="button"
+            onClick={() => setSort("updated")}
+            className={cn(
+              "rounded-md px-3 py-1.5 text-sm transition-colors",
+              sort === "updated"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {t("notes.sortUpdated")}
+          </button>
+          <button
+            type="button"
+            onClick={() => setSort("title")}
+            className={cn(
+              "rounded-md px-3 py-1.5 text-sm transition-colors",
+              sort === "title"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {t("notes.list.sortTitle")}
+          </button>
+        </div>
+      </div>
+
+      {!hasAny ? (
+        <p className="text-muted-foreground text-sm">
+          {search.trim() ? t("notes.list.noSearchResults") : t("notes.noNotesYet")}
+        </p>
+      ) : (
+        <>
+          <div className="flex flex-col gap-2 md:hidden">
+            <NoteSection
+              title={t("notes.list.sectionPinned")}
+              notes={sections.pinned}
+              defaultNoteId={defaultNoteId}
+              pinnedIds={pinnedIds}
+              showPinAction
+              onTogglePin={togglePin}
+              variant="compact"
+              indexOffset={0}
+            />
+            <NoteSection
+              title={t("notes.list.sectionRecent")}
+              notes={sections.recent}
+              defaultNoteId={defaultNoteId}
+              pinnedIds={pinnedIds}
+              showPinAction
+              onTogglePin={togglePin}
+              variant="compact"
+              indexOffset={sections.pinned.length}
+            />
+            <NoteSection
+              title={t("notes.list.sectionAll")}
+              notes={sortedAll}
+              defaultNoteId={defaultNoteId}
+              pinnedIds={pinnedIds}
+              showPinAction
+              onTogglePin={togglePin}
+              variant="compact"
+              indexOffset={sections.pinned.length + sections.recent.length}
+            />
+          </div>
+
+          <div className="hidden md:block">
+            <NoteSection
+              title={t("notes.list.sectionPinned")}
+              notes={sections.pinned}
+              defaultNoteId={defaultNoteId}
+              pinnedIds={pinnedIds}
+              showPinAction
+              onTogglePin={togglePin}
+              variant="card"
+              indexOffset={0}
+            />
+            <NoteSection
+              title={t("notes.list.sectionRecent")}
+              notes={sections.recent}
+              defaultNoteId={defaultNoteId}
+              pinnedIds={pinnedIds}
+              showPinAction
+              onTogglePin={togglePin}
+              variant="card"
+              indexOffset={sections.pinned.length}
+            />
+            <NoteSection
+              title={t("notes.list.sectionAll")}
+              notes={sortedAll}
+              defaultNoteId={defaultNoteId}
+              pinnedIds={pinnedIds}
+              showPinAction
+              onTogglePin={togglePin}
+              variant="card"
+              indexOffset={sections.pinned.length + sections.recent.length}
+            />
+          </div>
+        </>
+      )}
+    </>
+  );
+};

--- a/src/components/note/NotesListView.tsx
+++ b/src/components/note/NotesListView.tsx
@@ -77,9 +77,9 @@ export const NotesListView: React.FC<NotesListViewProps> = ({ notes, isLoading }
   const { t } = useTranslation();
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<NoteListSort>("updated");
-  const { pinnedIds, togglePin } = usePinnedNotes();
   const { data: myNote } = useMyNote();
   const defaultNoteId = myNote?.id ?? null;
+  const { pinnedIds, togglePin } = usePinnedNotes({ defaultNoteId });
 
   const filtered = useMemo(() => filterNotesByTitle(notes, search), [notes, search]);
 

--- a/src/components/note/NotesListView.tsx
+++ b/src/components/note/NotesListView.tsx
@@ -111,6 +111,7 @@ export const NotesListView: React.FC<NotesListViewProps> = ({ notes, isLoading }
           <button
             type="button"
             onClick={() => setSort("updated")}
+            aria-pressed={sort === "updated"}
             className={cn(
               "rounded-md px-3 py-1.5 text-sm transition-colors",
               sort === "updated"
@@ -123,6 +124,7 @@ export const NotesListView: React.FC<NotesListViewProps> = ({ notes, isLoading }
           <button
             type="button"
             onClick={() => setSort("title")}
+            aria-pressed={sort === "title"}
             className={cn(
               "rounded-md px-3 py-1.5 text-sm transition-colors",
               sort === "title"

--- a/src/hooks/usePinnedNotes.ts
+++ b/src/hooks/usePinnedNotes.ts
@@ -62,12 +62,11 @@ export function usePinnedNotes(options: UsePinnedNotesOptions = {}): {
   const togglePin = useCallback(
     (noteId: string) => {
       if (defaultNoteId && noteId === defaultNoteId) return;
-      setStoredPinnedIds((current) => {
-        const next = togglePinnedNoteId(noteId, current);
-        writePinnedNoteIds(next);
-        window.dispatchEvent(new Event(NOTE_PINNED_CHANGED_EVENT));
-        return next;
-      });
+      const current = stripDefaultNoteFromPinnedIds(readPinnedNoteIds(), defaultNoteId);
+      const next = togglePinnedNoteId(noteId, current);
+      setStoredPinnedIds(next);
+      writePinnedNoteIds(next);
+      window.dispatchEvent(new Event(NOTE_PINNED_CHANGED_EVENT));
     },
     [defaultNoteId],
   );

--- a/src/hooks/usePinnedNotes.ts
+++ b/src/hooks/usePinnedNotes.ts
@@ -1,26 +1,37 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   isNotePinned,
   NOTE_PINNED_CHANGED_EVENT,
   NOTE_PINNED_STORAGE_KEY,
   readPinnedNoteIds,
+  stripDefaultNoteFromPinnedIds,
   togglePinnedNoteId,
   writePinnedNoteIds,
 } from "@/lib/notePinnedStorage";
 
 /**
+ * Options for {@link usePinnedNotes}.
+ * {@link usePinnedNotes} のオプション。
+ */
+export interface UsePinnedNotesOptions {
+  /** Resolved default note id; removed from persisted user pins when known. / 既定ノート ID（判明後はユーザーピンから除去） */
+  defaultNoteId?: string | null;
+}
+
+/**
  * User-pinned note ids persisted in localStorage.
  * localStorage に保存するノートのピン留め状態。
  */
-export function usePinnedNotes(): {
+export function usePinnedNotes(options: UsePinnedNotesOptions = {}): {
   pinnedIds: string[];
   isPinned: (noteId: string) => boolean;
   togglePin: (noteId: string) => void;
 } {
-  const [pinnedIds, setPinnedIds] = useState<string[]>(() => readPinnedNoteIds());
+  const defaultNoteId = options.defaultNoteId ?? null;
+  const [storedPinnedIds, setStoredPinnedIds] = useState<string[]>(() => readPinnedNoteIds());
 
   useEffect(() => {
-    const sync = () => setPinnedIds(readPinnedNoteIds());
+    const sync = () => setStoredPinnedIds(readPinnedNoteIds());
     const onStorage = (event: StorageEvent) => {
       if (event.key === null || event.key === NOTE_PINNED_STORAGE_KEY) {
         sync();
@@ -34,14 +45,32 @@ export function usePinnedNotes(): {
     };
   }, []);
 
-  const togglePin = useCallback((noteId: string) => {
-    setPinnedIds((current) => {
-      const next = togglePinnedNoteId(noteId, current);
-      writePinnedNoteIds(next);
-      window.dispatchEvent(new Event(NOTE_PINNED_CHANGED_EVENT));
-      return next;
-    });
-  }, []);
+  useEffect(() => {
+    if (!defaultNoteId) return;
+    const stored = readPinnedNoteIds();
+    const next = stripDefaultNoteFromPinnedIds(stored, defaultNoteId);
+    if (next.length === stored.length) return;
+    writePinnedNoteIds(next);
+    window.dispatchEvent(new Event(NOTE_PINNED_CHANGED_EVENT));
+  }, [defaultNoteId]);
+
+  const pinnedIds = useMemo(
+    () => stripDefaultNoteFromPinnedIds(storedPinnedIds, defaultNoteId),
+    [storedPinnedIds, defaultNoteId],
+  );
+
+  const togglePin = useCallback(
+    (noteId: string) => {
+      if (defaultNoteId && noteId === defaultNoteId) return;
+      setStoredPinnedIds((current) => {
+        const next = togglePinnedNoteId(noteId, current);
+        writePinnedNoteIds(next);
+        window.dispatchEvent(new Event(NOTE_PINNED_CHANGED_EVENT));
+        return next;
+      });
+    },
+    [defaultNoteId],
+  );
 
   const isPinned = useCallback((noteId: string) => isNotePinned(noteId, pinnedIds), [pinnedIds]);
 

--- a/src/hooks/usePinnedNotes.ts
+++ b/src/hooks/usePinnedNotes.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   isNotePinned,
+  NOTE_PINNED_CHANGED_EVENT,
   NOTE_PINNED_STORAGE_KEY,
   readPinnedNoteIds,
   togglePinnedNoteId,
@@ -19,19 +20,25 @@ export function usePinnedNotes(): {
   const [pinnedIds, setPinnedIds] = useState<string[]>(() => readPinnedNoteIds());
 
   useEffect(() => {
+    const sync = () => setPinnedIds(readPinnedNoteIds());
     const onStorage = (event: StorageEvent) => {
       if (event.key === null || event.key === NOTE_PINNED_STORAGE_KEY) {
-        setPinnedIds(readPinnedNoteIds());
+        sync();
       }
     };
     window.addEventListener("storage", onStorage);
-    return () => window.removeEventListener("storage", onStorage);
+    window.addEventListener(NOTE_PINNED_CHANGED_EVENT, sync);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(NOTE_PINNED_CHANGED_EVENT, sync);
+    };
   }, []);
 
   const togglePin = useCallback((noteId: string) => {
     setPinnedIds((current) => {
       const next = togglePinnedNoteId(noteId, current);
       writePinnedNoteIds(next);
+      window.dispatchEvent(new Event(NOTE_PINNED_CHANGED_EVENT));
       return next;
     });
   }, []);

--- a/src/hooks/usePinnedNotes.ts
+++ b/src/hooks/usePinnedNotes.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  isNotePinned,
+  NOTE_PINNED_STORAGE_KEY,
+  readPinnedNoteIds,
+  togglePinnedNoteId,
+  writePinnedNoteIds,
+} from "@/lib/notePinnedStorage";
+
+/**
+ * User-pinned note ids persisted in localStorage.
+ * localStorage に保存するノートのピン留め状態。
+ */
+export function usePinnedNotes(): {
+  pinnedIds: string[];
+  isPinned: (noteId: string) => boolean;
+  togglePin: (noteId: string) => void;
+} {
+  const [pinnedIds, setPinnedIds] = useState<string[]>(() => readPinnedNoteIds());
+
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === null || event.key === NOTE_PINNED_STORAGE_KEY) {
+        setPinnedIds(readPinnedNoteIds());
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  const togglePin = useCallback((noteId: string) => {
+    setPinnedIds((current) => {
+      const next = togglePinnedNoteId(noteId, current);
+      writePinnedNoteIds(next);
+      return next;
+    });
+  }, []);
+
+  const isPinned = useCallback((noteId: string) => isNotePinned(noteId, pinnedIds), [pinnedIds]);
+
+  return { pinnedIds, isPinned, togglePin };
+}

--- a/src/i18n/locales/en/notes.json
+++ b/src/i18n/locales/en/notes.json
@@ -24,6 +24,18 @@
   "creating": "Creating...",
   "createFailed": "Failed to create note",
   "sectionParticipating": "Notes you've joined",
+  "list": {
+    "sectionPinned": "Frequently used",
+    "sectionRecent": "Recent",
+    "sectionAll": "All notes",
+    "searchPlaceholder": "Search notes",
+    "sortTitle": "Title",
+    "noSearchResults": "No notes match your search.",
+    "pin": "Pin note",
+    "unpin": "Unpin note",
+    "pinned": "Pinned",
+    "pagesShort": "pages"
+  },
   "noNotesYet": "You haven't joined any notes yet.",
   "sectionPublic": "Public notes",
   "publicNotesPlaceholder": "A list of notes anyone can join and related UI will be implemented after spec is finalized.",

--- a/src/i18n/locales/ja/notes.json
+++ b/src/i18n/locales/ja/notes.json
@@ -24,6 +24,18 @@
   "creating": "作成中...",
   "createFailed": "ノートの作成に失敗しました",
   "sectionParticipating": "参加しているノート",
+  "list": {
+    "sectionPinned": "よく使う",
+    "sectionRecent": "最近",
+    "sectionAll": "すべて",
+    "searchPlaceholder": "ノートを検索",
+    "sortTitle": "タイトル順",
+    "noSearchResults": "該当するノートがありません。",
+    "pin": "ピン留め",
+    "unpin": "ピン留めを解除",
+    "pinned": "ピン留め済み",
+    "pagesShort": "ページ"
+  },
   "noNotesYet": "参加しているノートはまだありません。",
   "sectionPublic": "みんなのノート",
   "publicNotesPlaceholder": "誰でも参加できるノートの一覧や、様々な情報に触れられるUIは仕様検討後に実装予定です。",

--- a/src/lib/noteListSections.test.ts
+++ b/src/lib/noteListSections.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import type { NoteSummary } from "@/types/note";
+import {
+  buildNoteListSections,
+  buildSwitcherNotes,
+  filterNotesByTitle,
+  sortNotes,
+} from "./noteListSections";
+
+function makeNote(overrides: Partial<NoteSummary> & { id: string }): NoteSummary {
+  return {
+    id: overrides.id,
+    ownerUserId: "u1",
+    title: overrides.title ?? "Title",
+    visibility: "private",
+    editPermission: "owner_only",
+    isOfficial: false,
+    isDefault: false,
+    viewCount: 0,
+    showTagFilterBar: false,
+    defaultFilterTags: [],
+    createdAt: 0,
+    updatedAt: overrides.updatedAt ?? 0,
+    isDeleted: overrides.isDeleted ?? false,
+    role: "owner",
+    pageCount: 0,
+    memberCount: 0,
+  };
+}
+
+describe("buildNoteListSections", () => {
+  const notes = [
+    makeNote({ id: "default", title: "Default", updatedAt: 100 }),
+    makeNote({ id: "a", title: "A", updatedAt: 500 }),
+    makeNote({ id: "b", title: "B", updatedAt: 400 }),
+    makeNote({ id: "c", title: "C", updatedAt: 300 }),
+    makeNote({ id: "dead", title: "Dead", updatedAt: 900, isDeleted: true }),
+  ];
+
+  it("puts default note first in pinned and excludes deleted notes", () => {
+    const sections = buildNoteListSections(notes, ["c"], "default");
+    expect(sections.pinned.map((n) => n.id)).toEqual(["default", "c"]);
+    expect(sections.recent.map((n) => n.id)).toEqual(["a", "b"]);
+    expect(sections.all).toHaveLength(0);
+    expect(sections.pinned.some((n) => n.id === "dead")).toBe(false);
+  });
+
+  it("limits recent section to three by default", () => {
+    const many = [
+      makeNote({ id: "d", updatedAt: 10 }),
+      makeNote({ id: "e", updatedAt: 20 }),
+      makeNote({ id: "f", updatedAt: 30 }),
+      makeNote({ id: "g", updatedAt: 40 }),
+      makeNote({ id: "h", updatedAt: 50 }),
+    ];
+    const sections = buildNoteListSections(many, [], null);
+    expect(sections.recent).toHaveLength(3);
+    expect(sections.recent[0]?.id).toBe("h");
+    expect(sections.all.map((n) => n.id)).toEqual(["e", "d"]);
+  });
+});
+
+describe("buildSwitcherNotes", () => {
+  it("returns pinned plus recent only", () => {
+    const notes = [
+      makeNote({ id: "default", updatedAt: 1 }),
+      makeNote({ id: "a", updatedAt: 100 }),
+      makeNote({ id: "b", updatedAt: 90 }),
+      makeNote({ id: "c", updatedAt: 80 }),
+      makeNote({ id: "d", updatedAt: 70 }),
+      makeNote({ id: "e", updatedAt: 60 }),
+      makeNote({ id: "f", updatedAt: 50 }),
+    ];
+    const rows = buildSwitcherNotes(notes, [], "default", { recentCount: 5 });
+    expect(rows.map((n) => n.id)).toEqual(["default", "a", "b", "c", "d", "e"]);
+    expect(rows).toHaveLength(6);
+  });
+});
+
+describe("filterNotesByTitle", () => {
+  it("filters case-insensitively", () => {
+    const notes = [makeNote({ id: "1", title: "Team Alpha" })];
+    expect(filterNotesByTitle(notes, "alpha")).toHaveLength(1);
+    expect(filterNotesByTitle(notes, "  ")).toHaveLength(1);
+  });
+});
+
+describe("sortNotes", () => {
+  it("sorts by title", () => {
+    const notes = [makeNote({ id: "1", title: "Zed" }), makeNote({ id: "2", title: "Alpha" })];
+    expect(sortNotes(notes, "title").map((n) => n.id)).toEqual(["2", "1"]);
+  });
+});

--- a/src/lib/noteListSections.test.ts
+++ b/src/lib/noteListSections.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import type { NoteSummary } from "@/types/note";
 import {
   buildNoteListSections,
+  resolveNoteDisplayTitle,
   buildSwitcherNotes,
   filterNotesByTitle,
   sortNotes,
@@ -74,6 +75,13 @@ describe("buildSwitcherNotes", () => {
     const rows = buildSwitcherNotes(notes, [], "default", { recentCount: 5 });
     expect(rows.map((n) => n.id)).toEqual(["default", "a", "b", "c", "d", "e"]);
     expect(rows).toHaveLength(6);
+  });
+});
+
+describe("resolveNoteDisplayTitle", () => {
+  it("returns untitled label for null or blank titles", () => {
+    expect(resolveNoteDisplayTitle(null, "Untitled")).toBe("Untitled");
+    expect(resolveNoteDisplayTitle("  ", "Untitled")).toBe("Untitled");
   });
 });
 

--- a/src/lib/noteListSections.ts
+++ b/src/lib/noteListSections.ts
@@ -7,6 +7,18 @@ export const RECENT_SECTION_COUNT = 3;
 /** Recent rows in the title switcher (excluding pinned). / スイッチャーの「最近」行数 */
 export const SWITCHER_RECENT_COUNT = 5;
 
+/**
+ * Safe note title for UI (API may return null at runtime).
+ * UI 向けタイトル（実行時に null があり得る）。
+ */
+export function resolveNoteDisplayTitle(
+  title: string | null | undefined,
+  untitledLabel: string,
+): string {
+  const trimmed = (title ?? "").trim();
+  return trimmed.length > 0 ? trimmed : untitledLabel;
+}
+
 export type NoteListSort = "updated" | "title";
 
 export interface NoteListSections {

--- a/src/lib/noteListSections.ts
+++ b/src/lib/noteListSections.ts
@@ -1,0 +1,133 @@
+import type { NoteSummary } from "@/types/note";
+import { isNotePinned } from "@/lib/notePinnedStorage";
+
+/** Notes shown in the automatic "recent" block on `/notes`. / `/notes` の「最近」セクション件数 */
+export const RECENT_SECTION_COUNT = 3;
+
+/** Recent rows in the title switcher (excluding pinned). / スイッチャーの「最近」行数 */
+export const SWITCHER_RECENT_COUNT = 5;
+
+export type NoteListSort = "updated" | "title";
+
+export interface NoteListSections {
+  /** Default note + user pins. / 既定ノートとユーザーピン */
+  pinned: NoteSummary[];
+  /** Top N by `updatedAt` after pinned. / ピン以外の更新順上位 */
+  recent: NoteSummary[];
+  /** Remaining notes. / その他 */
+  all: NoteSummary[];
+}
+
+/**
+ * Live notes only (`!isDeleted`).
+ * 論理削除されていないノートだけを返す。
+ */
+export function filterLiveNotes(notes: NoteSummary[]): NoteSummary[] {
+  return notes.filter((note) => !note.isDeleted);
+}
+
+/**
+ * Case-insensitive title filter.
+ * タイトルの部分一致（大文字小文字無視）。
+ */
+export function filterNotesByTitle(notes: NoteSummary[], query: string): NoteSummary[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return notes;
+  return notes.filter((note) => (note.title || "").toLowerCase().includes(q));
+}
+
+/**
+ * Sort notes for the "all" section.
+ * 「すべて」セクション用のソート。
+ */
+export function sortNotes(notes: NoteSummary[], sort: NoteListSort): NoteSummary[] {
+  const copy = [...notes];
+  if (sort === "title") {
+    copy.sort((a, b) =>
+      (a.title || "").localeCompare(b.title || "", undefined, { sensitivity: "base" }),
+    );
+    return copy;
+  }
+  copy.sort((a, b) => b.updatedAt - a.updatedAt);
+  return copy;
+}
+
+/**
+ * Ordered pinned ids: default note first, then user pins (deduped).
+ * ピン表示順: 既定ノート → ユーザーピン（重複除去）。
+ */
+export function buildPinnedIdOrder(
+  defaultNoteId: string | null,
+  userPinnedIds: string[],
+): string[] {
+  const ordered: string[] = [];
+  if (defaultNoteId) ordered.push(defaultNoteId);
+  for (const id of userPinnedIds) {
+    if (!ordered.includes(id)) ordered.push(id);
+  }
+  return ordered;
+}
+
+/**
+ * Resolve pinned section notes from ids.
+ * ID 順にピンセクションのノートを並べる。
+ */
+export function resolvePinnedNotes(
+  notesById: Map<string, NoteSummary>,
+  pinnedIdOrder: string[],
+): NoteSummary[] {
+  const result: NoteSummary[] = [];
+  for (const id of pinnedIdOrder) {
+    const note = notesById.get(id);
+    if (note) result.push(note);
+  }
+  return result;
+}
+
+/**
+ * Split notes into pinned / recent / all for `/notes`.
+ * `/notes` 用にピン・最近・すべてへ分割する。
+ */
+export function buildNoteListSections(
+  notes: NoteSummary[],
+  userPinnedIds: string[],
+  defaultNoteId: string | null,
+  options?: { recentCount?: number },
+): NoteListSections {
+  const recentCount = options?.recentCount ?? RECENT_SECTION_COUNT;
+  const live = filterLiveNotes(notes);
+  const byId = new Map(live.map((note) => [note.id, note]));
+
+  const pinned = resolvePinnedNotes(byId, buildPinnedIdOrder(defaultNoteId, userPinnedIds));
+  const pinnedSet = new Set(pinned.map((n) => n.id));
+
+  const restByUpdated = live
+    .filter((note) => !pinnedSet.has(note.id))
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+
+  const recent = restByUpdated.slice(0, recentCount);
+  const recentSet = new Set(recent.map((n) => n.id));
+
+  const all = restByUpdated.filter((note) => !recentSet.has(note.id));
+
+  return { pinned, recent, all };
+}
+
+/**
+ * Notes shown in `NoteTitleSwitcher`: pinned block + recent (no full catalog).
+ * タイトルスイッチャー用: ピン＋最近のみ（全件は載せない）。
+ */
+export function buildSwitcherNotes(
+  notes: NoteSummary[],
+  userPinnedIds: string[],
+  defaultNoteId: string | null,
+  options?: { recentCount?: number },
+): NoteSummary[] {
+  const recentCount = options?.recentCount ?? SWITCHER_RECENT_COUNT;
+  const { pinned, recent } = buildNoteListSections(notes, userPinnedIds, defaultNoteId, {
+    recentCount,
+  });
+  return [...pinned, ...recent];
+}
+
+export { isNotePinned };

--- a/src/lib/noteListSections.ts
+++ b/src/lib/noteListSections.ts
@@ -19,8 +19,16 @@ export function resolveNoteDisplayTitle(
   return trimmed.length > 0 ? trimmed : untitledLabel;
 }
 
+/**
+ * Sort key for the "all notes" section on `/notes`.
+ * `/notes` の「すべて」セクションの並び順。
+ */
 export type NoteListSort = "updated" | "title";
 
+/**
+ * Grouped note rows for `/notes` (pinned / recent / all).
+ * `/notes` 向けのノート行グループ（よく使う / 最近 / すべて）。
+ */
 export interface NoteListSections {
   /** Default note + user pins. / 既定ノートとユーザーピン */
   pinned: NoteSummary[];

--- a/src/lib/notePinnedStorage.test.ts
+++ b/src/lib/notePinnedStorage.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  MAX_PINNED_NOTES,
+  readPinnedNoteIds,
+  togglePinnedNoteId,
+  writePinnedNoteIds,
+  NOTE_PINNED_STORAGE_KEY,
+} from "./notePinnedStorage";
+
+describe("notePinnedStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("round-trips pinned ids", () => {
+    writePinnedNoteIds(["a", "b"]);
+    expect(readPinnedNoteIds()).toEqual(["a", "b"]);
+  });
+
+  it("toggles pin on and off", () => {
+    expect(togglePinnedNoteId("a", [])).toEqual(["a"]);
+    expect(togglePinnedNoteId("a", ["a"])).toEqual([]);
+  });
+
+  it("drops oldest pin when at capacity", () => {
+    const full = Array.from({ length: MAX_PINNED_NOTES }, (_, i) => `id-${i}`);
+    const next = togglePinnedNoteId("new", full);
+    expect(next).toHaveLength(MAX_PINNED_NOTES);
+    expect(next[0]).toBe("id-1");
+    expect(next[MAX_PINNED_NOTES - 1]).toBe("new");
+  });
+
+  it("returns empty array for invalid JSON", () => {
+    localStorage.setItem(NOTE_PINNED_STORAGE_KEY, "not-json");
+    expect(readPinnedNoteIds()).toEqual([]);
+  });
+
+  it("ignores write failures", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(() => writePinnedNoteIds(["a"])).not.toThrow();
+  });
+});

--- a/src/lib/notePinnedStorage.test.ts
+++ b/src/lib/notePinnedStorage.test.ts
@@ -1,11 +1,19 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   MAX_PINNED_NOTES,
+  stripDefaultNoteFromPinnedIds,
   readPinnedNoteIds,
   togglePinnedNoteId,
   writePinnedNoteIds,
   NOTE_PINNED_STORAGE_KEY,
 } from "./notePinnedStorage";
+
+describe("stripDefaultNoteFromPinnedIds", () => {
+  it("removes the default note id from user pins", () => {
+    expect(stripDefaultNoteFromPinnedIds(["a", "default", "b"], "default")).toEqual(["a", "b"]);
+    expect(stripDefaultNoteFromPinnedIds(["a"], null)).toEqual(["a"]);
+  });
+});
 
 describe("notePinnedStorage", () => {
   beforeEach(() => {

--- a/src/lib/notePinnedStorage.ts
+++ b/src/lib/notePinnedStorage.ts
@@ -1,6 +1,9 @@
 /** localStorage key for user-pinned note ids. / ピン留めノート ID の保存キー */
 export const NOTE_PINNED_STORAGE_KEY = "zedi-note-pinned-ids";
 
+/** Fired in-tab when pin list changes (storage event is cross-tab only). */
+export const NOTE_PINNED_CHANGED_EVENT = "zedi-note-pinned-changed";
+
 /** Max user-pinned notes (default note is always shown separately). / ユーザーがピンできる上限 */
 export const MAX_PINNED_NOTES = 5;
 

--- a/src/lib/notePinnedStorage.ts
+++ b/src/lib/notePinnedStorage.ts
@@ -1,0 +1,56 @@
+/** localStorage key for user-pinned note ids. / ピン留めノート ID の保存キー */
+export const NOTE_PINNED_STORAGE_KEY = "zedi-note-pinned-ids";
+
+/** Max user-pinned notes (default note is always shown separately). / ユーザーがピンできる上限 */
+export const MAX_PINNED_NOTES = 5;
+
+/**
+ * Read pinned note ids from localStorage (newest pin last in array order).
+ * localStorage からピン留め ID 一覧を読み込む（配列順＝ピンした順）。
+ */
+export function readPinnedNoteIds(): string[] {
+  try {
+    const raw = localStorage.getItem(NOTE_PINNED_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is string => typeof id === "string");
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Persist pinned note ids. Silently no-ops on quota errors.
+ * ピン留め ID を保存する。quota 超過時は握りつぶす。
+ */
+export function writePinnedNoteIds(ids: string[]): void {
+  try {
+    localStorage.setItem(NOTE_PINNED_STORAGE_KEY, JSON.stringify(ids.slice(0, MAX_PINNED_NOTES)));
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Toggle a pin for `noteId`. Returns the updated id list (capped).
+ * `noteId` のピンを切り替え、更新後の ID 一覧を返す。
+ */
+export function togglePinnedNoteId(noteId: string, current: string[]): string[] {
+  const index = current.indexOf(noteId);
+  if (index >= 0) {
+    return current.filter((id) => id !== noteId);
+  }
+  if (current.length >= MAX_PINNED_NOTES) {
+    return [...current.slice(1), noteId];
+  }
+  return [...current, noteId];
+}
+
+/**
+ * Whether `noteId` is in the user pin list.
+ * ユーザーがピン留めしたノートかどうか。
+ */
+export function isNotePinned(noteId: string, pinnedIds: string[]): boolean {
+  return pinnedIds.includes(noteId);
+}

--- a/src/lib/notePinnedStorage.ts
+++ b/src/lib/notePinnedStorage.ts
@@ -1,7 +1,10 @@
 /** localStorage key for user-pinned note ids. / ピン留めノート ID の保存キー */
 export const NOTE_PINNED_STORAGE_KEY = "zedi-note-pinned-ids";
 
-/** Fired in-tab when pin list changes (storage event is cross-tab only). */
+/**
+ * Fired in-tab when pin list changes (`storage` is cross-tab only).
+ * ピン一覧が変わったときに同一タブへ通知する（`storage` は別タブ専用）。
+ */
 export const NOTE_PINNED_CHANGED_EVENT = "zedi-note-pinned-changed";
 
 /** Max user-pinned notes (default note is always shown separately). / ユーザーがピンできる上限 */
@@ -33,6 +36,18 @@ export function writePinnedNoteIds(ids: string[]): void {
   } catch {
     // ignore
   }
+}
+
+/**
+ * Remove the default note id from user pins (shown separately in the pinned section).
+ * 既定ノート ID をユーザーピンから除去する（ピンセクションでは別枠表示）。
+ */
+export function stripDefaultNoteFromPinnedIds(
+  pinnedIds: string[],
+  defaultNoteId: string | null,
+): string[] {
+  if (!defaultNoteId) return pinnedIds;
+  return pinnedIds.filter((id) => id !== defaultNoteId);
 }
 
 /**

--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate, Link } from "react-router-dom";
 import { Plus } from "lucide-react";
 import { NotesLayout } from "@/components/note/NotesLayout";
 import { useNotes, useCreateNote } from "@/hooks/useNoteQueries";
 import { useAuth } from "@/hooks/useAuth";
 import type { NoteEditPermission, NoteVisibility } from "@/types/note";
-import { NoteCard } from "@/components/note/NoteCard";
+import { NotesListView } from "@/components/note/NotesListView";
 import { NoteEditPermissionControls } from "@/components/note/NoteEditPermissionControls";
 import { allowedEditPermissions, visibilityKeys } from "@/lib/noteSettingsConfig";
 import { shouldConfirmPublicAnyLoggedInSave } from "@/lib/noteSharingRisk";
@@ -175,8 +175,6 @@ const Notes: React.FC = () => {
   const [visibility, setVisibility] = useState<NoteVisibility>("private");
   const [editPermission, setEditPermission] = useState<NoteEditPermission>("owner_only");
 
-  const sortedNotes = useMemo(() => [...notes].sort((a, b) => b.updatedAt - a.updatedAt), [notes]);
-
   const executeCreate = async () => {
     reopenCreateAfterPublicConfirmRef.current = false;
     try {
@@ -302,22 +300,7 @@ const Notes: React.FC = () => {
         </AlertDialogContent>
       </AlertDialog>
 
-      <section className="mb-10">
-        <h2 className="text-foreground mb-4 text-lg font-medium">
-          {t("notes.sectionParticipating")}
-        </h2>
-        {isLoading ? (
-          <p className="text-muted-foreground text-sm">{t("common.loading")}</p>
-        ) : sortedNotes.length === 0 ? (
-          <p className="text-muted-foreground text-sm">{t("notes.noNotesYet")}</p>
-        ) : (
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {sortedNotes.map((note, index) => (
-              <NoteCard key={note.id} note={note} index={index} />
-            ))}
-          </div>
-        )}
-      </section>
+      <NotesListView notes={notes} isLoading={isLoading} />
     </NotesLayout>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`/notes`（参加中のノート）の一覧を、メタデータ中心のセクション付きリスト UI に刷新しました。モバイルは 1 列リスト、デスクトップは同じ情報をカード風に表示します。`NoteTitleSwitcher` はピン留め＋最近更新したノートのみを表示し、全件スクロールは廃止しています。

## 変更点

- **セクション**: よく使う（既定ノート + ユーザーピン）/ 最近（更新順 3 件）/ すべて
- **検索・ソート**: タイトル検索、更新日順・タイトル順
- **ピン留め**: localStorage（最大 5 件）、行のピンボタンで切替（既定ノートはピン不可）
- **NoteListRow**: 役割アクセント・更新時刻・公開範囲・ページ数/メンバー数を表示
- **NoteTitleSwitcher**: ピン + 最近 5 件のみ（`buildSwitcherNotes`）

## 変更の種類

- [x] 新機能 (New feature)

## テスト方法

1. `/notes` を開き、セクション・検索・ソート・ピン留めを確認
2. ノート詳細でタイトルスイッチャーを開き、全件ではなくピン+最近のみ表示されることを確認
3. `bunx vitest run src/lib/noteListSections.test.ts src/lib/notePinnedStorage.test.ts src/components/note/NoteListRow.test.tsx src/components/note/NoteTitleSwitcher.test.tsx`

## チェックリスト

- [x] 上記 Vitest を実行済み
- [x] Lint（変更ファイル）問題なし
- [ ] スクリーンショットは未添付（Cloud Agent 環境）

## 関連 Issue

なし（UI 刷新の依頼に基づく実装）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22b6630e-333b-44be-a82d-5331802a8a5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22b6630e-333b-44be-a82d-5331802a8a5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pin/favorite notes with persistent storage and cross-tab updates; pinned + recent grouping in lists and switcher
  * Client-side search, sorting, and responsive list view (compact/card) with untitled-note fallbacks
  * Improved note rows and switcher with active selection behavior and consistent navigation

* **Tests**
  * Added comprehensive tests for list building, pin behavior, switcher, and row interactions

* **i18n**
  * Added localized strings for note list UI, actions, and labels

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/995?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->