### PR TITLE
ci: run server/api and server/hocuspocus vitest suites in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,12 +103,14 @@ jobs:
 
       # Workspace package tests are not picked up by the root vitest config,
       # so run their dedicated configs explicitly. Keep this list in sync with
-      # the `test:run` script in root package.json. server/mcp has its own job
-      # (`mcp-test`); server/hocuspocus is invoked only via `test:run` and not
+      # the `test:run` script in root package.json. The standalone server
+      # projects have their own jobs: server/api (`api-test`), server/mcp
+      # (`mcp-test`), server/hocuspocus (`hocuspocus-test`); they are not
       # duplicated here.
       # ルートの vitest 設定はワークスペース配下のテストを含まないため、
-      # 各パッケージの vitest.config を明示的に実行する。server/mcp は別 job
-      # （`mcp-test`）で動かすためここには含めない。
+      # 各パッケージの vitest.config を明示的に実行する。server/api・server/mcp・
+      # server/hocuspocus はそれぞれ別 job（`api-test` / `mcp-test` /
+      # `hocuspocus-test`）で動かすためここには含めない。
       - name: Run admin tests
         run: bunx vitest run --config admin/vitest.config.ts
 
@@ -273,6 +275,36 @@ jobs:
         working-directory: server/api
         run: bunx tsc --noEmit
 
+  api-test:
+    name: API Tests
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
+        with:
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          # server/api 配下で個別に install するため、ルートの install は不要。
+          # The job installs deps inside server/api instead of the root.
+          install-deps: "false"
+
+      # server/api はルートの Bun workspace に含まれないため、テストの前に
+      # ローカルで依存関係をインストールする (api-typecheck / mcp-test と同じ構成)。
+      # server/api is not part of the root Bun workspace; install its
+      # dependencies locally before running the vitest suite.
+      - name: Install API dependencies
+        working-directory: server/api
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        working-directory: server/api
+        run: bunx vitest run
+
   drizzle-migration-check:
     name: Drizzle Migration Check
     # Drizzle TS スキーマを変更したら必ずマイグレーション SQL を追加するルールの強制。
@@ -376,6 +408,36 @@ jobs:
 
       - name: Run tests
         working-directory: server/mcp
+        run: bun run test
+
+  hocuspocus-test:
+    name: Hocuspocus Server Tests
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
+        with:
+          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          attempt_limit: 3
+          attempt_delay: 5000
+
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          # server/hocuspocus 配下で個別に install するため、ルートの install は不要。
+          # The job installs deps inside server/hocuspocus instead of the root.
+          install-deps: "false"
+
+      # server/hocuspocus はルートの Bun workspace に含まれないため、
+      # テストの前にローカルで依存関係をインストールする。
+      # server/hocuspocus is not part of the root Bun workspace; install its
+      # dependencies locally before running the vitest suite.
+      - name: Install Hocuspocus dependencies
+        working-directory: server/hocuspocus
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        working-directory: server/hocuspocus
         run: bun run test
 
   mutation-light:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,13 +156,13 @@ terraform/        # インフラ定義
 - 理由 / Rationale:
   - Railway の Dockerfile ビルドは「各サービスの Root Directory」を build context に取る (例: `server/mcp`)。ここからルート `bun.lock` を参照するのは面倒で、context をサービス単位に閉じるほうが再現性が高い。  
     _Railway Dockerfile builds take each service's Root Directory as the build context. Scoping `bun.lock` per service keeps the build self-contained and reproducible._
-  - Bun workspace が Railway 上で安定して扱えるようになった時点で再検討する（`.github/workflows/ci.yml` の `api-typecheck` / `mcp-test` ジョブにも同じメモあり）。  
+  - Bun workspace が Railway 上で安定して扱えるようになった時点で再検討する（`.github/workflows/ci.yml` の `api-typecheck` / `api-test` / `mcp-test` / `hocuspocus-test` ジョブにも同じメモあり）。  
     _Revisit when Bun workspaces are first-class on Railway (the same note lives in `ci.yml`)._
 - 運用上の影響 / Operational impact:
   - ルートで `bun install` を実行しても `server/*` の依存は入らない。各サービスに入るには `cd server/<service> && bun install` する必要がある。  
     _Running `bun install` at the repo root does **not** install `server/*` dependencies; run `bun install` inside each service directory._
-  - CI (`.github/workflows/ci.yml`) でも各サービスディレクトリで個別に `bun install` → typecheck / test を行う。  
-    _CI installs and tests each service individually._
+  - CI (`.github/workflows/ci.yml`) でも各サービスディレクトリで個別に `bun install` してから typecheck / test を実行する。具体的には `server/api` は `api-typecheck`（型チェック）と `api-test`（vitest）、`server/mcp` は `mcp-test`（型チェック + テスト）、`server/hocuspocus` は `hocuspocus-test`（vitest）の各ジョブが担当する。  
+    _CI installs each service individually, then runs its checks: `server/api` via `api-typecheck` (types) + `api-test` (vitest), `server/mcp` via `mcp-test` (types + tests), and `server/hocuspocus` via `hocuspocus-test` (vitest)._
 - デプロイ / Deploy:
   - `server/api`, `server/hocuspocus`, `server/mcp` は Railway の GitHub 連携で自動デプロイされる (Root Directory をサービスディレクトリに設定)。CI (`deploy-dev.yml` / `deploy-prod.yml`) はフロントエンド (Cloudflare Pages) のデプロイと DB マイグレーションを担当する。  
     _All three `server/*` services auto-deploy via Railway's GitHub integration (each Railway service is configured with the matching Root Directory). The `deploy-*.yml` workflows cover Cloudflare Pages deploys and DB migrations only._


### PR DESCRIPTION
server/api's vitest suite (129 files / ~1,400 tests) was never run in CI —
only api-typecheck (`bunx tsc --noEmit`) ran, so a broken suite could slip
through unnoticed (e.g. the bun:test import in #992). server/hocuspocus had
the same gap: its tests were only wired into the root `test:run` script,
which CI does not execute (CI runs `test:coverage`).

Add `api-test` and `hocuspocus-test` jobs mirroring the `mcp-test` setup
(install deps inside the service dir, then `vitest run`), and align the
misleading comment in the `test` job. Update AGENTS.md so the CI
description matches reality, enumerating which job covers each service.

Closes #1010