### PR TITLE
Optimize getNoteRole to single correlated-subquery round trip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,11 @@ jobs:
     # for a follow-up PR rather than risking a noisy first integration.
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
+    # ブラウザ DL / apt が CI ネットワークの不調で停滞しても既定の 6h 待たずに
+    # 失敗させ、install ステップのリトライへ倒すためジョブ全体に上限を設ける。
+    # Cap the whole job so a stalled browser/apt download fails fast (letting the
+    # install step's retry kick in) instead of hanging for the default 6h.
+    timeout-minutes: 20
     steps:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
@@ -203,9 +208,19 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
 
       # Playwright のブラウザバイナリ + 必要な OS 依存を入れる。
-      # Install Playwright's browser binaries plus the matching OS deps.
-      - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+      # ネットワーク起因の停滞に備え、各試行を `timeout` で打ち切りつつ最大 3 回
+      # リトライする（既存の checkout と同じ wretry.action を使用）。停滞した試行
+      # はハングのまま終わらないため、`timeout` で非ゼロ終了させてリトライを促す。
+      # Install Playwright's browser binaries plus the matching OS deps. Guard
+      # against network stalls: bound each attempt with `timeout` (so a hung
+      # download exits non-zero and triggers a retry) and retry up to 3 times
+      # via the same wretry.action used for checkout above.
+      - name: Install Playwright browsers (with retry)
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: timeout 300 bunx playwright install --with-deps chromium
+          attempt_limit: 3
+          attempt_delay: 10000
 
       - name: Run PDF knowledge E2E
         run: bunx playwright test e2e/pdf-knowledge.spec.ts

--- a/server/api/src/__tests__/routes/notes/helpers.test.ts
+++ b/server/api/src/__tests__/routes/notes/helpers.test.ts
@@ -156,4 +156,14 @@ describe("getNoteRole — resolution order (issue #663)", () => {
     const result = await getNoteRole(NOTE_ID, VISITOR_ID, undefined, db as unknown as Database);
     expect(result.role).toBe("guest");
   });
+
+  it("never grants a member role to an email-less caller on a private note", async () => {
+    // 多層防御: email 無しの呼び出しでは、たとえ行に member ロールが乗っていても
+    // （空メール行への偶発一致など）採用せず private は null のままにする。
+    // Defense in depth: an email-less caller must not be granted access via a
+    // member role on the row (e.g. an accidental blank-email match).
+    const { db } = createMockDb([[mockRoleRow({ memberRole: "editor", domainRole: "editor" })]]);
+    const result = await getNoteRole(NOTE_ID, VISITOR_ID, undefined, db as unknown as Database);
+    expect(result.role).toBeNull();
+  });
 });

--- a/server/api/src/__tests__/routes/notes/helpers.test.ts
+++ b/server/api/src/__tests__/routes/notes/helpers.test.ts
@@ -2,11 +2,13 @@
  * `routes/notes/helpers.ts` の `getNoteRole` ロジックテスト。
  *
  * Unit tests for the role-resolution order implemented in `helpers.ts`
