### PR TITLE
refactor(front): enable TypeScript strict in src/ and enforce typecheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,21 @@ jobs:
 
       - uses: ./.github/actions/setup-toolchain
 
-      - run: bunx tsc --noEmit
+      # ルート `tsconfig.json` は `files: []` + project references のため、
+      # `bunx tsc --noEmit`（`-b` なし）はメインフロントエンド `src/` を一切
+      # 型チェックしない（参照プロジェクトは `-b` でしか処理されない）。Issue
+      # #1011 で `tsconfig.app.json` を `strict: true` 化したのに合わせ、`-p` で
+      # 明示してフロントの型エラーを PR で確実に検出する。
+      #
+      # The root `tsconfig.json` uses `files: []` + project references, so a bare
+      # `bunx tsc --noEmit` (without `-b`) type-checks none of the main frontend
+      # `src/` (referenced projects are only processed with `-b`). After Issue
+      # #1011 enabled `strict: true` in `tsconfig.app.json`, point `-p` at it so
+      # frontend type errors are actually caught in PRs.
+      - run: bunx tsc --noEmit -p tsconfig.app.json
 
-      # `bunx tsc --noEmit` 単独はルートの tsconfig（`src/` のみ）しか見ない
-      # ため、workspace パッケージ `@zedi/ui` を別途型チェックする。これを
+      # `tsc --noEmit -p tsconfig.app.json` はルートの tsconfig（`src/` のみ）しか
+      # 見ないため、workspace パッケージ `@zedi/ui` を別途型チェックする。これを
       # 怠ると `packages/ui` だけで起きる型エラー（例: Issue #913 の
       # react-day-picker v10 互換問題）が deploy 時まで気付かれない。
       #

--- a/src/components/aiChat/PromoteToWikiDialog.tsx
+++ b/src/components/aiChat/PromoteToWikiDialog.tsx
@@ -8,7 +8,7 @@
  * 3. User selects entities to create as wiki pages
  * 4. Selected entities are created as new pages via the existing create-page flow
  */
