### PR TITLE
ci: cache Playwright browsers to fix E2E (web) install timeouts (#1017)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,68 +207,37 @@ jobs:
 
       - uses: ./.github/actions/setup-toolchain
 
-      # Playwright のブラウザバイナリ取得を「キャッシュ + OS 依存と分離」で安定化する
-      # （Issue #1017）。従来の `playwright install --with-deps chromium` は
-      # ダウンロード 100% 完了「後」の展開フェーズで 5 分間無出力のまま停滞し、
-      # `timeout 300` の打ち切り（exit 124）× 3 試行で恒常的に失敗していた。
-      # 各リトライ冒頭で前回の中途半端な chromium build を「unused」として削除 →
-      # 再ダウンロードするため、リトライが状況を改善しない構造だった。
+      # === Issue #1017 診断ステップ（原因の切り分け。恒久対応ではない）=========
+      # これまでの run で判明していること:
+      #   * apt OS 依存のインストールは正常（直近 run で ~18s で完了）。
+      #   * chromium zip (164.7 MiB) のダウンロードは毎回 100% まで到達する。
+      #   * その「直後」から Playwright が一切のログを出さずに停止し、`timeout`
+      #     で打ち切られる（展開フェーズ or 次アセット取得で停滞している疑い）。
+      # → apt と browser DL を別ステップに分離し、apt 側は無実と確定済み。
+      #   残る不明点「100% 到達後のどのフェーズで止まるのか」を `DEBUG=pw:install`
+      #   で可視化する。展開（extract）/ headless-shell / ffmpeg 取得のどれで
+      #   停滞するかがログに出るので、それを見て恒久対応を決める。
       #
-      # 対策: ブラウザバイナリ（~/.cache/ms-playwright）を Playwright バージョンを
-      # キーにキャッシュし、ヒット時はダウンロード自体を回避する。OS 依存 (apt) は
-      # キャッシュ対象外なので別ステップで毎回入れる。restore / save を分離し、
-      # ブラウザ取得が成功したとき（= save ステップに到達できたとき）だけ保存する
-      # ことで、停滞して打ち切られた中途半端な build がキャッシュに焼き付くのを防ぐ。
-      #
-      # Stabilize Playwright browser provisioning via cache + split OS deps
-      # (Issue #1017). The old `playwright install --with-deps chromium` stalled
-      # for 5 minutes in the post-download extraction phase, getting killed by
-      # `timeout 300` (exit 124) on all 3 attempts. Each retry first removed the
-      # half-extracted chromium build as "unused" and re-downloaded it, so
-      # retrying never converged. Fix: cache the browser binaries keyed on the
-      # Playwright version so cache hits skip the download entirely. apt OS deps
-      # are not cacheable, so install them every run in a separate step. Restore
-      # and save are split so the cache is only written when the browser install
-      # actually succeeded (i.e. we reach the save step), preventing a stalled,
-      # half-extracted build from being baked into the cache.
-      - name: Resolve Playwright version
-        id: pw-version
-        run: echo "version=$(bunx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-
-      - name: Restore Playwright browsers cache
-        id: pw-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.version }}
-
+      # Diagnostic step for Issue #1017 (NOT a permanent fix). Established so far:
+      # apt deps succeed (~18s in the latest run); the chromium zip reliably
+      # reaches 100%, then Playwright goes completely silent until `timeout`
+      # kills it. apt is split out and already cleared as the culprit. This run
+      # turns on `DEBUG=pw:install` to reveal which post-download phase actually
+      # stalls (zip extraction vs. headless-shell / ffmpeg fetch) so we can pick
+      # the right permanent fix from real evidence rather than guessing.
       - name: Install Playwright system dependencies
         run: bunx playwright install-deps chromium
 