- * (issue #663). The mock DB from `setup.ts` returns results by call order,
- * so each query consumes one slot:
- *   1. findActiveNoteById
- *   2. noteMembers lookup (when email present)
- *   3. noteDomainAccess lookup (when no member match)
+ * (issue #663). `getNoteRole` は note 行・メンバーロール・ドメインロールを
+ * 1 クエリ（相関サブクエリ）で取得するため、モック DB は 1 スロットだけを
+ * 消費する: `[{ note, memberRole, domainRole }]`。
+ *
+ * `getNoteRole` resolves the note row plus the caller's member/domain roles in
+ * a single query (correlated subqueries), so the mock DB consumes exactly one
+ * slot: `[{ note, memberRole, domainRole }]`.
  *
  * 解決順: owner > member > domain access > visibility > none.
  */
@@ -60,7 +62,33 @@ function mockNoteRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
+/**
+ * `getNoteRole` が消費する combined 行を組み立てる。note 列はフラットに展開し、
+ * memberRole / domainRole を併せ持つ（本番クエリの select 形に合わせる）。
+ * Builds the combined row consumed by `getNoteRole`: note columns are flattened
+ * with memberRole / domainRole alongside them, matching the production select.
+ */
+function mockRoleRow(
+  overrides: {
+    note?: Record<string, unknown>;
+    memberRole?: "viewer" | "editor" | null;
+    domainRole?: "viewer" | "editor" | null;
+  } = {},
+) {
+  return {
+    ...mockNoteRow(overrides.note ?? {}),
+    memberRole: overrides.memberRole ?? null,
+    domainRole: overrides.domainRole ?? null,
+  };
+}
+
 describe("getNoteRole — resolution order (issue #663)", () => {
+  it("issues a single DB round trip", async () => {
+    const { db, chains } = createMockDb([[mockRoleRow()]]);
+    await getNoteRole(NOTE_ID, VISITOR_ID, VISITOR_EMAIL, db as unknown as Database);
+    expect(chains.length).toBe(1);
+  });
+
   it("returns null role when the note does not exist", async () => {
     const { db } = createMockDb([[]]);
     const result = await getNoteRole(NOTE_ID, VISITOR_ID, VISITOR_EMAIL, db as unknown as Database);
@@ -68,8 +96,10 @@ describe("getNoteRole — resolution order (issue #663)", () => {
     expect(result.role).toBeNull();
   });
 
-  it("returns 'owner' when caller owns the note (short-circuits later checks)", async () => {
-    const { db } = createMockDb([[mockNoteRow()]]);
+  it("returns 'owner' when caller owns the note (outranks member/domain)", async () => {
+    // owner はメンバー / ドメインのロールが乗っていても最優先で勝つ。
+    // Owner wins even if member/domain roles are also present on the row.
+    const { db } = createMockDb([[mockRoleRow({ memberRole: "editor", domainRole: "editor" })]]);
     const result = await getNoteRole(
       NOTE_ID,
       OWNER_ID,
@@ -80,79 +110,49 @@ describe("getNoteRole — resolution order (issue #663)", () => {
   });
 
   it("returns member role when the caller is an accepted member (wins over domain rule)", async () => {
-    // owner > member の後、member にヒットしたら domain のチェックはしない。
-    // After the member hit, the domain query must not fire (member > domain).
+    // member にヒットしたら domain より優先される（明示的に昇格済み）。
+    // A member match outranks any domain rule.
     const { db } = createMockDb([
-      [mockNoteRow()],
-      [{ role: "editor" }], // noteMembers → accepted editor
+      [mockRoleRow({ note: { ownerId: OWNER_ID }, memberRole: "editor", domainRole: "viewer" })],
     ]);
     const result = await getNoteRole(NOTE_ID, VISITOR_ID, VISITOR_EMAIL, db as unknown as Database);
     expect(result.role).toBe("editor");
   });
 
-  it("returns domain role when member check is empty and a rule matches", async () => {
-    // member 無し → domain ルールでヒット。editor として返る。
-    // No member, but a domain rule matches — returns editor.
-    const { db } = createMockDb([
-      [mockNoteRow()],
-      [], // noteMembers → empty
-      [{ role: "editor" }], // noteDomainAccess → editor rule
-    ]);
+  it("returns domain role when there is no member match", async () => {
+    // member 無し → domain ロール（SQL 側で最強ロールを集約済み）を返す。
+    // No member; returns the domain role (strongest role aggregated in SQL).
+    const { db } = createMockDb([[mockRoleRow({ memberRole: null, domainRole: "editor" })]]);
     const result = await getNoteRole(NOTE_ID, VISITOR_ID, VISITOR_EMAIL, db as unknown as Database);
     expect(result.role).toBe("editor");
   });
 
-  it("picks the strongest domain role when multiple rules match (editor > viewer)", async () => {
-    const { db } = createMockDb([
-      [mockNoteRow()],
-      [], // noteMembers → empty
-      [{ role: "viewer" }, { role: "editor" }], // multiple rules
-    ]);
+  it("returns the viewer domain role when that is the strongest match", async () => {
+    const { db } = createMockDb([[mockRoleRow({ memberRole: null, domainRole: "viewer" })]]);
     const result = await getNoteRole(NOTE_ID, VISITOR_ID, VISITOR_EMAIL, db as unknown as Database);
-    expect(result.role).toBe("editor");
-  });
-
-  it("matches the domain case-insensitively via the normalized email", async () => {
-    // `visitor@EXAMPLE.COM` でもルールに一致する。
-    // Upper-cased email domains must still resolve.
-    const { db } = createMockDb([
-      [mockNoteRow()],
-      [], // noteMembers → empty
-      [{ role: "viewer" }],
-    ]);
-    const result = await getNoteRole(
-      NOTE_ID,
-      VISITOR_ID,
-      "visitor@EXAMPLE.COM",
-      db as unknown as Database,
-    );
     expect(result.role).toBe("viewer");
   });
 
   it("falls through to 'guest' for public notes when no member or domain match", async () => {
-    const { db } = createMockDb([
-      [mockNoteRow({ visibility: "public" })],
-      [], // noteMembers → empty
-      [], // noteDomainAccess → empty
-    ]);
+    const { db } = createMockDb([[mockRoleRow({ note: { visibility: "public" } })]]);
+    const result = await getNoteRole(NOTE_ID, VISITOR_ID, VISITOR_EMAIL, db as unknown as Database);
+    expect(result.role).toBe("guest");
+  });
+
+  it("falls through to 'guest' for unlisted notes", async () => {
+    const { db } = createMockDb([[mockRoleRow({ note: { visibility: "unlisted" } })]]);
     const result = await getNoteRole(NOTE_ID, VISITOR_ID, VISITOR_EMAIL, db as unknown as Database);
     expect(result.role).toBe("guest");
   });
 
   it("returns null for private notes when nothing matches", async () => {
-    const { db } = createMockDb([
-      [mockNoteRow()],
-      [], // noteMembers → empty
-      [], // noteDomainAccess → empty
-    ]);
+    const { db } = createMockDb([[mockRoleRow()]]);
     const result = await getNoteRole(NOTE_ID, VISITOR_ID, VISITOR_EMAIL, db as unknown as Database);
     expect(result.role).toBeNull();
   });
 
-  it("skips member/domain checks when email is missing (still returns guest for public)", async () => {
-    // email 無しだと member / domain の問い合わせを発行しない。
-    // Without an email, skip member and domain queries entirely.
-    const { db } = createMockDb([[mockNoteRow({ visibility: "public" })]]);
+  it("returns guest for public notes even when the email is missing", async () => {
+    const { db } = createMockDb([[mockRoleRow({ note: { visibility: "public" } })]]);
     const result = await getNoteRole(NOTE_ID, VISITOR_ID, undefined, db as unknown as Database);
     expect(result.role).toBe("guest");
   });

--- a/server/api/src/__tests__/routes/notes/search.test.ts
+++ b/server/api/src/__tests__/routes/notes/search.test.ts
@@ -148,8 +148,9 @@ describe("GET /api/notes/:noteId/search", () => {
     // Any resolved member role allows searching, even on a private note.
     const privateNote = createMockNote({ ownerId: OTHER_USER_ID, visibility: "private" });
     const { app, chains } = createTestApp([
-      [privateNote], // findActiveNoteById
-      [{ role: "viewer" }], // member check matches
+      // getNoteRole: 1 クエリで note 列 + memberRole/domainRole を返す。
+      // getNoteRole resolves the note row + member/domain roles in one query.
+      [{ ...privateNote, memberRole: "viewer", domainRole: null }],
       { rows: [] }, // execute search
     ]);
 
@@ -171,9 +172,9 @@ describe("GET /api/notes/:noteId/search", () => {
     // they are allowed to search. Mirrors `GET /:noteId/pages` semantics.
     const publicNote = createMockNote({ ownerId: OTHER_USER_ID, visibility: "public" });
     const { app } = createTestApp([
-      [publicNote], // findActiveNoteById
-      [], // member check
-      [], // domain access → empty, falls through to visibility=public → guest
+      // getNoteRole: member/domain なし → visibility=public で guest に解決。
+      // No member/domain → falls through to visibility=public → guest.
+      [{ ...publicNote, memberRole: null, domainRole: null }],
       { rows: [] }, // execute search
     ]);
 

--- a/server/api/src/__tests__/routes/pageSnapshots.test.ts
+++ b/server/api/src/__tests__/routes/pageSnapshots.test.ts
@@ -165,10 +165,15 @@ describe("GET /api/pages/:id/snapshots", () => {
 
   it("allows access for note member", async () => {
     const pageRow = { id: PAGE_ID, ownerId: OWNER_ID, noteId: NOTE_ID };
+    // getNoteRole は 1 クエリで note 列 + memberRole/domainRole を返すため、
+    // member ロールは note 行に埋め込む（prefix の note スロットを差し替える）。
+    // getNoteRole resolves note + member/domain roles in one query, so embed the
+    // member role into the note row instead of a separate member-lookup slot.
     const app = createSnapshotsApp([
-      ...viewAccessPrefix("member@example.com", OWNER_ID, pageRow),
-      [{ role: "viewer" }],
-      [],
+      [pageRow], // page lookup
+      [{ email: "member@example.com" }], // user email lookup
+      [{ ...mockNote(OWNER_ID), memberRole: "viewer", domainRole: null }], // getNoteRole
+      [], // snapshots query
     ]);
 
     const res = await app.request(`/api/pages/${PAGE_ID}/snapshots`, {

--- a/server/api/src/__tests__/services/lintFindings.test.ts
+++ b/server/api/src/__tests__/services/lintFindings.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import {
+  getUnresolvedFindings,
+  getFindingsForPage,
+  DEFAULT_LINT_FINDINGS_LIMIT,
+} from "../../services/lintEngine/index.js";
+import type { Database } from "../../types/index.js";
+import { createMockDb } from "../createMockDb.js";
+
+/**
+ * 未解決 findings の取得クエリに防御的上限 (LIMIT) が適用されることを検証する。
+ * Verifies the unresolved-findings queries apply a defensive LIMIT so a user
+ * with a huge backlog cannot pull an unbounded result set into memory.
+ */
+describe("lint findings queries apply a defensive LIMIT", () => {
+  it("getUnresolvedFindings applies the default limit", async () => {
+    const { db, chains } = createMockDb([[]]);
+
+    await getUnresolvedFindings("owner-1", db as unknown as Database);
+
+    const limitOp = chains[0]?.ops.find((op) => op.method === "limit");
+    expect(limitOp).toBeDefined();
+    expect(limitOp?.args).toEqual([DEFAULT_LINT_FINDINGS_LIMIT]);
+  });
+
+  it("getFindingsForPage applies the default limit", async () => {
+    const { db, chains } = createMockDb([[]]);
+
+    await getFindingsForPage("owner-1", "page-1", db as unknown as Database);
+
+    const limitOp = chains[0]?.ops.find((op) => op.method === "limit");
+    expect(limitOp).toBeDefined();
+    expect(limitOp?.args).toEqual([DEFAULT_LINT_FINDINGS_LIMIT]);
+  });
+});

--- a/server/api/src/__tests__/services/pageAccessService.test.ts
+++ b/server/api/src/__tests__/services/pageAccessService.test.ts
@@ -137,8 +137,15 @@ describe("assertPageEditAccess (issue #823)", () => {
     const { db } = createMockDb([
       [{ id: PAGE_ID, ownerId: OTHER_USER_ID, noteId: NOTE_ID }],
       [{ email: USER_EMAIL }],
-      [noteRow(OTHER_USER_ID, { editPermission: "members_editors" })],
-      [{ role: "editor" }],
+      // getNoteRole: 1 クエリで note 列 + memberRole/domainRole を返す。
+      // getNoteRole resolves the note row + member/domain roles in one query.
+      [
+        {
+          ...noteRow(OTHER_USER_ID, { editPermission: "members_editors" }),
+          memberRole: "editor",
+          domainRole: null,
+        },
+      ],
     ]);
     await expect(assertPageEditAccess(asDb(db), PAGE_ID, USER_ID)).resolves.toBeUndefined();
   });

--- a/server/api/src/routes/notes/helpers.ts
+++ b/server/api/src/routes/notes/helpers.ts
@@ -3,7 +3,7 @@
  * マッパー、DB クエリ、権限チェック
  */
 import { HTTPException } from "hono/http-exception";
-import { eq, and, sql, inArray } from "drizzle-orm";
+import { eq, and, sql, inArray, getTableColumns } from "drizzle-orm";
 import { notes, noteMembers, noteDomainAccess, pages, users } from "../../schema/index.js";
 import type { Note } from "../../schema/index.js";
 import type { Database } from "../../types/index.js";
@@ -169,70 +169,65 @@ export async function getNoteRole(
   userEmail: string | undefined,
   db: Database,
 ): Promise<{ role: NoteRole; note: Note | null }> {
-  const note = await findActiveNoteById(db, noteId);
-  if (!note) return { role: null, note: null };
-
-  if (userId && note.ownerId === userId) return { role: "owner", note };
-
   const normalizedEmail = typeof userEmail === "string" ? userEmail.trim().toLowerCase() : "";
+  const domain = normalizedEmail.length > 0 ? extractEmailDomain(normalizedEmail) : null;
 
-  if (normalizedEmail.length > 0) {
-    // メンバーは大文字小文字を区別せずに突合する。schema 側では lower-case で
-    // 保存する運用だが、古い行や手動挿入の取りこぼしを避けるため `LOWER(...)`
-    // で比較する。ヒットした場合はドメインルールより強い（= メンバー昇格済み）。
-    //
-    // Match members case-insensitively. Rows should already be lower-cased by
-    // `members.ts`, but compare via `LOWER(...)` to cover legacy / manual data.
-    // A member match outranks any domain rule (they were explicitly upgraded).
-    const member = await db
-      .select({ role: noteMembers.role })
-      .from(noteMembers)
-      .where(
-        and(
-          eq(noteMembers.noteId, noteId),
-          sql`LOWER(${noteMembers.memberEmail}) = ${normalizedEmail}`,
-          eq(noteMembers.isDeleted, false),
-          eq(noteMembers.status, "accepted"),
-        ),
-      )
-      .limit(1);
+  // note 行・メンバーロール・ドメインロールを 1 往復で取得する。member / domain は
+  // 行の多重化を避けるため相関サブクエリで解決し、ドメインは最強ロール
+  // (editor > viewer) を SQL 側で集約する。優先順位 (#663) は JS 側で適用する。
+  //
+  // Fetch the note row plus the caller's member/domain roles in a single round
+  // trip. Member/domain are resolved via correlated subqueries to avoid row
+  // multiplication, and the domain subquery aggregates the strongest role
+  // (editor > viewer) in SQL. Resolution order (#663) is applied in JS below.
+  //
+  // メンバーは大文字小文字を区別せず突合する（古い行や手動挿入を取りこぼさない）。
+  // email / domain が空ならサブクエリは何にも一致せず null を返す。
+  // Members match case-insensitively (covers legacy/manual rows). When the
+  // email/domain is empty the subqueries match nothing and yield null.
+  const rows = await db
+    .select({
+      ...getTableColumns(notes),
+      memberRole: sql<NoteMemberRole | null>`(
+        SELECT ${noteMembers.role} FROM ${noteMembers}
+        WHERE ${noteMembers.noteId} = ${noteId}
+          AND LOWER(${noteMembers.memberEmail}) = ${normalizedEmail}
+          AND ${noteMembers.isDeleted} = false
+          AND ${noteMembers.status} = 'accepted'
+        LIMIT 1
+      )`,
+      domainRole: sql<NoteMemberRole | null>`(
+        SELECT CASE
+          WHEN bool_or(${noteDomainAccess.role} = 'editor') THEN 'editor'
+          WHEN count(*) > 0 THEN 'viewer'
+          ELSE NULL
+        END
+        FROM ${noteDomainAccess}
+        WHERE ${noteDomainAccess.noteId} = ${noteId}
+          AND ${noteDomainAccess.domain} = ${domain}
+          AND ${noteDomainAccess.isDeleted} = false
+      )`,
+    })
+    .from(notes)
+    .where(and(eq(notes.id, noteId), eq(notes.isDeleted, false)))
+    .limit(1);
 
-    const firstMember = member[0];
-    if (firstMember) {
-      return { role: firstMember.role as NoteMemberRole, note };
-    }
+  const row = rows[0];
+  if (!row) return { role: null, note: null };
 
-    // ドメイン招待ルール: `user@EXAMPLE.com` のドメイン部 `example.com` で一致
-    // した最強ロールを返す（editor > viewer）。該当ルール削除は即反映するため
-    // キャッシュせず DB を都度引く。
-    //
-    // Domain rule: pick the strongest role (editor beats viewer) among active
-    // rules matching the caller's email domain. We always query live so that
-    // revoking a rule takes effect immediately.
-    const domain = extractEmailDomain(normalizedEmail);
-    if (domain) {
-      const rules = await db
-        .select({ role: noteDomainAccess.role })
-        .from(noteDomainAccess)
-        .where(
-          and(
-            eq(noteDomainAccess.noteId, noteId),
-            eq(noteDomainAccess.domain, domain),
-            eq(noteDomainAccess.isDeleted, false),
-          ),
-        );
+  const { memberRole, domainRole, ...note } = row;
 
-      if (rules.length > 0) {
-        const hasEditor = rules.some((r) => r.role === "editor");
-        return { role: hasEditor ? "editor" : "viewer", note };
-      }
-    }
-  }
-
+  // 1. owner
+  if (userId && note.ownerId === userId) return { role: "owner", note };
+  // 2. member（domain より強い: 明示的に昇格済み）/ member outranks domain
+  if (memberRole) return { role: memberRole, note };
+  // 3. domain access（editor > viewer は SQL 側で集約済み）/ domain rule
+  if (domainRole) return { role: domainRole, note };
+  // 4. visibility
   if (note.visibility === "public" || note.visibility === "unlisted") {
     return { role: "guest", note };
   }
-
+  // 5. none
   return { role: null, note };
 }
 

--- a/server/api/src/routes/notes/helpers.ts
+++ b/server/api/src/routes/notes/helpers.ts
@@ -182,21 +182,32 @@ export async function getNoteRole(
   // (editor > viewer) in SQL. Resolution order (#663) is applied in JS below.
   //
   // メンバーは大文字小文字を区別せず突合する（古い行や手動挿入を取りこぼさない）。
-  // email / domain が空ならサブクエリは何にも一致せず null を返す。
-  // Members match case-insensitively (covers legacy/manual rows). When the
-  // email/domain is empty the subqueries match nothing and yield null.
-  const rows = await db
-    .select({
-      ...getTableColumns(notes),
-      memberRole: sql<NoteMemberRole | null>`(
+  // email が無い場合は member サブクエリを実行せず NULL を返す。これにより
+  // `member_email = ''` の空メール行への偶発的一致で匿名アクセスが付与される
+  // のを防ぎ（旧実装は email 無し時に member/domain チェックを丸ごとスキップ
+  // していた）、不要なサブクエリ実行も避ける。domain も同様に抽出できなければ
+  // 実行しない。
+  //
+  // Members match case-insensitively (covers legacy/manual rows). When there is
+  // no email we emit a literal NULL instead of running the member subquery: this
+  // prevents an empty-string match against a blank `member_email` row from
+  // granting anonymous access (the previous implementation skipped member/domain
+  // checks entirely when the email was empty) and avoids a needless subquery.
+  // The domain subquery is likewise skipped when no domain can be extracted.
+  const memberRoleExpr =
+    normalizedEmail.length > 0
+      ? sql<NoteMemberRole | null>`(
         SELECT ${noteMembers.role} FROM ${noteMembers}
         WHERE ${noteMembers.noteId} = ${noteId}
           AND LOWER(${noteMembers.memberEmail}) = ${normalizedEmail}
           AND ${noteMembers.isDeleted} = false
           AND ${noteMembers.status} = 'accepted'
         LIMIT 1
-      )`,
-      domainRole: sql<NoteMemberRole | null>`(
+      )`
+      : sql<NoteMemberRole | null>`NULL`;
+
+  const domainRoleExpr = domain
+    ? sql<NoteMemberRole | null>`(
         SELECT CASE
           WHEN bool_or(${noteDomainAccess.role} = 'editor') THEN 'editor'
           WHEN count(*) > 0 THEN 'viewer'
@@ -206,7 +217,14 @@ export async function getNoteRole(
         WHERE ${noteDomainAccess.noteId} = ${noteId}
           AND ${noteDomainAccess.domain} = ${domain}
           AND ${noteDomainAccess.isDeleted} = false
-      )`,
+      )`
+    : sql<NoteMemberRole | null>`NULL`;
+
+  const rows = await db
+    .select({
+      ...getTableColumns(notes),
+      memberRole: memberRoleExpr,
+      domainRole: domainRoleExpr,
     })
     .from(notes)
     .where(and(eq(notes.id, noteId), eq(notes.isDeleted, false)))
@@ -220,9 +238,13 @@ export async function getNoteRole(
   // 1. owner
   if (userId && note.ownerId === userId) return { role: "owner", note };
   // 2. member（domain より強い: 明示的に昇格済み）/ member outranks domain
-  if (memberRole) return { role: memberRole, note };
+  //    email が無い呼び出しでは member ロールを採用しない（多層防御。SQL 側でも
+  //    サブクエリを実行しないが、空メール行による偶発的な権限付与を二重に防ぐ）。
+  //    Never honor a member role for an email-less caller (defense in depth: the
+  //    SQL also skips the subquery, but this double-guards against blank rows).
+  if (normalizedEmail.length > 0 && memberRole) return { role: memberRole, note };
   // 3. domain access（editor > viewer は SQL 側で集約済み）/ domain rule
-  if (domainRole) return { role: domainRole, note };
+  if (domain && domainRole) return { role: domainRole, note };
   // 4. visibility
   if (note.visibility === "public" || note.visibility === "unlisted") {
     return { role: "guest", note };

--- a/server/api/src/services/lintEngine/index.ts
+++ b/server/api/src/services/lintEngine/index.ts
@@ -13,6 +13,17 @@ import { runStaleRule } from "./rules/stale.js";
 export type { LintFindingCandidate, LintRuleResult } from "./types.js";
 
 /**
+ * 未解決 findings 取得時の防御的上限。バックログが膨大なユーザーでも、無制限の
+ * 結果セットをメモリに読み込まないようにするための安全弁（ページネーションでは
+ * なくハードキャップ）。通常の利用では到達しない十分大きな値を設定する。
+ *
+ * Defensive cap for unresolved-finding queries — a hard safety bound (not
+ * pagination) so a user with a large backlog cannot pull an unbounded result
+ * set into memory. Set high enough that normal usage never hits it.
+ */
+export const DEFAULT_LINT_FINDINGS_LIMIT = 500;
+
+/**
  * 全 Lint ルールを実行し、結果を lint_findings テーブルに保存する。
  * 実行前に未解決の findings をクリアし、最新の結果のみを保持する。
  *
@@ -86,7 +97,8 @@ export async function getUnresolvedFindings(ownerId: string, db: Database) {
     .select()
     .from(lintFindings)
     .where(and(eq(lintFindings.ownerId, ownerId), isNull(lintFindings.resolvedAt)))
-    .orderBy(lintFindings.createdAt);
+    .orderBy(lintFindings.createdAt)
+    .limit(DEFAULT_LINT_FINDINGS_LIMIT);
 }
 
 /**
@@ -109,7 +121,8 @@ export async function getFindingsForPage(ownerId: string, pageId: string, db: Da
         sql`${pageId} = ANY(${lintFindings.pageIds})`,
       ),
     )
-    .orderBy(lintFindings.createdAt);
+    .orderBy(lintFindings.createdAt)
+    .limit(DEFAULT_LINT_FINDINGS_LIMIT);
 }
 
 /**

--- a/server/hocuspocus/src/coalescePerKey.test.ts
+++ b/server/hocuspocus/src/coalescePerKey.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import { coalescePerKey } from "./coalescePerKey.js";
+
+/** Promise を外部から解決できるようにする小さなヘルパー。 */
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("coalescePerKey", () => {
+  it("同一キーが in-flight の間は worker を多重起動しない", async () => {
+    const gate = deferred();
+    const worker = vi.fn(async (_key: string) => {
+      await gate.promise;
+    });
+    const run = coalescePerKey(worker);
+
+    // 1 回目: in-flight になる
+    const first = run("page-1");
+    // in-flight 中の追加呼び出しは新規 worker を起動しない
+    run("page-1");
+    run("page-1");
+
+    expect(worker).toHaveBeenCalledTimes(1);
+
+    // in-flight を解決すると、保留分をまとめて 1 回だけ追走させる
+    gate.resolve();
+    await first;
+    // マイクロタスクを進めて trailing 実行を反映
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(worker).toHaveBeenCalledTimes(2);
+  });
+
+  it("異なるキーは独立して並行実行される", async () => {
+    const worker = vi.fn(async (_key: string) => {});
+    const run = coalescePerKey(worker);
+
+    await Promise.all([run("a"), run("b"), run("c")]);
+
+    expect(worker).toHaveBeenCalledTimes(3);
+    expect(worker).toHaveBeenCalledWith("a");
+    expect(worker).toHaveBeenCalledWith("b");
+    expect(worker).toHaveBeenCalledWith("c");
+  });
+
+  it("in-flight 中に追加要求が無ければ追走しない", async () => {
+    const worker = vi.fn(async (_key: string) => {});
+    const run = coalescePerKey(worker);
+
+    await run("page-1");
+    await run("page-1");
+
+    // 連続だが各々 in-flight 期間に重ならないため、それぞれ 1 回ずつ
+    expect(worker).toHaveBeenCalledTimes(2);
+  });
+
+  it("worker が reject しても以降の実行を阻害しない", async () => {
+    const worker = vi
+      .fn<(key: string) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValue(undefined);
+    const run = coalescePerKey(worker);
+
+    await run("page-1");
+    await run("page-1");
+
+    expect(worker).toHaveBeenCalledTimes(2);
+  });
+
+  it("trailing 実行は最新要求 1 件分のみに集約される", async () => {
+    const gate = deferred();
+    let calls = 0;
+    const worker = vi.fn(async (_key: string) => {
+      calls += 1;
+      if (calls === 1) await gate.promise;
+    });
+    const run = coalescePerKey(worker);
+
+    const first = run("page-1");
+    // in-flight 中に 5 回要求しても trailing は 1 回に集約
+    for (let i = 0; i < 5; i++) run("page-1");
+
+    gate.resolve();
+    await first;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(worker).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/hocuspocus/src/coalescePerKey.ts
+++ b/server/hocuspocus/src/coalescePerKey.ts
@@ -1,0 +1,50 @@
+/**
+ * 非同期 worker をキー単位でコアレッシングするラッパーを生成する。
+ *
+ * あるキーの worker が in-flight の間に同じキーで再度呼び出された場合、
+ * 新たな worker は起動せず「追走フラグ」だけを立てる。in-flight が完了した
+ * 時点でフラグが立っていれば、最新状態を取り込むために worker をもう一度
+ * だけ実行する。これにより、1 キーあたり「実行中 1 + 待機 1」を上限として
+ * バースト（例: 連続保存ごとのグラフ再構築 HTTP）を間引く。
+ *
+ * Wraps an async worker so calls are coalesced per key. While a worker for a
+ * key is in flight, additional calls for the same key do not spawn another
+ * worker — they only set a trailing flag. When the in-flight run settles, a
+ * single trailing run is issued if any call arrived meanwhile, so the latest
+ * state is still picked up. This caps concurrency at one in-flight + one
+ * queued run per key, collapsing bursts (e.g. graph-sync HTTP per save).
+ *
+ * worker の reject はラッパー内で握りつぶし、以降の実行を阻害しない。
+ * Worker rejections are swallowed so they never block later runs.
+ */
+export function coalescePerKey(
+  worker: (key: string) => Promise<void>,
+): (key: string) => Promise<void> {
+  const inFlight = new Set<string>();
+  const pending = new Set<string>();
+
+  async function run(key: string): Promise<void> {
+    if (inFlight.has(key)) {
+      // 既に実行中: 追走フラグだけ立てて即返す。
+      pending.add(key);
+      return;
+    }
+
+    inFlight.add(key);
+    try {
+      await worker(key);
+    } catch {
+      // ベストエフォート: worker 側でログ済み想定。ここでは握りつぶす。
+    } finally {
+      inFlight.delete(key);
+    }
+
+    if (pending.has(key)) {
+      pending.delete(key);
+      // 最新状態を取り込むためにもう一度だけ実行する。
+      await run(key);
+    }
+  }
+
+  return run;
+}

--- a/server/hocuspocus/src/index.ts
+++ b/server/hocuspocus/src/index.ts
@@ -19,6 +19,7 @@ import {
 } from "./pageEditPermission.js";
 import { maybeCreateSnapshot } from "./snapshotUtils.js";
 import { applyWikiLinkMarksToYDoc } from "./ydocWikiLinkNormalizer.js";
+import { coalescePerKey } from "./coalescePerKey.js";
 
 const PORT = parseInt(process.env.PORT || "1234", 10);
 const REDIS_URL = process.env.REDIS_URL;
@@ -406,7 +407,7 @@ async function saveDocumentToDb(pageId: string, document: Y.Doc): Promise<void> 
   // Issue #880 Phase C: rebuild outgoing edges (links / ghost_links) via the
   // API's internal endpoint after persisting the document. Best-effort — a
   // failure does not roll back the content save.
-  void triggerGraphSync(pageId).catch((error) => {
+  void triggerGraphSyncCoalesced(pageId).catch((error) => {
     console.error(`[GraphSync] Failed to trigger graph sync for page ${pageId}:`, error);
   });
 }
@@ -472,6 +473,16 @@ async function triggerGraphSync(pageId: string): Promise<void> {
     console.warn(`[GraphSync] Request failed for page ${pageId}:`, error);
   }
 }
+
+/**
+ * ページ単位でコアレッシングしたグラフ同期トリガ。連続保存で in-flight が
+ * 重なっても、1 ページあたり「実行中 1 + 待機 1」に収束させて重複 HTTP を抑える。
+ *
+ * Per-page coalesced graph-sync trigger so overlapping saves collapse to at
+ * most one in-flight + one queued request per page instead of spawning a new
+ * HTTP call on every save.
+ */
+const triggerGraphSyncCoalesced = coalescePerKey(triggerGraphSync);
 
 function parseRedisOptions(redisUrl: string): Record<string, unknown> {
   const parsed = new URL(redisUrl);

--- a/src/components/editor/TiptapEditor/useEditorSetup.ts
+++ b/src/components/editor/TiptapEditor/useEditorSetup.ts
@@ -18,7 +18,21 @@ import type { TagSuggestionHandle } from "../extensions/TagSuggestion";
 import type { SlashSuggestionHandle } from "./SlashSuggestionLayer";
 import { createEditorExtensions, defaultEditorProps } from "./editorConfig";
 import type { TiptapEditorProps } from "./types";
+import { useDebouncedCallback } from "@/hooks/useDebouncedCallback";
 import i18n from "@/i18n";
+
+/**
+ * `onChange` を発火するまでの待機時間（ms）。連続入力中の document 全体の
+ * `JSON.stringify` と親コンポーネントの再レンダリングを 1 タイプごとから
+ * 入力が落ち着いたタイミングへ間引く。本文の永続化は協調編集 (Yjs) 経由で
+ * 別途行われるため、この遅延は派生用途（AI 文脈・エクスポート）にのみ影響する。
+ *
+ * Debounce window (ms) before emitting `onChange`. Collapses the per-keystroke
+ * full-document `JSON.stringify` + parent re-render into one fire after typing
+ * settles. Content persistence happens separately via Yjs collaboration, so
+ * this delay only affects derived consumers (AI context, export).
+ */
+const CONTENT_CHANGE_DEBOUNCE_MS = 300;
 
 /**
  * Keeps latest `workspaceRoot` in a ref without re-running `useEditor` (Issue #461).
@@ -164,6 +178,15 @@ export function useEditorSetup(options: UseEditorSetupOptions) {
   const workspaceRootRef = useWorkspaceRootRef(workspaceRoot);
   const noteIdRef = useNoteIdRef(noteId);
 
+  // 入力が落ち着いてから最新の document を一度だけシリアライズして通知する。
+  // editorRef は常に最新エディタを指すため、debounce 発火時点の内容を読む。
+  // Serialize the latest document once after typing settles. `editorRef`
+  // always points at the current editor, so we read its content at fire time.
+  const emitContentChange = useDebouncedCallback(() => {
+    const ed = editorRef.current;
+    if (ed) onChange(JSON.stringify(ed.getJSON()));
+  }, CONTENT_CHANGE_DEBOUNCE_MS);
+
   const editor = useEditor(
     {
       /* eslint-disable react-hooks/refs -- createEditorExtensions runs at render but refs are only read in ProseMirror/Tiptap handlers (not during render) */
@@ -237,7 +260,7 @@ export function useEditorSetup(options: UseEditorSetupOptions) {
           if (JSON.stringify(editor.getJSON()).length <= 50) return;
           isEditorInitializedRef.current = true;
         }
-        onChange(JSON.stringify(editor.getJSON()));
+        emitContentChange();
       },
       onCreate: () => {
         if (initialParsedContent) isEditorInitializedRef.current = true;

--- a/src/components/editor/extensions/WikiLinkSuggestion.tsx
+++ b/src/components/editor/extensions/WikiLinkSuggestion.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useImperativeHandle, useState, useCallback } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useState, useCallback, useMemo } from "react";
 import { cn } from "@zedi/ui";
 import { FileText, Plus } from "lucide-react";
 
@@ -99,8 +99,10 @@ export const WikiLinkSuggestion = forwardRef<WikiLinkSuggestionHandle, WikiLinkS
   ({ query, onSelect, onClose, pages }, ref) => {
     const [selectedIndex, setSelectedIndex] = useState(0);
 
-    // Get matching pages
-    const getItems = useCallback((): SuggestionItem[] => {
+    // Get matching pages. メモ化して query / pages が変わったときだけ再計算する。
+    // Memoized so the O(n) filter/sort only runs when query or pages change,
+    // not on every render (e.g. selectedIndex updates while navigating).
+    const items = useMemo<SuggestionItem[]>(() => {
       const normalizedQuery = query.toLowerCase().trim();
 
       // Get existing pages that match
@@ -118,20 +120,18 @@ export const WikiLinkSuggestion = forwardRef<WikiLinkSuggestionHandle, WikiLinkS
         (p) => !p.isDeleted && p.title.toLowerCase() === normalizedQuery,
       );
 
-      const items: SuggestionItem[] = [...matchingPages];
+      const nextItems: SuggestionItem[] = [...matchingPages];
 
       if (query.trim() && !exactMatch) {
-        items.push({
+        nextItems.push({
           id: "create-new",
           title: query.trim(),
           exists: false,
         });
       }
 
-      return items;
+      return nextItems;
     }, [query, pages]);
-
-    const items = getItems();
 
     // Reset selection when items change
     useEffect(() => {

--- a/src/components/settings/McpServerSettings.tsx
+++ b/src/components/settings/McpServerSettings.tsx
@@ -22,8 +22,14 @@ import { isValidMcpServerConfig, normalizeImportedConfig } from "@/lib/mcpServer
 export const McpServerSettings: React.FC = () => {
   const { t } = useTranslation();
   const { toast } = useToast();
-  const { servers, addServer, removeServer, updateServer, toggleServer, importServers } =
-    useMcpConfigStore();
+  // 個別セレクタで購読し、servers 変更時のみ再レンダリングする（アクションは安定参照）。
+  // Subscribe via individual selectors so only `servers` changes trigger a re-render.
+  const servers = useMcpConfigStore((s) => s.servers);
+  const addServer = useMcpConfigStore((s) => s.addServer);
+  const removeServer = useMcpConfigStore((s) => s.removeServer);
+  const updateServer = useMcpConfigStore((s) => s.updateServer);
+  const toggleServer = useMcpConfigStore((s) => s.toggleServer);
+  const importServers = useMcpConfigStore((s) => s.importServers);
 
   const [formOpen, setFormOpen] = useState(false);
   const [formSessionKey, setFormSessionKey] = useState(0);

--- a/src/contexts/AIChatContext.tsx
+++ b/src/contexts/AIChatContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useRef, useContext, useState, type ReactNode } from "react";
+import { createContext, useRef, useContext, useState, useMemo, type ReactNode } from "react";
 import { PageContext } from "../types/aiChat";
 
 interface AIChatContextValue {
@@ -24,18 +24,20 @@ export function AIChatProvider({ children }: { children: ReactNode }) {
   const contentAppendHandlerRef = useRef<((nextContent: string) => void) | null>(null);
   const insertAtCursorRef = useRef<((markdown: string) => boolean) | null>(null);
 
-  return (
-    <AIChatContext.Provider
-      value={{
-        pageContext,
-        setPageContext,
-        contentAppendHandlerRef,
-        insertAtCursorRef,
-      }}
-    >
-      {children}
-    </AIChatContext.Provider>
+  // value をメモ化し、pageContext が変わったときだけ参照を更新する。
+  // Memoize the context value so descendants only re-render when pageContext
+  // actually changes (refs and setPageContext are stable across renders).
+  const value = useMemo<AIChatContextValue>(
+    () => ({
+      pageContext,
+      setPageContext,
+      contentAppendHandlerRef,
+      insertAtCursorRef,
+    }),
+    [pageContext],
   );
+
+  return <AIChatContext.Provider value={value}>{children}</AIChatContext.Provider>;
 }
 
 /**

--- a/src/contexts/GlobalSearchContext.tsx
+++ b/src/contexts/GlobalSearchContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { useGlobalSearch } from "@/hooks/useGlobalSearch";
 import type { GlobalSearchResultItem } from "@/hooks/useGlobalSearch";
@@ -87,18 +87,35 @@ export function GlobalSearchProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const value: GlobalSearchContextValue = {
-    query,
-    setQuery,
-    searchResults,
-    hasQuery,
-    handleSelect,
-    handleSearchSubmit,
-    focusSearchInput,
-    isOpen,
-    open,
-    close,
-  };
+  // value をメモ化し、検索状態が変わったときだけ参照を更新する。
+  // Memoize so consumers re-render only when the underlying search state
+  // changes, not on every Provider render (callbacks are already stable).
+  const value = useMemo<GlobalSearchContextValue>(
+    () => ({
+      query,
+      setQuery,
+      searchResults,
+      hasQuery,
+      handleSelect,
+      handleSearchSubmit,
+      focusSearchInput,
+      isOpen,
+      open,
+      close,
+    }),
+    [
+      query,
+      setQuery,
+      searchResults,
+      hasQuery,
+      handleSelect,
+      handleSearchSubmit,
+      focusSearchInput,
+      isOpen,
+      open,
+      close,
+    ],
+  );
 
   return <GlobalSearchContext.Provider value={value}>{children}</GlobalSearchContext.Provider>;
 }

--- a/src/contexts/HeaderActionsContext.tsx
+++ b/src/contexts/HeaderActionsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
 
 /**
  * 共通ヘッダーの中央スロットに、ページ固有のアクションをポータル風に
@@ -42,12 +42,18 @@ export function HeaderActionsProvider({ children }: { children: ReactNode }) {
   const setLeftSlot = useCallback((el: HTMLElement | null) => setLeftSlotState(el), []);
   const setRightSlot = useCallback((el: HTMLElement | null) => setRightSlotState(el), []);
 
-  const value: HeaderActionsContextValue = {
-    leftSlot,
-    rightSlot,
-    setLeftSlot,
-    setRightSlot,
-  };
+  // value をメモ化し、スロット要素が変わったときだけ参照を更新する。
+  // Memoize so consumers only re-render when a slot element actually changes
+  // (the setters are stable via useCallback).
+  const value = useMemo<HeaderActionsContextValue>(
+    () => ({
+      leftSlot,
+      rightSlot,
+      setLeftSlot,
+      setRightSlot,
+    }),
+    [leftSlot, rightSlot, setLeftSlot, setRightSlot],
+  );
 
   return <HeaderActionsContext.Provider value={value}>{children}</HeaderActionsContext.Provider>;
 }


### PR DESCRIPTION
## 概要

`getNoteRole` を複数の独立クエリから単一の相関サブクエリベースのクエリに最適化し、DB 往復を 3 回から 1 回に削減します。同時に、複数の React Context で value オブジェクトをメモ化し、不要な再レンダリングを防ぎます。

## 変更点

### API サーバー (`server/api/src`)

- **`routes/notes/helpers.ts`**: `getNoteRole` を再実装
  - note 行・メンバーロール・ドメインロールを 1 クエリ（相関サブクエリ）で取得
  - メンバーロール取得を相関サブクエリに統合（case-insensitive email マッチ）
  - ドメインロール取得を相関サブクエリに統合し、SQL 側で最強ロール（editor > viewer）を集約
  - 優先順位（owner > member > domain > visibility > none）を JS 側で適用
  - `getTableColumns` を使用して note 列をフラットに展開

- **`__tests__/routes/notes/helpers.test.ts`**: テストを新クエリ形式に対応
  - `mockRoleRow()` ヘルパーを追加（combined 行を組み立て）
  - 各テストを単一 DB スロット消費に更新
  - 「複数ドメインルール」「大文字小文字マッチ」テストを削除（SQL 側で処理済み）
  - 「unlisted visibility」テストを追加

- **`services/lintEngine/index.ts`**: 防御的上限を追加
  - `DEFAULT_LINT_FINDINGS_LIMIT = 500` を定義
  - `getUnresolvedFindings` と `getFindingsForPage` に `.limit()` を適用
  - バックログが膨大なユーザーでも無制限の結果セットをメモリに読み込まない安全弁

- **`__tests__/services/lintFindings.test.ts`**: 新規テスト
  - findings クエリが防御的 LIMIT を適用することを検証

- **`__tests__/routes/notes/search.test.ts`** / **`__tests__/routes/pageSnapshots.test.ts`** / **`__tests__/services/pageAccessService.test.ts`**: モック DB スロットを更新
  - `getNoteRole` が 1 クエリで note + memberRole/domainRole を返すように調整

### Hocuspocus サーバー (`server/hocuspocus/src`)

- **`coalescePerKey.ts`**: 新規ユーティリティ
  - 非同期 worker をキー単位でコアレッシングするラッパー
  - in-flight 中の重複呼び出しを「追走フラグ」に集約
  - バースト（連続保存ごとのグラフ再構築 HTTP）を間引く

- **`coalescePerKey.test.ts`**: 新規テスト
  - 同一キーの多重起動防止
  - 異なるキーの並行実行
  - trailing 実行の集約
  - エラーハンドリング

- **`index.ts`**: グラフ同期トリガを最適化
  - `triggerGraphSyncCoalesced` を追加（`coalescePerKey` でラップ）
  - `saveDocumentToDb` から呼び出し

### React フロントエンド (`src`)

- **`contexts

https://claude.ai/code/session_01XgbeNj9c8fk6Tyg1JgioDU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Single-step note access resolution; lint findings queries capped at 500; per-page graph-sync coalescing; debounced editor change events; memoized contexts/selectors to reduce re-renders.

* **Bug Fixes**
  * Tightened access-role precedence and visibility behavior, including email-related edge-case handling for private notes and consistent search/snapshot access checks.

* **Tests**
  * Updated and added tests covering role-resolution, search/snapshot access, lint-findings limits, and per-key coalescing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/zedi/pull/997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->