### PR TITLE
feat(wiki): Wiki Compose instant draft + Understanding Layer

### DIFF
--- a/e2e/wiki-compose-instant.spec.ts
+++ b/e2e/wiki-compose-instant.spec.ts
@@ -1,0 +1,298 @@
+/**
+ * Wiki Compose instant-mode + Understanding Layer E2E.
+ *
+ * Instant モード（ゲート無し）の挙動を Playwright で固定する。実 LLM / 実 API は
+ * 使わず、`/api/pages/.../compose-sessions` 系を `page.route` で全てモックする。
+ *
+ * Pins the zero-friction path: the user lands on Compose and the article streams
+ * straight into the editor with NO Brief / Research / Outline gates, then the
+ * Understanding Layer (TL;DR / key terms / self-check) appears. The whole run is
+ * a single `POST .../run` SSE stream that ends with a `compose_completion` event
+ * followed by `done(completed)` — there is no `PATCH .../resume` round-trip.
+ *
+ * Wire contract: instant mode never interrupts, so the client must NOT issue a
+ * resume; if it did, the mock has no resume route and the catch-all returns 404.
+ *
+ * waitForTimeout 新規使用禁止。状態ベースの待機のみ使うこと。
+ */
+import { test, expect } from "./auth-mock";
+import type { Page, Route } from "@playwright/test";
+
+const NOTE_ID = "11111111-1111-4111-8111-111111111111";
+const PAGE_ID = "22222222-2222-4222-8222-222222222222";
+const SESSION_ID = "44444444-4444-4444-8444-444444444444";
+const SECTION_ID = "sec-overview";
+
+const PAGE_SNAPSHOT = {
+  pageId: PAGE_ID,
+  title: "Photosynthesis",
+  body: "",
+  hasContent: false,
+};
+
+const COMPLETION = {
+  markdown: "## Overview\n\nPhotosynthesis converts light energy into chemical energy.",
+  sections: [
+    {
+      sectionId: SECTION_ID,
+      heading: "Overview",
+      body: "Photosynthesis converts light energy into chemical energy stored in glucose.",
+      citedSourceIds: [],
+      completedAt: "2026-01-01T00:00:00.000Z",
+    },
+  ],
+  citedSources: [],
+  completedAt: "2026-01-01T00:00:00.000Z",
+  comprehensionAids: {
+    summary: "Plants use sunlight to turn water and CO2 into glucose and oxygen.",
+    keyTerms: [
+      { term: "Chlorophyll", definition: "The green pigment in plants that absorbs light energy." },
+    ],
+    questions: ["What does photosynthesis convert light energy into?"],
+  },
+};
+
+function sessionRow(status: string): Record<string, unknown> {
+  return {
+    id: SESSION_ID,
+    pageId: PAGE_ID,
+    userId: "user-1",
+    graphId: "wiki-compose",
+    backend: "zedi_managed",
+    phase: "init",
+    status,
+    metadata: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+/** Encode SSE records as `data: <JSON>\n\n`; the JSON carries the `type`. */
+function sseBody(records: Array<Record<string, unknown>>): Buffer {
+  const parts = records.map((record) => `data: ${JSON.stringify(record)}\n\n`);
+  return Buffer.from(new TextEncoder().encode(parts.join("")));
+}
+
+/**
+ * Instant-run SSE: started → structure phase → section stream → completion →
+ * done(completed). No interrupts.
+ */
+const INSTANT_RUN_RECORDS: Array<Record<string, unknown>> = [
+  { type: "started", sessionId: SESSION_ID, graphId: "wiki-compose" },
+  { type: "compose_snapshot", pageSnapshot: PAGE_SNAPSHOT },
+  { type: "compose_phase", phase: "structure", status: "entered" },
+  {
+    type: "compose_section",
+    sectionId: SECTION_ID,
+    heading: "Overview",
+    status: "started",
+    index: 1,
+    total: 1,
+  },
+  { type: "token", node: "draft_sections", content: "Photosynthesis converts light energy " },
+  { type: "token", node: "draft_sections", content: "into chemical energy stored in glucose." },
+  {
+    type: "compose_section",
+    sectionId: SECTION_ID,
+    heading: "Overview",
+    status: "completed",
+    index: 1,
+    total: 1,
+  },
+  { type: "compose_phase", phase: "completed", status: "entered" },
+  { type: "compose_completion", completion: COMPLETION },
+  { type: "done", status: "completed" },
+];
+
+const NOTE_ROW = {
+  id: NOTE_ID,
+  slug: "compose-note",
+  title: "Compose Note",
+  description: null,
+  visibility: "private",
+  owner_id: "local-user",
+  current_user_role: "owner",
+  page_count: 1,
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+const PAGE_ROW = {
+  id: PAGE_ID,
+  note_id: NOTE_ID,
+  owner_id: "local-user",
+  title: "Photosynthesis",
+  content_preview: "",
+  thumbnail_url: null,
+  source_url: null,
+  is_deleted: false,
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+/** Install the note/page API mocks needed to render the page view. */
+async function installPageViewMocks(page: Page): Promise<void> {
+  await page.route(
+    (url) => url.pathname.startsWith("/api/"),
+    async (route: Route) => {
+      await route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "not_found" }),
+      });
+    },
+  );
+  await page.route(
+    (url) => url.pathname === `/api/notes/${NOTE_ID}`,
+    async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(NOTE_ROW),
+      });
+    },
+  );
+  await page.route(
+    (url) => url.pathname === `/api/notes/${NOTE_ID}/pages`,
+    async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [PAGE_ROW], total: 1 }),
+      });
+    },
+  );
+  await page.route(
+    (url) => url.pathname === `/api/pages/${PAGE_ID}`,
+    async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PAGE_ROW),
+      });
+    },
+  );
+  await page.route(
+    (url) => url.pathname === `/api/pages/${PAGE_ID}/public-links`,
+    async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ outgoing_links: [], backlinks: [], ghost_links: [] }),
+      });
+    },
+  );
+}
+
+/**
+ * Install the Compose API mocks (create / get / run). Returns the captured run
+ * request bodies so the test can assert the client sends `mode: "instant"`.
+ */
+async function installComposeMocks(page: Page): Promise<{ runBodies: unknown[] }> {
+  let runCount = 0;
+  const runBodies: unknown[] = [];
+
+  await page.route(
+    (url) => url.pathname === `/api/pages/${PAGE_ID}/compose-sessions`,
+    async (route: Route) => {
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({ session: sessionRow("pending") }),
+        });
+        return;
+      }
+      await route.fallback();
+    },
+  );
+
+  await page.route(
+    (url) => url.pathname === `/api/pages/${PAGE_ID}/compose-sessions/${SESSION_ID}`,
+    async (route: Route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ session: sessionRow("running"), projection: null }),
+        });
+        return;
+      }
+      await route.fallback();
+    },
+  );
+
+  await page.route(
+    (url) => url.pathname === `/api/pages/${PAGE_ID}/compose-sessions/${SESSION_ID}/run`,
+    async (route: Route) => {
+      runCount += 1;
+      runBodies.push(route.request().postDataJSON());
+      if (runCount > 1) {
+        await route.fulfill({
+          status: 409,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "session_not_runnable" }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream", "cache-control": "no-cache" },
+        body: sseBody(INSTANT_RUN_RECORDS),
+      });
+    },
+  );
+
+  return { runBodies };
+}
+
+test.describe("Wiki Compose instant mode", () => {
+  test.setTimeout(60_000);
+
+  test("streams a draft with no gates and shows the Understanding Layer", async ({ page }) => {
+    await installPageViewMocks(page);
+    const { runBodies } = await installComposeMocks(page);
+
+    await page.goto(`/notes/${NOTE_ID}/${PAGE_ID}/compose`);
+
+    // The real page title is shown (delivered via the early compose_snapshot
+    // event, since instant mode has no Brief interrupt to carry it).
+    await expect(
+      page.getByTestId("compose-editor-pane").getByRole("heading", { level: 1 }),
+    ).toContainText("Photosynthesis", { timeout: 10000 });
+
+    // The article body renders directly into the editor — no Brief gate.
+    await expect(page.getByTestId(`editor-section-${SECTION_ID}`)).toContainText(
+      "Photosynthesis converts light energy",
+      { timeout: 10000 },
+    );
+
+    // No human-in-the-loop gates were shown.
+    await expect(page.getByTestId("submit-brief")).toHaveCount(0);
+    await expect(page.getByTestId("research-submit")).toHaveCount(0);
+    await expect(page.getByTestId("outline-submit")).toHaveCount(0);
+
+    // Phase stepper reaches "completed".
+    await expect(page.getByTestId("phase-step-completed")).toHaveAttribute("aria-current", "step", {
+      timeout: 10000,
+    });
+
+    // Understanding Layer is present with TL;DR, key terms and self-check.
+    const comprehension = page.getByTestId("comprehension-section");
+    await expect(comprehension).toBeVisible();
+    await expect(page.getByTestId("comprehension-summary")).toContainText("sunlight");
+    await expect(page.getByTestId("comprehension-term-0")).toContainText("Chlorophyll");
+
+    // Self-check question is an active-recall toggle.
+    const question = page.getByTestId("comprehension-question-0");
+    await expect(question).toContainText("What does photosynthesis convert");
+    await expect(question).toHaveAttribute("aria-pressed", "false");
+    await question.click();
+    await expect(question).toHaveAttribute("aria-pressed", "true");
+
+    // Wire contract: the client sent `mode: "instant"` and issued exactly one run.
+    expect(runBodies).toHaveLength(1);
+    const runBody = runBodies[0] as { input?: { mode?: unknown } };
+    expect(runBody?.input?.mode).toBe("instant");
+  });
+});