-      # キャッシュミス時のみブラウザバイナリを取得する。download 後の展開や
-      # 後続アセット（headless-shell / ffmpeg）取得の停滞に備え、1 試行あたりの
-      # 予算を 600s に広げ、最大 2 回リトライする（ジョブ全体 20 分に収める）。
-      # Only fetch browser binaries on a cache miss. Widen the per-attempt budget
-      # to 600s to absorb extraction / headless-shell / ffmpeg stalls, retrying
-      # up to 2 times (kept within the job's 20-minute cap).
-      - name: Install Playwright browsers (cache miss, with retry)
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        uses: Wandalen/wretry.action@v3
-        with:
-          command: timeout 600 bunx playwright install chromium
-          attempt_limit: 2
-          attempt_delay: 10000
-
-      # ブラウザ取得が成功した（このステップに到達できた）ときだけキャッシュを保存する。
-      # 上の install が失敗するとジョブはここに来ないため、壊れた状態は保存されない。
-      # Save the cache only after a successful install (we only reach this step if
-      # the install above did not fail), so corrupt state is never persisted.
-      - name: Save Playwright browsers cache
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.version }}
+      # 単発・無リトライで実行する。停滞は 100% 到達の直後に起きるため timeout 300
+      # でも停滞箇所の DEBUG ログは十分取得できる。リトライはジョブ 20 分の予算を
+      # 浪費して診断ログを埋もれさせるだけなので、この診断 run では付けない。
+      # Single attempt, no retry: the stall happens right after 100%, so a 300s
+      # bound is plenty to capture the DEBUG trace at the hang point. Retrying
+      # would only burn the 20-minute job budget and bury the diagnostic output.
+      - name: Install Playwright browsers (diagnostic, DEBUG=pw:install)
+        env:
+          DEBUG: pw:install
+        run: timeout 300 bunx playwright install chromium
 
       - name: Run PDF knowledge E2E
         run: bunx playwright test e2e/pdf-knowledge.spec.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,67 +207,37 @@ jobs:
 
       - uses: ./.github/actions/setup-toolchain
 
-      # === Issue #1017 診断ステップ（原因の切り分け。恒久対応ではない）=========
-      # 経過:
-      #   * run 27243476723 の `DEBUG=pw:install` で、chromium zip の DL は ~1.4s で
-      #     完了し、直後の `extracting archive`（展開）で停止することを確認。
-      #   * そこで「Bun の zlib/stream が原因」と仮説を立て、展開を Node(`npx`)で
-      #     実行するよう変更したが、run 27243906347 で **Node でも同一の停止**が
-      #     再現（DL 100% 到達後に無音 → timeout 124）。→ ランタイム(Node/Bun)は
-      #     原因ではないと確定。展開処理そのものが環境要因で停止している疑いが濃厚。
+      # Playwright のブラウザバイナリと OS 依存を入れる。
       #
-      # 本ステップは「Playwright の JS 展開」と「環境（ディスク/FS/CPU）」を切り分ける:
-      #   1. df/free/nproc でディスク空き・メモリ・CPU を記録
-      #   2. 同じ zip を curl で取得（DL 自体の健全性を再確認）
-      #   3. システムの `unzip` で $HOME 配下へ展開（Playwright を介さない展開）
-      # → システム unzip も停止すれば runner 環境（FS/ディスク）が原因。
-      #   unzip が成功すれば Playwright 1.57 の展開コードが原因と切り分けられる。
+      # Issue #1017: Playwright < 1.60 は Node 24.16+ 上で zip 展開（yauzl）が無限
+      # ハングする既知バグ（microsoft/playwright#40724）を持つ。GitHub ランナー
+      # 画像の Node が 24.16+ に上がった 5 月末以降、本ジョブの install が
+      # `extracting archive` で停止し timeout(exit 124) で恒常的に失敗していた
+      # （ワークフロー自体は不変）。切り分けで、同じ zip はシステムの `unzip` だと
+      # ~3s で展開でき（環境・ディスク・ネットワークは健全）、Playwright の JS 展開
+      # のみが停止することを確認済み。恒久対応は @playwright/test を 1.60 へ更新する
+      # こと（package.json / bun.lock）。本ワークフローはバージョン更新で直る。
+      # 展開を含む install は修正が検証済みの Node(`npx`)で実行し、OS 依存(apt)は
+      # 別ステップに分ける（apt は Bun でも正常）。
       #
