### PR TITLE
test(front): NoteMembers / DomainsSection / mcpConfigStore のテスト追加 (#1035)

### DIFF
--- a/src/pages/NoteMembers/NoteInviteLinksSection.test.tsx
+++ b/src/pages/NoteMembers/NoteInviteLinksSection.test.tsx
@@ -1,0 +1,389 @@
+/**
+ * NoteInviteLinksSection: 招待リンクの発行・コピー・取り消しと権限分岐。
+ * Tests invite-link create/copy/revoke flows and role-based UI constraints.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NoteInviteLinksSection } from "./NoteInviteLinksSection";
+import {
+  useCreateInviteLink,
+  useInviteLinksForNote,
+  useRevokeInviteLink,
+} from "@/hooks/auth/useInviteLinks";
+import type { InviteLinkRow } from "@/lib/api/types";
+
+const NOW_MS = Date.parse("2026-06-01T12:00:00.000Z");
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+    i18n: { language: "ja" },
+  }),
+}));
+
+const toastMock = vi.fn();
+vi.mock("@zedi/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@zedi/ui")>();
+  return {
+    ...actual,
+    useToast: () => ({ toast: toastMock }),
+  };
+});
+
+vi.mock("@/hooks/auth/useInviteLinks", () => ({
+  useInviteLinksForNote: vi.fn(),
+  useCreateInviteLink: vi.fn(),
+  useRevokeInviteLink: vi.fn(),
+}));
+
+function makeLink(overrides: Partial<InviteLinkRow> = {}): InviteLinkRow {
+  return {
+    id: "link-1",
+    note_id: "note-1",
+    token: "share-token",
+    role: "viewer",
+    created_by_user_id: "user-1",
+    expires_at: "2026-12-31T00:00:00.000Z",
+    max_uses: 10,
+    used_count: 2,
+    revoked_at: null,
+    require_sign_in: true,
+    label: "Team link",
+    created_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function renderSection(props: Partial<React.ComponentProps<typeof NoteInviteLinksSection>> = {}) {
+  return render(
+    <NoteInviteLinksSection
+      noteId="note-1"
+      now={() => NOW_MS}
+      editPermission="members_editors"
+      {...props}
+    />,
+  );
+}
+
+describe("NoteInviteLinksSection", () => {
+  let createMutateAsync: ReturnType<typeof vi.fn>;
+  let revokeMutateAsync: ReturnType<typeof vi.fn>;
+  let writeTextMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    toastMock.mockReset();
+    createMutateAsync = vi.fn().mockResolvedValue(makeLink({ token: "new-token" }));
+    revokeMutateAsync = vi.fn().mockResolvedValue({ revoked: true, revokedAt: "2026-06-02" });
+    writeTextMock = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(useInviteLinksForNote).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as never);
+    vi.mocked(useCreateInviteLink).mockReturnValue({
+      mutateAsync: createMutateAsync,
+      isPending: false,
+    } as never);
+    vi.mocked(useRevokeInviteLink).mockReturnValue({
+      mutateAsync: revokeMutateAsync,
+      isPending: false,
+    } as never);
+
+    Object.defineProperty(window, "location", {
+      value: { origin: "https://app.example.com" },
+      writable: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: writeTextMock },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows loading text while links are fetching", () => {
+    vi.mocked(useInviteLinksForNote).mockReturnValue({
+      data: [],
+      isLoading: true,
+    } as never);
+
+    renderSection();
+
+    expect(screen.getByText("common.loading")).toBeInTheDocument();
+  });
+
+  it("shows empty state when there are no links", () => {
+    renderSection();
+
+    expect(screen.getByText("notes.inviteLinksEmptyState")).toBeInTheDocument();
+  });
+
+  it("hides create and revoke controls in read-only mode but keeps copy", () => {
+    vi.mocked(useInviteLinksForNote).mockReturnValue({
+      data: [makeLink()],
+      isLoading: false,
+    } as never);
+
+    renderSection({ readOnly: true });
+
+    expect(
+      screen.queryByRole("button", { name: "notes.inviteLinksCreateCta" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("notes.inviteLinksRevokeAria")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("notes.inviteLinksCopyAria")).toBeInTheDocument();
+  });
+
+  it("renders active, expired, and exhausted status badges", () => {
+    vi.mocked(useInviteLinksForNote).mockReturnValue({
+      data: [
+        makeLink({ id: "active", label: "Active link" }),
+        makeLink({
+          id: "expired",
+          label: "Expired link",
+          expires_at: "2026-01-01T00:00:00.000Z",
+        }),
+        makeLink({
+          id: "exhausted",
+          label: "Exhausted link",
+          max_uses: 5,
+          used_count: 5,
+          expires_at: "2026-12-31T00:00:00.000Z",
+        }),
+      ],
+      isLoading: false,
+    } as never);
+
+    renderSection({ readOnly: true });
+
+    expect(screen.getByText("notes.inviteLinksStatusActive")).toBeInTheDocument();
+    expect(screen.getByText("notes.inviteLinksStatusExpired")).toBeInTheDocument();
+    expect(screen.getByText("notes.inviteLinksStatusExhausted")).toBeInTheDocument();
+  });
+
+  it("highlights editor links with the editor badge", () => {
+    vi.mocked(useInviteLinksForNote).mockReturnValue({
+      data: [makeLink({ role: "editor", label: "Editor link" })],
+      isLoading: false,
+    } as never);
+
+    renderSection({ readOnly: true });
+
+    expect(screen.getByText("notes.inviteLinksRoleEditorBadge")).toBeInTheDocument();
+  });
+
+  it("creates a viewer link, copies the URL, and resets the form", async () => {
+    renderSection();
+
+    fireEvent.change(screen.getByLabelText("notes.inviteLinksLabelAria"), {
+      target: { value: "  Ops link  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "notes.inviteLinksCreateCta" }));
+
+    await waitFor(() => {
+      expect(createMutateAsync).toHaveBeenCalledWith({
+        role: "viewer",
+        expiresInMs: 7 * 24 * 60 * 60 * 1000,
+        maxUses: 10,
+        label: "Ops link",
+        requireSignIn: true,
+      });
+    });
+    expect(writeTextMock).toHaveBeenCalledWith("https://app.example.com/invite-links/new-token");
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "notes.inviteLinkCreatedAndCopied",
+      description: "https://app.example.com/invite-links/new-token",
+    });
+    expect((screen.getByLabelText("notes.inviteLinksLabelAria") as HTMLInputElement).value).toBe(
+      "",
+    );
+  });
+
+  it("shows destructive toast when create fails", async () => {
+    createMutateAsync.mockRejectedValueOnce(new Error("rate limit"));
+    renderSection();
+
+    fireEvent.click(screen.getByRole("button", { name: "notes.inviteLinksCreateCta" }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "notes.inviteLinkCreateFailed",
+        variant: "destructive",
+      });
+    });
+  });
+
+  it("requires editor acknowledgement before create is enabled", async () => {
+    renderSection();
+
+    expect(screen.getByRole("button", { name: "notes.inviteLinksCreateCta" })).toBeEnabled();
+
+    fireEvent.click(screen.getByLabelText("notes.inviteLinksRoleAria"));
+    fireEvent.click(screen.getByRole("option", { name: "notes.inviteLinksRoleEditor" }));
+
+    expect(screen.getByText("notes.inviteLinksEditorConfirmTitle")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "notes.inviteLinksEditorConfirmAcknowledge" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("notes.inviteLinksEditorConfirmTitle")).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "notes.inviteLinksCreateCta" })).toBeEnabled();
+    expect(createMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("reverts to viewer when editor confirmation is cancelled", async () => {
+    renderSection();
+
+    fireEvent.click(screen.getByLabelText("notes.inviteLinksRoleAria"));
+    fireEvent.click(screen.getByRole("option", { name: "notes.inviteLinksRoleEditor" }));
+    fireEvent.click(screen.getByRole("button", { name: "common.cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("notes.inviteLinksEditorConfirmTitle")).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "notes.inviteLinksCreateCta" })).toBeEnabled();
+  });
+
+  it("blocks create with destructive toast when editPermission becomes owner_only with editor selected", async () => {
+    const { rerender } = render(
+      <NoteInviteLinksSection
+        noteId="note-1"
+        now={() => NOW_MS}
+        editPermission="members_editors"
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("notes.inviteLinksRoleAria"));
+    fireEvent.click(screen.getByRole("option", { name: "notes.inviteLinksRoleEditor" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "notes.inviteLinksEditorConfirmAcknowledge" }),
+    );
+
+    rerender(
+      <NoteInviteLinksSection noteId="note-1" now={() => NOW_MS} editPermission="owner_only" />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "notes.inviteLinksCreateCta" }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "notes.inviteLinksEditorUnavailableOwnerOnly",
+        variant: "destructive",
+      });
+    });
+    expect(createMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("sends selected expiry and max-uses presets to the create API", async () => {
+    renderSection();
+
+    fireEvent.click(screen.getByLabelText("notes.inviteLinksExpiryAria"));
+    fireEvent.click(screen.getByRole("option", { name: "notes.inviteLinksExpiry30d" }));
+    fireEvent.click(screen.getByLabelText("notes.inviteLinksMaxUsesAria"));
+    fireEvent.click(screen.getByRole("option", { name: "notes.inviteLinksMaxUsesUnlimited" }));
+    fireEvent.click(screen.getByRole("button", { name: "notes.inviteLinksCreateCta" }));
+
+    await waitFor(() => {
+      expect(createMutateAsync).toHaveBeenCalledWith({
+        role: "viewer",
+        expiresInMs: 30 * 24 * 60 * 60 * 1000,
+        maxUses: null,
+        label: null,
+        requireSignIn: true,
+      });
+    });
+  });
+
+  it("disables editor role option when editPermission is owner_only", () => {
+    renderSection({ editPermission: "owner_only" });
+
+    fireEvent.click(screen.getByLabelText("notes.inviteLinksRoleAria"));
+
+    expect(screen.getByRole("option", { name: "notes.inviteLinksRoleEditor" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("copies an existing link URL to the clipboard", async () => {
+    vi.mocked(useInviteLinksForNote).mockReturnValue({
+      data: [makeLink({ token: "existing-token" })],
+      isLoading: false,
+    } as never);
+
+    renderSection();
+
+    fireEvent.click(screen.getByLabelText("notes.inviteLinksCopyAria"));
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(
+        "https://app.example.com/invite-links/existing-token",
+      );
+    });
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "notes.inviteLinkCopied",
+      description: "https://app.example.com/invite-links/existing-token",
+    });
+  });
+
+  it("shows destructive toast when copy fails", async () => {
+    writeTextMock.mockRejectedValueOnce(new Error("denied"));
+    vi.mocked(useInviteLinksForNote).mockReturnValue({
+      data: [makeLink({ token: "existing-token" })],
+      isLoading: false,
+    } as never);
+
+    renderSection();
+
+    fireEvent.click(screen.getByLabelText("notes.inviteLinksCopyAria"));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "notes.inviteLinkCopyFailed",
+        description: "https://app.example.com/invite-links/existing-token",
+        variant: "destructive",
+      });
+    });
+  });
+
+  it("revokes a link and shows success toast", async () => {
+    vi.mocked(useInviteLinksForNote).mockReturnValue({
+      data: [makeLink({ id: "link-42" })],
+      isLoading: false,
+    } as never);
+
+    renderSection();
+
+    fireEvent.click(screen.getByLabelText("notes.inviteLinksRevokeAria"));
+
+    await waitFor(() => {
+      expect(revokeMutateAsync).toHaveBeenCalledWith({ linkId: "link-42" });
+    });
+    expect(toastMock).toHaveBeenCalledWith({ title: "notes.inviteLinkRevoked" });
+  });
+
+  it("shows destructive toast when revoke fails", async () => {
+    revokeMutateAsync.mockRejectedValueOnce(new Error("forbidden"));
+    vi.mocked(useInviteLinksForNote).mockReturnValue({
+      data: [makeLink({ id: "link-42" })],
+      isLoading: false,
+    } as never);
+
+    renderSection();
+
+    fireEvent.click(screen.getByLabelText("notes.inviteLinksRevokeAria"));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "notes.inviteLinkRevokeFailed",
+        variant: "destructive",
+      });
+    });
+  });
+});

--- a/src/pages/NoteMembers/NoteInviteLinksSection.test.tsx
+++ b/src/pages/NoteMembers/NoteInviteLinksSection.test.tsx
@@ -3,7 +3,7 @@
  * Tests invite-link create/copy/revoke flows and role-based UI constraints.
  */
 import React from "react";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NoteInviteLinksSection } from "./NoteInviteLinksSection";
 import {
@@ -94,15 +94,16 @@ describe("NoteInviteLinksSection", () => {
     Object.defineProperty(window, "location", {
       value: { origin: "https://app.example.com" },
       writable: true,
+      configurable: true,
     });
     Object.defineProperty(navigator, "clipboard", {
       value: { writeText: writeTextMock },
       configurable: true,
     });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
+    Object.defineProperty(document, "execCommand", {
+      value: vi.fn().mockReturnValue(false),
+      configurable: true,
+    });
   });
 
   it("shows loading text while links are fetching", () => {
@@ -329,6 +330,35 @@ describe("NoteInviteLinksSection", () => {
     expect(toastMock).toHaveBeenCalledWith({
       title: "notes.inviteLinkCopied",
       description: "https://app.example.com/invite-links/existing-token",
+    });
+  });
+
+  it("falls back to execCommand when clipboard API is unavailable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+    const execCommandMock = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      value: execCommandMock,
+      configurable: true,
+    });
+
+    vi.mocked(useInviteLinksForNote).mockReturnValue({
+      data: [makeLink({ token: "fallback-token" })],
+      isLoading: false,
+    } as never);
+
+    renderSection();
+
+    fireEvent.click(screen.getByLabelText("notes.inviteLinksCopyAria"));
+
+    await waitFor(() => {
+      expect(execCommandMock).toHaveBeenCalledWith("copy");
+    });
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "notes.inviteLinkCopied",
+      description: "https://app.example.com/invite-links/fallback-token",
     });
   });
 