--- a/server/api/src/__tests__/agents/graphs/wikiCompose/nodes/briefDialogue.test.ts
+++ b/server/api/src/__tests__/agents/graphs/wikiCompose/nodes/briefDialogue.test.ts
@@ -88,6 +88,8 @@ function state(overrides: Partial<WikiComposeStateType>): WikiComposeStateType {
     approvedOutline: null,
     draftedSections: [],
     completion: null,
+    mode: "guided",
+    comprehensionAids: null,
     chatSeed: null,
     pageSnapshot: null,
     ...overrides,

--- a/server/api/src/__tests__/agents/graphs/wikiCompose/nodes/briefDialogue.test.ts
+++ b/server/api/src/__tests__/agents/graphs/wikiCompose/nodes/briefDialogue.test.ts
@@ -36,6 +36,7 @@ vi.mock("../../../../../agents/graphs/wikiCompose/nodes/shared/loadPageSnapshot.
 
 vi.mock("../../../../../agents/graphs/wikiCompose/nodes/shared/dispatch.js", () => ({
   dispatchComposePhase: vi.fn(async () => undefined),
+  dispatchComposeSnapshot: vi.fn(async () => undefined),
 }));
 
 import { briefDialogue } from "../../../../../agents/graphs/wikiCompose/nodes/briefDialogue.js";

--- a/server/api/src/__tests__/agents/graphs/wikiCompose/nodes/draftSections.test.ts
+++ b/server/api/src/__tests__/agents/graphs/wikiCompose/nodes/draftSections.test.ts
@@ -75,6 +75,8 @@ function state(overrides: Partial<WikiComposeStateType>): WikiComposeStateType {
     approvedOutline: null,
     draftedSections: [],
     completion: null,
+    mode: "guided",
+    comprehensionAids: null,
     chatSeed: null,
     pageSnapshot: { pageId: "p-1", title: "My Page", body: "", hasContent: false },
     ...overrides,

--- a/server/api/src/__tests__/agents/graphs/wikiCompose/nodes/humanReviewBrief.test.ts
+++ b/server/api/src/__tests__/agents/graphs/wikiCompose/nodes/humanReviewBrief.test.ts
@@ -125,4 +125,38 @@ describe("humanReviewBrief", () => {
 
     await expect(humanReviewBrief(state({}), { configurable: {} } as never)).rejects.toThrow();
   });
+
+  it("instant mode auto-derives a brief without interrupting", async () => {
+    const update = await humanReviewBrief(state({ mode: "instant" }), {
+      configurable: {},
+    } as never);
+    const brief = update.brief as BriefResult;
+
+    expect(interrupt).not.toHaveBeenCalled();
+    expect(update.phase).toBe("brief:completed");
+    expect(brief.answers).toEqual([]);
+    expect(brief.summary).toContain("Title");
+  });
+
+  it("instant mode folds the chat seed outline + conversation into the brief", async () => {
+    const update = await humanReviewBrief(
+      state({
+        mode: "instant",
+        chatSeed: {
+          outline: "- History\n- Mechanism",
+          conversationText: "User: explain photosynthesis to a 10 year old",
+          userSchema: "Always include a 'See also' section.",
+        },
+      }),
+      { configurable: {} } as never,
+    );
+    const brief = update.brief as BriefResult;
+
+    expect(interrupt).not.toHaveBeenCalled();
+    // The promoted outline / conversation / schema must reach downstream nodes
+    // via the summary (they only read `brief.summary`, not `state.chatSeed`).
+    expect(brief.summary).toContain("- History");
+    expect(brief.summary).toContain("explain photosynthesis");
+    expect(brief.summary).toContain("See also");
+  });
 });

--- a/server/api/src/__tests__/agents/graphs/wikiCompose/nodes/humanReviewBrief.test.ts
+++ b/server/api/src/__tests__/agents/graphs/wikiCompose/nodes/humanReviewBrief.test.ts
@@ -51,6 +51,8 @@ function state(overrides: Partial<WikiComposeStateType>): WikiComposeStateType {
     approvedOutline: null,
     draftedSections: [],
     completion: null,
+    mode: "guided",
+    comprehensionAids: null,
     chatSeed: null,
     pageSnapshot: { pageId: "p-1", title: "Title", body: "body", hasContent: true },
     ...overrides,

--- a/server/api/src/__tests__/agents/graphs/wikiCompose/wikiComposeInstantMode.test.ts
+++ b/server/api/src/__tests__/agents/graphs/wikiCompose/wikiComposeInstantMode.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Wiki Compose instant-mode wiring tests.
+ *
+ * `mode: "instant"` の経路を固定する:
+ * - Brief / Outline の interrupt をスキップして、初回 `POST /run` だけで
+ *   START → draft → comprehension_aids → completed まで一気通貫する。
+ * - 完了 state に `completion`（理解支援 `comprehensionAids` 同梱）が載る。
+ *
+ * Pins the zero-friction instant path: a single run reaches `completed` with no
+ * human interrupts, and the comprehension aids are attached to the completion.
+ *
+ * LLM-backed nodes are mocked so the test pins wiring, not model quality.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { briefDialogue, structureDialogue, draftSections, comprehensionAids } = vi.hoisted(() => ({
+  briefDialogue: vi.fn(),
+  structureDialogue: vi.fn(),
+  draftSections: vi.fn(),
+  comprehensionAids: vi.fn(),
+}));
+
+// Keep the real interrupt + projection nodes (humanReviewBrief / humanReviewOutline /
+// completed); only mock the LLM-backed ones. The instant-mode guards live in the
+// real interrupt nodes, so they must NOT be mocked away.
+vi.mock("../../../../agents/graphs/wikiCompose/nodes/index.js", async () => {
+  const real = await vi.importActual<
+    typeof import("../../../../agents/graphs/wikiCompose/nodes/index.js")
+  >("../../../../agents/graphs/wikiCompose/nodes/index.js");
+  return {
+    ...real,
+    briefDialogue,
+    structureDialogue,
+    draftSections,
+    comprehensionAids,
+  };
+});
+
+import { GraphRunner } from "../../../../agents/runner/graphRunner.js";
+import { __resetRegistryForTests } from "../../../../agents/registry/graphRegistry.js";
+import {
+  WIKI_COMPOSE_GRAPH_ID,
+  registerWikiComposeGraph,
+} from "../../../../agents/graphs/wikiCompose/index.js";
+import type { GraphContext } from "../../../../agents/core/types/graphContext.js";
+import type { Database } from "../../../../types/index.js";
+import { MemorySaver } from "@langchain/langgraph";
+
+function fakeContext(threadId: string): GraphContext {
+  return {
+    threadId,
+    sessionId: threadId,
+    userId: "user-1",
+    pageId: "page-1",
+    graphId: WIKI_COMPOSE_GRAPH_ID,
+    backend: "zedi_managed",
+    tier: "free",
+    db: {} as Database,
+    feature: "wiki_compose:test",
+    userEmail: null,
+    contentLocale: "ja",
+  };
+}
+
+function defaultMocks() {
+  // briefDialogue still runs (real instant guard skips question generation in
+  // production, but the mock stands in for the LLM path); emit a snapshot so
+  // downstream prompts have a title and 0 questions.
+  briefDialogue.mockImplementation(async (state: { mode?: string }) => ({
+    briefQuestions: [],
+    briefDegraded: false,
+    pageSnapshot: { pageId: "page-1", title: "Photosynthesis", body: "", hasContent: false },
+    phase: "brief:await_user",
+    // mirror the incoming mode so the real interrupt nodes see it
+    mode: state.mode,
+  }));
+  structureDialogue.mockImplementation(async () => ({
+    outlineProposal: [{ id: "sec-1", heading: "Overview", depth: 1, intent: "intro" }],
+    phase: "structure:await_user",
+  }));
+  draftSections.mockImplementation(async () => ({
+    draftedSections: [
+      {
+        sectionId: "sec-1",
+        heading: "Overview",
+        body: "Photosynthesis converts light energy into chemical energy.",
+        citedSourceIds: [],
+        completedAt: "2026-01-01T00:00:01.000Z",
+      },
+    ],
+    phase: "draft:completed",
+  }));
+  comprehensionAids.mockImplementation(async () => ({
+    comprehensionAids: {
+      summary: "Plants turn sunlight into chemical energy.",
+      keyTerms: [{ term: "Chlorophyll", definition: "The green pigment that absorbs light." }],
+      questions: ["What does photosynthesis convert light energy into?"],
+    },
+  }));
+}
+
+describe("wikiComposeGraph — instant mode", () => {
+  beforeEach(() => {
+    __resetRegistryForTests();
+    registerWikiComposeGraph();
+    briefDialogue.mockReset();
+    structureDialogue.mockReset();
+    draftSections.mockReset();
+    comprehensionAids.mockReset();
+    defaultMocks();
+  });
+  afterEach(() => {
+    __resetRegistryForTests();
+  });
+
+  it("runs end-to-end with no interrupts when mode=instant", async () => {
+    const runner = new GraphRunner();
+    const result = await runner.invoke(
+      {
+        graphId: WIKI_COMPOSE_GRAPH_ID,
+        context: fakeContext("thread-instant"),
+        checkpointer: new MemorySaver(),
+        recursionLimit: 120,
+      },
+      { kind: "input", value: { mode: "instant" } },
+    );
+
+    // Single run reaches completion — no Brief / Outline gate.
+    expect(result.status).toBe("completed");
+    expect(briefDialogue).toHaveBeenCalledTimes(1);
+    expect(structureDialogue).toHaveBeenCalledTimes(1);
+    expect(draftSections).toHaveBeenCalledTimes(1);
+    expect(comprehensionAids).toHaveBeenCalledTimes(1);
+
+    const finalState = result.output as {
+      completion?: {
+        markdown?: string;
+        sections?: unknown[];
+        comprehensionAids?: { summary?: string; keyTerms?: unknown[]; questions?: unknown[] };
+      };
+    };
+    expect(finalState.completion?.markdown).toMatch(/Overview/);
+    expect(finalState.completion?.sections).toHaveLength(1);
+    // Understanding Layer is attached to the completion.
+    expect(finalState.completion?.comprehensionAids?.summary).toMatch(/sunlight/);
+    expect(finalState.completion?.comprehensionAids?.keyTerms).toHaveLength(1);
+    expect(finalState.completion?.comprehensionAids?.questions).toHaveLength(1);
+  });
+
+  it("still halts at the Brief interrupt in the default guided mode", async () => {
+    briefDialogue.mockImplementation(async () => ({
+      briefQuestions: [
+        {
+          id: "q-1",
+          question: "Scope?",
+          options: [{ id: "o-1", label: "broad" }],
+          required: false,
+        },
+      ],
+      briefDegraded: false,
+      pageSnapshot: { pageId: "page-1", title: "Photosynthesis", body: "", hasContent: false },
+      phase: "brief:await_user",
+    }));
+    const runner = new GraphRunner();
+    const result = await runner.invoke(
+      {
+        graphId: WIKI_COMPOSE_GRAPH_ID,
+        context: fakeContext("thread-guided"),
+        checkpointer: new MemorySaver(),
+        recursionLimit: 120,
+      },
+      { kind: "input", value: { messages: [{ role: "user", content: "title: Photosynthesis" }] } },
+    );
+
+    expect(result.status).toBe("interrupted");
+    expect(draftSections).not.toHaveBeenCalled();
+    expect(comprehensionAids).not.toHaveBeenCalled();
+  });
+});

--- a/server/api/src/__tests__/agents/graphs/wikiCompose/wikiComposeRouting.test.ts
+++ b/server/api/src/__tests__/agents/graphs/wikiCompose/wikiComposeRouting.test.ts
@@ -36,6 +36,8 @@ function minimalState(overrides: Partial<WikiComposeStateType> = {}): WikiCompos
     approvedOutline: null,
     draftedSections: [],
     completion: null,
+    mode: "guided",
+    comprehensionAids: null,
     ...overrides,
   };
 }

--- a/server/api/src/__tests__/agents/runner/sseMapper.test.ts
+++ b/server/api/src/__tests__/agents/runner/sseMapper.test.ts
@@ -182,4 +182,33 @@ describe("mapLangGraphEvent", () => {
       },
     ]);
   });
+
+  it("maps on_custom_event compose_completion to a typed compose_completion event", () => {
+    const completion = {
+      markdown: "## Overview\n\nBody.",
+      sections: [{ sectionId: "sec-1", heading: "Overview", body: "Body.", citedSourceIds: [] }],
+      citedSources: [],
+      completedAt: "2026-01-01T00:00:00.000Z",
+      comprehensionAids: {
+        summary: "TL;DR",
+        keyTerms: [{ term: "T", definition: "D" }],
+        questions: ["Q?"],
+      },
+    };
+    const ev: LangGraphRuntimeEvent = {
+      event: "on_custom_event",
+      name: "compose_completion",
+      data: { completion },
+    };
+    expect(mapLangGraphEvent(ev)).toEqual([{ type: "compose_completion", completion }]);
+  });
+
+  it("drops compose_completion when the completion payload is not an object", () => {
+    const ev: LangGraphRuntimeEvent = {
+      event: "on_custom_event",
+      name: "compose_completion",
+      data: { completion: "nope" },
+    };
+    expect(mapLangGraphEvent(ev)).toEqual([]);
+  });
 });

--- a/server/api/src/__tests__/agents/runner/sseMapper.test.ts
+++ b/server/api/src/__tests__/agents/runner/sseMapper.test.ts
@@ -211,4 +211,23 @@ describe("mapLangGraphEvent", () => {
     };
     expect(mapLangGraphEvent(ev)).toEqual([]);
   });