-      # Diagnostic for Issue #1017 (NOT a fix). The `npx` run (27243906347)
-      # reproduced the exact same post-download stall under Node, disproving the
-      # Bun-runtime hypothesis: extraction hangs regardless of runtime, so the
-      # cause is environmental or in Playwright's own extraction. This step
-      # isolates "Playwright's JS extraction" from "the runner filesystem/disk"
-      # by downloading the same zip with curl and extracting it with the system
-      # `unzip`. If system unzip also stalls → runner FS/disk is the culprit; if
-      # it succeeds → Playwright 1.57's extraction code is.
+      # Playwright <1.60 hangs forever unzipping (yauzl) on Node 24.16+
+      # (microsoft/playwright#40724). When the GitHub runner image moved to Node
+      # 24.16+ in late May, this job's install began stalling at `extracting
+      # archive` and failing with exit 124 — the workflow itself never changed.
+      # Isolation confirmed the same zip extracts in ~3s with the system `unzip`
+      # (env/disk/network all healthy); only Playwright's JS extraction hangs.
+      # The permanent fix is bumping @playwright/test to 1.60 (package.json /
+      # bun.lock). Run the install (which does the extraction) under Node via
+      # npx, where the fix is validated; keep apt deps in their own step.
       - name: Install Playwright system dependencies
         run: bunx playwright install-deps chromium
 