--- a/src/pages/NoteMembers/useNoteMembersController.test.ts
+++ b/src/pages/NoteMembers/useNoteMembersController.test.ts
@@ -107,6 +107,7 @@ describe("useNoteMembersController", () => {
 
     const { result } = renderHook(() => useNoteMembersController("note-1", false));
 
+    expect(useNoteMembers).toHaveBeenCalledWith("note-1", false);
     expect(result.current.members).toEqual([]);
     expect(result.current.isMembersLoading).toBe(false);
   });

--- a/src/pages/NoteMembers/useNoteMembersController.test.ts
+++ b/src/pages/NoteMembers/useNoteMembersController.test.ts
@@ -218,6 +218,40 @@ describe("useNoteMembersController", () => {
     expect(updateMutateAsync).not.toHaveBeenCalled();
   });
 
+  it("skips remove when noteId is empty", async () => {
+    const { result } = renderHook(() => useNoteMembersController("", true));
+
+    await act(async () => {
+      await result.current.handleRemoveMember("guest@example.com");
+    });
+
+    expect(removeMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("skips resend when noteId is empty", async () => {
+    const { result } = renderHook(() => useNoteMembersController("", true));
+
+    await act(async () => {
+      await result.current.handleResendInvitation("guest@example.com");
+    });
+
+    expect(resendMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("skips add when email is whitespace only", async () => {
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    act(() => {
+      result.current.setMemberEmail("   ");
+    });
+
+    await act(async () => {
+      await result.current.handleAddMember();
+    });
+
+    expect(addMutateAsync).not.toHaveBeenCalled();
+  });
+
   it("removes a member and toasts on success", async () => {
     const { result } = renderHook(() => useNoteMembersController("note-1", true));
 

--- a/src/pages/NoteMembers/useNoteMembersController.test.ts
+++ b/src/pages/NoteMembers/useNoteMembersController.test.ts
@@ -1,0 +1,304 @@
+/**
+ * useNoteMembersController: メンバー招待・ロール変更・削除・再送のハンドラ契約。
+ * Tests controller hook handlers for member invite, role update, remove, and resend.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useNoteMembersController } from "./useNoteMembersController";
+import {
+  useAddNoteMember,
+  useNoteMembers,
+  useRemoveNoteMember,
+  useResendInvitation,
+  useUpdateNoteMemberRole,
+} from "@/hooks/notes/useNoteQueries";
+import type { NoteMember } from "@/types/note";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "ja" },
+  }),
+}));
+
+const toastMock = vi.fn();
+vi.mock("@zedi/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@zedi/ui")>();
+  return {
+    ...actual,
+    useToast: () => ({ toast: toastMock }),
+  };
+});
+
+vi.mock("@/hooks/notes/useNoteQueries", () => ({
+  useNoteMembers: vi.fn(),
+  useAddNoteMember: vi.fn(),
+  useUpdateNoteMemberRole: vi.fn(),
+  useRemoveNoteMember: vi.fn(),
+  useResendInvitation: vi.fn(),
+}));
+
+const sampleMember: NoteMember = {
+  noteId: "note-1",
+  memberEmail: "guest@example.com",
+  role: "viewer",
+  status: "pending",
+  invitedByUserId: "user-1",
+  createdAt: 0,
+  updatedAt: 0,
+  isDeleted: false,
+  invitation: null,
+};
+
+describe("useNoteMembersController", () => {
+  let addMutateAsync: ReturnType<typeof vi.fn>;
+  let updateMutateAsync: ReturnType<typeof vi.fn>;
+  let removeMutateAsync: ReturnType<typeof vi.fn>;
+  let resendMutateAsync: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    toastMock.mockReset();
+    addMutateAsync = vi.fn().mockResolvedValue(undefined);
+    updateMutateAsync = vi.fn().mockResolvedValue(undefined);
+    removeMutateAsync = vi.fn().mockResolvedValue(undefined);
+    resendMutateAsync = vi.fn().mockResolvedValue({ resent: true });
+
+    vi.mocked(useNoteMembers).mockReturnValue({
+      data: [sampleMember],
+      isLoading: false,
+    } as never);
+    vi.mocked(useAddNoteMember).mockReturnValue({
+      mutateAsync: addMutateAsync,
+    } as never);
+    vi.mocked(useUpdateNoteMemberRole).mockReturnValue({
+      mutateAsync: updateMutateAsync,
+    } as never);
+    vi.mocked(useRemoveNoteMember).mockReturnValue({
+      mutateAsync: removeMutateAsync,
+    } as never);
+    vi.mocked(useResendInvitation).mockReturnValue({
+      mutateAsync: resendMutateAsync,
+    } as never);
+  });
+
+  it("starts with empty email and viewer role", () => {
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    expect(result.current.memberEmail).toBe("");
+    expect(result.current.memberRole).toBe("viewer");
+    expect(result.current.members).toEqual([sampleMember]);
+    expect(result.current.isMembersLoading).toBe(false);
+  });
+
+  it("exposes translated role options for viewer and editor", () => {
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    expect(result.current.roleOptions).toEqual([
+      { value: "viewer", label: "notes.roleViewer" },
+      { value: "editor", label: "notes.roleEditor" },
+    ]);
+  });
+
+  it("does not fetch members when enabled is false", () => {
+    vi.mocked(useNoteMembers).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as never);
+
+    const { result } = renderHook(() => useNoteMembersController("note-1", false));
+
+    expect(result.current.members).toEqual([]);
+    expect(result.current.isMembersLoading).toBe(false);
+  });
+
+  it("skips add when email is blank and does not call API", async () => {
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    await act(async () => {
+      await result.current.handleAddMember();
+    });
+
+    expect(addMutateAsync).not.toHaveBeenCalled();
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("skips add when noteId is empty", async () => {
+    const { result } = renderHook(() => useNoteMembersController("", true));
+
+    act(() => {
+      result.current.setMemberEmail("guest@example.com");
+    });
+
+    await act(async () => {
+      await result.current.handleAddMember();
+    });
+
+    expect(addMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("adds a member with trimmed email and resets form on success", async () => {
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    act(() => {
+      result.current.setMemberEmail("  guest@example.com  ");
+      result.current.setMemberRole("editor");
+    });
+
+    await act(async () => {
+      await result.current.handleAddMember();
+    });
+
+    expect(addMutateAsync).toHaveBeenCalledWith({
+      noteId: "note-1",
+      memberEmail: "guest@example.com",
+      role: "editor",
+    });
+    expect(result.current.memberEmail).toBe("");
+    expect(result.current.memberRole).toBe("viewer");
+    expect(toastMock).toHaveBeenCalledWith({ title: "notes.memberAdded" });
+  });
+
+  it("keeps form values and shows destructive toast when add fails", async () => {
+    addMutateAsync.mockRejectedValueOnce(new Error("conflict"));
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    act(() => {
+      result.current.setMemberEmail("guest@example.com");
+      result.current.setMemberRole("editor");
+    });
+
+    await act(async () => {
+      await result.current.handleAddMember();
+    });
+
+    expect(result.current.memberEmail).toBe("guest@example.com");
+    expect(result.current.memberRole).toBe("editor");
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "notes.memberAddFailed",
+      variant: "destructive",
+    });
+  });
+
+  it("updates member role and toasts on success", async () => {
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    await act(async () => {
+      await result.current.handleUpdateMemberRole("guest@example.com", "editor");
+    });
+
+    expect(updateMutateAsync).toHaveBeenCalledWith({
+      noteId: "note-1",
+      memberEmail: "guest@example.com",
+      role: "editor",
+    });
+    expect(toastMock).toHaveBeenCalledWith({ title: "notes.roleUpdated" });
+  });
+
+  it("shows destructive toast when role update fails", async () => {
+    updateMutateAsync.mockRejectedValueOnce(new Error("forbidden"));
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    await act(async () => {
+      await result.current.handleUpdateMemberRole("guest@example.com", "editor");
+    });
+
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "notes.roleUpdateFailed",
+      variant: "destructive",
+    });
+  });
+
+  it("skips role update when noteId is empty", async () => {
+    const { result } = renderHook(() => useNoteMembersController("", true));
+
+    await act(async () => {
+      await result.current.handleUpdateMemberRole("guest@example.com", "editor");
+    });
+
+    expect(updateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("removes a member and toasts on success", async () => {
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    await act(async () => {
+      await result.current.handleRemoveMember("guest@example.com");
+    });
+
+    expect(removeMutateAsync).toHaveBeenCalledWith({
+      noteId: "note-1",
+      memberEmail: "guest@example.com",
+    });
+    expect(toastMock).toHaveBeenCalledWith({ title: "notes.memberRemoved" });
+  });
+
+  it("shows destructive toast when remove fails", async () => {
+    removeMutateAsync.mockRejectedValueOnce(new Error("network"));
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    await act(async () => {
+      await result.current.handleRemoveMember("guest@example.com");
+    });
+
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "notes.memberRemoveFailed",
+      variant: "destructive",
+    });
+  });
+
+  it("resends invitation and toasts success when resent is true", async () => {
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    await act(async () => {
+      await result.current.handleResendInvitation("guest@example.com");
+    });
+
+    expect(resendMutateAsync).toHaveBeenCalledWith({
+      noteId: "note-1",
+      memberEmail: "guest@example.com",
+    });
+    expect(toastMock).toHaveBeenCalledWith({ title: "notes.resendInvitationSuccess" });
+  });
+
+  it("shows destructive toast when resend returns resent=false", async () => {
+    resendMutateAsync.mockResolvedValueOnce({ resent: false });
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    await act(async () => {
+      await result.current.handleResendInvitation("guest@example.com");
+    });
+
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "notes.resendInvitationFailed",
+      variant: "destructive",
+    });
+  });
+
+  it("shows destructive toast when resend throws", async () => {
+    resendMutateAsync.mockRejectedValueOnce(new Error("smtp"));
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    await act(async () => {
+      await result.current.handleResendInvitation("guest@example.com");
+    });
+
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "notes.resendInvitationFailed",
+      variant: "destructive",
+    });
+  });
+
+  it("reflects loading state from useNoteMembers", async () => {
+    vi.mocked(useNoteMembers).mockReturnValue({
+      data: [],
+      isLoading: true,
+    } as never);
+
+    const { result } = renderHook(() => useNoteMembersController("note-1", true));
+
+    await waitFor(() => {
+      expect(result.current.isMembersLoading).toBe(true);
+    });
+    expect(result.current.members).toEqual([]);
+  });
+});

--- a/src/pages/NoteSettings/sections/DomainsSection.test.tsx
+++ b/src/pages/NoteSettings/sections/DomainsSection.test.tsx
@@ -281,6 +281,27 @@ describe("DomainsSection", () => {
     expect((input as HTMLInputElement).value).toBe("acme.co.jp");
   });
 
+  it("shows destructive toast when API rejects a duplicate domain", async () => {
+    createMutateAsync.mockRejectedValueOnce(new ApiError("domain already exists", 409));
+    renderSection();
+    const input = screen.getByPlaceholderText("notes.domainPlaceholder");
+
+    fireEvent.change(input, { target: { value: "company.co.jp" } });
+    fireEvent.click(screen.getByRole("button", { name: "notes.domainTabAdd" }));
+
+    await waitFor(() => {
+      expect(createMutateAsync).toHaveBeenCalledWith({
+        domain: "company.co.jp",
+        role: "viewer",
+      });
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "notes.domainTabCreateFailed",
+        description: "domain already exists",
+        variant: "destructive",
+      });
+    });
+  });
+
   it("shows destructive toast with ApiError message on create failure", async () => {
     createMutateAsync.mockRejectedValueOnce(new ApiError("duplicate domain", 409));
     renderSection();

--- a/src/pages/NoteSettings/sections/DomainsSection.test.tsx
+++ b/src/pages/NoteSettings/sections/DomainsSection.test.tsx
@@ -1,0 +1,333 @@
+/**
+ * DomainsSection: ドメイン招待ルールの権限分岐・バリデーション・追加/削除。
+ * Tests domain access rules — permissions, validation, add/remove flows.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import DomainsSection from "./DomainsSection";
+import { NoteSettingsContext, type NoteSettingsContextValue } from "../NoteSettingsContext";
+import {
+  useCreateDomainAccess,
+  useDeleteDomainAccess,
+  useDomainAccessForNote,
+} from "@/hooks/auth/useDomainAccess";
+import { ApiError } from "@/lib/api";
+import type { Note, NoteAccess } from "@/types/note";
+import type { DomainAccessRow } from "@/lib/api/types";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+    i18n: { language: "ja" },
+  }),
+}));
+
+const toastMock = vi.fn();
+vi.mock("@zedi/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@zedi/ui")>();
+  return {
+    ...actual,
+    useToast: () => ({ toast: toastMock }),
+  };
+});
+
+vi.mock("@/hooks/auth/useDomainAccess", () => ({
+  useDomainAccessForNote: vi.fn(),
+  useCreateDomainAccess: vi.fn(),
+  useDeleteDomainAccess: vi.fn(),
+}));
+
+const baseNote: Note = {
+  id: "note-1",
+  ownerUserId: "user-1",
+  title: "Note",
+  visibility: "private",
+  editPermission: "owner_only",
+  isOfficial: false,
+  isDefault: false,
+  viewCount: 0,
+  showTagFilterBar: false,
+  defaultFilterTags: [],
+  createdAt: 0,
+  updatedAt: 0,
+  isDeleted: false,
+};
+
+const ownerAccess: NoteAccess = {
+  role: "owner",
+  visibility: "private",
+  editPermission: "owner_only",
+  canView: true,
+  canEdit: true,
+  canManageMembers: true,
+  canDeletePage: () => true,
+};
+
+const sampleRule: DomainAccessRow = {
+  id: "rule-1",
+  note_id: "note-1",
+  domain: "company.co.jp",
+  role: "viewer",
+  created_by_user_id: "user-1",
+  verified_at: null,
+  created_at: "2026-01-01T00:00:00.000Z",
+};
+
+function renderSection(overrides: Partial<NoteSettingsContextValue> = {}) {
+  const value: NoteSettingsContextValue = {
+    note: baseNote,
+    access: ownerAccess,
+    role: "owner",
+    canManage: true,
+    canViewAsEditor: false,
+    ...overrides,
+  };
+  return render(
+    <NoteSettingsContext.Provider value={value}>
+      <DomainsSection />
+    </NoteSettingsContext.Provider>,
+  );
+}
+
+describe("DomainsSection", () => {
+  let createMutateAsync: ReturnType<typeof vi.fn>;
+  let deleteMutateAsync: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    toastMock.mockReset();
+    createMutateAsync = vi.fn().mockResolvedValue(sampleRule);
+    deleteMutateAsync = vi.fn().mockResolvedValue({ removed: true, id: "rule-1" });
+
+    vi.mocked(useDomainAccessForNote).mockReturnValue({
+      data: [sampleRule],
+      isLoading: false,
+      isError: false,
+    } as never);
+    vi.mocked(useCreateDomainAccess).mockReturnValue({
+      mutateAsync: createMutateAsync,
+      isPending: false,
+    } as never);
+    vi.mocked(useDeleteDomainAccess).mockReturnValue({
+      mutateAsync: deleteMutateAsync,
+      isPending: false,
+    } as never);
+  });
+
+  it("shows no-permission message for viewers", () => {
+    renderSection({
+      canManage: false,
+      canViewAsEditor: false,
+      role: "viewer",
+    });
+
+    expect(screen.getByText("notes.noPermissionToManageMembers")).toBeInTheDocument();
+    expect(screen.queryByText("notes.domainTabAddHeading")).not.toBeInTheDocument();
+  });
+
+  it("renders read-only rule list for editors without add/remove controls", () => {
+    renderSection({
+      canManage: false,
+      canViewAsEditor: true,
+      role: "editor",
+    });
+
+    expect(screen.getByText("company.co.jp")).toBeInTheDocument();
+    expect(screen.queryByText("notes.domainTabAddHeading")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: 'notes.domainTabRemoveAria:{"domain":"company.co.jp"}',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows loading state while rules are fetching", () => {
+    vi.mocked(useDomainAccessForNote).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    } as never);
+
+    renderSection();
+
+    expect(screen.getByText("notes.domainTabLoading")).toBeInTheDocument();
+  });
+
+  it("shows alert when rule fetch fails", () => {
+    vi.mocked(useDomainAccessForNote).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as never);
+
+    renderSection();
+
+    expect(screen.getByRole("alert")).toHaveTextContent("notes.domainTabLoadFailed");
+  });
+
+  it("shows empty state when there are no rules", () => {
+    vi.mocked(useDomainAccessForNote).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    } as never);
+
+    renderSection();
+
+    expect(screen.getByText("notes.domainTabNoRules")).toBeInTheDocument();
+  });
+
+  it("shows unverified badge for rules without verified_at", () => {
+    renderSection();
+
+    expect(screen.getByText("notes.domainTabUnverifiedBadge")).toBeInTheDocument();
+  });
+
+  it("disables add for invalid domain format and shows inline error", () => {
+    renderSection();
+    const input = screen.getByPlaceholderText("notes.domainPlaceholder");
+
+    fireEvent.change(input, { target: { value: "not-a-domain" } });
+
+    expect(screen.getByText("notes.domainTabCreateFailedInvalid")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "notes.domainTabAdd" })).toBeDisabled();
+  });
+
+  it("rejects free email domains with an inline error", () => {
+    renderSection();
+    const input = screen.getByPlaceholderText("notes.domainPlaceholder");
+
+    fireEvent.change(input, { target: { value: "gmail.com" } });
+
+    expect(
+      screen.getByText('notes.domainTabCreateFailedFreeEmail:{"domain":"gmail.com"}'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "notes.domainTabAdd" })).toBeDisabled();
+  });
+
+  it("normalizes @-prefixed domains before create", async () => {
+    renderSection();
+    const input = screen.getByPlaceholderText("notes.domainPlaceholder");
+
+    fireEvent.change(input, { target: { value: "@acme.co.jp" } });
+    fireEvent.click(screen.getByRole("button", { name: "notes.domainTabAdd" }));
+
+    await waitFor(() => {
+      expect(createMutateAsync).toHaveBeenCalledWith({
+        domain: "acme.co.jp",
+        role: "viewer",
+      });
+    });
+  });
+
+  it("disables add when input is empty so create is not triggered", () => {
+    renderSection();
+
+    expect(screen.getByRole("button", { name: "notes.domainTabAdd" })).toBeDisabled();
+    expect(createMutateAsync).not.toHaveBeenCalled();
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("creates a viewer rule immediately and resets the form", async () => {
+    renderSection();
+    const input = screen.getByPlaceholderText("notes.domainPlaceholder");
+
+    fireEvent.change(input, { target: { value: "acme.co.jp" } });
+    fireEvent.click(screen.getByRole("button", { name: "notes.domainTabAdd" }));
+
+    await waitFor(() => {
+      expect(createMutateAsync).toHaveBeenCalledWith({
+        domain: "acme.co.jp",
+        role: "viewer",
+      });
+    });
+    expect(toastMock).toHaveBeenCalledWith({ title: "notes.domainTabCreated" });
+    expect((input as HTMLInputElement).value).toBe("");
+  });
+
+  it("opens confirmation dialog before creating an editor rule", async () => {
+    renderSection();
+    const input = screen.getByPlaceholderText("notes.domainPlaceholder");
+
+    fireEvent.change(input, { target: { value: "acme.co.jp" } });
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "notes.domainTabRoleEditor" }));
+    fireEvent.click(screen.getByRole("button", { name: "notes.domainTabAdd" }));
+
+    expect(screen.getByText("notes.domainTabEditorWarning")).toBeInTheDocument();
+    expect(createMutateAsync).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "common.confirm" }));
+
+    await waitFor(() => {
+      expect(createMutateAsync).toHaveBeenCalledWith({
+        domain: "acme.co.jp",
+        role: "editor",
+      });
+    });
+  });
+
+  it("does not create a rule when editor confirmation is cancelled", async () => {
+    renderSection();
+    const input = screen.getByPlaceholderText("notes.domainPlaceholder");
+
+    fireEvent.change(input, { target: { value: "acme.co.jp" } });
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "notes.domainTabRoleEditor" }));
+    fireEvent.click(screen.getByRole("button", { name: "notes.domainTabAdd" }));
+    fireEvent.click(screen.getByRole("button", { name: "common.cancel" }));
+
+    expect(createMutateAsync).not.toHaveBeenCalled();
+    expect((input as HTMLInputElement).value).toBe("acme.co.jp");
+  });
+
+  it("shows destructive toast with ApiError message on create failure", async () => {
+    createMutateAsync.mockRejectedValueOnce(new ApiError("duplicate domain", 409));
+    renderSection();
+    const input = screen.getByPlaceholderText("notes.domainPlaceholder");
+
+    fireEvent.change(input, { target: { value: "acme.co.jp" } });
+    fireEvent.click(screen.getByRole("button", { name: "notes.domainTabAdd" }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "notes.domainTabCreateFailed",
+        description: "duplicate domain",
+        variant: "destructive",
+      });
+    });
+  });
+
+  it("removes a rule and shows success toast", async () => {
+    renderSection();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: 'notes.domainTabRemoveAria:{"domain":"company.co.jp"}',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(deleteMutateAsync).toHaveBeenCalledWith({ accessId: "rule-1" });
+    });
+    expect(toastMock).toHaveBeenCalledWith({ title: "notes.domainTabRemoved" });
+  });
+
+  it("shows destructive toast when delete fails", async () => {
+    deleteMutateAsync.mockRejectedValueOnce(new Error("network"));
+    renderSection();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: 'notes.domainTabRemoveAria:{"domain":"company.co.jp"}',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "notes.domainTabRemoveFailed",
+        variant: "destructive",
+      });
+    });
+  });
+});

--- a/src/pages/NoteSettings/sections/DomainsSection.test.tsx
+++ b/src/pages/NoteSettings/sections/DomainsSection.test.tsx
@@ -302,23 +302,6 @@ describe("DomainsSection", () => {
     });
   });
 
-  it("shows destructive toast with ApiError message on create failure", async () => {
-    createMutateAsync.mockRejectedValueOnce(new ApiError("duplicate domain", 409));
-    renderSection();
-    const input = screen.getByPlaceholderText("notes.domainPlaceholder");
-
-    fireEvent.change(input, { target: { value: "acme.co.jp" } });
-    fireEvent.click(screen.getByRole("button", { name: "notes.domainTabAdd" }));
-
-    await waitFor(() => {
-      expect(toastMock).toHaveBeenCalledWith({
-        title: "notes.domainTabCreateFailed",
-        description: "duplicate domain",
-        variant: "destructive",
-      });
-    });
-  });
-
   it("removes a rule and shows success toast", async () => {
     renderSection();
 

--- a/src/stores/mcpConfigStore.test.ts
+++ b/src/stores/mcpConfigStore.test.ts
@@ -122,9 +122,7 @@ describe("useMcpConfigStore", () => {
         useMcpConfigStore.getState().toggleServer("alpha", false);
         useMcpConfigStore
           .getState()
-          .setServerStatus("alpha", "connected", undefined, [
-            { name: "tool", description: "d", inputSchema: {} },
-          ]);
+          .setServerStatus("alpha", "connected", undefined, [{ name: "tool", description: "d" }]);
         useMcpConfigStore.getState().addServer("alpha", HTTP_CONFIG);
       });
 
@@ -162,9 +160,7 @@ describe("useMcpConfigStore", () => {
         useMcpConfigStore.getState().toggleServer("alpha", false);
         useMcpConfigStore
           .getState()
-          .setServerStatus("alpha", "failed", "boom", [
-            { name: "tool", description: "d", inputSchema: {} },
-          ]);
+          .setServerStatus("alpha", "failed", "boom", [{ name: "tool", description: "d" }]);
         useMcpConfigStore.getState().updateServer("alpha", HTTP_CONFIG);
       });
 
@@ -174,7 +170,7 @@ describe("useMcpConfigStore", () => {
         enabled: false,
         status: "unknown",
         error: "boom",
-        tools: [{ name: "tool", description: "d", inputSchema: {} }],
+        tools: [{ name: "tool", description: "d" }],
       });
     });
 
@@ -199,7 +195,7 @@ describe("useMcpConfigStore", () => {
 
   describe("setServerStatus", () => {
     it("updates status, error, and tools", () => {
-      const tools = [{ name: "search", description: "search", inputSchema: {} }];
+      const tools = [{ name: "search", description: "search" }];
       useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
       useMcpConfigStore.getState().setServerStatus("alpha", "connected", undefined, tools);
 
@@ -211,7 +207,7 @@ describe("useMcpConfigStore", () => {
     });
 
     it("keeps existing tools when tools argument is undefined", () => {
-      const tools = [{ name: "search", description: "search", inputSchema: {} }];
+      const tools = [{ name: "search", description: "search" }];
       act(() => {
         useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
         useMcpConfigStore.getState().setServerStatus("alpha", "connected", undefined, tools);
@@ -298,9 +294,7 @@ describe("useMcpConfigStore", () => {
         useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
         useMcpConfigStore
           .getState()
-          .setServerStatus("alpha", "connected", "err", [
-            { name: "tool", description: "d", inputSchema: {} },
-          ]);
+          .setServerStatus("alpha", "connected", "err", [{ name: "tool", description: "d" }]);
         useMcpConfigStore.getState().toggleServer("alpha", false);
       });
 

--- a/src/stores/mcpConfigStore.test.ts
+++ b/src/stores/mcpConfigStore.test.ts
@@ -257,6 +257,13 @@ describe("useMcpConfigStore", () => {
   });
 
   describe("importServers", () => {
+    it("is a no-op for an empty import list", () => {
+      useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+      useMcpConfigStore.getState().importServers([]);
+
+      expect(useMcpConfigStore.getState().servers).toHaveLength(1);
+    });
+
     it("appends only new names", () => {
       useMcpConfigStore.getState().addServer("existing", STDIO_CONFIG);
       useMcpConfigStore.getState().importServers([
@@ -343,6 +350,26 @@ describe("useMcpConfigStore", () => {
           status: "unknown",
         },
       ]);
+    });
+
+    it("leaves v2 persisted data unchanged on rehydrate", async () => {
+      const persisted = {
+        name: "alpha",
+        config: { type: "http" as const, url: "https://example.com/mcp" },
+        enabled: false,
+        status: "unknown" as const,
+      };
+      localStorage.setItem(
+        "mcp-config-storage",
+        JSON.stringify({
+          version: 2,
+          state: { servers: [persisted] },
+        }),
+      );
+
+      await useMcpConfigStore.persist.rehydrate();
+
+      expect(useMcpConfigStore.getState().servers[0]).toEqual(persisted);
     });
 
     it("migrates v1 persisted configs by stripping secrets", async () => {

--- a/src/stores/mcpConfigStore.test.ts
+++ b/src/stores/mcpConfigStore.test.ts
@@ -1,5 +1,40 @@
-import { describe, it, expect } from "vitest";
-import { stripSensitiveConfigForPersist } from "./mcpConfigStore";
+import { describe, it, expect, beforeEach } from "vitest";
+import { act } from "@testing-library/react";
+import {
+  stripSensitiveConfigForPersist,
+  getMcpServersForQuery,
+  useMcpConfigStore,
+} from "./mcpConfigStore";
+import type { McpServerConfig, McpServerEntry } from "../types/mcp";
+
+const STDIO_CONFIG: McpServerConfig = {
+  type: "stdio",
+  command: "npx",
+  args: ["-y", "mcp"],
+  env: { TOKEN: "secret" },
+};
+
+const HTTP_CONFIG: McpServerConfig = {
+  type: "http",
+  url: "https://example.com/mcp",
+  headers: { Authorization: "Bearer secret" },
+};
+
+function resetStore(): void {
+  act(() => {
+    useMcpConfigStore.setState({ servers: [] });
+  });
+}
+
+function makeEntry(overrides: Partial<McpServerEntry> = {}): McpServerEntry {
+  return {
+    name: "server-a",
+    config: STDIO_CONFIG,
+    enabled: true,
+    status: "unknown",
+    ...overrides,
+  };
+}
 
 describe("stripSensitiveConfigForPersist", () => {
   it("drops env for stdio", () => {
@@ -19,5 +54,322 @@ describe("stripSensitiveConfigForPersist", () => {
       headers: { h: "v" },
     });
     expect(c).toEqual({ type: "http", url: "https://x/mcp" });
+  });
+
+  it("drops headers for sse", () => {
+    const c = stripSensitiveConfigForPersist({
+      type: "sse",
+      url: "https://x/sse",
+      headers: { h: "v" },
+    });
+    expect(c).toEqual({ type: "sse", url: "https://x/sse" });
+  });
+});
+
+describe("getMcpServersForQuery", () => {
+  it("returns undefined for an empty list", () => {
+    expect(getMcpServersForQuery([])).toBeUndefined();
+  });
+
+  it("returns undefined when every server is disabled", () => {
+    expect(
+      getMcpServersForQuery([
+        makeEntry({ name: "a", enabled: false }),
+        makeEntry({ name: "b", enabled: false }),
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("returns a record of enabled servers with raw config", () => {
+    const record = getMcpServersForQuery([
+      makeEntry({ name: "enabled", enabled: true, config: STDIO_CONFIG }),
+      makeEntry({ name: "disabled", enabled: false, config: HTTP_CONFIG }),
+    ]);
+
+    expect(record).toEqual({
+      enabled: STDIO_CONFIG,
+    });
+  });
+});
+
+describe("useMcpConfigStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetStore();
+  });
+
+  it("starts with an empty server list", () => {
+    expect(useMcpConfigStore.getState().servers).toEqual([]);
+  });
+
+  describe("addServer", () => {
+    it("appends a new server with enabled=true and status=unknown", () => {
+      useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+
+      expect(useMcpConfigStore.getState().servers).toEqual([
+        {
+          name: "alpha",
+          config: STDIO_CONFIG,
+          enabled: true,
+          status: "unknown",
+        },
+      ]);
+    });
+
+    it("overwrites an existing server in place and resets enabled/status", () => {
+      act(() => {
+        useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+        useMcpConfigStore.getState().toggleServer("alpha", false);
+        useMcpConfigStore
+          .getState()
+          .setServerStatus("alpha", "connected", undefined, [
+            { name: "tool", description: "d", inputSchema: {} },
+          ]);
+        useMcpConfigStore.getState().addServer("alpha", HTTP_CONFIG);
+      });
+
+      const [entry] = useMcpConfigStore.getState().servers;
+      expect(entry).toEqual({
+        name: "alpha",
+        config: HTTP_CONFIG,
+        enabled: true,
+        status: "unknown",
+      });
+      expect(useMcpConfigStore.getState().servers).toHaveLength(1);
+    });
+  });
+
+  describe("removeServer", () => {
+    it("removes an existing server", () => {
+      useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+      useMcpConfigStore.getState().removeServer("alpha");
+
+      expect(useMcpConfigStore.getState().servers).toEqual([]);
+    });
+
+    it("is a no-op for unknown names", () => {
+      useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+      useMcpConfigStore.getState().removeServer("missing");
+
+      expect(useMcpConfigStore.getState().servers).toHaveLength(1);
+    });
+  });
+
+  describe("updateServer", () => {
+    it("updates config and resets status to unknown while keeping enabled/error/tools", () => {
+      act(() => {
+        useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+        useMcpConfigStore.getState().toggleServer("alpha", false);
+        useMcpConfigStore
+          .getState()
+          .setServerStatus("alpha", "failed", "boom", [
+            { name: "tool", description: "d", inputSchema: {} },
+          ]);
+        useMcpConfigStore.getState().updateServer("alpha", HTTP_CONFIG);
+      });
+
+      expect(useMcpConfigStore.getState().servers[0]).toEqual({
+        name: "alpha",
+        config: HTTP_CONFIG,
+        enabled: false,
+        status: "unknown",
+        error: "boom",
+        tools: [{ name: "tool", description: "d", inputSchema: {} }],
+      });
+    });
+
+    it("does not add a server when the name is missing", () => {
+      useMcpConfigStore.getState().updateServer("missing", HTTP_CONFIG);
+
+      expect(useMcpConfigStore.getState().servers).toEqual([]);
+    });
+  });
+
+  describe("toggleServer", () => {
+    it("toggles enabled without touching status or config", () => {
+      useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+      useMcpConfigStore.getState().setServerStatus("alpha", "connected");
+      useMcpConfigStore.getState().toggleServer("alpha", false);
+
+      expect(useMcpConfigStore.getState().servers[0]?.enabled).toBe(false);
+      expect(useMcpConfigStore.getState().servers[0]?.status).toBe("connected");
+      expect(useMcpConfigStore.getState().servers[0]?.config).toEqual(STDIO_CONFIG);
+    });
+  });
+
+  describe("setServerStatus", () => {
+    it("updates status, error, and tools", () => {
+      const tools = [{ name: "search", description: "search", inputSchema: {} }];
+      useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+      useMcpConfigStore.getState().setServerStatus("alpha", "connected", undefined, tools);
+
+      expect(useMcpConfigStore.getState().servers[0]).toMatchObject({
+        status: "connected",
+        error: undefined,
+        tools,
+      });
+    });
+
+    it("keeps existing tools when tools argument is undefined", () => {
+      const tools = [{ name: "search", description: "search", inputSchema: {} }];
+      act(() => {
+        useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+        useMcpConfigStore.getState().setServerStatus("alpha", "connected", undefined, tools);
+        useMcpConfigStore.getState().setServerStatus("alpha", "pending");
+      });
+
+      expect(useMcpConfigStore.getState().servers[0]?.tools).toEqual(tools);
+    });
+
+    it("clears error when error is explicitly undefined", () => {
+      act(() => {
+        useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+        useMcpConfigStore.getState().setServerStatus("alpha", "failed", "boom");
+        useMcpConfigStore.getState().setServerStatus("alpha", "connected", undefined);
+      });
+
+      expect(useMcpConfigStore.getState().servers[0]?.error).toBeUndefined();
+    });
+  });
+
+  describe("updateStatuses", () => {
+    it("batch-updates only matching servers", () => {
+      act(() => {
+        useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+        useMcpConfigStore.getState().addServer("beta", HTTP_CONFIG);
+        useMcpConfigStore.getState().updateStatuses([
+          { name: "alpha", status: "connected" },
+          { name: "missing", status: "failed", error: "x" },
+        ]);
+      });
+
+      const servers = useMcpConfigStore.getState().servers;
+      expect(servers.find((s) => s.name === "alpha")?.status).toBe("connected");
+      expect(servers.find((s) => s.name === "beta")?.status).toBe("unknown");
+    });
+
+    it("is a no-op for an empty batch", () => {
+      useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+      useMcpConfigStore.getState().updateStatuses([]);
+
+      expect(useMcpConfigStore.getState().servers[0]?.status).toBe("unknown");
+    });
+  });
+
+  describe("importServers", () => {
+    it("appends only new names", () => {
+      useMcpConfigStore.getState().addServer("existing", STDIO_CONFIG);
+      useMcpConfigStore.getState().importServers([
+        { name: "existing", config: HTTP_CONFIG },
+        { name: "new-one", config: HTTP_CONFIG },
+      ]);
+
+      const servers = useMcpConfigStore.getState().servers;
+      expect(servers).toHaveLength(2);
+      expect(servers.find((s) => s.name === "existing")?.config).toEqual(STDIO_CONFIG);
+      expect(servers.find((s) => s.name === "new-one")).toEqual({
+        name: "new-one",
+        config: HTTP_CONFIG,
+        enabled: true,
+        status: "unknown",
+      });
+    });
+  });
+
+  describe("clearAll", () => {
+    it("removes every server", () => {
+      useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+      useMcpConfigStore.getState().clearAll();
+
+      expect(useMcpConfigStore.getState().servers).toEqual([]);
+    });
+  });
+
+  describe("persist + partialize", () => {
+    it("persists only stripped config and normalizes status to unknown", () => {
+      act(() => {
+        useMcpConfigStore.getState().addServer("alpha", STDIO_CONFIG);
+        useMcpConfigStore
+          .getState()
+          .setServerStatus("alpha", "connected", "err", [
+            { name: "tool", description: "d", inputSchema: {} },
+          ]);
+        useMcpConfigStore.getState().toggleServer("alpha", false);
+      });
+
+      const raw = localStorage.getItem("mcp-config-storage");
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw as string) as {
+        state: { servers: Array<Record<string, unknown>> };
+      };
+
+      expect(parsed.state.servers).toEqual([
+        {
+          name: "alpha",
+          config: { type: "stdio", command: "npx", args: ["-y", "mcp"] },
+          enabled: false,
+          status: "unknown",
+        },
+      ]);
+      expect(parsed.state.servers[0]).not.toHaveProperty("error");
+      expect(parsed.state.servers[0]).not.toHaveProperty("tools");
+    });
+
+    it("rehydrates persisted servers", async () => {
+      localStorage.setItem(
+        "mcp-config-storage",
+        JSON.stringify({
+          version: 2,
+          state: {
+            servers: [
+              {
+                name: "alpha",
+                config: { type: "http", url: "https://example.com/mcp" },
+                enabled: true,
+                status: "unknown",
+              },
+            ],
+          },
+        }),
+      );
+
+      await useMcpConfigStore.persist.rehydrate();
+
+      expect(useMcpConfigStore.getState().servers).toEqual([
+        {
+          name: "alpha",
+          config: { type: "http", url: "https://example.com/mcp" },
+          enabled: true,
+          status: "unknown",
+        },
+      ]);
+    });
+
+    it("migrates v1 persisted configs by stripping secrets", async () => {
+      localStorage.setItem(
+        "mcp-config-storage",
+        JSON.stringify({
+          version: 1,
+          state: {
+            servers: [
+              {
+                name: "alpha",
+                config: STDIO_CONFIG,
+                enabled: true,
+                status: "connected",
+              },
+            ],
+          },
+        }),
+      );
+
+      await useMcpConfigStore.persist.rehydrate();
+
+      expect(useMcpConfigStore.getState().servers[0]?.config).toEqual({
+        type: "stdio",
+        command: "npx",
+        args: ["-y", "mcp"],
+      });
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Issue #1035 の受け入れ条件に沿い、ノート設定まわりの未テスト箇所に仕様駆動の単体テストを追加しました。

## 変更点

- `NoteInviteLinksSection.test.tsx` — 発行・コピー・取り消し、editor 確認モーダル、`readOnly` / `owner_only` 分岐、ステータスバッジ
- `useNoteMembersController.test.ts` — `renderHook` による招待・ロール変更・削除・再送ハンドラ（成功/失敗/ガード）
- `DomainsSection.test.tsx` — 権限分岐、ドメインバリデーション（不正形式・フリーメール）、追加/削除、editor 確認ダイアログ
- `mcpConfigStore.test.ts` — 状態遷移（add/update/remove/toggle/status/import/clear）、`getMcpServersForQuery`、永続化 `partialize` / migrate v1→v2

## 変更の種類

- [x] 🧪 テスト (Tests)

## テスト方法

```bash
bunx vitest run \
  src/pages/NoteMembers/NoteInviteLinksSection.test.tsx \
  src/pages/NoteMembers/useNoteMembersController.test.ts \
  src/pages/NoteSettings/sections/DomainsSection.test.tsx \
  src/stores/mcpConfigStore.test.ts
```

フルスイート: `bun run test:run`（green）

## カバレッジ（対象ファイル）

| ファイル | Line coverage |
|---|---|
| `NoteInviteLinksSection.tsx` | ~90% |
| `useNoteMembersController.ts` | 100% |
| `DomainsSection.tsx` | ~94% |
| `mcpConfigStore.ts` | ~98% |

## Mutation

本 PR はテストのみのため `bun run test:mutation:changed` は対象 production ファイルが無くスキップされます。対象 4 ファイルに対して手動で Stryker を実行し、hook/store 中心に検出力を確認しました（`stryker.config.mutation-changed.mjs`）。

## チェックリスト

- [x] テストがすべてパスする
- [x] 対象ファイルのラインカバレッジ 80% 以上
- [x] Lint / format 済み

## 関連 Issue

Closes #1035
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-308c5942-233f-4569-9f73-4333f5a9efb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-308c5942-233f-4569-9f73-4333f5a9efb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for invite-link flows (create, copy, revoke, statuses, permission gating), member controller actions (invite, role updates, resend, remove), domain access rules (validation, add/remove, verification display, permission gating), and MCP server config (server lifecycle, status updates, persistence and migration). Suites validate UI states, confirmations, error handling, and toast notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->