+
+  it("maps on_custom_event compose_snapshot to a typed compose_snapshot event", () => {
+    const pageSnapshot = { pageId: "page-1", title: "Photosynthesis", body: "", hasContent: false };
+    const ev: LangGraphRuntimeEvent = {
+      event: "on_custom_event",
+      name: "compose_snapshot",
+      data: { pageSnapshot },
+    };
+    expect(mapLangGraphEvent(ev)).toEqual([{ type: "compose_snapshot", pageSnapshot }]);
+  });
+
+  it("drops compose_snapshot when the snapshot has no string title", () => {
+    const ev: LangGraphRuntimeEvent = {
+      event: "on_custom_event",
+      name: "compose_snapshot",
+      data: { pageSnapshot: { pageId: "page-1" } },
+    };
+    expect(mapLangGraphEvent(ev)).toEqual([]);
+  });
 });

--- a/server/api/src/agents/core/types/sseEvents.ts
+++ b/server/api/src/agents/core/types/sseEvents.ts
@@ -207,6 +207,21 @@ export interface SseComposeSectionEvent {
 }
 
 /**
+ * Wiki Compose のページスナップショット通知。`brief_dialogue` がセッション開始
+ * 直後に発火し、クライアントへページのタイトル/本文を早期に伝える。instant
+ * モードでは Brief 割り込みが無いため、これが無いとエディタが「無題」のまま
+ * になる。`pageSnapshot` の shape は `PageSnapshot`。
+ *
+ * Page snapshot event emitted by `brief_dialogue` at session start so the client
+ * shows the real title/body immediately (instant mode has no Brief interrupt to
+ * carry it). Kept `unknown` here to avoid coupling core wire types to the graph.
+ */
+export interface SseComposeSnapshotEvent {
+  type: "compose_snapshot";
+  pageSnapshot: unknown;
+}
+
+/**
  * Wiki Compose (#950) の完了通知。`completed` ノードが発火し、最終 Markdown・
  * セクション・引用ソース・理解支援（Understanding Layer）を 1 イベントで運ぶ。
  * 割り込みの無い instant モード実行で、単一 SSE ストリーム内に最終成果物を
@@ -241,6 +256,7 @@ export type SseEvent =
   | SseResearchBatchEvent
   | SseComposePhaseEvent
   | SseComposeSectionEvent
+  | SseComposeSnapshotEvent
   | SseComposeCompletionEvent;
 
 /**
@@ -265,5 +281,6 @@ export const SSE_EVENT_NAMES = {
   researchBatch: "research_batch",
   composePhase: "compose_phase",
   composeSection: "compose_section",
+  composeSnapshot: "compose_snapshot",
   composeCompletion: "compose_completion",
 } as const satisfies Record<string, SseEvent["type"]>;

--- a/server/api/src/agents/core/types/sseEvents.ts
+++ b/server/api/src/agents/core/types/sseEvents.ts
@@ -207,6 +207,23 @@ export interface SseComposeSectionEvent {
 }
 
 /**
+ * Wiki Compose (#950) の完了通知。`completed` ノードが発火し、最終 Markdown・
+ * セクション・引用ソース・理解支援（Understanding Layer）を 1 イベントで運ぶ。
+ * 割り込みの無い instant モード実行で、単一 SSE ストリーム内に最終成果物を
+ * 届けるための経路。`completion` の shape は `ComposeCompletion`。
+ *
+ * Completion event emitted by the `completed` node. Carries the final article
+ * (markdown + sections + cited sources + comprehension aids) so an instant-mode
+ * run can deliver the full result inside a single SSE stream. The frontend
+ * validates the `completion` shape (kept `unknown` here to avoid coupling the
+ * core wire types to the orchestrator graph value types).
+ */
+export interface SseComposeCompletionEvent {
+  type: "compose_completion";
+  completion: unknown;
+}
+
+/**
  * Wire-level SSE union.
  */
 export type SseEvent =
@@ -223,7 +240,8 @@ export type SseEvent =
   | SseResearchEvaluationEvent
   | SseResearchBatchEvent
   | SseComposePhaseEvent
-  | SseComposeSectionEvent;
+  | SseComposeSectionEvent
+  | SseComposeCompletionEvent;
 
 /**
  * SSE event 名（`event:` 行に流す名前）。`SseEvent["type"]` と同値だが、
@@ -247,4 +265,5 @@ export const SSE_EVENT_NAMES = {
   researchBatch: "research_batch",
   composePhase: "compose_phase",
   composeSection: "compose_section",
+  composeCompletion: "compose_completion",
 } as const satisfies Record<string, SseEvent["type"]>;

--- a/server/api/src/agents/graphs/wikiCompose/nodes/briefDialogue.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/briefDialogue.ts
@@ -19,7 +19,7 @@ import { createZediChatModel } from "../../../core/llm/modelFactory.js";
 import { resolveWikiComposeModelId } from "../../../core/llm/wikiComposeModelId.js";
 import { getGraphContext } from "../../../subgraphs/research/nodes/shared/getGraphContext.js";
 import { loadPageSnapshot } from "./shared/loadPageSnapshot.js";
-import { dispatchComposePhase } from "./shared/dispatch.js";
+import { dispatchComposePhase, dispatchComposeSnapshot } from "./shared/dispatch.js";
 import type { WikiComposeStateType, WikiComposeStateUpdate } from "../state.js";
 import type { BriefQuestion } from "../types.js";
 
@@ -116,6 +116,11 @@ export async function briefDialogue(
   // Load the snapshot once. Subsequent phases read from state, never the DB.
   // セッション開始時に 1 度だけ読み、以後は state を参照する。
   const snapshot = state.pageSnapshot ?? (await loadPageSnapshot(ctx.db, ctx.pageId));
+
+  // Surface the page title/body to the client early (both modes). In instant
+  // mode there is no Brief interrupt to carry the snapshot, so the editor would
+  // otherwise show "untitled" until completion.
+  await dispatchComposeSnapshot({ pageSnapshot: snapshot }, config);
 
   // Instant mode: skip Brief question generation entirely so the article can
   // stream immediately from the title. Zero questions routes straight to

--- a/server/api/src/agents/graphs/wikiCompose/nodes/briefDialogue.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/briefDialogue.ts
@@ -117,6 +117,20 @@ export async function briefDialogue(
   // セッション開始時に 1 度だけ読み、以後は state を参照する。
   const snapshot = state.pageSnapshot ?? (await loadPageSnapshot(ctx.db, ctx.pageId));
 
+  // Instant mode: skip Brief question generation entirely so the article can
+  // stream immediately from the title. Zero questions routes straight to
+  // `skip_research` → structure → draft (see `routeAfterBrief`), and
+  // `human_review_brief` won't interrupt in instant mode.
+  // 即時モードでは Brief 質問生成を丸ごとスキップし、タイトルから即ドラフトへ。
+  if (state.mode === "instant") {
+    return {
+      pageSnapshot: snapshot,
+      briefQuestions: [],
+      briefDegraded: false,
+      phase: "brief:await_user",
+    };
+  }
+
   const modelId = await resolveWikiComposeModelId("orchestrator", ctx.tier, ctx.db);
   const model = await createZediChatModel({
     modelId,

--- a/server/api/src/agents/graphs/wikiCompose/nodes/completed.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/completed.ts
@@ -11,7 +11,7 @@
  * sources for the final compose output. No LLM call.
  */
 import type { LangGraphRunnableConfig } from "@langchain/langgraph";
-import { dispatchComposePhase } from "./shared/dispatch.js";
+import { dispatchComposeCompletion, dispatchComposePhase } from "./shared/dispatch.js";
 import type { WikiComposeStateType, WikiComposeStateUpdate } from "../state.js";
 import type { ComposeCompletion, DraftedSection, Source } from "../types.js";
 
@@ -55,8 +55,17 @@ export async function completed(
     sections: ordered,
     citedSources,
     completedAt: new Date().toISOString(),
+    comprehensionAids: state.comprehensionAids ?? null,
   };
 
+  // Emit the full completion as a custom event so an instant-mode run (a single
+  // SSE stream with no interrupts) can deliver the final article + Understanding
+  // Layer to the client. In guided mode this runs during a non-streaming resume,
+  // where the event has no listener and is harmlessly dropped (the client reads
+  // the same completion from the resume response body).
+  // 即時モード（割り込み無しの単一 SSE）で完成記事＋理解支援をクライアントへ
+  // 届けるため、completion を custom event として発火する。
+  await dispatchComposeCompletion({ completion }, config);
   await dispatchComposePhase({ phase: "completed", status: "entered" }, config);
 
   return {

--- a/server/api/src/agents/graphs/wikiCompose/nodes/comprehensionAids.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/comprehensionAids.ts
@@ -1,0 +1,112 @@
+/**
+ * `comprehension_aids` — Wiki Compose Understanding Layer node.
+ *
+ * ドラフト済みセクションから、読者の理解度を高めるスキャフォールドを生成する:
+ * TL;DR 要約・キーワード用語集・自己確認用の理解度チェック質問。生成は
+ * 非ブロッキングで、失敗してもフロー全体は止めない（`completed` 前に走り、
+ * `completion` に同梱される）。
+ *
+ * Builds the Understanding Layer from the drafted sections: a TL;DR summary, a
+ * key-term glossary, and a few self-check questions. Generation is best-effort
+ * and never aborts the run — on any failure the node returns `null` aids.
+ */
+import type { LangGraphRunnableConfig } from "@langchain/langgraph";
+import { z } from "zod";
+import { composeContentLocaleInstruction } from "../../../core/composeLocale.js";
+import { createZediChatModel } from "../../../core/llm/modelFactory.js";
+import { resolveWikiComposeModelId } from "../../../core/llm/wikiComposeModelId.js";
+import { getGraphContext } from "../../../subgraphs/research/nodes/shared/getGraphContext.js";
+import type { WikiComposeStateType, WikiComposeStateUpdate } from "../state.js";
+import type { ComprehensionAids, DraftedSection } from "../types.js";
+
+/** Structured-output schema for the comprehension aids LLM call. */
+export const comprehensionAidsSchema = z.object({
+  summary: z.string().min(1).max(800),
+  keyTerms: z
+    .array(
+      z.object({
+        term: z.string().min(1).max(80),
+        definition: z.string().min(1).max(400),
+      }),
+    )
+    .max(8)
+    .default([]),
+  questions: z.array(z.string().min(1).max(300)).max(5).default([]),
+});
+
+const SYSTEM_PROMPT =
+  "You are a learning designer. Given a wiki article, produce aids that help a " +
+  "reader genuinely understand it. Return JSON with:\n" +
+  "1. `summary`: a single concise TL;DR paragraph (2–4 sentences) capturing the " +
+  "core idea.\n" +
+  "2. `keyTerms`: 3–6 important terms/concepts from the article, each with a " +
+  "short plain-language definition. Skip if the article is trivially short.\n" +
+  "3. `questions`: 2–4 self-check questions that test comprehension of the main " +
+  "points (active recall). Do NOT include answers.\n" +
+  "Base everything strictly on the provided article; do not invent facts.";
+
+/** Join the drafted section bodies into a single article excerpt for the prompt. */
+function buildArticleExcerpt(sections: DraftedSection[]): string {
+  const parts: string[] = [];
+  for (const s of sections) {
+    if (!s.body.trim()) continue;
+    parts.push(`## ${s.heading}\n\n${s.body.trim()}`);
+  }
+  return parts.join("\n\n").slice(0, 8000);
+}
+
+/**
+ * `comprehension_aids` node — derives the Understanding Layer from the draft.
+ */
+export async function comprehensionAids(
+  state: WikiComposeStateType,
+  config: LangGraphRunnableConfig,
+): Promise<WikiComposeStateUpdate> {
+  const sections = state.draftedSections;
+  const excerpt = buildArticleExcerpt(sections);
+  if (!excerpt.trim()) {
+    // Nothing drafted (e.g. all sections failed) — skip cleanly.
+    return { comprehensionAids: null };
+  }
+
+  try {
+    const ctx = getGraphContext(config);
+    const modelId = await resolveWikiComposeModelId("orchestrator", ctx.tier, ctx.db);
+    const model = await createZediChatModel({
+      modelId,
+      userId: ctx.userId,
+      tier: ctx.tier,
+      db: ctx.db,
+      feature: `${ctx.feature}:comprehension`,
+      backend: ctx.backend,
+      temperature: 0.3,
+      maxTokens: 1024,
+    });
+    const structured = model.withStructuredOutput(comprehensionAidsSchema, {
+      name: "comprehension_aids",
+    });
+    const pageTitle = state.pageSnapshot?.title ?? "(untitled)";
+    const raw = await structured.invoke([
+      {
+        role: "system",
+        content: SYSTEM_PROMPT + composeContentLocaleInstruction(ctx.contentLocale),
+      },
+      {
+        role: "user",
+        content: `[Article title]\n${pageTitle}\n\n[Article]\n${excerpt}`,
+      },
+    ]);
+
+    const aids: ComprehensionAids = {
+      summary: raw.summary,
+      keyTerms: (raw.keyTerms ?? []).map((k) => ({ term: k.term, definition: k.definition })),
+      questions: raw.questions ?? [],
+    };
+    return { comprehensionAids: aids };
+  } catch (err) {
+    // Non-fatal: the article is the primary output; aids are an enhancement.
+    // 失敗しても本文が主成果物なので止めない。
+    console.error("[comprehensionAids] generation failed:", err);
+    return { comprehensionAids: null };
+  }
+}

--- a/server/api/src/agents/graphs/wikiCompose/nodes/comprehensionAids.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/comprehensionAids.ts
@@ -29,9 +29,11 @@ export const comprehensionAidsSchema = z.object({
         definition: z.string().min(1).max(400),
       }),
     )