-      - name: Diagnose browser extraction (env vs Playwright) (#1017)
-        run: |
-          set -x
-          echo "::group::disk / memory / cpu"
-          df -h
-          free -h || true
-          nproc
-          echo "::endgroup::"
-          ZIP_URL="https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1200/chromium-linux.zip"
-          TMP_ZIP="${RUNNER_TEMP:-/tmp}/chromium-linux.zip"
-          echo "::group::download via curl"
-          time timeout 120 curl -sSL -o "$TMP_ZIP" "$ZIP_URL"
-          ls -la "$TMP_ZIP"
-          echo "::endgroup::"
-          echo "::group::extract via system unzip into \$HOME"
-          rm -rf "$HOME/pw-extract-test"
-          mkdir -p "$HOME/pw-extract-test"
-          if time timeout 240 unzip -q "$TMP_ZIP" -d "$HOME/pw-extract-test"; then
-            echo "SYSTEM_UNZIP_RESULT=ok"
-          else
-            echo "SYSTEM_UNZIP_RESULT=fail exit=$?"
-          fi
-          du -sh "$HOME/pw-extract-test" 2>/dev/null || true
-          df -h
-          echo "::endgroup::"
-
-      # 上の切り分け結果と比較するため、Playwright 本来の install も DEBUG 付き・
-      # 単発・短い timeout で 1 回だけ走らせ、同一環境で展開が停止することを再確認する。
-      # Run Playwright's own install once (DEBUG, single attempt, short timeout)
-      # to confirm it still stalls in the same environment, for direct comparison.
-      - name: Install Playwright browsers (diagnostic, DEBUG=pw:install)
-        env:
-          DEBUG: pw:install
-        run: timeout 180 npx playwright install chromium
+      - name: Install Playwright browsers (with retry)
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: timeout 300 npx playwright install chromium
+          attempt_limit: 3
+          attempt_delay: 10000
 
       - name: Run PDF knowledge E2E
         run: bunx playwright test e2e/pdf-knowledge.spec.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,45 +207,67 @@ jobs:
 
       - uses: ./.github/actions/setup-toolchain
 
-      # Issue #1017: E2E (web) の Playwright ブラウザインストールが恒常的に
-      # exit 124（timeout）で失敗していた問題の恒久対応。
+      # === Issue #1017 診断ステップ（原因の切り分け。恒久対応ではない）=========
+      # 経過:
+      #   * run 27243476723 の `DEBUG=pw:install` で、chromium zip の DL は ~1.4s で
+      #     完了し、直後の `extracting archive`（展開）で停止することを確認。
+      #   * そこで「Bun の zlib/stream が原因」と仮説を立て、展開を Node(`npx`)で
+      #     実行するよう変更したが、run 27243906347 で **Node でも同一の停止**が
+      #     再現（DL 100% 到達後に無音 → timeout 124）。→ ランタイム(Node/Bun)は
+      #     原因ではないと確定。展開処理そのものが環境要因で停止している疑いが濃厚。
       #
-      # 切り分けの結果（run 27243476723 の `DEBUG=pw:install` ログ）:
-      #   * chromium zip の DL は ~1.4s で完了（`download complete` までは正常）。
-      #   * 直後の `pw:install extracting archive`（zip 展開）で停止し、5 分後に
-      #     timeout で打ち切られていた。→ ネットワークではなく「展開処理」が原因。
+      # 本ステップは「Playwright の JS 展開」と「環境（ディスク/FS/CPU）」を切り分ける:
+      #   1. df/free/nproc でディスク空き・メモリ・CPU を記録
+      #   2. 同じ zip を curl で取得（DL 自体の健全性を再確認）
+      #   3. システムの `unzip` で $HOME 配下へ展開（Playwright を介さない展開）
+      # → システム unzip も停止すれば runner 環境（FS/ディスク）が原因。
+      #   unzip が成功すれば Playwright 1.57 の展開コードが原因と切り分けられる。
       #
-      # 展開は extract-zip（yauzl + Node の zlib stream）が担う純粋なローカル処理。
-      # これを `bunx`（= Bun ランタイム）で実行していたため、Bun の zlib/stream
-      # 実装で展開がハングしていた。ワークフロー未変更でも `setup-bun` の
-      # `bun-version: "1.3"` が実行時に最新 1.3.x を引くため、5 月末の Bun 更新で
-      # 静かに退行したと考えられる（5/28 以前は成功、の観測と整合）。
-      #
-      # 対応: 展開を含む `playwright install` を Bun ではなく **Node**（`npx`）で
-      # 実行する。apt 依存は別ステップのまま（Bun でも正常なので据え置き）。
-      # ネットワーク揺らぎに備え timeout + wretry で最大 2 回リトライする。
-      #
-      # Permanent fix for Issue #1017. The `DEBUG=pw:install` trace (run
-      # 27243476723) showed the chromium zip downloads in ~1.4s, then Playwright
-      # hangs in `extracting archive` until `timeout` kills it — so the culprit
-      # is zip extraction, not the network. Extraction is extract-zip (yauzl +
-      # Node zlib streams), a pure local op. We were running it via `bunx` (Bun
-      # runtime), and Bun's zlib/stream implementation hangs on it. The workflow
-      # was unchanged, but `setup-bun`'s `bun-version: "1.3"` resolves the latest
-      # 1.3.x at run time, so a late-May Bun update silently regressed this
-      # (consistent with "passed before 5/28"). Fix: run `playwright install`
-      # (and thus the extraction) under Node via `npx` instead of Bun. apt deps
-      # stay in their own step (they work fine under Bun). Bound each attempt
-      # with `timeout` and retry up to twice for network flake.
+      # Diagnostic for Issue #1017 (NOT a fix). The `npx` run (27243906347)
+      # reproduced the exact same post-download stall under Node, disproving the
+      # Bun-runtime hypothesis: extraction hangs regardless of runtime, so the
+      # cause is environmental or in Playwright's own extraction. This step
+      # isolates "Playwright's JS extraction" from "the runner filesystem/disk"
+      # by downloading the same zip with curl and extracting it with the system
+      # `unzip`. If system unzip also stalls → runner FS/disk is the culprit; if
+      # it succeeds → Playwright 1.57's extraction code is.
       - name: Install Playwright system dependencies
         run: bunx playwright install-deps chromium
 
-      - name: Install Playwright browsers (Node runtime, with retry)
-        uses: Wandalen/wretry.action@v3
-        with:
-          command: timeout 300 npx playwright install chromium
-          attempt_limit: 2
-          attempt_delay: 10000
+      - name: Diagnose browser extraction (env vs Playwright) (#1017)
+        run: |
+          set -x
+          echo "::group::disk / memory / cpu"
+          df -h
+          free -h || true
+          nproc
+          echo "::endgroup::"
+          ZIP_URL="https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1200/chromium-linux.zip"
+          TMP_ZIP="${RUNNER_TEMP:-/tmp}/chromium-linux.zip"
+          echo "::group::download via curl"
+          time timeout 120 curl -sSL -o "$TMP_ZIP" "$ZIP_URL"
+          ls -la "$TMP_ZIP"
+          echo "::endgroup::"
+          echo "::group::extract via system unzip into \$HOME"
+          rm -rf "$HOME/pw-extract-test"
+          mkdir -p "$HOME/pw-extract-test"
+          if time timeout 240 unzip -q "$TMP_ZIP" -d "$HOME/pw-extract-test"; then
+            echo "SYSTEM_UNZIP_RESULT=ok"
+          else
+            echo "SYSTEM_UNZIP_RESULT=fail exit=$?"
+          fi
+          du -sh "$HOME/pw-extract-test" 2>/dev/null || true
+          df -h
+          echo "::endgroup::"
+
+      # 上の切り分け結果と比較するため、Playwright 本来の install も DEBUG 付き・
+      # 単発・短い timeout で 1 回だけ走らせ、同一環境で展開が停止することを再確認する。
+      # Run Playwright's own install once (DEBUG, single attempt, short timeout)
+      # to confirm it still stalls in the same environment, for direct comparison.
+      - name: Install Playwright browsers (diagnostic, DEBUG=pw:install)
+        env:
+          DEBUG: pw:install
+        run: timeout 180 npx playwright install chromium
 
       - name: Run PDF knowledge E2E
         run: bunx playwright test e2e/pdf-knowledge.spec.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,20 +207,68 @@ jobs:
 
       - uses: ./.github/actions/setup-toolchain
 
-      # Playwright のブラウザバイナリ + 必要な OS 依存を入れる。
-      # ネットワーク起因の停滞に備え、各試行を `timeout` で打ち切りつつ最大 3 回
-      # リトライする（既存の checkout と同じ wretry.action を使用）。停滞した試行
-      # はハングのまま終わらないため、`timeout` で非ゼロ終了させてリトライを促す。
-      # Install Playwright's browser binaries plus the matching OS deps. Guard
-      # against network stalls: bound each attempt with `timeout` (so a hung
-      # download exits non-zero and triggers a retry) and retry up to 3 times
-      # via the same wretry.action used for checkout above.
-      - name: Install Playwright browsers (with retry)
+      # Playwright のブラウザバイナリ取得を「キャッシュ + OS 依存と分離」で安定化する
+      # （Issue #1017）。従来の `playwright install --with-deps chromium` は
+      # ダウンロード 100% 完了「後」の展開フェーズで 5 分間無出力のまま停滞し、
+      # `timeout 300` の打ち切り（exit 124）× 3 試行で恒常的に失敗していた。
+      # 各リトライ冒頭で前回の中途半端な chromium build を「unused」として削除 →
+      # 再ダウンロードするため、リトライが状況を改善しない構造だった。
+      #
+      # 対策: ブラウザバイナリ（~/.cache/ms-playwright）を Playwright バージョンを
+      # キーにキャッシュし、ヒット時はダウンロード自体を回避する。OS 依存 (apt) は
+      # キャッシュ対象外なので別ステップで毎回入れる。restore / save を分離し、
+      # ブラウザ取得が成功したとき（= save ステップに到達できたとき）だけ保存する
+      # ことで、停滞して打ち切られた中途半端な build がキャッシュに焼き付くのを防ぐ。
+      #
+      # Stabilize Playwright browser provisioning via cache + split OS deps
+      # (Issue #1017). The old `playwright install --with-deps chromium` stalled
+      # for 5 minutes in the post-download extraction phase, getting killed by
+      # `timeout 300` (exit 124) on all 3 attempts. Each retry first removed the
+      # half-extracted chromium build as "unused" and re-downloaded it, so
+      # retrying never converged. Fix: cache the browser binaries keyed on the
+      # Playwright version so cache hits skip the download entirely. apt OS deps
+      # are not cacheable, so install them every run in a separate step. Restore
+      # and save are split so the cache is only written when the browser install
+      # actually succeeded (i.e. we reach the save step), preventing a stalled,
+      # half-extracted build from being baked into the cache.
+      - name: Resolve Playwright version
+        id: pw-version
+        run: echo "version=$(bunx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Playwright browsers cache
+        id: pw-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.version }}
+
+      - name: Install Playwright system dependencies
+        run: bunx playwright install-deps chromium
+
+      # キャッシュミス時のみブラウザバイナリを取得する。download 後の展開や
+      # 後続アセット（headless-shell / ffmpeg）取得の停滞に備え、1 試行あたりの
+      # 予算を 600s に広げ、最大 2 回リトライする（ジョブ全体 20 分に収める）。
+      # Only fetch browser binaries on a cache miss. Widen the per-attempt budget
+      # to 600s to absorb extraction / headless-shell / ffmpeg stalls, retrying
+      # up to 2 times (kept within the job's 20-minute cap).
+      - name: Install Playwright browsers (cache miss, with retry)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
         uses: Wandalen/wretry.action@v3
         with:
-          command: timeout 300 bunx playwright install --with-deps chromium
-          attempt_limit: 3
+          command: timeout 600 bunx playwright install chromium
+          attempt_limit: 2
           attempt_delay: 10000
+
+      # ブラウザ取得が成功した（このステップに到達できた）ときだけキャッシュを保存する。
+      # 上の install が失敗するとジョブはここに来ないため、壊れた状態は保存されない。
+      # Save the cache only after a successful install (we only reach this step if
+      # the install above did not fail), so corrupt state is never persisted.
+      - name: Save Playwright browsers cache
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.version }}
 
       - name: Run PDF knowledge E2E
         run: bunx playwright test e2e/pdf-knowledge.spec.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -46,9 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -63,9 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -91,9 +91,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
           path: coverage/
@@ -135,9 +135,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -199,9 +199,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -217,8 +217,9 @@ jobs:
       # ~3s で展開でき（環境・ディスク・ネットワークは健全）、Playwright の JS 展開
       # のみが停止することを確認済み。恒久対応は @playwright/test を 1.60 へ更新する
       # こと（package.json / bun.lock）。本ワークフローはバージョン更新で直る。
-      # 展開を含む install は修正が検証済みの Node(`npx`)で実行し、OS 依存(apt)は
-      # 別ステップに分ける（apt は Bun でも正常）。
+      # 展開を含む install は修正が検証済みの Node(`npx`)で実行する。apt 取得や
+      # 一過性のネットワーク停滞に備え、`--with-deps` ごと timeout + wretry で最大
+      # 3 回リトライする（checkout と同じ wretry.action。apt も retry 対象に含める）。
       #
       # Playwright <1.60 hangs forever unzipping (yauzl) on Node 24.16+
       # (microsoft/playwright#40724). When the GitHub runner image moved to Node
