### PR TITLE
perf(web): 検索結果の仮想化とメッセージ/Lint の描画コスト削減

### DIFF
--- a/src/components/ai-chat/AIChatMessage.tsx
+++ b/src/components/ai-chat/AIChatMessage.tsx
@@ -6,7 +6,7 @@ import { ChatMessage, ChatAction } from "../../types/aiChat";
 import { getDisplayContent } from "../../lib/aiChatActions";
 import { AIChatActionCard } from "./AIChatActionCard";
 import { AIChatWikiLink } from "./AIChatWikiLink";
-import { UserMessageBubble, renderUserContent } from "./AIChatUserMessageBubble";
+import { UserMessageBubble, UserMessageContent } from "./AIChatUserMessageBubble";
 import { CodeBlockWithCopy } from "./AIChatCodeBlock";
 import { replaceWikiLinksInMarkdown } from "./aiChatMarkdownHelpers";
 import ReactMarkdown from "react-markdown";
@@ -101,7 +101,10 @@ export function AIChatMessage({
               isStreaming={isStreaming}
             />
           ) : isUser ? (
-            renderUserContent(displayContent, message.referencedPages)
+            <UserMessageContent
+              content={displayContent}
+              referencedPages={message.referencedPages}
+            />
           ) : message.isStreaming && displayContent === "" ? (
             <AIChatMessageSkeleton />
           ) : (

--- a/src/components/ai-chat/AIChatUserMessageBubble.test.tsx
+++ b/src/components/ai-chat/AIChatUserMessageBubble.test.tsx
@@ -31,6 +31,30 @@ describe("UserMessageContent", () => {
     expect(screen.getByText(/and/)).toBeInTheDocument();
   });
 
+  it("ignores empty-title referenced pages without breaking on bare @", () => {
+    const { container } = render(
+      <UserMessageContent
+        content="ping @bob @Alpha"
+        referencedPages={[
+          { id: "empty", title: "" },
+          { id: "a", title: "Alpha" },
+        ]}
+      />,
+    );
+
+    // 空タイトルは除外され、@ 単体や @bob は誤ってバッジ化されない。
+    expect(screen.getByText("Alpha").tagName).toBe("SPAN");
+    expect(container.textContent).toContain("ping @bob ");
+  });
+
+  it("renders plain text when every referenced page has an empty title", () => {
+    const { container } = render(
+      <UserMessageContent content="hi @x" referencedPages={[{ id: "1", title: "" }]} />,
+    );
+    expect(container.textContent).toBe("hi @x");
+    expect(container.querySelector("span")).toBeNull();
+  });
+
   it("prefers the longest matching title for overlapping prefixes", () => {
     render(
       <UserMessageContent

--- a/src/components/ai-chat/AIChatUserMessageBubble.test.tsx
+++ b/src/components/ai-chat/AIChatUserMessageBubble.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { UserMessageContent } from "./AIChatUserMessageBubble";
+
+describe("UserMessageContent", () => {
+  it("renders plain text when there are no referenced pages", () => {
+    const { container } = render(<UserMessageContent content="hello @World" />);
+    // バッジ化されず、生テキストとして表示される。
+    expect(container.textContent).toBe("hello @World");
+    expect(container.querySelector("span")).toBeNull();
+  });
+
+  it("renders @PageTitle as an inline badge when referenced", () => {
+    render(
+      <UserMessageContent
+        content="see @Alpha and @Beta here"
+        referencedPages={[
+          { id: "a", title: "Alpha" },
+          { id: "b", title: "Beta" },
+        ]}
+      />,
+    );
+
+    // バッジ化された参照ページが表示される。
+    const alpha = screen.getByText("Alpha");
+    const beta = screen.getByText("Beta");
+    expect(alpha.tagName).toBe("SPAN");
+    expect(beta.tagName).toBe("SPAN");
+    // 周囲のプレーンテキストも保持される。
+    expect(screen.getByText(/see/)).toBeInTheDocument();
+    expect(screen.getByText(/and/)).toBeInTheDocument();
+  });
+
+  it("prefers the longest matching title for overlapping prefixes", () => {
+    render(
+      <UserMessageContent
+        content="@AI Chat done"
+        referencedPages={[
+          { id: "1", title: "AI" },
+          { id: "2", title: "AI Chat" },
+        ]}
+      />,
+    );
+
+    // 長いタイトル優先で "AI Chat" 全体が 1 つのバッジになる。
+    expect(screen.getByText("AI Chat").tagName).toBe("SPAN");
+    expect(screen.queryByText("AI", { exact: true })).toBeNull();
+  });
+});

--- a/src/components/ai-chat/AIChatUserMessageBubble.tsx
+++ b/src/components/ai-chat/AIChatUserMessageBubble.tsx
@@ -37,7 +37,15 @@ export const UserMessageContent = memo(function UserMessageContent({
   const parsed = useMemo(() => {
     if (!referencedPages || referencedPages.length === 0) return null;
 
-    const sortedPages = [...referencedPages].sort((a, b) => b.title.length - a.title.length);
+    // 空タイトルは除外する。残すと `escapedTitles.join("|")` に空の選択肢が入り、
+    // `@(?:Alpha|)` のように `@` 単体へ無条件マッチして表示が崩れるため。
+    // Drop empty titles: otherwise `escapedTitles.join("|")` yields an empty
+    // alternative (e.g. `@(?:Alpha|)`) that matches a bare `@` and breaks rendering.
+    const sortedPages = [...referencedPages]
+      .filter((p) => p.title.trim() !== "")
+      .sort((a, b) => b.title.length - a.title.length);
+    if (sortedPages.length === 0) return null;
+
     const titleToPage = new Map(sortedPages.map((p) => [`@${p.title}`, p]));
     const escapedTitles = sortedPages.map((p) => p.title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
     // Allow boundary after @Title: whitespace, end, or punctuation (e.g. @AI Chat, @ページ。)

--- a/src/components/ai-chat/AIChatUserMessageBubble.tsx
+++ b/src/components/ai-chat/AIChatUserMessageBubble.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, useCallback } from "react";
+import React, { useRef, useState, useEffect, useCallback, useMemo, memo } from "react";
 import { useTranslation } from "react-i18next";
 import { FileText } from "lucide-react";
 import type { ReferencedPage } from "../../types/aiChat";
@@ -16,23 +16,43 @@ export interface UserMessageBubbleProps {
   isStreaming: boolean;
 }
 
-/** Render user message content with inline @PageTitle styled as badges */
-export function renderUserContent(content: string, referencedPages?: ReferencedPage[]) {
-  if (!referencedPages || referencedPages.length === 0) {
+/**
+ * Render user message content with inline @PageTitle styled as badges.
+ *
+ * `referencedPages` をキーに sort/map/RegExp/split の構築を `useMemo` 化し、
+ * `memo` で props 不変時の再 render を抑える。会話が長くなるほど毎 render の
+ * 正規表現再構築が累積していたのを避ける（issue #1000 Item 2）。
+ *
+ * Memoizes the sort/map/RegExp/split work on `referencedPages` and wraps the
+ * component in `memo`, avoiding the per-render regex rebuild that accumulated
+ * as conversations grew (issue #1000 Item 2).
+ */
+export const UserMessageContent = memo(function UserMessageContent({
+  content,
+  referencedPages,
+}: {
+  content: string;
+  referencedPages?: ReferencedPage[];
+}) {
+  const parsed = useMemo(() => {
+    if (!referencedPages || referencedPages.length === 0) return null;
+
+    const sortedPages = [...referencedPages].sort((a, b) => b.title.length - a.title.length);
+    const titleToPage = new Map(sortedPages.map((p) => [`@${p.title}`, p]));
+    const escapedTitles = sortedPages.map((p) => p.title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+    // Allow boundary after @Title: whitespace, end, or punctuation (e.g. @AI Chat, @ページ。)
+    const pattern = new RegExp(`(@(?:${escapedTitles.join("|")}))(?=[\\s\\p{P}\\p{S}]|$)`, "gu");
+    return { titleToPage, parts: content.split(pattern) };
+  }, [content, referencedPages]);
+
+  if (!parsed) {
     return <div className="break-words whitespace-pre-wrap">{content}</div>;
   }
 
-  const sortedPages = [...referencedPages].sort((a, b) => b.title.length - a.title.length);
-  const titleToPage = new Map(sortedPages.map((p) => [`@${p.title}`, p]));
-  const escapedTitles = sortedPages.map((p) => p.title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
-  // Allow boundary after @Title: whitespace, end, or punctuation (e.g. @AI Chat, @ページ。)
-  const pattern = new RegExp(`(@(?:${escapedTitles.join("|")}))(?=[\\s\\p{P}\\p{S}]|$)`, "gu");
-  const parts = content.split(pattern);
-
   return (
     <div className="break-words whitespace-pre-wrap">
-      {parts.map((part, i) => {
-        const matchedRef = titleToPage.get(part);
+      {parsed.parts.map((part, i) => {
+        const matchedRef = parsed.titleToPage.get(part);
         if (matchedRef) {
           return (
             <span
@@ -48,7 +68,7 @@ export function renderUserContent(content: string, referencedPages?: ReferencedP
       })}
     </div>
   );
-}
+});
 
 /**
  *
@@ -251,7 +271,7 @@ export function UserMessageBubble({
       onPointerLeave={canEdit ? handlePointerUp : undefined}
       onPointerCancel={canEdit ? handlePointerCancel : undefined}
     >
-      {renderUserContent(content, referencedPages)}
+      <UserMessageContent content={content} referencedPages={referencedPages} />
     </div>
   );
 }

--- a/src/components/layout/Header/HeaderSearchBar.tsx
+++ b/src/components/layout/Header/HeaderSearchBar.tsx
@@ -88,7 +88,6 @@ export function HeaderSearchBar() {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
-  const listRef = useRef<HTMLUListElement>(null);
   const footerRef = useRef<HTMLButtonElement>(null);
 
   const handleShortcutFocus = useCallback(() => {
@@ -111,13 +110,15 @@ export function HeaderSearchBar() {
     queueMicrotask(() => setActiveIndex(-1));
   }, [query]);
 
+  // footer 行のスクロール追従のみ親で担当する。結果リストは仮想化済みで
+  // off-screen 行が DOM に無いため、リスト側の追従は HeaderSearchDropdownContent
+  // が `virtualizer.scrollToIndex` で行う。
+  // The parent only scrolls the footer row into view. The result list is
+  // virtualized (off-screen rows are not in the DOM), so its scroll-into-view
+  // is handled inside HeaderSearchDropdownContent via `scrollToIndex`.
   useEffect(() => {
-    if (activeIndex === -1) return;
     if (activeIndex === itemCount) {
       footerRef.current?.scrollIntoView({ block: "nearest" });
-    } else {
-      const items = listRef.current?.querySelectorAll("[role='option']");
-      items?.[activeIndex]?.scrollIntoView({ block: "nearest" });
     }
   }, [activeIndex, itemCount]);
 
@@ -195,7 +196,6 @@ export function HeaderSearchBar() {
         activeIndex={activeIndex}
         query={query}
         hasQuery={hasQuery}
-        listRef={listRef}
         footerRef={footerRef}
         getOptionId={getOptionId}
         onSelectItem={onSelectItem}

--- a/src/components/layout/Header/HeaderSearchDropdownContent.test.tsx
+++ b/src/components/layout/Header/HeaderSearchDropdownContent.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Popover, PopoverAnchor } from "@zedi/ui";
+import type { GlobalSearchResultItem } from "@/hooks/useGlobalSearch";
+
+// ─── 仮想化のモック ────────────────────────────────────────────────
+// jsdom はレイアウトを行わずスクロール要素の高さが 0 になるため、PageGrid.test.tsx
+// と同じく `useVirtualizer` を決定的な window にモックして仮想化レンダリングだけ
+// を検証する。`scrollToIndex` も呼ばれるのでスタブに含める。
+// jsdom does no layout, so mock `useVirtualizer` with a deterministic window
+// (mirroring PageGrid.test.tsx) and stub `scrollToIndex`.
+const VIRTUAL_ROW_HEIGHT = 40;
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, i) => ({
+        index: i,
+        key: `row-${i}`,
+        start: i * VIRTUAL_ROW_HEIGHT,
+        size: VIRTUAL_ROW_HEIGHT,
+        end: (i + 1) * VIRTUAL_ROW_HEIGHT,
+        lane: 0,
+      })),
+    getTotalSize: () => count * VIRTUAL_ROW_HEIGHT,
+    scrollToIndex: vi.fn(),
+    measure: vi.fn(),
+    measureElement: vi.fn(),
+  }),
+}));
+
+import { HeaderSearchDropdownContent } from "./HeaderSearchDropdownContent";
+
+function makeResults(n: number): GlobalSearchResultItem[] {
+  return Array.from({ length: n }, (_, i) => ({
+    kind: "page",
+    pageId: `page-${i}`,
+    noteId: `note-${i}`,
+    title: `Result ${i}`,
+    highlightedText: "",
+    matchType: "title",
+  })) as unknown as GlobalSearchResultItem[];
+}
+
+function renderDropdown(
+  overrides: Partial<Parameters<typeof HeaderSearchDropdownContent>[0]> = {},
+) {
+  const searchResults = overrides.searchResults ?? makeResults(3);
+  const onSelectItem = vi.fn();
+  const setActiveIndex = vi.fn();
+  const props: Parameters<typeof HeaderSearchDropdownContent>[0] = {
+    hasContent: true,
+    showEmpty: false,
+    showResults: searchResults.length > 0,
+    searchResults,
+    itemCount: searchResults.length,
+    activeIndex: -1,
+    query: "result",
+    hasQuery: true,
+    footerRef: { current: null },
+    getOptionId: (index: number) =>
+      index === searchResults.length ? "header-search-footer" : `header-search-option-${index}`,
+    onSelectItem,
+    setActiveIndex,
+    closeDropdown: vi.fn(),
+    handleSearchSubmit: vi.fn(),
+    ...overrides,
+  };
+  // PopoverContent は Radix の Popover コンテキストを要求するため、open な
+  // Popover でラップする。
+  render(
+    <Popover open>
+      <PopoverAnchor />
+      <HeaderSearchDropdownContent {...props} />
+    </Popover>,
+  );
+  return { onSelectItem, setActiveIndex, props };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("HeaderSearchDropdownContent", () => {
+  it("renders result options with stable ids and aria-selected for the active row", () => {
+    renderDropdown({ activeIndex: 1 });
+
+    const options = screen.getAllByRole("option");
+    // 3 件の結果 + footer の「すべて表示」行
+    expect(options).toHaveLength(4);
+
+    expect(screen.getByText("Result 0").closest("button")).toHaveAttribute(
+      "id",
+      "header-search-option-0",
+    );
+    expect(screen.getByText("Result 1").closest("button")).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("Result 0").closest("button")).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+  });
+
+  it("calls onSelectItem when an option is clicked", () => {
+    const { onSelectItem, props } = renderDropdown();
+    fireEvent.click(screen.getByText("Result 2"));
+    expect(onSelectItem).toHaveBeenCalledWith(props.searchResults[2]);
+  });
+
+  it("updates the active index on mouse enter", () => {
+    const { setActiveIndex } = renderDropdown();
+    fireEvent.mouseEnter(screen.getByText("Result 1"));
+    expect(setActiveIndex).toHaveBeenCalledWith(1);
+  });
+
+  it("renders the show-all footer when there is a query", () => {
+    renderDropdown();
+    expect(screen.getByText(/の検索結果をすべて表示/)).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/Header/HeaderSearchDropdownContent.test.tsx
+++ b/src/components/layout/Header/HeaderSearchDropdownContent.test.tsx
@@ -11,6 +11,12 @@ import type { GlobalSearchResultItem } from "@/hooks/useGlobalSearch";
 // (mirroring PageGrid.test.tsx) and stub `scrollToIndex`.
 const VIRTUAL_ROW_HEIGHT = 40;
 
+// scrollToIndex はレンダーをまたいで参照を保つよう module スコープに置き、
+// マウスホバー時に呼ばれない／キーボード追従時に呼ばれることを検証する。
+// Hoisted so the same spy persists across renders, to assert hover does not
+// scroll while keyboard navigation does.
+const scrollToIndexMock = vi.hoisted(() => vi.fn());
+
 vi.mock("@tanstack/react-virtual", () => ({
   useVirtualizer: ({ count }: { count: number }) => ({
     getVirtualItems: () =>
@@ -23,7 +29,7 @@ vi.mock("@tanstack/react-virtual", () => ({
         lane: 0,
       })),
     getTotalSize: () => count * VIRTUAL_ROW_HEIGHT,
-    scrollToIndex: vi.fn(),
+    scrollToIndex: scrollToIndexMock,
     measure: vi.fn(),
     measureElement: vi.fn(),
   }),
@@ -68,13 +74,19 @@ function renderDropdown(
   };
   // PopoverContent は Radix の Popover コンテキストを要求するため、open な
   // Popover でラップする。
-  render(
+  const ui = (p: Parameters<typeof HeaderSearchDropdownContent>[0]) => (
     <Popover open>
       <PopoverAnchor />
-      <HeaderSearchDropdownContent {...props} />
-    </Popover>,
+      <HeaderSearchDropdownContent {...p} />
+    </Popover>
   );
-  return { onSelectItem, setActiveIndex, props };
+  const { rerender } = render(ui(props));
+  return {
+    onSelectItem,
+    setActiveIndex,
+    props,
+    rerenderWith: (next: Partial<typeof props>) => rerender(ui({ ...props, ...next })),
+  };
 }
 
 beforeEach(() => {
@@ -115,5 +127,22 @@ describe("HeaderSearchDropdownContent", () => {
   it("renders the show-all footer when there is a query", () => {
     renderDropdown();
     expect(screen.getByText(/の検索結果をすべて表示/)).toBeInTheDocument();
+  });
+
+  it("follows the active row with scrollToIndex on keyboard navigation", () => {
+    const { rerenderWith } = renderDropdown({ activeIndex: -1 });
+    scrollToIndexMock.mockClear();
+    // キーボード操作相当: activeIndex prop が外部から変わる。
+    rerenderWith({ activeIndex: 2 });
+    expect(scrollToIndexMock).toHaveBeenCalledWith(2, { align: "auto" });
+  });
+
+  it("does not scroll-snap when the active row changes via mouse hover", () => {
+    const { rerenderWith } = renderDropdown({ activeIndex: -1 });
+    scrollToIndexMock.mockClear();
+    // ホバーで activeIndex が変わったことを記録してから prop 変更を反映する。
+    fireEvent.mouseEnter(screen.getByText("Result 1"));
+    rerenderWith({ activeIndex: 1 });
+    expect(scrollToIndexMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/layout/Header/HeaderSearchDropdownContent.tsx
+++ b/src/components/layout/Header/HeaderSearchDropdownContent.tsx
@@ -75,6 +75,14 @@ export function HeaderSearchDropdownContent({
   // Scroll container referenced by the virtualizer's `getScrollElement`.
   const scrollRef = useRef<HTMLDivElement>(null);
 
+  // 直近の activeIndex 変更がマウスホバー由来かを記録する。ホバー由来の追従は
+  // ホイールスクロール中にポインタ下の行へスナップバックして操作を阻害するため、
+  // キーボード操作時のみスクロール追従する（下の effect で参照）。
+  // Tracks whether the latest activeIndex change came from mouse hover. Hover
+  // -driven follow would snap back to the row under the pointer mid-wheel-scroll
+  // and fight the user, so we only follow on keyboard navigation.
+  const wasMouseChangeRef = useRef(false);
+
   const rowVirtualizer = useVirtualizer({
     count: searchResults.length,
     getScrollElement: () => scrollRef.current,
@@ -85,14 +93,18 @@ export function HeaderSearchDropdownContent({
   // キーボードナビの active 行を描画ウィンドウ内に入れる。仮想化で off-screen の
   // option は DOM から外れるため、`aria-activedescendant` が解決できるよう、また
   // 視認できるよう `scrollToIndex` でウィンドウ内へ寄せる（footer 行は対象外）。
+  // ただしマウスホバー由来の変更時はスクロール追従をスキップし、ホイール
+  // スクロール中のスナップ競合を防ぐ。
   // Keep the keyboard-active row inside the virtual window: virtualization
   // drops off-screen options from the DOM, so scroll the active index into
   // view so `aria-activedescendant` resolves and the row is visible (the
-  // footer row is handled by the parent and is never virtualized).
+  // footer row is handled by the parent and is never virtualized). Skip the
+  // follow for hover-driven changes to avoid snapping against wheel scroll.
   useEffect(() => {
-    if (activeIndex >= 0 && activeIndex < searchResults.length) {
+    if (activeIndex >= 0 && activeIndex < searchResults.length && !wasMouseChangeRef.current) {
       rowVirtualizer.scrollToIndex(activeIndex, { align: "auto" });
     }
+    wasMouseChangeRef.current = false;
   }, [activeIndex, searchResults.length, rowVirtualizer]);
 
   return (
@@ -153,7 +165,10 @@ export function HeaderSearchDropdownContent({
                       activeIndex === index ? "bg-accent text-accent-foreground" : "hover:bg-muted",
                     )}
                     onClick={() => onSelectItem(item)}
-                    onMouseEnter={() => setActiveIndex(index)}
+                    onMouseEnter={() => {
+                      wasMouseChangeRef.current = true;
+                      setActiveIndex(index);
+                    }}
                   >
                     {isPdf ? (
                       <BookOpen className="text-muted-foreground h-4 w-4 shrink-0" />

--- a/src/components/layout/Header/HeaderSearchDropdownContent.tsx
+++ b/src/components/layout/Header/HeaderSearchDropdownContent.tsx
@@ -1,9 +1,20 @@
+import { useEffect, useRef } from "react";
 import { FileText, Link as LinkIcon, ArrowRight, BookOpen } from "lucide-react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { PopoverContent } from "@zedi/ui";
 import { cn } from "@zedi/ui";
 import type { GlobalSearchResultItem } from "@/hooks/useGlobalSearch";
 
 const EMPTY_MESSAGE = "ページが見つかりません";
+
+/**
+ * 1 行分の推定高さ（px）。検索結果の各行は `truncate` で単一行に固定されるため、
+ * 列によらず一定。`useVirtualizer` の `estimateSize` に使う。
+ *
+ * Estimated height (px) of a single result row. Rows are single-line
+ * (`truncate`), so the height is uniform and a fixed estimate is exact.
+ */
+const SEARCH_ROW_HEIGHT = 40;
 
 /**
  *
@@ -17,7 +28,6 @@ export interface HeaderSearchDropdownContentProps {
   activeIndex: number;
   query: string;
   hasQuery: boolean;
-  listRef: React.RefObject<HTMLUListElement | null>;
   footerRef: React.RefObject<HTMLButtonElement | null>;
   getOptionId: (index: number) => string;
   onSelectItem: (item: GlobalSearchResultItem) => void;
@@ -54,7 +64,6 @@ export function HeaderSearchDropdownContent({
   activeIndex,
   query,
   hasQuery,
-  listRef,
   footerRef,
   getOptionId,
   onSelectItem,
@@ -62,6 +71,30 @@ export function HeaderSearchDropdownContent({
   closeDropdown,
   handleSearchSubmit,
 }: HeaderSearchDropdownContentProps) {
+  // スクロールコンテナ。`useVirtualizer` の `getScrollElement` から参照する。
+  // Scroll container referenced by the virtualizer's `getScrollElement`.
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: searchResults.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => SEARCH_ROW_HEIGHT,
+    overscan: 10,
+  });
+
+  // キーボードナビの active 行を描画ウィンドウ内に入れる。仮想化で off-screen の
+  // option は DOM から外れるため、`aria-activedescendant` が解決できるよう、また
+  // 視認できるよう `scrollToIndex` でウィンドウ内へ寄せる（footer 行は対象外）。
+  // Keep the keyboard-active row inside the virtual window: virtualization
+  // drops off-screen options from the DOM, so scroll the active index into
+  // view so `aria-activedescendant` resolves and the row is visible (the
+  // footer row is handled by the parent and is never virtualized).
+  useEffect(() => {
+    if (activeIndex >= 0 && activeIndex < searchResults.length) {
+      rowVirtualizer.scrollToIndex(activeIndex, { align: "auto" });
+    }
+  }, [activeIndex, searchResults.length, rowVirtualizer]);
+
   return (
     <PopoverContent
       id="header-search-list"
@@ -85,22 +118,38 @@ export function HeaderSearchDropdownContent({
       )}
 
       {showResults && (
-        <div className="overflow-y-auto py-2">
+        <div ref={scrollRef} className="overflow-y-auto py-2">
           <p className="text-muted-foreground px-3 py-1.5 text-xs font-medium">
             候補 ({searchResults.length}件)
           </p>
-          <ul ref={listRef} className="list-none" role="group" aria-label="検索候補">
-            {searchResults.map((item, index) => {
+          <ul
+            className="relative list-none"
+            role="group"
+            aria-label="検索候補"
+            style={{ height: rowVirtualizer.getTotalSize() }}
+          >
+            {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+              const index = virtualRow.index;
+              const item = searchResults[index];
+              if (!item) return null;
               const isPdf = item.kind === "pdf_highlight";
               return (
-                <li key={getResultKey(item)} role="none">
+                <li
+                  key={getResultKey(item)}
+                  role="none"
+                  className="absolute top-0 left-0 w-full"
+                  style={{
+                    height: virtualRow.size,
+                    transform: `translateY(${virtualRow.start}px)`,
+                  }}
+                >
                   <button
                     id={getOptionId(index)}
                     type="button"
                     role="option"
                     aria-selected={activeIndex === index}
                     className={cn(
-                      "flex w-full items-center gap-2 px-3 py-2 text-left text-sm outline-none",
+                      "flex h-full w-full items-center gap-2 px-3 py-2 text-left text-sm outline-none",
                       activeIndex === index ? "bg-accent text-accent-foreground" : "hover:bg-muted",
                     )}
                     onClick={() => onSelectItem(item)}

--- a/src/components/page/LintSuggestions.test.tsx
+++ b/src/components/page/LintSuggestions.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// ─── 依存モック ────────────────────────────────────────────────────
+interface FindingLike {
+  id: string;
+  rule: string;
+  severity: string;
+  page_ids: string[];
+  detail: Record<string, unknown>;
+  created_at: string;
+}
+
+const queryData: { current: FindingLike[] | undefined } = { current: undefined };
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({
+    data: queryData.current,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ isSignedIn: true, isLoaded: true }),
+}));
+
+vi.mock("react-i18next", () => ({
+  // 翻訳キーをそのまま返す簡易スタブ。formatDetail / ruleLabel は detail 由来の
+  // 文字列を返すので、本テストの検証には十分。
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// 依存モック後に import する。Import after mocks so they apply.
+import { LintSuggestions } from "./LintSuggestions";
+
+beforeEach(() => {
+  queryData.current = undefined;
+});
+
+describe("LintSuggestions", () => {
+  it("renders the typed detail summary (suggestion) for a finding", () => {
+    queryData.current = [
+      {
+        id: "f1",
+        rule: "orphan",
+        severity: "warn",
+        page_ids: ["p1"],
+        detail: { suggestion: "リンクを追加しましょう" },
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+    render(<LintSuggestions pageId="p1" />);
+    expect(screen.getByText("リンクを追加しましょう")).toBeInTheDocument();
+  });
+
+  it("falls back to JSON.stringify for an unrecognized detail shape", () => {
+    queryData.current = [
+      {
+        id: "f2",
+        rule: "conflict",
+        severity: "error",
+        page_ids: ["p1"],
+        detail: { foo: "bar", count: 2 },
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+    render(<LintSuggestions pageId="p1" />);
+    expect(screen.getByText('{"foo":"bar","count":2}')).toBeInTheDocument();
+  });
+
+  it("renders nothing when there are no findings", () => {
+    queryData.current = [];
+    const { container } = render(<LintSuggestions pageId="p1" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/page/LintSuggestions.tsx
+++ b/src/components/page/LintSuggestions.tsx
@@ -11,7 +11,7 @@ import {
   Zap,
 } from "lucide-react";
 import { Badge, Button, Skeleton } from "@zedi/ui";
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/hooks/useAuth";
 
@@ -202,6 +202,17 @@ export function LintSuggestions({ pageId }: LintSuggestionsProps) {
     },
   });
 
+  // detail の整形（fallback で `JSON.stringify`）を毎 render ではなく findings /
+  // 言語の変化時のみ実行する。`findings` は React Query の参照が安定しているため、
+  // 同一データなら再計算をスキップできる（issue #1000 Item 4）。
+  // Precompute the formatted detail strings (the fallback runs `JSON.stringify`)
+  // so they recompute only when findings or the language change, instead of on
+  // every render. `findings` keeps a stable reference from React Query.
+  const formattedDetails = useMemo(
+    () => (findings ?? []).map((f) => formatDetail(f.detail, t)),
+    [findings, t],
+  );
+
   // 未認証 (ゲスト) では LintSuggestions 自体を描画しない。
   // 公開ノートの閲覧経路 `NotePagePublicView` でも `currentPageId` を渡すように
   // なったため、ここでゲストを除外しないと毎回 401 を返すリクエストが走る。
@@ -251,7 +262,7 @@ export function LintSuggestions({ pageId }: LintSuggestionsProps) {
         <span>{t("common.page.lintTitle", { count: findings.length })}</span>
       </div>
       <div className="space-y-2">
-        {findings.map((f) => (
+        {findings.map((f, i) => (
           <div key={f.id} className="bg-muted/50 flex items-start gap-3 rounded-lg border p-3">
             <div className="mt-0.5 shrink-0">{severityIcon(f.severity)}</div>
             <div className="min-w-0 flex-1">
@@ -261,7 +272,7 @@ export function LintSuggestions({ pageId }: LintSuggestionsProps) {
                   {ruleLabel(f.rule)}
                 </Badge>
               </div>
-              <p className="text-muted-foreground mt-1 text-sm">{formatDetail(f.detail, t)}</p>
+              <p className="text-muted-foreground mt-1 text-sm">{formattedDetails[i]}</p>
             </div>
             <Button
               type="button"


### PR DESCRIPTION
issue #1000 の follow-up。調査の結果、Item 1 の PageGrid 仮想化と
Item 3 (useWikiLinkStatusSync の署名生成) は既に対応済みだったため、
残る描画コストに対応する。

- 検索結果ドロップダウン (HeaderSearchDropdownContent) を
  @tanstack/react-virtual で仮想化。キーボードナビの active 行は
  scrollToIndex で描画ウィンドウ内へ寄せ、aria-activedescendant の
  解決とスクロール追従を維持。親の querySelectorAll ベースの追従と
  不要になった listRef を撤去。
- AIChatUserMessageBubble の renderUserContent を memo 化した
  UserMessageContent コンポーネントへ置換し、sort/map/RegExp/split の
  構築を useMemo 化（Item 2）。
- LintSuggestions の formatDetail (fallback で JSON.stringify) を
  useMemo で事前計算し毎 render の serialize を回避（Item 4）。

各変更にテストを追加。既存テストは green、挙動・アクセシビリティに
回帰なし。

https://claude.ai/code/session_01XtKKGg3VZ5xdxVJpF9TFBC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Virtualized search dropdown for smoother scrolling and lower rendering cost with large result sets.
  * More efficient user message rendering in chat and memoized lint suggestion detail formatting to reduce re-renders.
  * Improved keyboard navigation scrolling behavior in the header search dropdown.

* **Tests**
  * Added thorough tests for chat user messages, header search dropdown behavior, and lint suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->