-    .max(8)
+    // Bounds mirror the system prompt (3–6 terms) so schema and instructions agree.
+    .max(6)
     .default([]),
-  questions: z.array(z.string().min(1).max(300)).max(5).default([]),
+  // Bounds mirror the system prompt (2–4 questions).
+  questions: z.array(z.string().min(1).max(300)).max(4).default([]),
 });
 
 const SYSTEM_PROMPT =

--- a/server/api/src/agents/graphs/wikiCompose/nodes/humanReviewBrief.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/humanReviewBrief.ts
@@ -46,26 +46,56 @@ function summariseBrief(answers: BriefAnswer[], questions: Map<string, string>):
 }
 
 /**
+ * Build the auto-derived Brief for instant mode. Folds the page title and any
+ * chat seed (user-approved outline + conversation + schema from Promote to
+ * Wiki) into the natural-language summary that downstream nodes read, so the
+ * instant draft honours the promoted content instead of a generic title-only
+ * article.
+ *
+ * 即時モードの自動 Brief を生成する。タイトルと chatSeed（承認済みアウトライン・
+ * 会話・スキーマ）を要約に畳み込み、後段ノードが促進元の内容を反映できるようにする。
+ */
+function buildInstantBrief(state: WikiComposeStateType): BriefResult {
+  const title = state.pageSnapshot?.title?.trim();
+  const seed = state.chatSeed;
+  const lines: string[] = [];
+  if (title) {
+    lines.push(`Write a clear, well-structured wiki article about "${title}".`);
+  }
+  if (seed?.outline?.trim()) {
+    lines.push("", "User-approved outline to follow:", seed.outline.trim().slice(0, 2000));
+  }
+  if (seed?.conversationText?.trim()) {
+    const convo = seed.conversationText.trim();
+    lines.push("", "Source conversation excerpt:", convo.slice(0, 2000));
+  }
+  if (seed?.userSchema?.trim()) {
+    lines.push("", "User wiki schema to honour:", seed.userSchema.trim().slice(0, 1500));
+  }
+  return {
+    answers: [],
+    summary: lines.length > 0 ? lines.join("\n") : "(no brief)",
+    appendToExisting: false,
+  };
+}
+
+/**
  * `human_review_brief` node — interrupt + resume projection.
  */
 export async function humanReviewBrief(
   state: WikiComposeStateType,
   _config: LangGraphRunnableConfig,
 ): Promise<WikiComposeStateUpdate> {
-  // Instant mode: never block on the Brief. Auto-derive an empty brief so the
-  // flow continues straight to structure → draft. The natural-language summary
-  // falls back to the page title so downstream prompts still have context.
-  // 即時モードでは Brief で止まらず、タイトルを要約に使った空 Brief で続行する。
+  // Instant mode: never block on the Brief. Auto-derive a brief so the flow
+  // continues straight to structure → draft. Crucially, fold in the chat seed
+  // (Promote to Wiki / AI chat) so the user-approved outline and conversation
+  // still drive the article instead of a generic title-only draft — downstream
+  // `structureDialogue` / `draftSections` only read `brief.summary`, not
+  // `state.chatSeed`, so the seed must be surfaced here (Codex P2 on PR #1048).
+  // 即時モードでは Brief で止まらないが、Promote to Wiki 由来の chatSeed
+  // （承認済みアウトライン・会話）を要約に畳み込み、汎用記事化を防ぐ。
   if (state.mode === "instant") {
-    const title = state.pageSnapshot?.title?.trim();
-    const brief: BriefResult = {
-      answers: [],
-      summary: title
-        ? `Write a clear, well-structured wiki article about "${title}".`
-        : "(no brief)",
-      appendToExisting: false,
-    };
-    return { brief, phase: "brief:completed" };
+    return { brief: buildInstantBrief(state), phase: "brief:completed" };
   }
 
   const payload: WikiComposeInterruptPayload = {

--- a/server/api/src/agents/graphs/wikiCompose/nodes/humanReviewBrief.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/humanReviewBrief.ts
@@ -52,6 +52,22 @@ export async function humanReviewBrief(
   state: WikiComposeStateType,
   _config: LangGraphRunnableConfig,
 ): Promise<WikiComposeStateUpdate> {
+  // Instant mode: never block on the Brief. Auto-derive an empty brief so the
+  // flow continues straight to structure → draft. The natural-language summary
+  // falls back to the page title so downstream prompts still have context.
+  // 即時モードでは Brief で止まらず、タイトルを要約に使った空 Brief で続行する。
+  if (state.mode === "instant") {
+    const title = state.pageSnapshot?.title?.trim();
+    const brief: BriefResult = {
+      answers: [],
+      summary: title
+        ? `Write a clear, well-structured wiki article about "${title}".`
+        : "(no brief)",
+      appendToExisting: false,
+    };
+    return { brief, phase: "brief:completed" };
+  }
+
   const payload: WikiComposeInterruptPayload = {
     kind: "human_review_brief",
     questions: state.briefQuestions,

--- a/server/api/src/agents/graphs/wikiCompose/nodes/humanReviewOutline.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/humanReviewOutline.ts
@@ -21,6 +21,15 @@ export async function humanReviewOutline(
   state: WikiComposeStateType,
   _config: LangGraphRunnableConfig,
 ): Promise<WikiComposeStateUpdate> {
+  // Instant mode: auto-approve the orchestrator's proposed outline so drafting
+  // starts without a gate. The user can still refine later from the completed
+  // article (Understanding Layer / guided re-run).
+  // 即時モードでは提案アウトラインを自動承認し、ゲートなしでドラフトへ進む。
+  if (state.mode === "instant") {
+    const approvedOutline: ApprovedOutline = { sections: state.outlineProposal };
+    return { approvedOutline, phase: "structure:completed" };
+  }
+
   const payload: WikiComposeInterruptPayload = {
     kind: "human_review_outline",
     outline: state.outlineProposal,

--- a/server/api/src/agents/graphs/wikiCompose/nodes/index.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/index.ts
@@ -9,6 +9,7 @@ export { humanReviewBrief } from "./humanReviewBrief.js";
 export { structureDialogue } from "./structureDialogue.js";
 export { humanReviewOutline } from "./humanReviewOutline.js";
 export { draftSections } from "./draftSections.js";
+export { comprehensionAids } from "./comprehensionAids.js";
 export { completed } from "./completed.js";
 export { skipResearch } from "./skipResearch.js";
 export { conflictResolution } from "./conflictResolution.js";

--- a/server/api/src/agents/graphs/wikiCompose/nodes/shared/dispatch.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/shared/dispatch.ts
@@ -8,6 +8,7 @@
  */
 import { dispatchCustomEvent } from "@langchain/core/callbacks/dispatch";
 import type { LangGraphRunnableConfig } from "@langchain/langgraph";
+import type { ComposeCompletion } from "../../types.js";
 
 /** Payload shape for `compose_phase` custom events. */
 export interface ComposePhasePayload {
@@ -38,4 +39,21 @@ export async function dispatchComposeSection(
   config: LangGraphRunnableConfig,
 ): Promise<void> {
   await dispatchCustomEvent("compose_section", payload, config);
+}
+
+/** Payload shape for `compose_completion` custom events. */
+export interface ComposeCompletionPayload {
+  completion: ComposeCompletion;
+}
+
+/**
+ * Dispatch a `compose_completion` SSE custom event carrying the full final
+ * completion (markdown + sections + comprehension aids). Used by instant-mode
+ * runs to deliver the article in a single SSE stream.
+ */
+export async function dispatchComposeCompletion(
+  payload: ComposeCompletionPayload,
+  config: LangGraphRunnableConfig,
+): Promise<void> {
+  await dispatchCustomEvent("compose_completion", payload, config);
 }

--- a/server/api/src/agents/graphs/wikiCompose/nodes/shared/dispatch.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/shared/dispatch.ts
@@ -8,7 +8,7 @@
  */
 import { dispatchCustomEvent } from "@langchain/core/callbacks/dispatch";
 import type { LangGraphRunnableConfig } from "@langchain/langgraph";
-import type { ComposeCompletion } from "../../types.js";
+import type { ComposeCompletion, PageSnapshot } from "../../types.js";
 
 /** Payload shape for `compose_phase` custom events. */
 export interface ComposePhasePayload {
@@ -39,6 +39,23 @@ export async function dispatchComposeSection(
   config: LangGraphRunnableConfig,
 ): Promise<void> {
   await dispatchCustomEvent("compose_section", payload, config);
+}
+
+/** Payload shape for `compose_snapshot` custom events. */
+export interface ComposeSnapshotPayload {
+  pageSnapshot: PageSnapshot;
+}
+
+/**
+ * Dispatch a `compose_snapshot` SSE custom event so the client learns the page
+ * title/body early — in instant mode there is no Brief interrupt to carry it.
+ * 即時モードでは Brief 割り込みが無いため、タイトル等を早期に届ける。
+ */
+export async function dispatchComposeSnapshot(
+  payload: ComposeSnapshotPayload,
+  config: LangGraphRunnableConfig,
+): Promise<void> {
+  await dispatchCustomEvent("compose_snapshot", payload, config);
 }
 
 /** Payload shape for `compose_completion` custom events. */

--- a/server/api/src/agents/graphs/wikiCompose/state.ts
+++ b/server/api/src/agents/graphs/wikiCompose/state.ts
@@ -33,6 +33,8 @@ import type {
   BriefResult,
   ComposeChatSeed,
   ComposeCompletion,
+  ComposeMode,
+  ComprehensionAids,
   DraftedSection,
   OutlineSection,
   PageSnapshot,
@@ -94,6 +96,19 @@ function mergeSectionsById(
  */
 export const WikiComposeState = Annotation.Root({
   ...BaseState.spec,
+
+  /**
+   * 実行モード。`instant` のときは Brief / Outline の interrupt をスキップして
+   * 即座にドラフトする（初回 `POST /run` input から投影）。既定は `guided`。
+   *
+   * Run mode. `instant` skips the Brief/Outline interrupts so the article
+   * drafts immediately; `guided` (default) keeps the human-in-the-loop gates.
+   * Projected from the first `POST /run` input.
+   */
+  mode: Annotation<ComposeMode>({
+    reducer: (prev, next) => next ?? prev,
+    default: () => "guided",
+  }),
 
   // ── Brief phase ───────────────────────────────────────────────────────────
   /**
@@ -217,6 +232,15 @@ export const WikiComposeState = Annotation.Root({
   }),
   /** 完了サマリ。`completed` ノードが書く。 */
   completion: Annotation<ComposeCompletion | null>({
+    reducer: (prev, next) => (next === undefined ? prev : next),
+    default: () => null,
+  }),
+  /**
+   * 理解支援スキャフォールド。`comprehension_aids` ノードが書き、`completed`
+   * が `completion` に同梱する。生成失敗時は null のまま。
+   * Understanding-layer scaffolds written by `comprehension_aids`.
+   */
+  comprehensionAids: Annotation<ComprehensionAids | null>({
     reducer: (prev, next) => (next === undefined ? prev : next),
     default: () => null,
   }),

--- a/server/api/src/agents/graphs/wikiCompose/types.ts
+++ b/server/api/src/agents/graphs/wikiCompose/types.ts
@@ -177,6 +177,46 @@ export interface DraftedSection {
 }
 
 /**
+ * Compose run mode.
+ *
+ * - `guided` (default): the classic human-in-the-loop flow that stops at the
+ *   Brief / Research / Outline interrupts before drafting.
+ * - `instant`: zero-friction draft. The orchestrator auto-derives the Brief and
+ *   auto-approves its own outline so the article streams immediately with no
+ *   blocking gates. The Brief questions / sources / outline are still computed
+ *   and surfaced as optional, non-blocking enrichment.
+ *
+ * Compose 実行モード。`instant` はタイトルから即座に本文をストリーム生成する
+ * ストレスのない経路（ゲートで止まらない）。`guided` は従来の HITL 経路。
+ */
+export type ComposeMode = "guided" | "instant";
+
+/**
+ * 理解支援（Understanding Layer）。完成した記事から導出する、読者の理解度を
+ * 高めるためのスキャフォールド。ブロッキングせず completion に同梱して提示する。
+ *
+ * Comprehension scaffolds derived from the drafted article to raise reader
+ * understanding. Surfaced as a non-blocking layer alongside the completion:
+ * a TL;DR summary, a key-term glossary, and a few self-check questions.
+ */
+export interface ComprehensionAids {
+  /** One-paragraph TL;DR of the whole article. */
+  summary: string;
+  /** Key terms with short plain-language definitions. */
+  keyTerms: ComprehensionKeyTerm[];
+  /** Self-check comprehension questions (active recall prompts). */
+  questions: string[];
+}
+
+/** One glossary entry in {@link ComprehensionAids}. */
+export interface ComprehensionKeyTerm {
+  /** Term / concept name. */
+  term: string;
+  /** Short, plain-language definition. */
+  definition: string;
+}
+
+/**
  * Final compose output stamped onto state at the `completed` node.
  *
  * 完了時のサマリ。フロントは `/notes/:noteId/:pageId` に戻るときの最終本文を
@@ -191,6 +231,11 @@ export interface ComposeCompletion {
   citedSources: Source[];
   /** ISO timestamp at completion. */
   completedAt: string;
+  /**
+   * Understanding-layer scaffolds derived from the article. `null` when
+   * generation failed or produced nothing (kept non-fatal).
+   */
+  comprehensionAids?: ComprehensionAids | null;
 }
 
 /**

--- a/server/api/src/agents/graphs/wikiCompose/types.ts
+++ b/server/api/src/agents/graphs/wikiCompose/types.ts
@@ -208,7 +208,10 @@ export interface ComprehensionAids {
   questions: string[];
 }
 
-/** One glossary entry in {@link ComprehensionAids}. */
+/**
+ * One glossary entry in {@link ComprehensionAids}.
+ * {@link ComprehensionAids} の用語集エントリ 1 件。
+ */
 export interface ComprehensionKeyTerm {
   /** Term / concept name. */
   term: string;
@@ -234,6 +237,7 @@ export interface ComposeCompletion {
   /**
    * Understanding-layer scaffolds derived from the article. `null` when
    * generation failed or produced nothing (kept non-fatal).
+   * 記事から導出した理解支援。生成失敗・空のときは `null`（非致命）。
    */
   comprehensionAids?: ComprehensionAids | null;
 }

--- a/server/api/src/agents/graphs/wikiCompose/wikiComposeGraph.ts
+++ b/server/api/src/agents/graphs/wikiCompose/wikiComposeGraph.ts
@@ -56,6 +56,7 @@ import {
   structureDialogue,
   humanReviewOutline,
   draftSections,
+  comprehensionAids,
   completed,
   skipResearch,
   conflictResolution,
@@ -66,7 +67,7 @@ import { routeAfterBrief, routeAfterResearch } from "./routing.js";
 /** Registered graph id. */
 export const WIKI_COMPOSE_GRAPH_ID = "wiki-compose" as const;
 /** Registered graph version. Bump when behaviour changes meaningfully. */
-export const WIKI_COMPOSE_GRAPH_VERSION = "1.1.0";
+export const WIKI_COMPOSE_GRAPH_VERSION = "1.2.0";
 
 const factory: GraphFactory = ({ checkpointer }: GraphFactoryInput): CompiledGraphLike => {
   const builder = new StateGraph(WikiComposeState)
@@ -89,6 +90,7 @@ const factory: GraphFactory = ({ checkpointer }: GraphFactoryInput): CompiledGra
     .addNode("human_review_outline", humanReviewOutline)
     // Draft + completion
     .addNode("draft_sections", draftSections)
+    .addNode("comprehension_aids", comprehensionAids)
     .addNode("completed", completed)
     // Edges
     .addEdge(START, "brief_dialogue")
@@ -119,8 +121,9 @@ const factory: GraphFactory = ({ checkpointer }: GraphFactoryInput): CompiledGra
     // Structure phase.
     .addEdge("structure_dialogue", "human_review_outline")
     .addEdge("human_review_outline", "draft_sections")
-    // Draft + completion.
-    .addEdge("draft_sections", "completed")
+    // Draft → Understanding Layer → completion.
+    .addEdge("draft_sections", "comprehension_aids")
+    .addEdge("comprehension_aids", "completed")
     .addEdge("completed", END);
 
   return checkpointer ? builder.compile({ checkpointer }) : builder.compile();
@@ -135,10 +138,12 @@ export function registerWikiComposeGraph(): void {
     version: WIKI_COMPOSE_GRAPH_VERSION,
     phase: "orchestrator",
     description:
-      "Wiki Compose P2+P5 orchestrator. Brief → optional research → optional conflict resolution → " +
-      "structure → draft → completed. Conditional: skip research (empty Brief / chat outline seed), " +
-      "conflict resolution (≥2 rejected sources with ≥1 approved). Interrupts: brief, research, " +
-      "conflict (conditional), outline.",
+      "Wiki Compose orchestrator. Brief → optional research → optional conflict resolution → " +
+      "structure → draft → comprehension aids → completed. Conditional: skip research (empty Brief / " +
+      "chat outline seed), conflict resolution (≥2 rejected sources with ≥1 approved). Interrupts: " +
+      "brief, research, conflict (conditional), outline. `mode: instant` skips the brief/outline " +
+      "interrupts so the article streams immediately; the comprehension_aids node always adds an " +
+      "Understanding Layer (TL;DR / key terms / self-check questions) to the completion.",
     factory,
   });
 }

--- a/server/api/src/agents/runner/sseMapper.ts
+++ b/server/api/src/agents/runner/sseMapper.ts
@@ -214,6 +214,8 @@ function mapCustomEvent(event: LangGraphRuntimeEvent): SseEvent[] {
       return mapComposePhase(data);
     case "compose_section":
       return mapComposeSection(data);
+    case "compose_completion":
+      return mapComposeCompletion(data);
     default:
       // Unknown custom event names are dropped silently; emitting them as `status`
       // would risk leaking implementation detail to the wire.
@@ -275,6 +277,15 @@ function mapComposeSection(data: Record<string, unknown>): SseComposeSectionEven
     return [];
   }
   return [{ type: "compose_section", sectionId, heading, status, index, total }];
+}
+
+function mapComposeCompletion(data: Record<string, unknown>): SseEvent[] {
+  const completion = data.completion;
+  // The completion object is validated structurally by the frontend reducer;
+  // here we only require it to be a non-null object before forwarding.
+  // completion の詳細検証はフロント側で行う。ここでは object であることだけ確認。
+  if (!completion || typeof completion !== "object" || Array.isArray(completion)) return [];
+  return [{ type: "compose_completion", completion }];
 }
 
 function mapResearchBatch(data: Record<string, unknown>): SseResearchBatchEvent[] {

--- a/server/api/src/agents/runner/sseMapper.ts
+++ b/server/api/src/agents/runner/sseMapper.ts
@@ -214,6 +214,8 @@ function mapCustomEvent(event: LangGraphRuntimeEvent): SseEvent[] {
       return mapComposePhase(data);
     case "compose_section":
       return mapComposeSection(data);
+    case "compose_snapshot":
+      return mapComposeSnapshot(data);
     case "compose_completion":
       return mapComposeCompletion(data);
     default:
@@ -277,6 +279,15 @@ function mapComposeSection(data: Record<string, unknown>): SseComposeSectionEven
     return [];
   }
   return [{ type: "compose_section", sectionId, heading, status, index, total }];
+}
+
+function mapComposeSnapshot(data: Record<string, unknown>): SseEvent[] {
+  const snap = data.pageSnapshot;
+  if (!snap || typeof snap !== "object" || Array.isArray(snap)) return [];
+  const s = snap as { title?: unknown };
+  // Require at least a string title so the client has something useful.
+  if (typeof s.title !== "string") return [];
+  return [{ type: "compose_snapshot", pageSnapshot: snap }];
 }
 
 function mapComposeCompletion(data: Record<string, unknown>): SseEvent[] {

--- a/server/api/src/routes/composeSessionProjection.ts
+++ b/server/api/src/routes/composeSessionProjection.ts
@@ -29,7 +29,10 @@ export interface ComposeSessionUiProjection {
   outlineProposal?: unknown[];
   draftedSections?: unknown[];
   completedMarkdown?: string | null;
-  /** Understanding Layer scaffolds (TL;DR / key terms / questions). */
+  /**
+   * Understanding Layer scaffolds (TL;DR / key terms / questions).
+   * 理解支援スキャフォールド（TL;DR / 重要用語 / 理解度チェック）。
+   */
   comprehensionAids?: unknown;
 }
 

--- a/server/api/src/routes/composeSessionProjection.ts
+++ b/server/api/src/routes/composeSessionProjection.ts
@@ -29,6 +29,8 @@ export interface ComposeSessionUiProjection {
   outlineProposal?: unknown[];
   draftedSections?: unknown[];
   completedMarkdown?: string | null;
+  /** Understanding Layer scaffolds (TL;DR / key terms / questions). */
+  comprehensionAids?: unknown;
 }
 
 function phaseFromSessionRow(phase: string, status: WikiComposeSessionStatus): string {
@@ -79,13 +81,28 @@ export function projectComposeStateValues(
 
   const completion = state.completion;
   if (completion && typeof completion === "object") {
-    const c = completion as { markdown?: string; sections?: unknown[] };
+    const c = completion as {
+      markdown?: string;
+      sections?: unknown[];
+      comprehensionAids?: unknown;
+    };
     if (typeof c.markdown === "string") {
       projection.completedMarkdown = c.markdown;
     }
     if (Array.isArray(c.sections)) {
       projection.draftedSections = c.sections;
     }
+    if (c.comprehensionAids && typeof c.comprehensionAids === "object") {
+      projection.comprehensionAids = c.comprehensionAids;
+    }
+  }
+  // Fallback to the standalone state channel when completion isn't built yet.
+  if (
+    projection.comprehensionAids === undefined &&
+    state.comprehensionAids &&
+    typeof state.comprehensionAids === "object"
+  ) {
+    projection.comprehensionAids = state.comprehensionAids;
   }
 
   const interrupts = state.__interrupt__;

--- a/src/components/wikiCompose/ComposePanel.tsx
+++ b/src/components/wikiCompose/ComposePanel.tsx
@@ -14,10 +14,12 @@ import { PhaseStepper } from "./PhaseStepper";
 import { DialogueSection } from "./DialogueSection";
 import { ResearchSection } from "./ResearchSection";
 import { ConflictResolutionSection } from "./ConflictResolutionSection";
+import { ComprehensionSection } from "./ComprehensionSection";
 import { ActivitySection } from "./ActivitySection";
 import type {
   BriefAnswer,
   BriefQuestion,
+  ComprehensionAids,
   OutlineSection,
   PageSnapshot,
   ResearchBatch,
@@ -39,6 +41,9 @@ export interface ComposePanelProps {
   researchConflictSummary: ResearchConflictSummary | null;
 
   outlineProposal: OutlineSection[];
+
+  /** Understanding Layer scaffolds, shown once the article completes. */
+  comprehensionAids: ComprehensionAids | null;
 
   activity: ComposeActivity[];
 
@@ -68,6 +73,7 @@ export const ComposePanel: React.FC<ComposePanelProps> = (props) => {
     approvedSources,
     researchConflictSummary,
     outlineProposal,
+    comprehensionAids,
     activity,
     onSubmitBrief,
     onSubmitResearchApproval,
@@ -117,6 +123,9 @@ export const ComposePanel: React.FC<ComposePanelProps> = (props) => {
             onSubmit={onSubmitResearchApproval}
           />
         ) : null}
+
+        {/* Understanding Layer — non-blocking, shown once aids are available. */}
+        {comprehensionAids ? <ComprehensionSection aids={comprehensionAids} /> : null}
 
         <ActivitySection activity={activity} isStreaming={isStreaming} />
       </div>

--- a/src/components/wikiCompose/ComposePanel.tsx
+++ b/src/components/wikiCompose/ComposePanel.tsx
@@ -42,7 +42,10 @@ export interface ComposePanelProps {
 
   outlineProposal: OutlineSection[];
 
-  /** Understanding Layer scaffolds, shown once the article completes. */
+  /**
+   * Understanding Layer scaffolds, shown once the article completes.
+   * 記事完成後に表示する理解支援スキャフォールド。
+   */
   comprehensionAids: ComprehensionAids | null;
 
   activity: ComposeActivity[];

--- a/src/components/wikiCompose/ComprehensionSection.tsx
+++ b/src/components/wikiCompose/ComprehensionSection.tsx
@@ -1,0 +1,107 @@
+/**
+ * `ComprehensionSection` — Understanding Layer panel for Wiki Compose.
+ *
+ * 完成した記事から導出した理解支援を、ブロッキングせずに提示する非同期レイヤー。
+ * TL;DR 要約・キーワード用語集・自己確認用の理解度チェック（能動想起）を表示し、
+ * 「即座に本文が出るストレスの無さ」と「理解度の向上」を両立させる。
+ *
+ * Non-blocking panel that surfaces a TL;DR, a key-term glossary, and self-check
+ * comprehension questions derived from the completed article. The questions use
+ * a local checklist (active recall) so the reader engages instead of skimming.
+ */
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { BookOpen, Check, HelpCircle, Sparkles } from "lucide-react";
+import { cn } from "@zedi/ui";
+import type { ComprehensionAids } from "@/lib/wikiCompose/types";
+
+export interface ComprehensionSectionProps {
+  aids: ComprehensionAids;
+}
+
+/** Render the Understanding Layer. Returns null when there is nothing to show. */
+export const ComprehensionSection: React.FC<ComprehensionSectionProps> = ({ aids }) => {
+  const { t } = useTranslation();
+  const [checked, setChecked] = useState<Record<number, boolean>>({});
+
+  const hasSummary = aids.summary.trim().length > 0;
+  const hasTerms = aids.keyTerms.length > 0;
+  const hasQuestions = aids.questions.length > 0;
+  if (!hasSummary && !hasTerms && !hasQuestions) return null;
+
+  return (
+    <section
+      data-testid="comprehension-section"
+      className="border-border rounded-md border bg-emerald-50/40 p-3 dark:bg-emerald-950/20"
+    >
+      <header className="mb-2 flex items-center gap-1.5">
+        <Sparkles className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+        <h3 className="text-sm font-semibold">{t("wikiCompose.comprehension.title")}</h3>
+      </header>
+
+      {hasSummary ? (
+        <div data-testid="comprehension-summary" className="mb-3">
+          <p className="text-muted-foreground mb-1 text-[11px] font-semibold tracking-wide uppercase">
+            {t("wikiCompose.comprehension.summary")}
+          </p>
+          <p className="text-sm leading-relaxed">{aids.summary}</p>
+        </div>
+      ) : null}
+
+      {hasTerms ? (
+        <div className="mb-3">
+          <p className="text-muted-foreground mb-1 flex items-center gap-1 text-[11px] font-semibold tracking-wide uppercase">
+            <BookOpen className="h-3 w-3" />
+            {t("wikiCompose.comprehension.keyTerms")}
+          </p>
+          <dl className="space-y-1.5">
+            {aids.keyTerms.map((term, i) => (
+              <div key={`${term.term}-${i}`} data-testid={`comprehension-term-${i}`}>
+                <dt className="text-sm font-medium">{term.term}</dt>
+                <dd className="text-muted-foreground text-xs leading-relaxed">{term.definition}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      ) : null}
+
+      {hasQuestions ? (
+        <div>
+          <p className="text-muted-foreground mb-1 flex items-center gap-1 text-[11px] font-semibold tracking-wide uppercase">
+            <HelpCircle className="h-3 w-3" />
+            {t("wikiCompose.comprehension.selfCheck")}
+          </p>
+          <ul className="space-y-1">
+            {aids.questions.map((q, i) => (
+              <li key={`q-${i}`}>
+                <button
+                  type="button"
+                  data-testid={`comprehension-question-${i}`}
+                  aria-pressed={Boolean(checked[i])}
+                  onClick={() => setChecked((prev) => ({ ...prev, [i]: !prev[i] }))}
+                  className={cn(
+                    "flex w-full items-start gap-2 rounded px-1.5 py-1 text-left text-sm transition-colors",
+                    "hover:bg-emerald-100/50 dark:hover:bg-emerald-900/30",
+                    checked[i] && "text-muted-foreground line-through",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border",
+                      checked[i]
+                        ? "border-emerald-500 bg-emerald-500 text-white"
+                        : "border-muted-foreground/40",
+                    )}
+                  >
+                    {checked[i] ? <Check className="h-3 w-3" /> : null}
+                  </span>
+                  <span className="min-w-0 flex-1">{q}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+};

--- a/src/components/wikiCompose/ComprehensionSection.tsx
+++ b/src/components/wikiCompose/ComprehensionSection.tsx
@@ -15,7 +15,12 @@ import { BookOpen, Check, HelpCircle, Sparkles } from "lucide-react";
 import { cn } from "@zedi/ui";
 import type { ComprehensionAids } from "@/lib/wikiCompose/types";
 
+/**
+ * Props for {@link ComprehensionSection}.
+ * {@link ComprehensionSection} の props。
+ */
 export interface ComprehensionSectionProps {
+  /** Understanding Layer scaffolds to render. 表示する理解支援スキャフォールド。 */
   aids: ComprehensionAids;
 }
 

--- a/src/hooks/wiki/useWikiComposeSession.test.ts
+++ b/src/hooks/wiki/useWikiComposeSession.test.ts
@@ -319,7 +319,7 @@ describe("useWikiComposeSession", () => {
 
     expect(mocks.runSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        body: { contentLocale: "ja" },
+        body: { contentLocale: "ja", mode: "instant" },
       }),
     );
   });
@@ -401,6 +401,7 @@ describe("useWikiComposeSession", () => {
       expect.objectContaining({
         body: {
           contentLocale: "ja",
+          mode: "instant",
           chatSeed: {
             outline: "- topic",
             conversationText: "User: seed me",

--- a/src/hooks/wiki/useWikiComposeSession.ts
+++ b/src/hooks/wiki/useWikiComposeSession.ts
@@ -25,6 +25,7 @@ import {
 import { useInitialComposeBackend } from "@/hooks/wiki/useInitialComposeBackend";
 import type {
   BriefAnswer,
+  ComposeMode,
   ComposeSession,
   DraftedSection,
   OutlineSection,
@@ -52,6 +53,12 @@ export interface UseWikiComposeSessionArgs {
   /** When to auto-invoke `start()`. Default `on-mount`. */
   startPolicy?: ComposeStartPolicy;
   backend?: ComposeExecutionBackend;
+  /**
+   * Run mode. `instant` (default) streams a draft immediately with no gates;
+   * `guided` keeps the Brief / Research / Outline human-in-the-loop steps.
+   * Sent in the first `POST /run` input so the orchestrator picks the path.
+   */
+  mode?: ComposeMode;
 }
 
 /** Hook return shape. */
@@ -89,6 +96,7 @@ export function useWikiComposeSession(
     initialInput,
     composeSeed,
     backend: backendOverride = "zedi_managed",
+    mode = "instant",
   } = args;
 
   const startPolicy = resolveStartPolicy(args);
@@ -164,13 +172,15 @@ export function useWikiComposeSession(
       update({ session, status: session.status, error: null, ...projectionHydration });
 
       const metadataSeed = parseComposeSeedFromMetadata(session.metadata);
-      const runInput =
+      const baseInput =
         initialInput ??
         (metadataSeed
           ? {
               chatSeed: metadataSeed,
             }
-          : undefined);
+          : {});
+      // Always carry the run `mode` so the orchestrator picks instant vs guided.
+      const runInput = { ...baseInput, mode };
 
       if (session.status === "pending" || session.status === "failed") {
         await streamRun(session, withContentLocale(runInput));
@@ -179,7 +189,7 @@ export function useWikiComposeSession(
       const message = err instanceof Error ? err.message : String(err);
       update({ error: message });
     }
-  }, [pageId, initialSessionId, initialInput, composeSeed, backend, streamRun, update]);
+  }, [pageId, initialSessionId, initialInput, composeSeed, backend, mode, streamRun, update]);
 
   const submitBrief = useCallback<UseWikiComposeSessionReturn["submitBrief"]>(
     async (input) => {

--- a/src/i18n/locales/en/wikiCompose.json
+++ b/src/i18n/locales/en/wikiCompose.json
@@ -92,6 +92,12 @@
     "streaming": "Streaming…",
     "finalMarkdown": "Final Markdown"
   },
+  "comprehension": {
+    "title": "Deepen your understanding",
+    "summary": "TL;DR",
+    "keyTerms": "Key terms",
+    "selfCheck": "Check your understanding"
+  },
   "activity": {
     "title": "Activity",
     "live": "live",

--- a/src/i18n/locales/ja/wikiCompose.json
+++ b/src/i18n/locales/ja/wikiCompose.json
@@ -92,6 +92,12 @@
     "streaming": "ストリーミング中…",
     "finalMarkdown": "完成 Markdown"
   },
+  "comprehension": {
+    "title": "理解を深める",
+    "summary": "要点（TL;DR）",
+    "keyTerms": "キーワード",
+    "selfCheck": "理解度チェック"
+  },
   "activity": {
     "title": "アクティビティ",
     "live": "ライブ",

--- a/src/lib/wikiCompose/types.ts
+++ b/src/lib/wikiCompose/types.ts
@@ -90,6 +90,37 @@ export interface DraftedSection {
   completedAt: string;
 }
 
+// ── Understanding Layer ────────────────────────────────────────────────────
+/** One glossary entry in {@link ComprehensionAids}. */
+export interface ComprehensionKeyTerm {
+  term: string;
+  definition: string;
+}
+
+/**
+ * Understanding-layer scaffolds derived from the completed article: a TL;DR
+ * summary, a key-term glossary, and self-check questions. Surfaced as an
+ * optional, non-blocking panel to raise reader comprehension.
+ *
+ * 完成記事から導出する理解支援（TL;DR・用語集・理解度チェック）。
+ */
+export interface ComprehensionAids {
+  summary: string;
+  keyTerms: ComprehensionKeyTerm[];
+  questions: string[];
+}
+
+/**
+ * Final compose output. Mirrors the backend `ComposeCompletion` and is carried
+ * by the `compose_completion` SSE event (instant mode) and the resume response
+ * (guided mode).
+ */
+export interface ComposeCompletion {
+  markdown: string;
+  sections: DraftedSection[];
+  comprehensionAids?: ComprehensionAids | null;
+}
+
 // ── Compose session row (REST shape from POST/GET) ─────────────────────────
 export type ComposeSessionStatus =
   | "pending"
@@ -139,6 +170,7 @@ export interface ComposeSessionUiProjection {
   outlineProposal?: OutlineSection[];
   draftedSections?: DraftedSection[];
   completedMarkdown?: string | null;
+  comprehensionAids?: ComprehensionAids | null;
 }
 
 // ── Interrupt payloads (discriminated union) ───────────────────────────────
@@ -213,7 +245,17 @@ export type ComposeSseEvent =
       status: "started" | "completed";
       index: number;
       total: number;
+    }
+  | {
+      type: "compose_completion";
+      completion: ComposeCompletion;
     };
 
 /** Convenience tag for the orchestrator graph id used by the frontend. */
 export const WIKI_COMPOSE_GRAPH_ID = "wiki-compose";
+
+/**
+ * Compose run mode. `instant` streams a draft immediately (no gates);
+ * `guided` keeps the Brief / Research / Outline human-in-the-loop steps.
+ */
+export type ComposeMode = "guided" | "instant";

--- a/src/lib/wikiCompose/types.ts
+++ b/src/lib/wikiCompose/types.ts
@@ -114,6 +114,9 @@ export interface ComprehensionAids {
  * Final compose output. Mirrors the backend `ComposeCompletion` and is carried
  * by the `compose_completion` SSE event (instant mode) and the resume response
  * (guided mode).
+ *
+ * Compose の最終成果物。バックエンドの `ComposeCompletion` をミラーし、
+ * instant モードは `compose_completion` SSE、guided モードは resume 応答で運ぶ。
  */
 export interface ComposeCompletion {
   markdown: string;
@@ -261,5 +264,8 @@ export const WIKI_COMPOSE_GRAPH_ID = "wiki-compose";
 /**
  * Compose run mode. `instant` streams a draft immediately (no gates);
  * `guided` keeps the Brief / Research / Outline human-in-the-loop steps.
+ *
+ * Compose 実行モード。`instant` はゲート無しで即ドラフトをストリームし、
+ * `guided` は Brief / 調査 / 構成の human-in-the-loop ステップを維持する。
  */
 export type ComposeMode = "guided" | "instant";

--- a/src/lib/wikiCompose/types.ts
+++ b/src/lib/wikiCompose/types.ts
@@ -247,6 +247,10 @@ export type ComposeSseEvent =
       total: number;
     }
   | {
+      type: "compose_snapshot";
+      pageSnapshot: PageSnapshot;
+    }
+  | {
       type: "compose_completion";
       completion: ComposeCompletion;
     };

--- a/src/lib/wikiCompose/wikiComposeSessionReducer.test.ts
+++ b/src/lib/wikiCompose/wikiComposeSessionReducer.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for the instant-mode / Understanding-Layer additions to the Wiki
+ * Compose reducer.
+ *
+ * - `compose_completion` SSE → final article + comprehension aids (instant mode
+ *   delivers everything in one stream, with no outline gate).
+ * - `compose_section` started → live outline entry so tokens render in place.
+ * - `coerceComprehensionAids` validation.
+ * - resume output (guided mode) carries comprehension aids.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  INITIAL_WIKI_COMPOSE_SESSION_STATE,
+  coerceComprehensionAids,
+  reduceComposeResumeOutput,
+  reduceComposeSseEvent,
+  type WikiComposeSessionState,
+} from "./wikiComposeSessionReducer";
+import type { ComposeSseEvent } from "./types";
+
+const base: WikiComposeSessionState = INITIAL_WIKI_COMPOSE_SESSION_STATE;
+
+describe("coerceComprehensionAids", () => {
+  it("parses a well-formed aids object", () => {
+    const aids = coerceComprehensionAids({
+      summary: "TL;DR",
+      keyTerms: [{ term: "T", definition: "D" }],
+      questions: ["Q1", "Q2"],
+    });
+    expect(aids).toEqual({
+      summary: "TL;DR",
+      keyTerms: [{ term: "T", definition: "D" }],
+      questions: ["Q1", "Q2"],
+    });
+  });
+
+  it("drops malformed key terms and non-string questions", () => {
+    const aids = coerceComprehensionAids({
+      summary: "S",
+      keyTerms: [{ term: "ok", definition: "d" }, { term: 1 }, null],
+      questions: ["good", 42, null],
+    });
+    expect(aids).toEqual({
+      summary: "S",
+      keyTerms: [{ term: "ok", definition: "d" }],
+      questions: ["good"],
+    });
+  });
+
+  it("returns null when everything is empty/invalid", () => {
+    expect(coerceComprehensionAids(null)).toBeNull();
+    expect(coerceComprehensionAids({ summary: "", keyTerms: [], questions: [] })).toBeNull();
+  });
+});
+
+describe("reduceComposeSseEvent — instant mode", () => {
+  it("compose_section started adds a live outline entry and resets the buffer", () => {
+    const event: ComposeSseEvent = {
+      type: "compose_section",
+      sectionId: "sec-1",
+      heading: "Overview",
+      status: "started",
+      index: 1,
+      total: 1,
+    };
+    const patch = reduceComposeSseEvent(base, event);
+    expect(patch.streamingSectionId).toBe("sec-1");
+    expect(patch.outlineProposal).toEqual([
+      { id: "sec-1", heading: "Overview", depth: 1, intent: "" },
+    ]);
+    expect(patch.sectionBuffers).toEqual({ "sec-1": "" });
+  });
+
+  it("compose_section started does not duplicate an existing outline entry", () => {
+    const prev: WikiComposeSessionState = {
+      ...base,
+      outlineProposal: [{ id: "sec-1", heading: "Overview", depth: 1, intent: "x" }],
+    };
+    const patch = reduceComposeSseEvent(prev, {
+      type: "compose_section",
+      sectionId: "sec-1",
+      heading: "Overview",
+      status: "started",
+      index: 1,
+      total: 1,
+    });
+    expect(patch.outlineProposal).toHaveLength(1);
+  });
+
+  it("token appends into the streaming section buffer", () => {
+    const prev: WikiComposeSessionState = {
+      ...base,
+      streamingSectionId: "sec-1",
+      sectionBuffers: { "sec-1": "Hello " },
+    };
+    const patch = reduceComposeSseEvent(prev, { type: "token", content: "world" });
+    expect(patch.sectionBuffers).toEqual({ "sec-1": "Hello world" });
+  });
+
+  it("compose_completion sets markdown, drafted sections, outline fallback and aids", () => {
+    const event: ComposeSseEvent = {
+      type: "compose_completion",
+      completion: {
+        markdown: "## Overview\n\nBody.",
+        sections: [
+          {
+            sectionId: "sec-1",
+            heading: "Overview",
+            body: "Body.",
+            citedSourceIds: [],
+            completedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+        comprehensionAids: {
+          summary: "TL;DR",
+          keyTerms: [{ term: "T", definition: "D" }],
+          questions: ["Q?"],
+        },
+      },
+    };
+    const patch = reduceComposeSseEvent(base, event);
+    expect(patch.phase).toBe("completed");
+    expect(patch.completedMarkdown).toMatch(/Overview/);
+    expect(patch.draftedSections?.["sec-1"]?.body).toBe("Body.");
+    expect(patch.outlineProposal).toEqual([
+      { id: "sec-1", heading: "Overview", depth: 1, intent: "" },
+    ]);
+    expect(patch.comprehensionAids?.summary).toBe("TL;DR");
+    expect(patch.comprehensionAids?.questions).toEqual(["Q?"]);
+  });
+
+  it("compose_completion preserves an existing outline instead of overwriting", () => {
+    const prev: WikiComposeSessionState = {
+      ...base,
+      outlineProposal: [{ id: "sec-1", heading: "Custom", depth: 1, intent: "kept" }],
+    };
+    const patch = reduceComposeSseEvent(prev, {
+      type: "compose_completion",
+      completion: {
+        markdown: "x",
+        sections: [
+          {
+            sectionId: "sec-1",
+            heading: "Overview",
+            body: "B",
+            citedSourceIds: [],
+            completedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+    // Existing outline (with the user's intent text) is not replaced.
+    expect(patch.outlineProposal).toBeUndefined();
+  });
+});
+
+describe("reduceComposeResumeOutput — guided mode aids", () => {
+  it("extracts comprehension aids from the completion in a resume response", () => {
+    const patch = reduceComposeResumeOutput(
+      {
+        completion: {
+          markdown: "## A\n\nB",
+          sections: [
+            {
+              sectionId: "sec-1",
+              heading: "A",
+              body: "B",
+              citedSourceIds: [],
+              completedAt: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+          comprehensionAids: { summary: "S", keyTerms: [], questions: ["Q?"] },
+        },
+      },
+      "completed",
+    );
+    expect(patch.phase).toBe("completed");
+    expect(patch.comprehensionAids?.summary).toBe("S");
+    expect(patch.comprehensionAids?.questions).toEqual(["Q?"]);
+  });
+});

--- a/src/lib/wikiCompose/wikiComposeSessionReducer.ts
+++ b/src/lib/wikiCompose/wikiComposeSessionReducer.ts
@@ -11,6 +11,7 @@ import type {
   ComposeSessionStatus,
   ComposeSessionUiProjection,
   ComposeSseEvent,
+  ComprehensionAids,
   DraftedSection,
   OutlineSection,
   PageSnapshot,
@@ -48,6 +49,8 @@ export interface WikiComposeSessionState {
   sectionBuffers: Record<string, string>;
   activity: ComposeActivity[];
   completedMarkdown: string | null;
+  /** Understanding Layer scaffolds, surfaced once the article completes. */
+  comprehensionAids: ComprehensionAids | null;
   error: string | null;
   isStreaming: boolean;
 }
@@ -68,6 +71,7 @@ export const INITIAL_WIKI_COMPOSE_SESSION_STATE: WikiComposeSessionState = {
   sectionBuffers: {},
   activity: [],
   completedMarkdown: null,
+  comprehensionAids: null,
   error: null,
   isStreaming: false,
 };
@@ -188,6 +192,71 @@ function reduceInterrupt(
   }
 }
 
+/**
+ * Validate a loosely-typed `comprehensionAids` blob (from SSE / resume /
+ * projection) into a {@link ComprehensionAids}, or `null` when unusable.
+ */
+export function coerceComprehensionAids(value: unknown): ComprehensionAids | null {
+  if (!value || typeof value !== "object") return null;
+  const v = value as { summary?: unknown; keyTerms?: unknown; questions?: unknown };
+  const summary = typeof v.summary === "string" ? v.summary : "";
+  const keyTerms = Array.isArray(v.keyTerms)
+    ? v.keyTerms
+        .filter(
+          (t): t is { term: string; definition: string } =>
+            Boolean(t) &&
+            typeof t === "object" &&
+            typeof (t as { term?: unknown }).term === "string" &&
+            typeof (t as { definition?: unknown }).definition === "string",
+        )
+        .map((t) => ({ term: t.term, definition: t.definition }))
+    : [];
+  const questions = Array.isArray(v.questions)
+    ? v.questions.filter((q): q is string => typeof q === "string")
+    : [];
+  if (!summary && keyTerms.length === 0 && questions.length === 0) return null;
+  return { summary, keyTerms, questions };
+}
+
+/**
+ * Project a `ComposeCompletion`-shaped object into UI state. Shared by the
+ * `compose_completion` SSE event (instant mode) and the resume response body
+ * (guided mode). Builds an outline fallback from the section headings when the
+ * approved outline isn't otherwise available (instant mode has no outline gate).
+ */
+function applyCompletion(
+  prev: WikiComposeSessionState,
+  completion: { markdown?: unknown; sections?: unknown; comprehensionAids?: unknown },
+): Partial<WikiComposeSessionState> {
+  const partial: Partial<WikiComposeSessionState> = { phase: "completed" };
+  if (typeof completion.markdown === "string" && completion.markdown.length > 0) {
+    partial.completedMarkdown = completion.markdown;
+  }
+  if (Array.isArray(completion.sections)) {
+    const draftedSections: Record<string, DraftedSection> = {};
+    const outlineFromSections: OutlineSection[] = [];
+    for (const section of completion.sections) {
+      if (!section || typeof section !== "object") continue;
+      const s = section as DraftedSection;
+      if (typeof s.sectionId !== "string") continue;
+      draftedSections[s.sectionId] = s;
+      outlineFromSections.push({
+        id: s.sectionId,
+        heading: s.heading ?? "",
+        depth: 1,
+        intent: "",
+      });
+    }
+    partial.draftedSections = draftedSections;
+    if (prev.outlineProposal.length === 0 && outlineFromSections.length > 0) {
+      partial.outlineProposal = outlineFromSections;
+    }
+  }
+  const aids = coerceComprehensionAids(completion.comprehensionAids);
+  if (aids) partial.comprehensionAids = aids;
+  return partial;
+}
+
 /** Map an SSE event into a state update. */
 export function reduceComposeSseEvent(
   prev: WikiComposeSessionState,
@@ -267,8 +336,21 @@ export function reduceComposeSseEvent(
       };
     case "compose_section":
       if (event.status === "started") {
+        // Instant mode streams without an outline gate, so add a live outline
+        // entry on first sight of a section. The EditorPane renders by walking
+        // `outlineProposal`, so this is what makes tokens visible in real time.
+        // 即時モードはアウトライン承認が無いため、初出のセクションを
+        // outline に追加してトークンをライブ描画する。
+        const hasSection = prev.outlineProposal.some((s) => s.id === event.sectionId);
+        const outlineProposal = hasSection
+          ? prev.outlineProposal
+          : [
+              ...prev.outlineProposal,
+              { id: event.sectionId, heading: event.heading, depth: 1, intent: "" },
+            ];
         return {
           streamingSectionId: event.sectionId,
+          outlineProposal,
           sectionBuffers: { ...prev.sectionBuffers, [event.sectionId]: "" },
           activity: appendActivity(prev.activity, {
             label: i18n.t("wikiCompose.activity.drafting", { heading: event.heading }),
@@ -294,6 +376,8 @@ export function reduceComposeSseEvent(
         sectionBuffers: { ...prev.sectionBuffers, [id]: prior + event.content },
       };
     }
+    case "compose_completion":
+      return applyCompletion(prev, event.completion);
     case "interrupt":
       return reduceInterrupt(prev, event.payload);
     case "done":
@@ -343,6 +427,8 @@ export function hydrateComposeFromProjection(
   }
   if (projection.outlineProposal?.length) partial.outlineProposal = projection.outlineProposal;
   if (projection.completedMarkdown) partial.completedMarkdown = projection.completedMarkdown;
+  const hydratedAids = coerceComprehensionAids(projection.comprehensionAids);
+  if (hydratedAids) partial.comprehensionAids = hydratedAids;
   if (projection.draftedSections?.length) {
     const draftedSections: Record<string, DraftedSection> = {};
     for (const section of projection.draftedSections) {
@@ -389,7 +475,10 @@ export function reduceComposeResumeOutput(
     const c = completion as {
       markdown?: string;
       sections?: DraftedSection[];
+      comprehensionAids?: unknown;
     };
+    const aids = coerceComprehensionAids(c.comprehensionAids);
+    if (aids) partial.comprehensionAids = aids;
     if (typeof c.markdown === "string" && c.markdown.length > 0) {
       partial.completedMarkdown = c.markdown;
     }

--- a/src/lib/wikiCompose/wikiComposeSessionReducer.ts
+++ b/src/lib/wikiCompose/wikiComposeSessionReducer.ts
@@ -376,6 +376,9 @@ export function reduceComposeSseEvent(
         sectionBuffers: { ...prev.sectionBuffers, [id]: prior + event.content },
       };
     }
+    case "compose_snapshot":
+      // Early page title/body for both modes (instant has no Brief interrupt).
+      return event.pageSnapshot ? { pageSnapshot: event.pageSnapshot } : {};
     case "compose_completion":
       return applyCompletion(prev, event.completion);
     case "interrupt":

--- a/src/pages/WikiComposePage.tsx
+++ b/src/pages/WikiComposePage.tsx
@@ -17,7 +17,7 @@ import {
 } from "@zedi/ui";
 import { useWikiComposeSession } from "@/hooks/wiki/useWikiComposeSession";
 import { COMPOSE_SEED_STATE_KEY, type ComposeNavigationSeed } from "@/lib/wikiCompose/navigation";
-import type { DraftedSection } from "@/lib/wikiCompose/types";
+import type { ComposeMode, DraftedSection } from "@/lib/wikiCompose/types";
 import { EditorPane } from "@/components/wikiCompose/EditorPane";
 import { ComposePanel } from "@/components/wikiCompose/ComposePanel";
 
@@ -39,6 +39,12 @@ const WikiComposePage: React.FC = () => {
   const noteId = params.noteId ?? "";
   const pageId = params.pageId ?? "";
   const sessionId = params.sessionId ?? null;
+
+  // Default to the zero-friction instant draft; `?mode=guided` opts into the
+  // classic human-in-the-loop flow (Brief → Research → Outline gates).
+  // 既定は即時ドラフト。`?mode=guided` で従来の対話フローに切り替える。
+  const mode: ComposeMode =
+    new URLSearchParams(location.search).get("mode") === "guided" ? "guided" : "instant";
 
   const [composeSeed] = useState((): ComposeNavigationSeed | undefined => {
     const raw = (location.state as Record<string, unknown> | null)?.[COMPOSE_SEED_STATE_KEY];
@@ -69,6 +75,7 @@ const WikiComposePage: React.FC = () => {
     startPolicy: sessionId ? "on-mount" : "when-backend-ready",
     composeSeed,
     initialInput,
+    mode,
   });
 
   useEffect(() => {
@@ -197,6 +204,7 @@ const WikiComposePage: React.FC = () => {
       approvedSources={session.approvedSources}
       researchConflictSummary={session.researchConflictSummary}
       outlineProposal={session.outlineProposal}
+      comprehensionAids={session.comprehensionAids}
       activity={session.activity}
       onSubmitBrief={session.submitBrief}
       onSubmitResearchApproval={session.submitResearchApproval}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Wiki 生成の UX を「即時性 × 理解度」の両立へ刷新する。以前の「タイトルから即座にコンテンツ生成」のストレスの無さを取り戻しつつ、ユーザーの理解度を高める仕組み（Understanding Layer）を非ブロッキングで載せる。

従来の Wiki Compose は `ブリーフ → 調査 → 構成 → 執筆` の **4 つの承認ゲート**を通過するまで本文が一切表示されなかった（旧 `wikiGenerator` の即時生成は UI 未接続の死蔵コード）。本 PR では Compose に **instant モード**を追加し、ゲートを撤廃して記事を即ストリーム表示する。さらに完成記事から **理解支援（TL;DR / キーワード用語集 / 理解度チェック）** を生成して右ペインに任意レイヤーとして提示する。

[Instant mode: gate-free draft + Understanding Layer](https://cursor.com/agents/bc-a2f570d8-66d6-4ae4-adb2-5978f93c49ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finstant_completed_understanding.png)

即時モード完了状態。フェーズは 4 ゲートを止まらず `完了` へ到達し、左に記事、右に「理解を深める」（要点・キーワード・理解度チェック）が出る。

[wiki_instant_understanding.webm](https://cursor.com/agents/bc-a2f570d8-66d6-4ae4-adb2-5978f93c49ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwiki_instant_understanding.webm)

## 変更点

- **API**: `wiki-compose` グラフに `mode: "instant" | "guided"` を追加。instant では `brief_dialogue` が質問生成を省略し、`human_review_brief` / `human_review_outline` が `interrupt()` をスキップして自動継続 → ゲート無しで `draft_sections` まで一気通貫（`guided` 既定は従来通り）。
- **API**: 新ノード `comprehension_aids`（`draft_sections → comprehension_aids → completed`）が記事から TL;DR・用語集・理解度チェックを生成。失敗しても非致命（`null`）。`ComposeCompletion.comprehensionAids` に同梱。
- **API**: 新 SSE イベント `compose_completion`（割り込み無しの instant 単一ストリームで最終記事＋理解支援を配信）と `compose_snapshot`（instant では Brief 割り込みが無いためページタイトルを早期配信）。`completed` / `brief_dialogue` が発火、`sseMapper` がマッピング、`composeSessionProjection` が再開時に復元。
- **Front**: `WikiComposePage` は既定で instant、`?mode=guided` で従来フロー。`useWikiComposeSession` が run input に `mode` を載せる。
- **Front**: reducer が `compose_completion` / `compose_snapshot` を処理し、`compose_section started` で outline をライブ追加してトークンを即描画。新 `ComprehensionSection`（要点・キーワード・能動想起の理解度チェック）を `ComposePanel` に追加。i18n（en/ja）。

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `cd server/api && bun run test:run`（`wikiComposeInstantMode` / `sseMapper` 等、45 tests pass）
2. `npx vitest run src/lib/wikiCompose/wikiComposeSessionReducer.test.ts`（9 tests pass）
3. `npx playwright test e2e/wiki-compose-instant.spec.ts e2e/wiki-compose.spec.ts`（instant + 既存 guided 共に pass）
4. `npx tsc -b --noEmit`（front）/ `tsc --noEmit`（server/api）

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

上記ヒーロー画像・動画を参照。

## 関連 Issue

<!-- Wiki Compose (#950) follow-up -->

## 備考 / 残課題

- instant モードは初回パスで調査（Web grounding / citation）をスキップして速度優先。出典付き深掘りは「深める」アフォーダンスとして follow-up 予定。
- DB スキーマ変更なし（LangGraph state チャネル追加のみ）。`[skip drizzle-check]`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2f570d8-66d6-4ae4-adb2-5978f93c49ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2f570d8-66d6-4ae4-adb2-5978f93c49ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instant mode for Wiki Compose (default) streams page title, sections, and final output without interruption
  * Understanding Layer: TL;DR, key-term glossary, and self-check questions added to the editor right pane with interactive toggles
  * Mode selectable via URL and exposed in the compose session API

* **Tests**
  * E2E and unit coverage for instant-mode flows, new SSE events, and comprehension-aids handling

* **Documentation**
  * Added English and Japanese translations for the comprehension UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->