@@ -228,14 +229,12 @@ jobs:
       # (env/disk/network all healthy); only Playwright's JS extraction hangs.
       # The permanent fix is bumping @playwright/test to 1.60 (package.json /
       # bun.lock). Run the install (which does the extraction) under Node via
-      # npx, where the fix is validated; keep apt deps in their own step.
-      - name: Install Playwright system dependencies
-        run: bunx playwright install-deps chromium
-
+      # npx; keep apt deps inside `--with-deps` so the whole step (apt + browser
+      # download/extract) stays under wretry's bounded retry on transient stalls.
       - name: Install Playwright browsers (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          command: timeout 300 npx playwright install chromium
+          command: timeout 300 npx playwright install --with-deps chromium
           attempt_limit: 3
           attempt_delay: 10000
 
@@ -244,7 +243,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report-pdf-knowledge
           path: playwright-report/
@@ -256,9 +255,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -290,9 +289,9 @@ jobs:
       # PR ベースとの diff を取るため履歴を全部取得する。
       # Need full history so the script can diff against the PR base.
       - name: Checkout (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           with: |
             fetch-depth: 0
           attempt_limit: 3
@@ -327,9 +326,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -351,9 +350,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -389,9 +388,9 @@ jobs:
         run: echo "MUTATION_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - name: Checkout (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -409,7 +408,7 @@ jobs:
 
       - name: Upload mutation report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mutation-report
           path: reports/mutation/
@@ -429,9 +428,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           with: |
             fetch-depth: 0
           attempt_limit: 3
@@ -448,6 +447,6 @@ jobs:
       # Detect accidentally committed secrets (API keys, private keys, tokens).
       # 誤ってコミットされた秘密情報（API キー、秘密鍵、トークン）を検出する。
       - name: Detect secrets (gitleaks)
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,6 @@ jobs:
       # Detect accidentally committed secrets (API keys, private keys, tokens).
       # 誤ってコミットされた秘密情報（API キー、秘密鍵、トークン）を検出する。
       - name: Detect secrets (gitleaks)
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,37 +207,45 @@ jobs:
 
       - uses: ./.github/actions/setup-toolchain
 
-      # === Issue #1017 診断ステップ（原因の切り分け。恒久対応ではない）=========
-      # これまでの run で判明していること:
-      #   * apt OS 依存のインストールは正常（直近 run で ~18s で完了）。
-      #   * chromium zip (164.7 MiB) のダウンロードは毎回 100% まで到達する。
-      #   * その「直後」から Playwright が一切のログを出さずに停止し、`timeout`
-      #     で打ち切られる（展開フェーズ or 次アセット取得で停滞している疑い）。
-      # → apt と browser DL を別ステップに分離し、apt 側は無実と確定済み。
-      #   残る不明点「100% 到達後のどのフェーズで止まるのか」を `DEBUG=pw:install`
-      #   で可視化する。展開（extract）/ headless-shell / ffmpeg 取得のどれで
-      #   停滞するかがログに出るので、それを見て恒久対応を決める。
+      # Issue #1017: E2E (web) の Playwright ブラウザインストールが恒常的に
+      # exit 124（timeout）で失敗していた問題の恒久対応。
       #
-      # Diagnostic step for Issue #1017 (NOT a permanent fix). Established so far:
-      # apt deps succeed (~18s in the latest run); the chromium zip reliably
-      # reaches 100%, then Playwright goes completely silent until `timeout`
-      # kills it. apt is split out and already cleared as the culprit. This run
-      # turns on `DEBUG=pw:install` to reveal which post-download phase actually
-      # stalls (zip extraction vs. headless-shell / ffmpeg fetch) so we can pick
-      # the right permanent fix from real evidence rather than guessing.
+      # 切り分けの結果（run 27243476723 の `DEBUG=pw:install` ログ）:
+      #   * chromium zip の DL は ~1.4s で完了（`download complete` までは正常）。
+      #   * 直後の `pw:install extracting archive`（zip 展開）で停止し、5 分後に
+      #     timeout で打ち切られていた。→ ネットワークではなく「展開処理」が原因。
+      #
+      # 展開は extract-zip（yauzl + Node の zlib stream）が担う純粋なローカル処理。
+      # これを `bunx`（= Bun ランタイム）で実行していたため、Bun の zlib/stream
+      # 実装で展開がハングしていた。ワークフロー未変更でも `setup-bun` の
+      # `bun-version: "1.3"` が実行時に最新 1.3.x を引くため、5 月末の Bun 更新で
+      # 静かに退行したと考えられる（5/28 以前は成功、の観測と整合）。
+      #
+      # 対応: 展開を含む `playwright install` を Bun ではなく **Node**（`npx`）で
+      # 実行する。apt 依存は別ステップのまま（Bun でも正常なので据え置き）。
+      # ネットワーク揺らぎに備え timeout + wretry で最大 2 回リトライする。
+      #
+      # Permanent fix for Issue #1017. The `DEBUG=pw:install` trace (run
+      # 27243476723) showed the chromium zip downloads in ~1.4s, then Playwright
+      # hangs in `extracting archive` until `timeout` kills it — so the culprit
+      # is zip extraction, not the network. Extraction is extract-zip (yauzl +
+      # Node zlib streams), a pure local op. We were running it via `bunx` (Bun
+      # runtime), and Bun's zlib/stream implementation hangs on it. The workflow
+      # was unchanged, but `setup-bun`'s `bun-version: "1.3"` resolves the latest
+      # 1.3.x at run time, so a late-May Bun update silently regressed this
+      # (consistent with "passed before 5/28"). Fix: run `playwright install`
+      # (and thus the extraction) under Node via `npx` instead of Bun. apt deps
+      # stay in their own step (they work fine under Bun). Bound each attempt
+      # with `timeout` and retry up to twice for network flake.
       - name: Install Playwright system dependencies
         run: bunx playwright install-deps chromium
 
-      # 単発・無リトライで実行する。停滞は 100% 到達の直後に起きるため timeout 300
-      # でも停滞箇所の DEBUG ログは十分取得できる。リトライはジョブ 20 分の予算を
-      # 浪費して診断ログを埋もれさせるだけなので、この診断 run では付けない。
-      # Single attempt, no retry: the stall happens right after 100%, so a 300s
-      # bound is plenty to capture the DEBUG trace at the hang point. Retrying
-      # would only burn the 20-minute job budget and bury the diagnostic output.
-      - name: Install Playwright browsers (diagnostic, DEBUG=pw:install)
-        env:
-          DEBUG: pw:install
-        run: timeout 300 bunx playwright install chromium
+      - name: Install Playwright browsers (Node runtime, with retry)
+        uses: Wandalen/wretry.action@v3
+        with:
+          command: timeout 300 npx playwright install chromium
+          attempt_limit: 2
+          attempt_delay: 10000
 
       - name: Run PDF knowledge E2E
         run: bunx playwright test e2e/pdf-knowledge.spec.ts

--- a/bun.lock
+++ b/bun.lock
@@ -132,7 +132,7 @@
         "@commitlint/config-conventional": "^21.0.0",
         "@eslint/js": "^9.32.0",
         "@libsql/client": "^0.17.0",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "^1.60.0",
         "@stryker-mutator/core": "^9.6.0",
         "@stryker-mutator/vitest-runner": "^9.6.0",
         "@tailwindcss/postcss": "^4.2.2",
@@ -858,7 +858,7 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
-    "@playwright/test": ["@playwright/test@1.57.0", "", { "dependencies": { "playwright": "1.57.0" }, "bin": { "playwright": "cli.js" } }, "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA=="],
+    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -2662,9 +2662,9 @@
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
-    "playwright": ["playwright@1.57.0", "", { "dependencies": { "playwright-core": "1.57.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw=="],
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
 
-    "playwright-core": ["playwright-core@1.57.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ=="],
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
 
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
 

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "@commitlint/config-conventional": "^21.0.0",
     "@eslint/js": "^9.32.0",
     "@libsql/client": "^0.17.0",
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.60.0",
     "@stryker-mutator/core": "^9.6.0",
     "@stryker-mutator/vitest-runner": "^9.6.0",
     "@tailwindcss/postcss": "^4.2.2",


### PR DESCRIPTION
E2E (web) ジョブが "Install Playwright browsers" でダウンロード完了後の
展開フェーズに 5 分間停滞し、timeout 300 の打ち切り（exit 124）× 3 試行で
恒常的に失敗していた。各リトライ冒頭で中途半端な chromium build を削除して
再ダウンロードするため、リトライが状況を改善しない構造だった。

- ~/.cache/ms-playwright を Playwright バージョンキーでキャッシュし、ヒット時は
  ダウンロード自体を回避（actions/cache の restore/save を分離）
- save はブラウザ取得成功時のみ実行し、停滞して打ち切られた壊れた状態が
  キャッシュに焼き付くのを防ぐ
- OS 依存 (apt) はキャッシュ対象外のため install-deps を別ステップで毎回実行
- ブラウザ取得は cache miss 時のみ、timeout を 600s に拡大し attempt_limit 2 に
  （ジョブ全体 20 分に収める）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned CI actions to fixed revisions to stabilize workflow execution and artifact uploads.
  * Revised end-to-end install step to run Playwright under npx with a bounded timeout/retry and added explanatory comments to avoid install hangs, improving CI robustness.
  * Upgraded Playwright test dependency to ^1.60.0 to improve test reliability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->