### PR TITLE
test(front): add InviteLinkPage and WikiComposePage tests (#1034)

### DIFF
--- a/src/pages/InviteLinkPage.test.tsx
+++ b/src/pages/InviteLinkPage.test.tsx
@@ -1,0 +1,349 @@
+/**
+ * InviteLinkPage: share-link acceptance flow tests.
+ * 共有リンク受諾ページの統合テスト。
+ *
+ * Covers loading / invalid / preview-error / status-blocked / sign-in / join branches
+ * without reading the page implementation (spec-driven).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import InviteLinkPage from "./InviteLinkPage";
+import { ApiError } from "@/lib/api/apiClient";
+import type { InviteLinkPreviewResponse } from "@/lib/api/types";
+
+const { mockNavigate, mockToast, mockSignInSocial, mockRedeemMutate, mockUseParams } = vi.hoisted(
+  () => ({
+    mockNavigate: vi.fn(),
+    mockToast: vi.fn(),
+    mockSignInSocial: vi.fn(),
+    mockRedeemMutate: vi.fn(),
+    mockUseParams: vi.fn(() => ({ token: "share-token" })),
+  }),
+);
+
+let authState = { isLoaded: true, isSignedIn: false };
+let previewState: {
+  data: InviteLinkPreviewResponse | undefined;
+  isLoading: boolean;
+  error: Error | null;
+} = {
+  data: undefined,
+  isLoading: false,
+  error: null,
+};
+let redeemState = {
+  isPending: false,
+  error: null as Error | null,
+};
+
+const validPreview: InviteLinkPreviewResponse = {
+  status: "valid",
+  noteId: "note-abc",
+  noteTitle: "Shared Note",
+  inviterName: "Alice",
+  role: "editor",
+  expiresAt: "2026-12-31T00:00:00.000Z",
+  remainingUses: 3,
+  maxUses: 10,
+  usedCount: 7,
+  requireSignIn: true,
+  label: null,
+};
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => mockUseParams(),
+  };
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+    i18n: { language: "ja" },
+  }),
+}));
+
+vi.mock("@zedi/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@zedi/ui")>();
+  return {
+    ...actual,
+    useToast: () => ({ toast: mockToast }),
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  signIn: { social: mockSignInSocial },
+}));
+
+vi.mock("@/hooks/auth/useAuth", () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock("@/hooks/auth/useInviteLinks", () => ({
+  useInviteLinkPreview: () => ({
+    data: previewState.data,
+    isLoading: previewState.isLoading,
+    error: previewState.error,
+  }),
+  useRedeemInviteLink: () => ({
+    mutateAsync: mockRedeemMutate,
+    isPending: redeemState.isPending,
+    error: redeemState.error,
+  }),
+}));
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/invite-links/:token" element={<InviteLinkPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function resetPreview(overrides?: Partial<typeof previewState>) {
+  previewState = {
+    data: undefined,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe("InviteLinkPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseParams.mockReturnValue({ token: "share-token" });
+    authState = { isLoaded: true, isSignedIn: false };
+    redeemState = { isPending: false, error: null };
+    resetPreview();
+    mockSignInSocial.mockResolvedValue(undefined);
+    mockRedeemMutate.mockResolvedValue({
+      noteId: "note-abc",
+      role: "editor",
+      isNewRedemption: true,
+      alreadyMember: false,
+      status: "accepted",
+    });
+  });
+
+  describe("loading state", () => {
+    it("shows link title and loading message while auth is not loaded", () => {
+      authState = { isLoaded: false, isSignedIn: false };
+      renderAt("/invite-links/token-1");
+
+      expect(screen.getByText("invite.linkTitle")).toBeInTheDocument();
+      expect(screen.getByText("invite.loading")).toBeInTheDocument();
+    });
+
+    it("shows loading message while preview is fetching", () => {
+      resetPreview({ isLoading: true, data: undefined });
+      renderAt("/invite-links/token-1");
+
+      expect(screen.getByText("invite.linkTitle")).toBeInTheDocument();
+      expect(screen.getByText("invite.loading")).toBeInTheDocument();
+    });
+  });
+
+  describe("invalid state", () => {
+    it("shows invalid status when the route token is empty", () => {
+      mockUseParams.mockReturnValue({ token: "" });
+      renderAt("/invite-links/share-token");
+
+      expect(screen.getByText("invite.linkStatusInvalid")).toBeInTheDocument();
+    });
+
+    it("shows invalid status when preview returns 404 ApiError", () => {
+      resetPreview({
+        error: new ApiError("Not found", 404, "NOT_FOUND"),
+      });
+      renderAt("/invite-links/missing-token");
+
+      expect(screen.getByText("invite.linkStatusInvalid")).toBeInTheDocument();
+    });
+  });
+
+  describe("preview error (non-404)", () => {
+    it("shows the preview error message with destructive styling", () => {
+      resetPreview({
+        error: new ApiError("Server unavailable", 503, "SERVICE_UNAVAILABLE"),
+      });
+      renderAt("/invite-links/token-1");
+
+      const message = screen.getByText("Server unavailable");
+      expect(message).toBeInTheDocument();
+      expect(message).toHaveClass("text-destructive");
+    });
+  });
+
+  describe("non-valid preview status", () => {
+    it.each([
+      ["revoked", "invite.linkStatusRevoked"],
+      ["expired", "invite.linkStatusExpired"],
+      ["exhausted", "invite.linkStatusExhausted"],
+    ] as const)("shows %s status message", (status, expectedKey) => {
+      resetPreview({
+        data: { ...validPreview, status },
+      });
+      renderAt("/invite-links/token-1");
+
+      expect(screen.getByText(expectedKey)).toBeInTheDocument();
+    });
+
+    it("falls back to invalid message for an unknown preview status", () => {
+      resetPreview({
+        data: { ...validPreview, status: "unknown" as InviteLinkPreviewResponse["status"] },
+      });
+      renderAt("/invite-links/token-1");
+
+      expect(screen.getByText("invite.linkStatusInvalid")).toBeInTheDocument();
+    });
+  });
+
+  describe("valid preview — signed out (SignInPane)", () => {
+    beforeEach(() => {
+      authState = { isLoaded: true, isSignedIn: false };
+      resetPreview({ data: validPreview });
+    });
+
+    it("shows note title, inviter, role, and sign-in requirement", () => {
+      renderAt("/invite-links/share-token");
+
+      expect(screen.getByRole("heading", { name: "Shared Note" })).toBeInTheDocument();
+      expect(screen.getByText(/invite\.linkInviterLabel:.*"name":"Alice"/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/invite\.linkRoleLabel:.*"role":"invite\.roleEditor"/),
+      ).toBeInTheDocument();
+      expect(screen.getByText("invite.linkSignInRequired")).toBeInTheDocument();
+    });
+
+    it("shows viewer role label when the invite grants viewer access", () => {
+      resetPreview({
+        data: { ...validPreview, role: "viewer" },
+      });
+      renderAt("/invite-links/share-token");
+
+      expect(
+        screen.getByText(/invite\.linkRoleLabel:.*"role":"invite\.roleViewer"/),
+      ).toBeInTheDocument();
+    });
+
+    it("renders Google and GitHub sign-in buttons", () => {
+      renderAt("/invite-links/share-token");
+
+      expect(screen.getByRole("button", { name: "invite.signInWithGoogle" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "invite.signInWithGitHub" })).toBeInTheDocument();
+    });
+
+    it("starts Google social sign-in with returnTo callback URL", async () => {
+      renderAt("/invite-links/share-token");
+      fireEvent.click(screen.getByRole("button", { name: "invite.signInWithGoogle" }));
+
+      await waitFor(() => expect(mockSignInSocial).toHaveBeenCalledTimes(1));
+      expect(mockSignInSocial).toHaveBeenCalledWith({
+        provider: "google",
+        callbackURL: "http://localhost:3000/auth/callback?returnTo=%2Finvite-links%2Fshare-token",
+      });
+    });
+
+    it("starts GitHub social sign-in with returnTo callback URL", async () => {
+      renderAt("/invite-links/share-token");
+      fireEvent.click(screen.getByRole("button", { name: "invite.signInWithGitHub" }));
+
+      await waitFor(() => expect(mockSignInSocial).toHaveBeenCalledTimes(1));
+      expect(mockSignInSocial).toHaveBeenCalledWith({
+        provider: "github",
+        callbackURL: "http://localhost:3000/auth/callback?returnTo=%2Finvite-links%2Fshare-token",
+      });
+    });
+
+    it("shows destructive toast when social sign-in fails", async () => {
+      mockSignInSocial.mockRejectedValueOnce(new Error("OAuth failed"));
+      renderAt("/invite-links/share-token");
+      fireEvent.click(screen.getByRole("button", { name: "invite.signInWithGoogle" }));
+
+      await waitFor(() =>
+        expect(mockToast).toHaveBeenCalledWith({
+          variant: "destructive",
+          description: "auth.signIn.error",
+        }),
+      );
+    });
+  });
+
+  describe("valid preview — signed in (JoinPane)", () => {
+    beforeEach(() => {
+      authState = { isLoaded: true, isSignedIn: true };
+      resetPreview({ data: validPreview });
+    });
+
+    it("shows join details including inviter, role, expiry, and remaining uses", () => {
+      renderAt("/invite-links/share-token");
+
+      expect(screen.getByText(/invite\.linkInviterLabel:.*"name":"Alice"/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/invite\.linkRoleLabel:.*"role":"invite\.roleEditor"/),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/invite\.linkExpiresLabel:/)).toBeInTheDocument();
+      expect(screen.getByText(/invite\.linkRemainingLabel:.*"count":3/)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "invite.linkJoinCta" })).toBeInTheDocument();
+    });
+
+    it("shows unlimited label when remaining uses is null", () => {
+      resetPreview({
+        data: { ...validPreview, remainingUses: null },
+      });
+      renderAt("/invite-links/share-token");
+
+      expect(screen.getByText("invite.linkUnlimitedLabel")).toBeInTheDocument();
+    });
+
+    it("shows optional link label when preview includes one", () => {
+      resetPreview({
+        data: { ...validPreview, label: "Team onboarding link" },
+      });
+      renderAt("/invite-links/share-token");
+
+      expect(screen.getByText("Team onboarding link")).toBeInTheDocument();
+    });
+
+    it("redeems the link and navigates to the note on success", async () => {
+      renderAt("/invite-links/share-token");
+      fireEvent.click(screen.getByRole("button", { name: "invite.linkJoinCta" }));
+
+      await waitFor(() => expect(mockRedeemMutate).toHaveBeenCalledTimes(1));
+      expect(mockRedeemMutate).toHaveBeenCalledWith({ token: "share-token" });
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/notes/note-abc"));
+    });
+
+    it("shows redeem error alert when the redeem mutation reports an error", () => {
+      redeemState = { isPending: false, error: new Error("redeem failed") };
+      renderAt("/invite-links/share-token");
+
+      expect(screen.getByRole("alert")).toHaveTextContent("invite.linkRedeemError");
+    });
+
+    it("does not navigate when join redeem fails", async () => {
+      mockRedeemMutate.mockRejectedValueOnce(new Error("redeem failed"));
+      renderAt("/invite-links/share-token");
+      fireEvent.click(screen.getByRole("button", { name: "invite.linkJoinCta" }));
+
+      await waitFor(() => expect(mockRedeemMutate).toHaveBeenCalledTimes(1));
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it("disables join button and shows joining label while redeem is pending", () => {
+      redeemState = { isPending: true, error: null };
+      renderAt("/invite-links/share-token");
+
+      const joinButton = screen.getByRole("button", { name: "invite.linkJoining" });
+      expect(joinButton).toBeDisabled();
+    });
+  });
+});

--- a/src/pages/InviteLinkPage.test.tsx
+++ b/src/pages/InviteLinkPage.test.tsx
@@ -248,7 +248,7 @@ describe("InviteLinkPage", () => {
       await waitFor(() => expect(mockSignInSocial).toHaveBeenCalledTimes(1));
       expect(mockSignInSocial).toHaveBeenCalledWith({
         provider: "google",
-        callbackURL: "http://localhost:3000/auth/callback?returnTo=%2Finvite-links%2Fshare-token",
+        callbackURL: `${window.location.origin}/auth/callback?returnTo=%2Finvite-links%2Fshare-token`,
       });
     });
 
@@ -259,7 +259,7 @@ describe("InviteLinkPage", () => {
       await waitFor(() => expect(mockSignInSocial).toHaveBeenCalledTimes(1));
       expect(mockSignInSocial).toHaveBeenCalledWith({
         provider: "github",
-        callbackURL: "http://localhost:3000/auth/callback?returnTo=%2Finvite-links%2Fshare-token",
+        callbackURL: `${window.location.origin}/auth/callback?returnTo=%2Finvite-links%2Fshare-token`,
       });
     });
 

--- a/src/pages/WikiComposePage.test.tsx
+++ b/src/pages/WikiComposePage.test.tsx
@@ -162,9 +162,8 @@ describe("WikiComposePage", () => {
           pageSnapshot: {
             pageId: "page-1",
             title: "Architecture Notes",
-            content: "",
-            tags: [],
-            updatedAt: "2026-05-24T00:00:00Z",
+            body: "",
+            hasContent: false,
           },
         }),
       );
@@ -172,6 +171,14 @@ describe("WikiComposePage", () => {
       renderWikiCompose();
 
       expect(screen.getByText("Architecture Notes")).toBeInTheDocument();
+    });
+
+    it("shows fallback title in the header when page snapshot is missing", () => {
+      vi.mocked(useWikiComposeSession).mockReturnValue(createMockSession({ pageSnapshot: null }));
+
+      renderWikiCompose();
+
+      expect(screen.getByText("wikiCompose.page.titleFallback")).toBeInTheDocument();
     });
 
     it("shows raw phase text when the translation key is unresolved", () => {

--- a/src/pages/WikiComposePage.test.tsx
+++ b/src/pages/WikiComposePage.test.tsx
@@ -1,0 +1,415 @@
+/**
+ * WikiComposePage: route wiring, header actions, session error retry, layout direction.
+ * WikiComposePage: ルート配線、ヘッダー操作、セッションエラー再試行、レイアウト方向。
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import WikiComposePage from "./WikiComposePage";
+import { useWikiComposeSession } from "@/hooks/wiki/useWikiComposeSession";
+import { useIsMobile } from "@zedi/ui";
+import { COMPOSE_SEED_STATE_KEY } from "@/lib/wikiCompose/navigation";
+import { INITIAL_WIKI_COMPOSE_SESSION_STATE } from "@/lib/wikiCompose/wikiComposeSessionReducer";
+
+const { mockNavigate, mockUseParams, mockUseLocation } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockUseParams: vi.fn(),
+  mockUseLocation: vi.fn(),
+}));
+
+const mockCancel = vi.fn().mockResolvedValue(undefined);
+const mockStart = vi.fn().mockResolvedValue(undefined);
+const mockSubmitBrief = vi.fn().mockResolvedValue(undefined);
+const mockSubmitResearchApproval = vi.fn().mockResolvedValue(undefined);
+const mockSubmitOutline = vi.fn().mockResolvedValue(undefined);
+const mockSubmitConflictAck = vi.fn().mockResolvedValue(undefined);
+
+function createMockSession(
+  overrides: Partial<ReturnType<typeof useWikiComposeSession>> = {},
+): ReturnType<typeof useWikiComposeSession> {
+  return {
+    ...INITIAL_WIKI_COMPOSE_SESSION_STATE,
+    completedMarkdown: null,
+    start: mockStart,
+    submitBrief: mockSubmitBrief,
+    submitResearchApproval: mockSubmitResearchApproval,
+    submitOutline: mockSubmitOutline,
+    submitConflictAck: mockSubmitConflictAck,
+    cancel: mockCancel,
+    canRetryStart: false,
+    ...overrides,
+  };
+}
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => mockUseParams(),
+    useLocation: () => mockUseLocation(),
+  };
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => {
+      if (typeof fallback === "string") return fallback;
+      return key;
+    },
+    i18n: { language: "en" },
+  }),
+  initReactI18next: { type: "3rdParty", init: () => undefined },
+}));
+
+vi.mock("@/hooks/wiki/useWikiComposeSession", () => ({
+  useWikiComposeSession: vi.fn(() => createMockSession()),
+}));
+
+vi.mock("@zedi/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@zedi/ui")>();
+  return {
+    ...actual,
+    useIsMobile: vi.fn(() => false),
+    ResizablePanelGroup: ({
+      direction,
+      children,
+      className,
+    }: {
+      direction?: "horizontal" | "vertical";
+      children?: React.ReactNode;
+      className?: string;
+    }) => (
+      <div data-testid="resizable-panel-group" data-direction={direction} className={className}>
+        {children}
+      </div>
+    ),
+    ResizablePanel: ({ children }: { children?: React.ReactNode }) => (
+      <div data-testid="resizable-panel">{children}</div>
+    ),
+    ResizableHandle: () => <div data-testid="resizable-handle" />,
+  };
+});
+
+vi.mock("@/components/wikiCompose/EditorPane", () => ({
+  EditorPane: () => <div data-testid="editor-pane">EditorPane</div>,
+}));
+
+vi.mock("@/components/wikiCompose/ComposePanel", () => ({
+  ComposePanel: () => <div data-testid="compose-panel">ComposePanel</div>,
+}));
+
+function renderWikiCompose(initialPath = "/notes/note-1/page-1/compose") {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/notes/:noteId/:pageId/compose/:sessionId?" element={<WikiComposePage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("WikiComposePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseParams.mockReturnValue({
+      noteId: "note-1",
+      pageId: "page-1",
+      sessionId: undefined,
+    });
+    mockUseLocation.mockReturnValue({
+      pathname: "/notes/note-1/page-1/compose",
+      search: "",
+      hash: "",
+      state: null,
+    });
+    vi.mocked(useWikiComposeSession).mockReturnValue(createMockSession());
+    vi.mocked(useIsMobile).mockReturnValue(false);
+  });
+
+  describe("missing pageId", () => {
+    it("shows destructive alert without header when pageId is missing", () => {
+      mockUseParams.mockReturnValue({
+        noteId: "note-1",
+        pageId: "",
+        sessionId: undefined,
+      });
+
+      renderWikiCompose("/notes/note-1/page-1/compose");
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByText("wikiCompose.page.missingPageIdTitle")).toBeInTheDocument();
+      expect(screen.getByText("wikiCompose.page.missingPageIdDescription")).toBeInTheDocument();
+      expect(screen.queryByTestId("compose-header")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("normal UI", () => {
+    it("renders header with back and cancel controls", () => {
+      renderWikiCompose();
+
+      expect(screen.getByTestId("compose-header")).toBeInTheDocument();
+      expect(screen.getByTestId("compose-back")).toBeInTheDocument();
+      expect(screen.getByTestId("compose-cancel")).toBeInTheDocument();
+      expect(screen.getByTestId("editor-pane")).toBeInTheDocument();
+      expect(screen.getByTestId("compose-panel")).toBeInTheDocument();
+    });
+
+    it("shows page snapshot title in the header when available", () => {
+      vi.mocked(useWikiComposeSession).mockReturnValue(
+        createMockSession({
+          pageSnapshot: {
+            pageId: "page-1",
+            title: "Architecture Notes",
+            content: "",
+            tags: [],
+            updatedAt: "2026-05-24T00:00:00Z",
+          },
+        }),
+      );
+
+      renderWikiCompose();
+
+      expect(screen.getByText("Architecture Notes")).toBeInTheDocument();
+    });
+
+    it("shows raw phase text when the translation key is unresolved", () => {
+      vi.mocked(useWikiComposeSession).mockReturnValue(createMockSession({ phase: "brief" }));
+
+      renderWikiCompose();
+
+      expect(screen.getByText("brief")).toBeInTheDocument();
+    });
+  });
+
+  describe("back navigation", () => {
+    it("navigates to the note page when noteId and pageId are present", () => {
+      renderWikiCompose();
+
+      fireEvent.click(screen.getByRole("button", { name: "wikiCompose.page.back" }));
+
+      expect(mockNavigate).toHaveBeenCalledWith("/notes/note-1/page-1");
+    });
+
+    it("navigates back one step when noteId or pageId is missing", () => {
+      mockUseParams.mockReturnValue({
+        noteId: "",
+        pageId: "page-1",
+        sessionId: undefined,
+      });
+
+      renderWikiCompose();
+
+      fireEvent.click(screen.getByRole("button", { name: "wikiCompose.page.back" }));
+
+      expect(mockNavigate).toHaveBeenCalledWith(-1);
+    });
+  });
+
+  describe("cancel action", () => {
+    it("calls session.cancel then navigates to the note page", async () => {
+      renderWikiCompose();
+
+      fireEvent.click(screen.getByRole("button", { name: "wikiCompose.page.cancel" }));
+
+      await waitFor(() => expect(mockCancel).toHaveBeenCalledTimes(1));
+      expect(mockNavigate).toHaveBeenCalledWith("/notes/note-1/page-1");
+    });
+  });
+
+  describe("session terminal status", () => {
+    it("disables cancel and shows close label when session is completed", () => {
+      vi.mocked(useWikiComposeSession).mockReturnValue(createMockSession({ status: "completed" }));
+
+      renderWikiCompose();
+
+      const cancelButton = screen.getByRole("button", { name: "wikiCompose.page.close" });
+      expect(cancelButton).toBeDisabled();
+    });
+
+    it("disables cancel and keeps cancel label when session is cancelled", () => {
+      vi.mocked(useWikiComposeSession).mockReturnValue(createMockSession({ status: "cancelled" }));
+
+      renderWikiCompose();
+
+      const cancelButton = screen.getByRole("button", { name: "wikiCompose.page.cancel" });
+      expect(cancelButton).toBeDisabled();
+    });
+  });
+
+  describe("session error", () => {
+    it("shows error banner and retry button that calls session.start", async () => {
+      vi.mocked(useWikiComposeSession).mockReturnValue(
+        createMockSession({
+          error: "network failed",
+          canRetryStart: true,
+        }),
+      );
+
+      renderWikiCompose();
+
+      expect(screen.getByText("network failed")).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId("compose-retry"));
+
+      await waitFor(() => expect(mockStart).toHaveBeenCalledTimes(1));
+    });
+
+    it("does not show retry button when canRetryStart is false", () => {
+      vi.mocked(useWikiComposeSession).mockReturnValue(
+        createMockSession({
+          error: "network failed",
+          canRetryStart: false,
+        }),
+      );
+
+      renderWikiCompose();
+
+      expect(screen.getByText("network failed")).toBeInTheDocument();
+      expect(screen.queryByTestId("compose-retry")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("session id display", () => {
+    it("shows session prefix with first 8 characters of session id", () => {
+      vi.mocked(useWikiComposeSession).mockReturnValue(
+        createMockSession({
+          session: {
+            id: "abcdef12-rest-of-id",
+            pageId: "page-1",
+            userId: "user-1",
+            graphId: "wiki-compose",
+            backend: "zedi_managed",
+            phase: "brief",
+            status: "pending",
+            metadata: null,
+            lastError: null,
+            closedAt: null,
+            createdAt: "2026-05-24T00:00:00Z",
+            updatedAt: "2026-05-24T00:00:00Z",
+          },
+        }),
+      );
+
+      renderWikiCompose();
+
+      expect(screen.getByText("wikiCompose.page.sessionPrefix abcdef12…")).toBeInTheDocument();
+    });
+  });
+
+  describe("layout direction", () => {
+    it("uses horizontal panel group on desktop", () => {
+      vi.mocked(useIsMobile).mockReturnValue(false);
+
+      renderWikiCompose();
+
+      expect(screen.getByTestId("resizable-panel-group")).toHaveAttribute(
+        "data-direction",
+        "horizontal",
+      );
+    });
+
+    it("uses vertical panel group on mobile", () => {
+      vi.mocked(useIsMobile).mockReturnValue(true);
+
+      renderWikiCompose();
+
+      expect(screen.getByTestId("resizable-panel-group")).toHaveAttribute(
+        "data-direction",
+        "vertical",
+      );
+    });
+  });
+
+  describe("session URL sync", () => {
+    it("replaces URL with session id when session appears without sessionId in route", async () => {
+      vi.mocked(useWikiComposeSession).mockReturnValue(
+        createMockSession({
+          session: {
+            id: "sess-abcd-1234",
+            pageId: "page-1",
+            userId: "user-1",
+            graphId: "wiki-compose",
+            backend: "zedi_managed",
+            phase: "brief",
+            status: "pending",
+            metadata: null,
+            lastError: null,
+            closedAt: null,
+            createdAt: "2026-05-24T00:00:00Z",
+            updatedAt: "2026-05-24T00:00:00Z",
+          },
+        }),
+      );
+
+      renderWikiCompose();
+
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith("/notes/note-1/page-1/compose/sess-abcd-1234", {
+          replace: true,
+        }),
+      );
+    });
+  });
+
+  describe("compose seed state", () => {
+    it("clears location.state when session status leaves idle or pending", async () => {
+      const composeSeed = {
+        outline: "Outline from chat",
+        conversationText: "User asked about wiki",
+      };
+      mockUseLocation.mockReturnValue({
+        pathname: "/notes/note-1/page-1/compose",
+        search: "",
+        hash: "",
+        state: { [COMPOSE_SEED_STATE_KEY]: composeSeed },
+      });
+      vi.mocked(useWikiComposeSession).mockReturnValue(createMockSession({ status: "running" }));
+
+      renderWikiCompose();
+
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith("/notes/note-1/page-1/compose", {
+          replace: true,
+          state: null,
+        }),
+      );
+    });
+
+    it("does not clear location.state while session is still idle", () => {
+      const composeSeed = {
+        outline: "Outline from chat",
+        conversationText: "User asked about wiki",
+      };
+      mockUseLocation.mockReturnValue({
+        pathname: "/notes/note-1/page-1/compose",
+        search: "",
+        hash: "",
+        state: { [COMPOSE_SEED_STATE_KEY]: composeSeed },
+      });
+      vi.mocked(useWikiComposeSession).mockReturnValue(createMockSession({ status: "idle" }));
+
+      renderWikiCompose();
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it("does not clear location.state while session is still pending", () => {
+      const composeSeed = {
+        outline: "Outline from chat",
+        conversationText: "User asked about wiki",
+      };
+      mockUseLocation.mockReturnValue({
+        pathname: "/notes/note-1/page-1/compose",
+        search: "",
+        hash: "",
+        state: { [COMPOSE_SEED_STATE_KEY]: composeSeed },
+      });
+      vi.mocked(useWikiComposeSession).mockReturnValue(createMockSession({ status: "pending" }));
+
+      renderWikiCompose();
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Issue #1034 のうち、カバレッジ 0% だった `InviteLinkPage` と `WikiComposePage` に Testing Library ベースのページ統合テストを追加する。`/spec-test` パイプライン（仕様抽出 → テスト設計 → カバレッジ確認）で作成。

## 変更点

### `src/pages/`
- **`InviteLinkPage.test.tsx`**（22 ケース）: loading / invalid / preview error / status blocked / sign-in / join の各分岐、Google・GitHub サインイン、参加（redeem）操作
- **`WikiComposePage.test.tsx`**（18 ケース）: pageId 欠落、ヘッダー操作（戻る・キャンセル）、エラーバナー＋リトライ、モバイル/デスクトップレイアウト、セッション URL 同期、compose seed の state クリア

## 変更の種類

- [x] 🧪 テスト (Tests)

## テスト方法

```bash
bunx vitest run src/pages/InviteLinkPage.test.tsx src/pages/WikiComposePage.test.tsx
bunx vitest run --coverage src/pages/InviteLinkPage.test.tsx src/pages/WikiComposePage.test.tsx
```

## カバレッジ（対象ファイル）

| ファイル | Lines |
|---|---|
| `InviteLinkPage.tsx` | 100% |
| `WikiComposePage.tsx` | 100% |

## Mutation テスト

対象ページは `stryker.config.mjs` の既定 mutate スコープ外のため、明示的 `--mutate` で実行。スコア: InviteLinkPage 87.39% covered / WikiComposePage 71.79% covered。残存ミュータントの多くはアイコン表示・useMemo 依存配列・i18n フォールバック等の低リスク箇所。

## チェックリスト

- [x] テストがすべてパスする（40 tests）
- [x] Lint エラーがない
- [x] Prettier 適用済み
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Related to #1034（本 PR は 2/7 ページ。残り: SearchResults, ExtensionAuthCallback, AIChatDetail, IndexPage, Notes）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49b4a2a5-d048-4e0a-be56-a138383fd0a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49b4a2a5-d048-4e0a-be56-a138383fd0a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for invite-link flows (auth states, preview/error/blocked/valid scenarios, sign-in interactions, redeem behavior, UI states and navigation).
  * Added comprehensive tests for wiki compose flows (route/session handling, header/actions, session lifecycle and errors, navigation, responsive layout, URL synchronization and cleanup).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->