-import React, { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { Loader2, X } from "lucide-react";
 import { Button, useToast } from "@zedi/ui";
 import { useTranslation } from "react-i18next";
@@ -253,7 +253,8 @@ function PromoteToWikiDialogBody({
       // Treat a missing `noteId` as a failed creation rather than navigating
       // to `/notes/undefined/...`.
       const firstCreated = created.find(
-        (p): p is NonNullable<typeof p> => p != null && Boolean(p.id) && Boolean(p.noteId),
+        (p): p is NonNullable<typeof p> & { noteId: string } =>
+          p != null && Boolean(p.id) && Boolean(p.noteId),
       );
       if (!firstCreated) throw new Error("no pages created");
 

--- a/src/components/editor/CodeBlockWithCopyNodeView.tsx
+++ b/src/components/editor/CodeBlockWithCopyNodeView.tsx
@@ -61,7 +61,7 @@ const CodeBlockWithCopyNodeView: React.FC<NodeViewProps> = ({ node }) => {
   return (
     <NodeViewWrapper as="div" className="group/code relative" spellCheck={false}>
       <pre ref={preRef} className="overflow-x-auto" spellCheck={false}>
-        <NodeViewContent
+        <NodeViewContent<"code">
           as="code"
           className={language ? `language-${language}` : ""}
           spellCheck={false}

--- a/src/components/editor/ExecutableCodeBlockNodeView.tsx
+++ b/src/components/editor/ExecutableCodeBlockNodeView.tsx
@@ -66,7 +66,7 @@ export const ExecutableCodeBlockNodeView: React.FC<NodeViewProps> = ({
       />
 
       <pre className="m-0 overflow-x-auto px-3 py-2 text-sm" spellCheck={false}>
-        <NodeViewContent
+        <NodeViewContent<"code">
           as="code"
           className={cn(
             language ? `language-${language}` : "",

--- a/src/components/editor/FloatingWikiLinkInputBar.test.tsx
+++ b/src/components/editor/FloatingWikiLinkInputBar.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render, screen, fireEvent } from "@testing-library/react";
 

--- a/src/components/editor/HtmlArtifactNodeView.test.tsx
+++ b/src/components/editor/HtmlArtifactNodeView.test.tsx
@@ -107,7 +107,8 @@ describe("HtmlArtifactNodeView", () => {
       window.dispatchEvent(
         new MessageEvent("message", {
           data: { type: "zedi-artifact-resize", height: Number.NaN },
-          source: mockSource,
+          // mockSource stands in for the iframe's contentWindow (MessageEventSource)
+          source: mockSource as unknown as MessageEventSource,
         }),
       );
     });
@@ -129,7 +130,8 @@ describe("HtmlArtifactNodeView", () => {
       window.dispatchEvent(
         new MessageEvent("message", {
           data: { type: "zedi-artifact-resize", height: 1_000_000 },
-          source: mockSource,
+          // mockSource stands in for the iframe's contentWindow (MessageEventSource)
+          source: mockSource as unknown as MessageEventSource,
         }),
       );
     });

--- a/src/components/editor/MediaPlaceholderNodeView.tsx
+++ b/src/components/editor/MediaPlaceholderNodeView.tsx
@@ -152,6 +152,7 @@ export function MediaPlaceholderNodeView({ node, editor, getPos, deleteNode }: N
   const replaceWithMediaNode = useCallback(
     (attrs: { src: string; alt: string; poster?: string | null }) => {
       const pos = getPos();
+      if (pos === undefined) return;
       const { view, state } = editor;
       const schema = state.schema;
       const type = schema.nodes[targetNodeType];

--- a/src/components/editor/PageActionHub/PageActionHub.test.tsx
+++ b/src/components/editor/PageActionHub/PageActionHub.test.tsx
@@ -154,9 +154,9 @@ describe("PageActionHub", () => {
   });
 
   it("ハンドルの close() で閉じ、再オープン時は list / close() then reopen lands on list", async () => {
-    let handle: PageActionHubHandle | null = null;
+    const handleRef: { current: PageActionHubHandle | null } = { current: null };
     const onMount = (h: PageActionHubHandle) => {
-      handle = h;
+      handleRef.current = h;
     };
     const user = userEvent.setup();
     render(<Harness ctx={makeCtx()} onMount={onMount} />);
@@ -164,11 +164,11 @@ describe("PageActionHub", () => {
     await user.click(screen.getByTestId("open-trigger"));
     await user.click(screen.getByRole("button", { name: /Search image/ }));
 
-    await waitFor(() => expect(handle).not.toBeNull());
+    await waitFor(() => expect(handleRef.current).not.toBeNull());
 
     // close() を呼ぶ
     // Call close() through the imperative handle.
-    handle?.close();
+    handleRef.current?.close();
 
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();

--- a/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.tsx
+++ b/src/components/editor/TiptapEditor/EditorBubbleMenuToolbar.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { Editor } from "@tiptap/core";
 import { cn } from "@zedi/ui";
 import {

--- a/src/components/editor/TiptapEditor/SlashAgentLoadingOverlay.tsx
+++ b/src/components/editor/TiptapEditor/SlashAgentLoadingOverlay.tsx
@@ -3,7 +3,7 @@
  * Claude Code スラッシュ実行中のオーバーレイ。
  */
 
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Loader2 } from "lucide-react";
 
 interface SlashAgentLoadingOverlayProps {

--- a/src/components/editor/TiptapEditor/SlashMenuRows.tsx
+++ b/src/components/editor/TiptapEditor/SlashMenuRows.tsx
@@ -3,7 +3,6 @@
  * ブロック＋エージェントのスラッシュ行を描画する。
  */
 
-import React from "react";
 import { cn } from "@zedi/ui";
 import { Bot } from "lucide-react";
 import { slashMenuIconMap, agentSlashIconName } from "./slashSuggestionIcons";

--- a/src/components/editor/TiptapEditor/SlashPathCompletionSection.tsx
+++ b/src/components/editor/TiptapEditor/SlashPathCompletionSection.tsx
@@ -3,7 +3,7 @@
  * メインスラッシュメニュー下のワークスペースパス補完一覧。
  */
 
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 import { cn } from "@zedi/ui";
 
 interface SlashPathCompletionSectionProps {

--- a/src/components/editor/TiptapEditor/SlashSuggestionMenu.tsx
+++ b/src/components/editor/TiptapEditor/SlashSuggestionMenu.tsx
@@ -3,7 +3,7 @@
  * スラッシュコマンドメニュー本体（ref でキーボード）。ブロック＋任意の Claude エージェント行。
  */
 
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 import { SlashMenuRows } from "./SlashMenuRows";
 import { SlashPathCompletionSection } from "./SlashPathCompletionSection";
 import type { SlashSuggestionHandle } from "./slashSuggestionHandle";

--- a/src/components/editor/TiptapEditor/TagSuggestionLayer.tsx
+++ b/src/components/editor/TiptapEditor/TagSuggestionLayer.tsx
@@ -12,7 +12,7 @@ interface TagSuggestionLayerProps {
   editor: Editor | null;
   suggestionState: TagSuggestionState | null;
   position: { top: number; left: number } | null;
-  suggestionRef: React.RefObject<TagSuggestionHandle>;
+  suggestionRef: React.RefObject<TagSuggestionHandle | null>;
   onSelect: (item: TagSuggestionItem) => void;
   onClose: () => void;
   /**

--- a/src/components/editor/TiptapEditor/WikiLinkSuggestionLayer.tsx
+++ b/src/components/editor/TiptapEditor/WikiLinkSuggestionLayer.tsx
@@ -12,7 +12,7 @@ interface WikiLinkSuggestionLayerProps {
   editor: Editor | null;
   suggestionState: WikiLinkSuggestionState | null;
   position: { top: number; left: number } | null;
-  suggestionRef: React.RefObject<WikiLinkSuggestionHandle>;
+  suggestionRef: React.RefObject<WikiLinkSuggestionHandle | null>;
   onSelect: (item: SuggestionItem) => void;
   onClose: () => void;
   /**

--- a/src/components/editor/TiptapEditor/mermaidCodeBlockNormalizeExtension.test.ts
+++ b/src/components/editor/TiptapEditor/mermaidCodeBlockNormalizeExtension.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { Editor } from "@tiptap/core";
+import { Editor, type Content } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import { Mermaid } from "../extensions/MermaidExtension";
 import { MermaidCodeBlockNormalize } from "./mermaidCodeBlockNormalizeExtension";
@@ -29,7 +29,7 @@ describe("MermaidCodeBlockNormalize", () => {
    * Mermaid node (the real NodeView relies on React rendering inside the DOM,
    * which isn't needed for these unit tests).
    */
-  function createEditor(content: unknown): Editor {
+  function createEditor(content: Content): Editor {
     const el = document.createElement("div");
     const editor = new Editor({
       element: el,

--- a/src/components/editor/TiptapEditor/useSuggestionEffects.test.ts
+++ b/src/components/editor/TiptapEditor/useSuggestionEffects.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+import { DecorationSet } from "@tiptap/pm/view";
 import { useSuggestionEffects } from "./useSuggestionEffects";
 import type { Editor } from "@tiptap/core";
-import { wikiLinkSuggestionPluginKey } from "../extensions/wikiLinkSuggestionPlugin";
-import { slashSuggestionPluginKey } from "../extensions/slashSuggestionPlugin";
-import { tagSuggestionPluginKey } from "../extensions/tagSuggestionPlugin";
+import {
+  wikiLinkSuggestionPluginKey,
+  type WikiLinkSuggestionState,
+} from "../extensions/wikiLinkSuggestionPlugin";
+import {
+  slashSuggestionPluginKey,
+  type SlashSuggestionState,
+} from "../extensions/slashSuggestionPlugin";
+import { tagSuggestionPluginKey, type TagSuggestionState } from "../extensions/tagSuggestionPlugin";
 
 const mockCheckReferenced = vi.fn();
 vi.mock("@/hooks/usePageQueries", () => ({
@@ -44,15 +51,13 @@ const editorContainerRef = { current: document.createElement("div") };
 describe("useSuggestionEffects", () => {
   const defaultOptions = {
     editor: null as Editor | null,
-    suggestionState: null as { active: boolean; range: { from: number; to: number } | null } | null,
-    slashState: null as { active: boolean; range: { from: number; to: number } | null } | null,
-    tagSuggestionState: null as {
-      active: boolean;
-      range: { from: number; to: number } | null;
-    } | null,
+    suggestionState: null as WikiLinkSuggestionState | null,
+    slashState: null as SlashSuggestionState | null,
+    tagSuggestionState: null as TagSuggestionState | null,
     editorContainerRef,
     pageId: "page-1",
     handleInsertImageClick: vi.fn(),
+    handleInsertCameraImageClick: vi.fn(),
   };
 
   beforeEach(() => {
@@ -63,7 +68,12 @@ describe("useSuggestionEffects", () => {
     const { result } = renderHook(() =>
       useSuggestionEffects({
         ...defaultOptions,
-        suggestionState: { active: true, range: { from: 0, to: 5 } },
+        suggestionState: {
+          active: true,
+          query: "",
+          range: { from: 0, to: 5 },
+          decorations: DecorationSet.empty,
+        },
       }),
     );
 
@@ -86,7 +96,12 @@ describe("useSuggestionEffects", () => {
       useSuggestionEffects({
         ...defaultOptions,
         editor: mockEditor,
-        suggestionState: { active: true, range: { from: 0, to: 5 } },
+        suggestionState: {
+          active: true,
+          query: "",
+          range: { from: 0, to: 5 },
+          decorations: DecorationSet.empty,
+        },
       }),
     );
 
@@ -114,7 +129,12 @@ describe("useSuggestionEffects", () => {
       useSuggestionEffects({
         ...defaultOptions,
         editor: mockEditor,
-        suggestionState: { active: true, range: { from: 0, to: 5 } },
+        suggestionState: {
+          active: true,
+          query: "",
+          range: { from: 0, to: 5 },
+          decorations: DecorationSet.empty,
+        },
       }),
     );
 
@@ -201,7 +221,12 @@ describe("useSuggestionEffects", () => {
       useSuggestionEffects({
         ...defaultOptions,
         editor: mockEditor,
-        tagSuggestionState: { active: true, range: { from: 1, to: 5 } },
+        tagSuggestionState: {
+          active: true,
+          query: "",
+          range: { from: 1, to: 5 },
+          decorations: DecorationSet.empty,
+        },
       }),
     );
 
@@ -238,7 +263,12 @@ describe("useSuggestionEffects", () => {
       useSuggestionEffects({
         ...defaultOptions,
         editor: mockEditor,
-        tagSuggestionState: { active: true, range: { from: 1, to: 5 } },
+        tagSuggestionState: {
+          active: true,
+          query: "",
+          range: { from: 1, to: 5 },
+          decorations: DecorationSet.empty,
+        },
       }),
     );
 
@@ -264,7 +294,12 @@ describe("useSuggestionEffects", () => {
     const { result } = renderHook(() =>
       useSuggestionEffects({
         ...defaultOptions,
-        tagSuggestionState: { active: true, range: { from: 0, to: 5 } },
+        tagSuggestionState: {
+          active: true,
+          query: "",
+          range: { from: 0, to: 5 },
+          decorations: DecorationSet.empty,
+        },
       }),
     );
 

--- a/src/components/editor/TiptapEditor/useTagStatusSync.test.tsx
+++ b/src/components/editor/TiptapEditor/useTagStatusSync.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, act } from "@testing-library/react";
 import { useTagStatusSync } from "./useTagStatusSync";
@@ -21,7 +20,7 @@ vi.mock("@/hooks/useNoteQueries", () => ({
 vi.mock("@/hooks/usePageQueries", () => ({
   useWikiLinkExistsChecker: vi.fn(
     (options?: { notePages?: MockNotePage[]; pageNoteId?: string | null }) => ({
-      checkExistence: vi.fn(async (titles: string[]) => {
+      checkExistence: vi.fn(async () => {
         const inScope = options?.pageNoteId ? (options.notePages ?? []) : [];
         const pageTitles = new Set(inScope.map((page) => page.title.toLowerCase().trim()));
         // issue #737: `pageTitleToId` を返すモック契約。

--- a/src/components/editor/TiptapEditor/useTiptapEditorController.ts
+++ b/src/components/editor/TiptapEditor/useTiptapEditorController.ts
@@ -60,7 +60,7 @@ function useEditorControllers(args: {
   tagSuggestionRef: RefObject<TagSuggestionHandle | null>;
   handleInsertImageClick: () => void;
   handleInsertCameraImageClick: () => void;
-  handleImageUpload: (files: File[]) => Promise<void>;
+  handleImageUpload: (files: FileList | File[]) => void;
   /** Note-linked workspace root for `@file:` (Issue #461). */
   workspaceRoot: string | null;
   /** Note id for Tauri workspace registry (Issue #461). */
@@ -233,7 +233,7 @@ export function useTiptapEditorController({
   const editorControllers = useEditorControllers({
     content,
     onChange,
-    placeholder,
+    placeholder: placeholder ?? "",
     autoFocus,
     pageId: pageId ?? "",
     isReadOnly,

--- a/src/components/editor/TiptapEditor/useWikiLinkStatusSync.test.tsx
+++ b/src/components/editor/TiptapEditor/useWikiLinkStatusSync.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, act } from "@testing-library/react";
 import { useWikiLinkStatusSync } from "./useWikiLinkStatusSync";
@@ -20,7 +19,7 @@ vi.mock("@/hooks/useNoteQueries", () => ({
 vi.mock("@/hooks/usePageQueries", () => ({
   useWikiLinkExistsChecker: vi.fn(
     (options?: { notePages?: MockNotePage[]; pageNoteId?: string | null }) => ({
-      checkExistence: vi.fn(async (titles: string[]) => {
+      checkExistence: vi.fn(async () => {
         const inScope = options?.pageNoteId ? (options.notePages ?? []) : [];
         const pageTitles = new Set(inScope.map((page) => page.title.toLowerCase().trim()));
         // issue #737: `pageTitleToId` を返すモック契約。`targetId` 解決を伴う

--- a/src/components/editor/WikiLinkInputBar.test.tsx
+++ b/src/components/editor/WikiLinkInputBar.test.tsx
@@ -21,7 +21,9 @@ vi.mock("@/hooks/useWikiLinkCandidates", () => ({
 
 const mockCheckExistence = vi.fn();
 const mockCheckReferenced = vi.fn();
-const mockUseWikiLinkExistsChecker = vi.fn(() => ({ checkExistence: mockCheckExistence }));
+const mockUseWikiLinkExistsChecker = vi.fn((_options: unknown) => ({
+  checkExistence: mockCheckExistence,
+}));
 vi.mock("@/hooks/usePageQueries", () => ({
   useWikiLinkExistsChecker: (options: unknown) => mockUseWikiLinkExistsChecker(options),
   useCheckGhostLinkReferenced: () => ({ checkReferenced: mockCheckReferenced }),

--- a/src/components/editor/executableCodeBlock/ExecutableCodeBlockConfirmDialog.tsx
+++ b/src/components/editor/executableCodeBlock/ExecutableCodeBlockConfirmDialog.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import {
   AlertDialog,

--- a/src/components/editor/executableCodeBlock/ExecutableCodeBlockOutputPanel.tsx
+++ b/src/components/editor/executableCodeBlock/ExecutableCodeBlockOutputPanel.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { statusLabelForExecutableRun } from "./executableCodeBlockI18n";
 import type { ExecutableRunStatus } from "../extensions/ExecutableCodeBlockExtension";

--- a/src/components/editor/executableCodeBlock/ExecutableCodeBlockToolbar.tsx
+++ b/src/components/editor/executableCodeBlock/ExecutableCodeBlockToolbar.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Play, Bot, Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@zedi/ui";

--- a/src/components/editor/extensions/ExecutableCodeBlockExtension.ts
+++ b/src/components/editor/extensions/ExecutableCodeBlockExtension.ts
@@ -16,11 +16,13 @@ export interface ExecutableCodeBlockOptions {
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
-    /**
-     * Inserts an executable code block (Claude Code / Bash).
-     * 実行可能コードブロック（Claude Code / Bash）を挿入する。
-     */
-    insertExecutableCodeBlock: (attrs?: { language?: string }) => ReturnType;
+    executableCodeBlock: {
+      /**
+       * Inserts an executable code block (Claude Code / Bash).
+       * 実行可能コードブロック（Claude Code / Bash）を挿入する。
+       */
+      insertExecutableCodeBlock: (attrs?: { language?: string }) => ReturnType;
+    };
   }
 }
 

--- a/src/components/editor/extensions/FileReferenceExtension.ts
+++ b/src/components/editor/extensions/FileReferenceExtension.ts
@@ -113,7 +113,7 @@ export const FileReference = Mark.create<FileReferenceOptions>({
       new Plugin({
         key: new PluginKey("fileReferenceClick"),
         props: {
-          handleClick: (view, _pos, event) => {
+          handleClick: (_view, _pos, event) => {
             const target = event.target as HTMLElement | null;
             const el = target?.closest?.("[data-file-ref]") as HTMLElement | null;
             if (!el) return false;

--- a/src/components/editor/extensions/StorageImageExtension.ts
+++ b/src/components/editor/extensions/StorageImageExtension.ts
@@ -29,9 +29,13 @@ export interface StorageImageOptions extends ImageOptions {
  * Image node extending Tiptap's Image extension with storage-provider integration and Gyazo permalink input rules.
  */
 export const StorageImage = Image.extend<StorageImageOptions>({
-  addOptions() {
+  addOptions(): StorageImageOptions {
+    // `this.parent` is always defined for an extended extension at runtime, so
+    // the spread supplies the required `ImageOptions` fields (inline / allowBase64
+    // / resize). Cast narrows the optional-chained `... | undefined` away.
+    const parentOptions = this.parent?.() as StorageImageOptions;
     return {
-      ...this.parent?.(),
+      ...parentOptions,
       HTMLAttributes: {},
       getProviderLabel: undefined,
       canDeleteFromStorage: undefined,

--- a/src/components/editor/extensions/TagExtension.test.ts
+++ b/src/components/editor/extensions/TagExtension.test.ts
@@ -368,7 +368,16 @@ describe("TagExtension input rule", () => {
      */
     function typeAt(editor: Editor, pos: number, text: string): boolean | undefined {
       const { view } = editor;
-      return view.someProp("handleTextInput", (handler) => handler(view, pos, pos, text));
+      return view.someProp("handleTextInput", (handler) =>
+        // ProseMirror invokes `handleTextInput` with 4 args at runtime; the
+        // extra `deflt` param in its type is unused here.
+        (handler as (v: typeof view, from: number, to: number, text: string) => boolean)(
+          view,
+          pos,
+          pos,
+          text,
+        ),
+      );
     }
 
     it("applies the tag mark when `#tech ` is completed by a space", () => {
@@ -621,7 +630,10 @@ describe("Tag extension configuration", () => {
         ...extension,
         parent: undefined,
       };
-      const attrs = addAttributes.call(context) as Record<string, unknown>;
+      // Mock `this` context only needs the runtime fields the handler reads.
+      const attrs = addAttributes.call(
+        context as unknown as ThisParameterType<typeof addAttributes>,
+      ) as Record<string, unknown>;
       const targetId = attrs.targetId as ReturnType<typeof getTargetIdSpec>;
       if (!targetId) throw new Error("targetId attribute missing");
       return targetId;

--- a/src/components/editor/extensions/WikiLinkExtension.test.ts
+++ b/src/components/editor/extensions/WikiLinkExtension.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { WikiLink, WIKI_LINK_PASTE_REGEX } from "./WikiLinkExtension";
 
 /**
@@ -100,7 +100,10 @@ describe("WikiLinkExtension paste rule", () => {
         options: { HTMLAttributes: {}, onLinkClick },
         parent: undefined,
       };
-      const plugins = addProseMirrorPlugins.call(context) as Array<{
+      // Mock `this` context only needs the runtime fields the handler reads.
+      const plugins = addProseMirrorPlugins.call(
+        context as unknown as ThisParameterType<typeof addProseMirrorPlugins>,
+      ) as Array<{
         spec: {
           props: {
             handleClick?: HandleClick;
@@ -242,7 +245,10 @@ describe("WikiLinkExtension paste rule", () => {
           ...extension,
           parent: undefined,
         };
-        const attrs = addAttributes.call(context) as Record<string, unknown>;
+        // Mock `this` context only needs the runtime fields the handler reads.
+        const attrs = addAttributes.call(
+          context as unknown as ThisParameterType<typeof addAttributes>,
+        ) as Record<string, unknown>;
         const targetId = attrs.targetId as ReturnType<typeof getTargetIdSpec>;
         if (!targetId) throw new Error("targetId attribute missing");
         return targetId;

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -5,7 +5,6 @@
  * 共通レイアウト: ヘッダー・メイン（左サイドバーなし）・モバイルボトムナビ、
  * および CSS 変数。
  */
-import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { AppLayout } from "./AppLayout";

--- a/src/components/layout/BottomNav/BottomNavTab.tsx
+++ b/src/components/layout/BottomNav/BottomNavTab.tsx
@@ -4,7 +4,7 @@ import { cn } from "@zedi/ui";
 
 interface BottomNavTabProps {
   to: string;
-  icon: React.FC<{ className?: string }>;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   label: string;
   active: boolean;
 }

--- a/src/components/layout/Header/NavigationMenu.test.tsx
+++ b/src/components/layout/Header/NavigationMenu.test.tsx
@@ -9,7 +9,6 @@
  * {@link NavigationMenu} のテスト。項目は共通の {@link PRIMARY_NAV_ITEMS} を参照し、
  * ヘッダーとモバイルボトムナビの表示項目が常に一致することを保証する。
  */
-import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/src/components/layout/ImageCreateDialog.test.tsx
+++ b/src/components/layout/ImageCreateDialog.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { AIProviderType, APIMode } from "@/types/ai";
 
 // --- Mocks ---
 // vi.mock() は hoist されるので、共有する値は vi.hoisted() で作る。
@@ -13,9 +14,9 @@ const mocks = vi.hoisted(() => ({
   },
   useAISettingsMock: {
     settings: {
-      provider: "openai" as const,
+      provider: "openai" as AIProviderType,
       apiKey: "sk-test",
-      apiMode: "user_api_key" as const,
+      apiMode: "user_api_key" as APIMode,
       model: "gpt-5-mini",
       modelId: "openai:gpt-5-mini",
       isConfigured: true,
@@ -78,8 +79,10 @@ async function advanceToPreview(user: ReturnType<typeof userEvent.setup>) {
 }
 
 describe("ImageCreateDialog", () => {
-  let onOpenChange: ReturnType<typeof vi.fn>;
-  let onCreated: ReturnType<typeof vi.fn>;
+  let onOpenChange: ReturnType<typeof vi.fn<(open: boolean) => void>>;
+  let onCreated: ReturnType<
+    typeof vi.fn<(imageUrl: string, extractedText?: string, description?: string) => void>
+  >;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -91,8 +94,8 @@ describe("ImageCreateDialog", () => {
     useAISettingsMock.settings.model = "gpt-5-mini";
     useAISettingsMock.settings.modelId = "openai:gpt-5-mini";
     useAISettingsMock.settings.isConfigured = true;
-    onOpenChange = vi.fn();
-    onCreated = vi.fn();
+    onOpenChange = vi.fn<(open: boolean) => void>();
+    onCreated = vi.fn<(imageUrl: string, extractedText?: string, description?: string) => void>();
   });
 
   afterEach(() => {

--- a/src/components/layout/MobileHeader.test.tsx
+++ b/src/components/layout/MobileHeader.test.tsx
@@ -8,7 +8,6 @@
  * ロゴ・検索 Sheet のトグル・既存のデスクトップウィジェット（NavigationMenu /
  * UnifiedMenu）は描画されない（役割はボトムナビへ移動）。
  */
-import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";

--- a/src/components/note/NoteWorkspaceToolbar.tsx
+++ b/src/components/note/NoteWorkspaceToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { FolderOpen, FolderTree, Trash2 } from "lucide-react";
 import { Button, Dialog, DialogContent, DialogHeader, DialogTitle } from "@zedi/ui";
 import { useTranslation } from "react-i18next";

--- a/src/components/note/PageEditorContent.tsx
+++ b/src/components/note/PageEditorContent.tsx
@@ -31,10 +31,10 @@ function getCollaborationState(collaboration: UseCollaborationReturn | undefined
   isInitialSyncPending: boolean;
   collaborationConfig: CollaborationConfig | undefined;
 } {
-  const ready = Boolean(
-    collaboration?.ydoc && collaboration?.xmlFragment && collaboration?.collaborationUser,
-  );
-  if (!ready || !collaboration) {
+  const ydoc = collaboration?.ydoc;
+  const xmlFragment = collaboration?.xmlFragment;
+  const collaborationUser = collaboration?.collaborationUser;
+  if (!collaboration || !ydoc || !xmlFragment || !collaborationUser) {
     return {
       useCollaborationMode: false,
       isInitialSyncPending: false,
@@ -42,10 +42,10 @@ function getCollaborationState(collaboration: UseCollaborationReturn | undefined
     };
   }
   const config: CollaborationConfig = {
-    ydoc: collaboration.ydoc,
-    xmlFragment: collaboration.xmlFragment,
+    ydoc,
+    xmlFragment,
     awareness: collaboration.awareness,
-    user: collaboration.collaborationUser,
+    user: collaborationUser,
     updateCursor: collaboration.updateCursor,
     updateSelection: collaboration.updateSelection,
     isSynced: collaboration.isSynced,

--- a/src/components/page/LinkGroupRow.tsx
+++ b/src/components/page/LinkGroupRow.tsx
@@ -10,7 +10,7 @@ interface LinkGroupRowProps {
    * `/notes/:noteId/:pageId` 遷移用に noteId も渡す（Issue #889 Phase 3）。
    * Passes `noteId` so the parent can build the `/notes/:noteId/:pageId` URL.
    */
-  onPageClick: (pageId: string, noteId: string) => void;
+  onPageClick: (pageId: string, noteId: string | null) => void;
 }
 
 /**

--- a/src/components/page/LinkSection.tsx
+++ b/src/components/page/LinkSection.tsx
@@ -12,7 +12,7 @@ interface LinkSectionProps {
    * `/notes/:noteId/:pageId` requires both ids — pass the page's `noteId` to
    * the parent (Issue #889 Phase 3).
    */
-  onPageClick: (pageId: string, noteId: string) => void;
+  onPageClick: (pageId: string, noteId: string | null) => void;
 }
 
 /**

--- a/src/components/page/LinkedPagesSection.tsx
+++ b/src/components/page/LinkedPagesSection.tsx
@@ -135,7 +135,7 @@ export function LinkedPagesSection({
    * Navigate to a linked page. `PageCard` carries `noteId`, so we can build
    * `/notes/:noteId/:pageId` directly (Issue #889 Phase 3).
    */
-  const handlePageClick = (id: string, noteId: string) => {
+  const handlePageClick = (id: string, noteId: string | null) => {
     navigate(`/notes/${noteId}/${id}`);
   };
 

--- a/src/components/page/PageGrid.test.tsx
+++ b/src/components/page/PageGrid.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { PageSummary } from "@/types/page";

--- a/src/components/pdfReader/PdfPageCanvas.tsx
+++ b/src/components/pdfReader/PdfPageCanvas.tsx
@@ -92,6 +92,7 @@ function PdfPageCanvasImpl({ pdfDoc, pageNumber, scale, onViewportReady }: PdfPa
         }
 
         renderTask = page.render({
+          canvas,
           canvasContext: ctx,
           viewport,
           // dpr=1 のときは undefined を渡してデフォルトパスを温存する。

--- a/src/components/search/SearchResultCard.tsx
+++ b/src/components/search/SearchResultCard.tsx
@@ -38,11 +38,13 @@ export interface SearchResultCardPageItem extends SearchResultCardBase {
   kind: "page";
   pageId: string;
   /**
-   * 所属ノート ID。Issue #889 Phase 3 で `/pages/:id` を廃止し、全ページ結果が
-   * `/notes/:noteId/:pageId` に統合された。Issue #825 で型も non-null。
-   * Owning note id; required after Issue #889 Phase 3 / #825.
+   * 所属ノート ID。`null` は個人ページ（`Boolean(noteId)` で shared/personal を
+   * 判定）。note-native ページは `/notes/:noteId/:pageId` へ遷移する（Issue #889
+   * Phase 3）。`Page.noteId` の暫定 `string | null` を反映。
+   * Owning note id; `null` is a personal page (shared vs personal is decided by
+   * `Boolean(noteId)`). Mirrors the interim `string | null` on `Page.noteId`.
    */
-  noteId: string;
+  noteId: string | null;
   sourceUrl?: string;
 }
 

--- a/src/components/settings/AISettingsFormUserKeySection.tsx
+++ b/src/components/settings/AISettingsFormUserKeySection.tsx
@@ -7,7 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Alert, AlertDescription, AlertTitle } from "@zedi/ui";
 import { CollapsibleHelp } from "./CollapsibleHelp";
 import { ApiKeySourcesHelp } from "./ApiKeySourcesHelp";
-import type { AIProvider } from "@/types/ai";
+import type { AIProvider, AISettings } from "@/types/ai";
 import { useTranslation } from "react-i18next";
 
 interface AISettingsFormUserKeySectionProps {
@@ -18,7 +18,7 @@ interface AISettingsFormUserKeySectionProps {
   currentProvider: AIProvider | undefined;
   showApiKey: boolean;
   onToggleShowApiKey: () => void;
-  onUpdateSettings: (updates: { provider?: string; apiKey?: string; model?: string }) => void;
+  onUpdateSettings: (updates: Partial<AISettings>) => void;
   isSaving: boolean;
   isTesting: boolean;
   testResult: { success: boolean; message: string } | null;

--- a/src/components/settings/LanguageSettingsCard.tsx
+++ b/src/components/settings/LanguageSettingsCard.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Languages } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@zedi/ui";
 import { useTranslation } from "react-i18next";

--- a/src/components/settings/McpServerFormRemoteFields.tsx
+++ b/src/components/settings/McpServerFormRemoteFields.tsx
@@ -3,7 +3,6 @@
  * HTTP/SSE fields for the MCP server form (Issue #463).
  */
 
-import React from "react";
 import { Plus, Trash2 } from "lucide-react";
 import { Button } from "@zedi/ui";
 import { Input } from "@zedi/ui";

--- a/src/components/settings/McpServerFormStdioFields.tsx
+++ b/src/components/settings/McpServerFormStdioFields.tsx
@@ -4,7 +4,6 @@
  */
 
 import type { TFunction } from "i18next";
-import React from "react";
 import { Plus, Trash2 } from "lucide-react";
 import { Button } from "@zedi/ui";
 import { Input } from "@zedi/ui";

--- a/src/components/settings/McpServerRow.tsx
+++ b/src/components/settings/McpServerRow.tsx
@@ -3,7 +3,6 @@
  * Single row in the MCP server list (Issue #463).
  */
 
-import React from "react";
 import { Pencil, Trash2 } from "lucide-react";
 import { Button } from "@zedi/ui";
 import { Badge } from "@zedi/ui";

--- a/src/components/settings/ProfileFormFields.tsx
+++ b/src/components/settings/ProfileFormFields.tsx
@@ -21,7 +21,7 @@ export interface ProfileFormFieldsProps {
   onAvatarRemove: () => void;
   /** When true, show the "Remove avatar" button (user has set a custom avatar). / true のとき「アバターを削除」ボタンを表示。 */
   hasCustomAvatar: boolean;
-  fileInputRef: React.RefObject<HTMLInputElement>;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
   /** Optional error message below display name (e.g. "Display name is required"). / 表示名の下に出す任意のエラーメッセージ。 */
   displayNameError?: string;
   /** Optional id prefix for inputs (e.g. "onboarding" for onboarding-displayName). / 入力要素の id プレフィックス（例: onboarding）。 */

--- a/src/components/settings/ProfileSettingsCard.tsx
+++ b/src/components/settings/ProfileSettingsCard.tsx
@@ -10,7 +10,7 @@ export interface ProfileSettingsCardProps {
   avatarUrl: string | undefined;
   displayName: string | undefined;
   updateProfileAndSave: (updates: { displayName?: string; avatarUrl?: string }) => void;
-  fileInputRef: React.RefObject<HTMLInputElement>;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
   onAvatarFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   /** Called when user removes avatar; parent should revoke blob URL and clear ref before updating. / アバター削除時。親で blob URL を revoke し ref をクリアしてから更新すること。 */
   onAvatarRemove?: () => void;
@@ -43,7 +43,7 @@ export function ProfileSettingsCard({
       <CardContent className="space-y-6">
         <ProfileFormFields
           displayName={profile.displayName ?? ""}
-          avatarDisplayUrl={profile.avatarUrl || avatarUrl}
+          avatarDisplayUrl={profile.avatarUrl || avatarUrl || ""}
           displayNameForAvatar={displayName}
           onDisplayNameChange={(value) => updateProfileAndSave({ displayName: value })}
           onAvatarChange={onAvatarFileChange}

--- a/src/components/settings/useSettingsSummaries.ts
+++ b/src/components/settings/useSettingsSummaries.ts
@@ -18,7 +18,7 @@ function effectiveStorageProviderId(provider: string): StorageProviderType {
  * 各設定セクションカード向けの 1 行サマリーを生成する。
  */
 export function useSettingsSummaries(): Record<SettingsSectionId, string> {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const general = useGeneralSettings();
   const ai = useAISettings();
   const storage = useStorageSettings();

--- a/src/hooks/useAIChatMessageCallbacks.test.ts
+++ b/src/hooks/useAIChatMessageCallbacks.test.ts
@@ -25,7 +25,11 @@ vi.mock("@/lib/messageTree", async (importOriginal) => {
 import { executeSendMessage, executeRegenerateAssistant } from "./useAIChatExecute";
 import { patchMessageInTree } from "@/lib/messageTree";
 
-function createParams(overrides: Partial<Parameters<typeof useAIChatMessageCallbacks>[0]> = {}) {
+type CallbackParams = Parameters<typeof useAIChatMessageCallbacks>[0];
+
+function createParams(
+  overrides: Partial<CallbackParams> = {},
+): CallbackParams & { setTree: ReturnType<typeof vi.fn> } {
   const userMsg: TreeChatMessage = {
     id: "u1",
     role: "user",
@@ -60,7 +64,7 @@ function createParams(overrides: Partial<Parameters<typeof useAIChatMessageCallb
     abortControllerRef: { current: null },
     pendingBranchFromUserIdRef: { current: null },
     ...overrides,
-  } as ReturnType<typeof createParams>;
+  } as CallbackParams & { setTree: ReturnType<typeof vi.fn> };
 }
 
 describe("useAIChatMessageCallbacks", () => {

--- a/src/hooks/useAIChatPanelContentLifecycle.test.ts
+++ b/src/hooks/useAIChatPanelContentLifecycle.test.ts
@@ -128,7 +128,7 @@ describe("useAIChatPanelContentLifecycle", () => {
 
   it("resets conversation when page context changes", () => {
     const params: LifecycleParams = {
-      pageContext: { type: "note", pageId: "p1", pageTitle: "Page 1", pageContent: "" },
+      pageContext: { type: "editor", pageId: "p1", pageTitle: "Page 1", pageContent: "" },
       activeConversationId: "c1",
       activeConversation: makeConversation("c1"),
       messages: [],
@@ -149,7 +149,7 @@ describe("useAIChatPanelContentLifecycle", () => {
     rerender({
       params: {
         ...params,
-        pageContext: { type: "note", pageId: "p2", pageTitle: "Page 2", pageContent: "" },
+        pageContext: { type: "editor", pageId: "p2", pageTitle: "Page 2", pageContent: "" },
       },
     });
 

--- a/src/hooks/useAIChatPanelContentLogic.test.ts
+++ b/src/hooks/useAIChatPanelContentLogic.test.ts
@@ -417,9 +417,9 @@ describe("useAIChatPanelContentLogic - handlers wiring", () => {
 
     act(() => {
       // Move to a different tab first to assert the switch back to "chat".
-      result.current.setActiveViewTab("branchTree");
+      result.current.setActiveViewTab("branch");
     });
-    expect(result.current.activeViewTab).toBe("branchTree");
+    expect(result.current.activeViewTab).toBe("branch");
 
     act(() => {
       result.current.handleSelectBranch("u1");

--- a/src/hooks/useEditorWikiLinkShortcuts.test.ts
+++ b/src/hooks/useEditorWikiLinkShortcuts.test.ts
@@ -44,12 +44,12 @@ function dispatchKeyDown(init: KeyboardEventInit & { key: string }): KeyboardEve
 }
 
 describe("useEditorWikiLinkShortcuts - Cmd/Ctrl+K", () => {
-  let focusInputBar: ReturnType<typeof vi.fn>;
-  let convertSelectionToWikiLink: ReturnType<typeof vi.fn>;
+  let focusInputBar: ReturnType<typeof vi.fn<() => void>>;
+  let convertSelectionToWikiLink: ReturnType<typeof vi.fn<() => Promise<void>>>;
 
   beforeEach(() => {
-    focusInputBar = vi.fn();
-    convertSelectionToWikiLink = vi.fn().mockResolvedValue(undefined);
+    focusInputBar = vi.fn<() => void>();
+    convertSelectionToWikiLink = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
   });
 
   it("Cmd+K (mac) を捕捉して focusInputBar を呼び preventDefault する / catches Cmd+K on mac and invokes focusInputBar with preventDefault", () => {
@@ -126,12 +126,12 @@ describe("useEditorWikiLinkShortcuts - Cmd/Ctrl+K", () => {
 });
 
 describe("useEditorWikiLinkShortcuts - Cmd/Ctrl+Shift+L", () => {
-  let focusInputBar: ReturnType<typeof vi.fn>;
-  let convertSelectionToWikiLink: ReturnType<typeof vi.fn>;
+  let focusInputBar: ReturnType<typeof vi.fn<() => void>>;
+  let convertSelectionToWikiLink: ReturnType<typeof vi.fn<() => Promise<void>>>;
 
   beforeEach(() => {
-    focusInputBar = vi.fn();
-    convertSelectionToWikiLink = vi.fn().mockResolvedValue(undefined);
+    focusInputBar = vi.fn<() => void>();
+    convertSelectionToWikiLink = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
   });
 
   it("非空選択時に convertSelectionToWikiLink を呼ぶ / invokes convertSelectionToWikiLink when selection is non-empty", () => {
@@ -236,12 +236,12 @@ describe("useEditorWikiLinkShortcuts - Cmd/Ctrl+Shift+L", () => {
 });
 
 describe("useEditorWikiLinkShortcuts - 共通ガード / shared guards", () => {
-  let focusInputBar: ReturnType<typeof vi.fn>;
-  let convertSelectionToWikiLink: ReturnType<typeof vi.fn>;
+  let focusInputBar: ReturnType<typeof vi.fn<() => void>>;
+  let convertSelectionToWikiLink: ReturnType<typeof vi.fn<() => Promise<void>>>;
 
   beforeEach(() => {
-    focusInputBar = vi.fn();
-    convertSelectionToWikiLink = vi.fn().mockResolvedValue(undefined);
+    focusInputBar = vi.fn<() => void>();
+    convertSelectionToWikiLink = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
   });
 
   it("editor が null のときは何もしない / no-op when editor is null", () => {

--- a/src/hooks/useGlobalSearch.test.ts
+++ b/src/hooks/useGlobalSearch.test.ts
@@ -288,7 +288,6 @@ function createSharedRow(
 ): SearchPageResultRow {
   return {
     kind: "page",
-    id: overrides.id,
     note_id: "note-default" as string,
     owner_id: "u1",
     title: "shared",
@@ -311,7 +310,6 @@ function createHighlightRow(
 ): SearchPdfHighlightResultRow {
   return {
     kind: "pdf_highlight",
-    highlight_id: overrides.highlight_id,
     source_id: "src-1",
     owner_id: "u1",
     pdf_page: 1,

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -113,15 +113,17 @@ export interface GlobalSearchPageResultItem extends GlobalSearchResultBase {
   kind: "page";
   pageId: string;
   /**
-   * 所属ノート ID。Issue #823 / #825 で全ページが non-null `note_id` を持つ
-   * ようになって以降は必須。`/notes/:noteId/:pageId` の遷移先を組み立てる
-   * （Issue #889 Phase 3 で `/pages/:id` を廃止）。
+   * 所属ノート ID。`null` は個人ページ（`Page.noteId` の暫定 `string | null` を
+   * 反映）。note-native ページでは `/notes/:noteId/:pageId` の遷移先に使う
+   * （Issue #889 Phase 3 で `/pages/:id` を廃止）。null 個人ページの遷移は
+   * 個人ページ概念の根絶エピックで解消する。
    *
-   * Owning note id. Required since every page has a non-null `note_id` after
-   * Issues #823 / #825, and Issue #889 Phase 3 retired the standalone
-   * `/pages/:id` route — navigation always lands on `/notes/:noteId/:pageId`.
+   * Owning note id. `null` is a personal page (mirrors the interim
+   * `string | null` on `Page.noteId`). For note-native pages it builds the
+   * `/notes/:noteId/:pageId` target (Issue #889 Phase 3 retired `/pages/:id`).
+   * Navigating null personal pages is addressed by the personal-page removal epic.
    */
-  noteId: string;
+  noteId: string | null;
   sourceUrl?: string;
 }
 

--- a/src/hooks/useLinkedPages.ts
+++ b/src/hooks/useLinkedPages.ts
@@ -19,7 +19,9 @@ import type { PagePublicLinksResponse, PagePublicLinkCard } from "@/lib/api/type
  */
 export interface PageCard {
   id: string;
-  noteId: string;
+  // `null` は個人ページ（`Page.noteId` の暫定 `string | null` を反映）。
+  // `null` is a personal page, mirroring the interim `string | null` on `Page.noteId`.
+  noteId: string | null;
   title: string;
   preview: string; // Content preview (50 chars)
   updatedAt: number;

--- a/src/hooks/useMermaidGenerator.test.ts
+++ b/src/hooks/useMermaidGenerator.test.ts
@@ -221,7 +221,13 @@ describe("useMermaidGenerator", () => {
   });
 
   it("checkAIConfigured returns true and sets flag when settings load", async () => {
-    mockGetAISettingsOrThrow.mockResolvedValue({ provider: "google" });
+    mockGetAISettingsOrThrow.mockResolvedValue({
+      provider: "google",
+      apiKey: "",
+      model: "",
+      modelId: "",
+      isConfigured: true,
+    });
 
     const { result } = renderHook(() => useMermaidGenerator());
 

--- a/src/hooks/useWikiSchema.ts
+++ b/src/hooks/useWikiSchema.ts
@@ -3,7 +3,7 @@
  * ユーザーの Wiki スキーマ（「憲法」）ページの取得・更新フック。
  */
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAuth } from "@/hooks/useAuth";
+import { useUser } from "@/hooks/useAuth";
 
 /**
  * Response shape from GET /api/wiki-schema.
@@ -67,7 +67,7 @@ async function updateWikiSchema(body: {
  * @returns `{ data, isLoading, error, updateSchema }` — data is null when no schema exists yet.
  */
 export function useWikiSchema() {
-  const { user } = useAuth();
+  const { user } = useUser();
   const queryClient = useQueryClient();
   const queryKey = getWikiSchemaKey(user?.id);
 

--- a/src/hooks/useWorkflowRunSession.test.ts
+++ b/src/hooks/useWorkflowRunSession.test.ts
@@ -373,8 +373,10 @@ describe("useWorkflowRunSession - cleanup and signals", () => {
   });
 
   it("handlePause aborts the current step controller", async () => {
-    let capturedStepAbort: AbortController | null = null;
-    let resolveExecution: ((value: WorkflowExecutionOutcome) => void) | null = null;
+    // `null as` keeps the declared type from being narrowed to `null` when the
+    // variable is only assigned inside the mock callback below.
+    let capturedStepAbort = null as AbortController | null;
+    let resolveExecution = null as ((value: WorkflowExecutionOutcome) => void) | null;
 
     mockRunWorkflowExecution.mockImplementation(
       async (params: {
@@ -412,9 +414,11 @@ describe("useWorkflowRunSession - cleanup and signals", () => {
   });
 
   it("handleStop aborts both workflow and current-step controllers", async () => {
-    let capturedStepAbort: AbortController | null = null;
-    let capturedWorkflowSignal: AbortSignal | null = null;
-    let resolveExecution: ((value: WorkflowExecutionOutcome) => void) | null = null;
+    // `null as` keeps the declared type from being narrowed to `null` when the
+    // variable is only assigned inside the mock callback below.
+    let capturedStepAbort = null as AbortController | null;
+    let capturedWorkflowSignal = null as AbortSignal | null;
+    let resolveExecution = null as ((value: WorkflowExecutionOutcome) => void) | null;
 
     mockRunWorkflowExecution.mockImplementation(
       async (params: {
@@ -453,9 +457,11 @@ describe("useWorkflowRunSession - cleanup and signals", () => {
   });
 
   it("aborts in-flight controllers on unmount", async () => {
-    let capturedStepAbort: AbortController | null = null;
-    let capturedWorkflowSignal: AbortSignal | null = null;
-    let resolveExecution: ((value: WorkflowExecutionOutcome) => void) | null = null;
+    // `null as` keeps the declared type from being narrowed to `null` when the
+    // variable is only assigned inside the mock callback below.
+    let capturedStepAbort = null as AbortController | null;
+    let capturedWorkflowSignal = null as AbortSignal | null;
+    let resolveExecution = null as ((value: WorkflowExecutionOutcome) => void) | null;
 
     mockRunWorkflowExecution.mockImplementation(
       async (params: {

--- a/src/lib/aiChat/aiChatActionHelpers.test.ts
+++ b/src/lib/aiChat/aiChatActionHelpers.test.ts
@@ -395,46 +395,50 @@ describe("convertMarkdownToTiptapContent (URL sanitization)", () => {
 
 describe("getCreatePageOutline", () => {
   it("returns trimmed outline", () => {
-    const action = {
+    const action: CreatePageAction = {
       type: "create-page",
       title: "T",
+      content: "",
       outline: "- A\n- B",
       suggestedLinks: [],
       reason: "r",
-    } as CreatePageAction;
+    };
     expect(getCreatePageOutline(action)).toBe("- A\n- B");
   });
 
   it("returns empty string when outline missing", () => {
-    const action = {
+    const action: CreatePageAction = {
       type: "create-page",
       title: "T",
+      content: "",
       suggestedLinks: [],
       reason: "r",
-    } as CreatePageAction;
+    };
     expect(getCreatePageOutline(action)).toBe("");
   });
 
   it("uses outline field, not title", () => {
-    const action = {
+    const action: CreatePageAction = {
       type: "create-page",
       title: "TitleOnly",
+      content: "",
       outline: "OutlineBody",
       suggestedLinks: [],
       reason: "r",
-    } as CreatePageAction;
+    };
     expect(getCreatePageOutline(action)).toBe("OutlineBody");
     expect(getCreatePageOutline(action)).not.toContain("TitleOnly");
   });
 
   it("trims outline whitespace via optional chain", () => {
-    const action = {
+    const action: CreatePageAction = {
       type: "create-page",
       title: "T",
+      content: "",
       outline: "  padded  ",
       suggestedLinks: [],
       reason: "r",
-    } as CreatePageAction;
+    };
     expect(getCreatePageOutline(action)).toBe("padded");
   });
 });

--- a/src/lib/aiChat/runAIChatAction.test.ts
+++ b/src/lib/aiChat/runAIChatAction.test.ts
@@ -56,6 +56,7 @@ describe("runAIChatAction — create", () => {
     await runAIChatAction(deps, {
       type: "create-page",
       title: "Wiki Topic",
+      content: "",
       outline: "- A\n- B",
       suggestedLinks: [],
       reason: "test",
@@ -414,6 +415,7 @@ describe("runAIChatAction — create navigation guards", () => {
     await runAIChatAction(deps, {
       type: "create-page",
       title: "T",
+      content: "",
       outline: "",
       suggestedLinks: [],
       reason: "r",

--- a/src/lib/aiServiceDirectProviders.ts
+++ b/src/lib/aiServiceDirectProviders.ts
@@ -182,7 +182,7 @@ export async function callAnthropic(
 
     callbacks.onComplete?.({
       content,
-      finishReason: response.stop_reason,
+      finishReason: response.stop_reason ?? undefined,
     });
   }
 }

--- a/src/lib/aiServiceServer.test.ts
+++ b/src/lib/aiServiceServer.test.ts
@@ -3,9 +3,9 @@
  * AI サービス（API サーバー経由・SSE）のテスト。
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import { callAIWithServer } from "./aiServiceServer";
-import type { AIServiceRequest, AIServiceCallbacks } from "./aiService";
+import type { AIServiceRequest } from "./aiService";
 
 /**
  * Build a mock streaming Response whose body is a `ReadableStream<Uint8Array>`
@@ -38,9 +38,7 @@ function buildRequest(overrides: Partial<AIServiceRequest> = {}): AIServiceReque
   };
 }
 
-function buildCallbacks(): Required<
-  Pick<AIServiceCallbacks, "onChunk" | "onComplete" | "onError" | "onUsageUpdate">
-> {
+function buildCallbacks(): Record<"onChunk" | "onComplete" | "onError" | "onUsageUpdate", Mock> {
   return {
     onChunk: vi.fn(),
     onComplete: vi.fn(),

--- a/src/lib/collaboration/CollaborationManager.ts
+++ b/src/lib/collaboration/CollaborationManager.ts
@@ -81,7 +81,7 @@ export class CollaborationManager {
       url: wsUrl,
       name: documentName,
       document: this.ydoc,
-      token: () => this.getAuthToken(),
+      token: async () => (await this.getAuthToken()) ?? "",
       onStatus: ({ status }) => {
         this.updateState({
           status: status as ConnectionStatus,

--- a/src/lib/conversationMigration.test.ts
+++ b/src/lib/conversationMigration.test.ts
@@ -4,7 +4,8 @@ import { migrateConversation, needsMigration } from "./conversationMigration";
 
 describe("needsMigration", () => {
   it("returns true when legacy messages array is present without messageMap", () => {
-    expect(needsMigration({ messages: [] } as Conversation)).toBe(true);
+    // Partial fixture: needsMigration only inspects messages/messageMap.
+    expect(needsMigration({ messages: [] } as unknown as Conversation)).toBe(true);
     expect(
       needsMigration({
         messages: [{ id: "u1", role: "user", content: "Hi", timestamp: 0 }],

--- a/src/lib/markdownExport.ts
+++ b/src/lib/markdownExport.ts
@@ -38,7 +38,7 @@ function convertNode(node: TiptapNode): string {
   return handler ? handler(node) : convertChildren(node);
 }
 
-Object.assign(nodeHandlers, {
+Object.assign<Record<string, NodeHandler>, Record<string, NodeHandler>>(nodeHandlers, {
   doc: (n) => convertChildren(n),
   paragraph: (n) => convertChildren(n) + "\n\n",
   heading: (n) => {

--- a/src/lib/mermaidGenerator.ts
+++ b/src/lib/mermaidGenerator.ts
@@ -3,7 +3,7 @@
 import OpenAI from "openai";
 import Anthropic from "@anthropic-ai/sdk";
 import { GoogleGenAI } from "@google/genai";
-import { AISettings } from "@/types/ai";
+import { AISettings, AIProviderType } from "@/types/ai";
 import { loadAISettings } from "./aiSettings";
 import i18n from "@/i18n";
 
@@ -219,7 +219,7 @@ async function generateWithGoogle(
       },
     });
 
-    const code = response.text.trim();
+    const code = (response.text ?? "").trim();
 
     const detectedType = detectDiagramType(code, diagramTypes);
 
@@ -318,7 +318,11 @@ export async function generateMermaidDiagram(
   }
 
   // user_api_keyモード: 既存の直接SDK呼び出し
-  switch (settings.provider) {
+  // 上の guard で claude-code は除外済みだが、防御的な case を残すため広い union で switch する。
+  // The guard above already excludes claude-code, but widen the switch input back to the
+  // full provider union so the defensive `case "claude-code"` stays type-valid.
+  const provider = settings.provider as AIProviderType;
+  switch (provider) {
     case "openai":
       return generateWithOpenAI(settings, text, diagramTypes, callbacks);
     case "anthropic":
@@ -331,7 +335,7 @@ export async function generateMermaidDiagram(
       );
       break;
     default: {
-      const _exhaustive: never = settings.provider;
+      const _exhaustive: never = provider;
       callbacks.onError(new Error(`Unknown provider: ${_exhaustive}`));
     }
   }

--- a/src/lib/messageTree.ts
+++ b/src/lib/messageTree.ts
@@ -41,7 +41,7 @@ export function getActivePath(map: MessageMap, activeLeafId: string | null): Tre
       return [];
     }
     guard.add(current);
-    const node = map[current];
+    const node: TreeChatMessage | undefined = map[current];
     if (!node) {
       return [];
     }

--- a/src/lib/messageTreeLayout.ts
+++ b/src/lib/messageTreeLayout.ts
@@ -88,6 +88,9 @@ export function buildFlowGraph(
     const pos = dagreGraph.node(m.id);
     const isOnActivePath = activePathIds.has(m.id);
     const isActiveLeaf = activeLeafId === m.id;
+    // collectFromRoot は system を除外済みなので role は user/assistant に限られる。
+    // collectFromRoot already excludes system, so role is narrowed to user/assistant.
+    const role: BranchNodeData["role"] = m.role === "user" ? "user" : "assistant";
 
     return {
       id: m.id,
@@ -97,7 +100,7 @@ export function buildFlowGraph(
         y: pos.y - NODE_HEIGHT / 2,
       },
       data: {
-        role: m.role,
+        role,
         contentPreview: contentPreview(m.content),
         isOnActivePath,
         isActiveLeaf,

--- a/src/lib/pageRepository/StorageAdapterPageRepository.test.ts
+++ b/src/lib/pageRepository/StorageAdapterPageRepository.test.ts
@@ -3,6 +3,7 @@ import { StorageAdapterPageRepository } from "./StorageAdapterPageRepository";
 import type { StorageAdapter } from "@/lib/storageAdapter/StorageAdapter";
 import type { ApiClient } from "@/lib/api/apiClient";
 import type { PageMetadata, Link } from "@/lib/storageAdapter/types";
+import type { SyncPageItem } from "@/lib/api/types";
 
 vi.mock("@/lib/contentUtils", () => ({
   getPageListPreview: vi.fn((content: string) => (content ? content.slice(0, 50) : "")),
@@ -29,6 +30,7 @@ function createMockAdapter(): StorageAdapter {
     setLastSyncTime: vi.fn().mockResolvedValue(undefined),
     initialize: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
+    resetDatabase: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -466,6 +468,8 @@ describe("StorageAdapterPageRepository", () => {
 
     it("writes a personal page (`note_id: null`) through to the adapter and returns it", async () => {
       const nowIso = "2026-04-23T00:00:00.000Z";
+      // Personal copies arrive from the API with note_id = null (SyncPageItem types
+      // it as string; importPersonalPageFromApi handles null at runtime).
       const page = await repo.importPersonalPageFromApi({
         id: "copy-1",
         owner_id: AUTH_USER_ID,
@@ -478,7 +482,7 @@ describe("StorageAdapterPageRepository", () => {
         created_at: nowIso,
         updated_at: nowIso,
         is_deleted: false,
-      });
+      } as unknown as SyncPageItem);
 
       expect(page).not.toBeNull();
       expect(page?.id).toBe("copy-1");

--- a/src/lib/pdfKnowledge/pdfjsLoader.ts
+++ b/src/lib/pdfKnowledge/pdfjsLoader.ts
@@ -65,7 +65,15 @@ function ensureWorkerConfigured(): void {
  */
 export function getPdfDocument(data: Uint8Array): Promise<PdfDocumentProxy> {
   ensureWorkerConfigured();
-  return pdfjsLib.getDocument({
+  // `isEvalSupported` は実行時に有効なオプションだが、この pdfjs-dist の型定義
+  // (DocumentInitParameters) からは外れているため、その項目だけ型を拡張する。
+  // `isEvalSupported` is a valid runtime option but is missing from this
+  // pdfjs-dist version's DocumentInitParameters type, so widen just that field.
+  type DocumentInitParameters = Extract<
+    Parameters<typeof pdfjsLib.getDocument>[0],
+    { data?: unknown }
+  >;
+  const params: DocumentInitParameters & { isEvalSupported?: boolean } = {
     data,
     cMapUrl: CMAP_URL,
     cMapPacked: true,
@@ -74,7 +82,8 @@ export function getPdfDocument(data: Uint8Array): Promise<PdfDocumentProxy> {
     // Disable internal eval for untrusted PDFs as a defense-in-depth measure.
     isEvalSupported: false,
     // Workers are configured globally; using a fresh task per call is fine.
-  }).promise;
+  };
+  return pdfjsLib.getDocument(params).promise;
 }
 
 /**

--- a/src/lib/seedTutorialPages.test.ts
+++ b/src/lib/seedTutorialPages.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import type { TFunction } from "i18next";
 import { buildSeedTutorialPages } from "./seedTutorialPages";
 
 /**
@@ -31,9 +32,12 @@ function jaT(key: string): string {
   return table[key] ?? key;
 }
 
+// Minimal key→string mock; buildSeedTutorialPages only invokes t(key).
+const jaTFn = jaT as unknown as TFunction;
+
 describe("buildSeedTutorialPages", () => {
   it("returns three pages with parseable Tiptap JSON", () => {
-    const pages = buildSeedTutorialPages(jaT);
+    const pages = buildSeedTutorialPages(jaTFn);
     expect(pages).toHaveLength(3);
     for (const p of pages) {
       const doc = JSON.parse(p.content) as { type: string; content: unknown[] };
@@ -43,7 +47,7 @@ describe("buildSeedTutorialPages", () => {
   });
 
   it("uses first heading text from t", () => {
-    const [first] = buildSeedTutorialPages(jaT);
+    const [first] = buildSeedTutorialPages(jaTFn);
     const doc = JSON.parse(first.content) as {
       content: Array<{ type: string; content?: unknown[] }>;
     };

--- a/src/lib/storage/convertToWebP.test.ts
+++ b/src/lib/storage/convertToWebP.test.ts
@@ -50,7 +50,7 @@ describe("convertToWebP", () => {
           queueMicrotask(() => {
             Object.defineProperty(this, "naturalWidth", { value: 1 });
             Object.defineProperty(this, "naturalHeight", { value: 1 });
-            this.onload?.();
+            this.onload?.(new Event("load"));
           });
         }
       },
@@ -90,7 +90,7 @@ describe("convertToWebP", () => {
           queueMicrotask(() => {
             Object.defineProperty(this, "naturalWidth", { value: 1 });
             Object.defineProperty(this, "naturalHeight", { value: 1 });
-            this.onload?.();
+            this.onload?.(new Event("load"));
           });
         }
       },
@@ -121,7 +121,7 @@ describe("convertToWebP", () => {
           queueMicrotask(() => {
             Object.defineProperty(this, "naturalWidth", { value: 1 });
             Object.defineProperty(this, "naturalHeight", { value: 1 });
-            this.onload?.();
+            this.onload?.(new Event("load"));
           });
         }
       },
@@ -156,7 +156,7 @@ describe("convertToWebP", () => {
           queueMicrotask(() => {
             Object.defineProperty(this, "naturalWidth", { value: 1 });
             Object.defineProperty(this, "naturalHeight", { value: 1 });
-            this.onload?.();
+            this.onload?.(new Event("load"));
           });
         }
       },

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -23,7 +23,8 @@ export function getStorageProvider(
   const { provider, config } = settings;
 
   // Legacy: cloudflare-r2 is no longer supported; use default storage
-  const effectiveProvider = provider === "cloudflare-r2" ? "s3" : (provider as StorageProviderType);
+  const effectiveProvider =
+    (provider as string) === "cloudflare-r2" ? "s3" : (provider as StorageProviderType);
 
   switch (effectiveProvider) {
     case "s3":

--- a/src/lib/storage/providers/S3Provider.test.ts
+++ b/src/lib/storage/providers/S3Provider.test.ts
@@ -6,12 +6,12 @@ function createTestFile(): File {
 }
 
 describe("S3Provider", () => {
-  let getToken: ReturnType<typeof vi.fn>;
+  let getToken: ReturnType<typeof vi.fn<() => Promise<string | null>>>;
   let provider: S3Provider;
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    getToken = vi.fn<[], Promise<string | null>>().mockResolvedValue("test-jwt-token");
+    getToken = vi.fn<() => Promise<string | null>>().mockResolvedValue("test-jwt-token");
     const ctx: S3ProviderContext = {
       getToken,
       baseUrl: "https://api.example.com",

--- a/src/lib/storage/providers/S3Provider.ts
+++ b/src/lib/storage/providers/S3Provider.ts
@@ -37,7 +37,6 @@ function throwIfAborted(signal?: AbortSignal): void {
  */
 export class S3Provider implements StorageProviderInterface {
   readonly name = "デフォルトストレージ";
-  private readonly getToken: () => Promise<string | null>;
   private readonly baseUrl: string;
 
   /**
@@ -47,7 +46,6 @@ export class S3Provider implements StorageProviderInterface {
     if (!context.getToken) {
       throw new Error("S3Provider requires getToken in context");
     }
-    this.getToken = context.getToken;
     this.baseUrl = context.baseUrl ?? getDefaultBaseUrl();
   }
 

--- a/src/lib/sync/syncWithApi.test.ts
+++ b/src/lib/sync/syncWithApi.test.ts
@@ -29,6 +29,7 @@ function createMockAdapter(overrides: Partial<StorageAdapter> = {}): StorageAdap
     setLastSyncTime: vi.fn().mockResolvedValue(undefined),
     initialize: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
+    resetDatabase: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -661,7 +662,10 @@ describe("syncWithApi", () => {
 
     const upsertMock = adapter.upsertPage as ReturnType<typeof vi.fn>;
     const upsertedById = new Map<string, PageMetadata>(
-      upsertMock.mock.calls.map(([m]: [PageMetadata]) => [m.id, m]),
+      upsertMock.mock.calls.map((call) => {
+        const m = call[0] as PageMetadata;
+        return [m.id, m] as [string, PageMetadata];
+      }),
     );
     expect(upsertedById.get("p1")?.noteId).toBeNull();
     expect(upsertedById.get("p2")?.noteId).toBe("note-1");

--- a/src/lib/webClipper/clipWebPage.ts
+++ b/src/lib/webClipper/clipWebPage.ts
@@ -93,14 +93,14 @@ export async function clipWebPage(
     throw new Error("本文の抽出に失敗しました。このページは対応していない可能性があります。");
   }
 
-  const sanitizedContent = sanitizeHtml(article.content);
+  const sanitizedContent = sanitizeHtml(article.content ?? "");
   return {
     title: ogp.title || article.title || doc.title || "無題",
     content: sanitizedContent,
-    textContent: article.textContent,
+    textContent: article.textContent ?? "",
     excerpt: ogp.description || article.excerpt || "",
-    byline: article.byline,
-    siteName: ogp.siteName || article.siteName,
+    byline: article.byline ?? null,
+    siteName: ogp.siteName || article.siteName || null,
     thumbnailUrl: resolveUrl(url, ogp.image),
     sourceUrl: url,
   };

--- a/src/lib/wikiGenerator.test.ts
+++ b/src/lib/wikiGenerator.test.ts
@@ -188,8 +188,8 @@ describe("generateWikiContentStream", () => {
     });
 
     vi.mocked(callAIService).mockImplementation((_s, _req, handlers) => {
-      handlers.onChunk("Hello ");
-      handlers.onChunk("[[World]].");
+      handlers.onChunk?.("Hello ");
+      handlers.onChunk?.("[[World]].");
       handlers.onComplete?.({ content: "" });
       return Promise.resolve();
     });
@@ -236,8 +236,8 @@ describe("generateWikiContentStream", () => {
     });
 
     vi.mocked(callAIService).mockImplementation((_s, _req, handlers) => {
-      handlers.onChunk("Streamed ");
-      handlers.onChunk("body");
+      handlers.onChunk?.("Streamed ");
+      handlers.onChunk?.("body");
       handlers.onComplete?.({} as unknown as AIServiceResponse);
       return Promise.resolve();
     });
@@ -257,7 +257,7 @@ describe("generateWikiContentStream", () => {
     vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings });
     const svcErr = new Error("stream service failed");
     vi.mocked(callAIService).mockImplementation((_s, _req, handlers) => {
-      handlers.onError(svcErr);
+      handlers.onError?.(svcErr);
       return Promise.resolve();
     });
 
@@ -348,8 +348,8 @@ describe("generateWikiContentFromChatOutlineStream — api_server", () => {
     });
 
     vi.mocked(callAIService).mockImplementation((_s, _req, handlers) => {
-      handlers.onChunk("# ");
-      handlers.onChunk("Hello");
+      handlers.onChunk?.("# ");
+      handlers.onChunk?.("Hello");
       handlers.onComplete?.({ content: "# Hello" });
       return Promise.resolve();
     });
@@ -396,8 +396,8 @@ describe("generateWikiContentFromChatOutlineStream — api_server", () => {
   it("uses streamed chunks when onComplete returns undefined content", async () => {
     vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings, apiMode: "api_server" });
     vi.mocked(callAIService).mockImplementation((_s, _req, handlers) => {
-      handlers.onChunk("Part1");
-      handlers.onChunk("Part2");
+      handlers.onChunk?.("Part1");
+      handlers.onChunk?.("Part2");
       handlers.onComplete?.({ content: undefined } as unknown as AIServiceResponse);
       return Promise.resolve();
     });
@@ -422,7 +422,7 @@ describe("generateWikiContentFromChatOutlineStream — api_server", () => {
     vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings, apiMode: "api_server" });
     const err = new Error("chat svc");
     vi.mocked(callAIService).mockImplementation((_s, _req, handlers) => {
-      handlers.onError(err);
+      handlers.onError?.(err);
       return Promise.resolve();
     });
 
@@ -496,7 +496,7 @@ describe("generateWikiContentFromChatOutlineStream — user_api_key", () => {
     });
 
     vi.mocked(streamWikiStyleFromFullPrompt).mockImplementation((_s, _req, handlers) => {
-      handlers.onChunk("x");
+      handlers.onChunk?.("x");
       handlers.onComplete({ content: "x", wikiLinks: [] });
       return Promise.resolve();
     });

--- a/src/lib/wikiGenerator/wikiGeneratorProviders.ts
+++ b/src/lib/wikiGenerator/wikiGeneratorProviders.ts
@@ -93,12 +93,9 @@ function isClaudeWebSearchSupported(model: string): boolean {
 }
 
 /** Anthropic messages.stream に渡すパラメータ（tools はオプション） */
-interface AnthropicStreamParams {
-  model: string;
-  max_tokens: number;
-  messages: Array<{ role: "user"; content: string }>;
+type AnthropicStreamParams = Anthropic.MessageStreamParams & {
   tools?: Array<{ type: "web_search_20250305"; name: string; max_uses: number }>;
-}
+};
 
 /**
  * Anthropicでストリーミング生成（Web検索対応）

--- a/src/lib/workflow/runWorkflowExecution.test.ts
+++ b/src/lib/workflow/runWorkflowExecution.test.ts
@@ -49,7 +49,8 @@ describe("runWorkflowExecution", () => {
 
     expect(r).toEqual({ outcome: "completed" });
     expect(streamClaudeQuery).toHaveBeenCalledTimes(1);
-    const lastNote = onNote.mock.calls.at(-1)?.[0] as string;
+    const calls = onNote.mock.calls;
+    const lastNote = calls[calls.length - 1]?.[0] as string;
     expect(lastNote).toContain("base");
     expect(lastNote).toContain("Workflow: W");
     expect(lastNote).toContain("done");

--- a/src/lib/workflow/runWorkflowExecution.ts
+++ b/src/lib/workflow/runWorkflowExecution.ts
@@ -158,7 +158,7 @@ async function runWorkflowStepsLoop(
   };
 
   const emitNote = (
-    currentStepIndex: number,
+    _currentStepIndex: number,
     statuses: WorkflowStepRunStatus[],
     streamingStepIndex: number | null,
     streamingText: string,

--- a/src/lib/ydoc/__tests__/yDocToTiptapJson.test.ts
+++ b/src/lib/ydoc/__tests__/yDocToTiptapJson.test.ts
@@ -49,7 +49,8 @@ describe("yXmlFragmentToTiptapJson", () => {
     const doc = new Y.Doc();
     const fragment = doc.getXmlFragment("default");
     const heading = new Y.XmlElement("heading");
-    heading.setAttribute("level", 2);
+    // Tiptap stores heading level as a number; Y typings expect string attrs.
+    heading.setAttribute("level", 2 as unknown as string);
     const text = new Y.XmlText();
     text.insert(0, "Title");
     heading.insert(0, [text]);

--- a/src/pages/NotePageView.tsx
+++ b/src/pages/NotePageView.tsx
@@ -873,9 +873,11 @@ const NotePageView: React.FC = () => {
     navigate(`/notes/${noteId}`);
   }, [navigate, noteId]);
 
-  const canEdit = canEditPage(access, userId, page);
+  const canEdit = canEditPage(access ?? undefined, userId ?? undefined, page);
   const isTitleEditable =
-    page?.noteId != null ? Boolean(access?.canEdit) : canEdit && canEditTitle(userId, page);
+    page?.noteId != null
+      ? Boolean(access?.canEdit)
+      : canEdit && canEditTitle(userId ?? undefined, page);
   const collaborationPageId = page?.id ?? "";
   const isCollaborationEnabled = Boolean(collaborationPageId && isSignedIn && canEdit);
   const collaboration = useCollaboration({

--- a/src/pages/NoteView/index.tsx
+++ b/src/pages/NoteView/index.tsx
@@ -52,7 +52,10 @@ const NoteView: React.FC = () => {
   } = useNote(noteId ?? "", { allowRemote: true });
 
   const noteSource = source === "remote" ? "remote" : "local";
-  const { canView, canEdit, canManageMembers } = getNoteViewPermissions(access, noteSource);
+  const { canView, canEdit, canManageMembers } = getNoteViewPermissions(
+    access ?? undefined,
+    noteSource,
+  );
   const isLoading = isNoteLoading;
   const isNotFound = !note || !access?.canView;
 
@@ -123,13 +126,15 @@ const NoteView: React.FC = () => {
       floatingAction={
         canEdit ? (
           <div className="mr-4 mb-4 flex flex-col items-end gap-2">
-            <FloatingActionButton
-              noteId={note.id}
-              initialClipUrl={validClipUrl ?? undefined}
-              onClipDialogClosedWithInitialUrl={
-                validClipUrl ? handleClipDialogClosedWithInitialUrl : undefined
-              }
-            />
+            {validClipUrl ? (
+              <FloatingActionButton
+                noteId={note.id}
+                initialClipUrl={validClipUrl}
+                onClipDialogClosedWithInitialUrl={handleClipDialogClosedWithInitialUrl}
+              />
+            ) : (
+              <FloatingActionButton noteId={note.id} />
+            )}
           </div>
         ) : undefined
       }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -38,4 +38,5 @@ global.IntersectionObserver = class IntersectionObserver {
   unobserve = vi.fn();
   disconnect = vi.fn();
   takeRecords = vi.fn().mockReturnValue([]);
-};
+  // Test stub: shape matches the runtime usage, not the full DOM lib type.
+} as unknown as typeof IntersectionObserver;

--- a/src/types/page.ts
+++ b/src/types/page.ts
@@ -6,17 +6,25 @@ export interface Page {
   id: string;
   ownerUserId: string;
   /**
-   * 所属ノート ID。Issue #823 でデフォルトノート（マイノート）が導入され、
-   * すべてのページはちょうど 1 つのノートに所属するようになった。旧 `/home`
-   * 表示用の「個人ページ（`note_id IS NULL`）」概念は廃止され、Issue #825 で
-   * フロント型も non-null に揃えた。
+   * 所属ノート ID。`null` は「個人ページ（`note_id IS NULL`）」を表す。
    *
-   * Owning note ID. After issue #823 every page belongs to exactly one note
-   * (the caller's default note replaces the legacy "personal page" concept,
-   * where `note_id` was `null`). Issue #825 tightened the frontend type to
-   * non-null to match the API contract.
+   * Issue #823/#825 はデフォルトノート導入に伴いこの概念を廃止する方針だが、
+   * ストレージ層（`PageMetadata.noteId: string | null`）・ゲストストア
+   * (`pageStore`)・IndexedDB の個人ページ判定 (`noteId === null`) が依然として
+   * `null` を生成・依存しているため、フロントのドメイン型も実態に合わせて
+   * `string | null` とする（`strict: true` 化で型穴を顕在化）。`null` をソース
+   * から完全に除去して non-null へ再 tighten するのは個人ページ概念の根絶
+   * エピックで対応する。
+   *
+   * Owning note ID. `null` denotes a legacy "personal page" (`note_id IS NULL`).
+   * Issues #823/#825 aim to retire this concept, but the storage layer
+   * (`PageMetadata.noteId: string | null`), the guest store (`pageStore`), and
+   * IndexedDB's personal-page filter (`noteId === null`) still produce and rely
+   * on `null`, so the frontend domain type matches reality as `string | null`
+   * (surfaced by enabling `strict: true`). Eliminating `null` at the source and
+   * re-tightening to non-null is tracked by the personal-page removal epic.
    */
-  noteId: string;
+  noteId: string | null;
   title: string;
   content: string; // Tiptap JSON stringified
   contentPreview?: string;
@@ -35,13 +43,13 @@ export interface PageSummary {
   id: string;
   ownerUserId: string;
   /**
-   * 所属ノート ID。`Page.noteId` と同様、Issue #823 / #825 によりフロント型も
-   * non-null になった。
+   * 所属ノート ID。`Page.noteId` と同様、`null` は個人ページを表す暫定形。
+   * 詳細と今後の方針（個人ページ概念の根絶エピック）は `Page.noteId` を参照。
    *
-   * Owning note ID. Mirrors the non-null contract on `Page.noteId` after
-   * issues #823 and #825.
+   * Owning note ID. Like `Page.noteId`, `null` denotes a personal page as an
+   * interim shape; see `Page.noteId` for details and the planned removal epic.
    */
-  noteId: string;
+  noteId: string | null;
   title: string;
   contentPreview?: string;
   thumbnailUrl?: string;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,13 +15,13 @@
     "jsx": "react-jsx",
 
     /* Linting */
-    "strict": false,
+    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noImplicitAny": false,
     "noFallthroughCasesInSwitch": false,
 
     "types": [],
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
Satisfies the #1011 acceptance criteria:
- tsconfig.app.json: strict: true (+ ignoreDeprecations "6.0" for the TS 6.0
  `baseUrl` TS5101 deprecation; drop the now-redundant noImplicitAny: false).
- CI: the existing `type-check` job ran a bare `bunx tsc --noEmit`, which
  type-checks NONE of src/ — the root tsconfig.json is `files: []` + project
  references and is only processed with `-b`. Point it at
  `-p tsconfig.app.json` so frontend type errors are actually caught in PRs.

Resolved 227 strict errors across 89 files (types only, behavior-preserving),
notably:
- Page/PageSummary.noteId: string -> string | null to match the storage layer
  (PageMetadata.noteId is string|null; pageStore and the repository emit null
  for personal pages). Interim type-honesty surfaced by strict; null handled at
  the search / linked-pages consumers. Eliminating null at the source and
  re-tightening to non-null is tracked by the personal-page removal epic.
- markdownExport: typed nodeHandlers via Object.assign generics.
- mermaid / storage / web-clipper / collaboration: null|undefined coalescing
  matching the target types.
- tiptap: NodeViewContent<"code">, nested command module augmentation, ref
  widening (RefObject<T | null>).
- Test fixtures typed (vi.fn<...> signatures, valid union literals, mock shapes).

Behavior-affecting fix surfaced by strict:
- useWikiSchema destructured `user` from useAuth(), but useAuth exposes no
  `user` (only userId), so `user` was always undefined and `enabled: !!user`
  kept the wiki-schema query permanently disabled. Switched to useUser().

Verified: tsc -p tsconfig.app.json = 0 errors, eslint 0 errors, prettier clean,
260 frontend test files / 2652 tests pass.

https://claude.ai/code/session_015u86X91VM5DHsdsbjwEshC