### PR TITLE
ci(mutation): nightly を完走可能にする（dry run タイムアウト解消・break 無効化） (#1050)

### DIFF
--- a/.cursor/skills/stryker-mutation-diff/SKILL.md
+++ b/.cursor/skills/stryker-mutation-diff/SKILL.md
@@ -32,7 +32,8 @@ Collects paths from git, joins them as a single `--mutate` argument (comma-separ
 # Working tree vs HEAD (staged + unstaged + untracked under src/)
 bun run test:mutation:changed
 
-# Recommended for slow machines / first failure: extend initial test run timeout (default is 5 minutes)
+# Recommended for slow machines / first failure: extend initial test run timeout
+# (repo default is 20 minutes via `stryker.config.mjs` dryRunTimeoutMinutes)
 bun run test:mutation:changed -- --dryRunTimeoutMinutes 30
 
 # Optional: ignore static mutants (often much faster)
@@ -69,7 +70,7 @@ STRYKER_HTML_REPORT=0 bun run test:mutation:changed
 
 | Symptom                                                  | Likely cause                                                                            | Action                                                                                                       |
 | -------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `Initial test run timed out`                             | Default dry-run limit is **5 minutes**; Vitest + `perTest` coverage can exceed it.      | Retry with `--dryRunTimeoutMinutes 15` or `30`.                                                              |
+| `Initial test run timed out`                             | Repo dry-run limit is **20 minutes** (`stryker.config.mjs`); Vitest + `perTest` coverage can exceed it on slow machines. | Retry with `--dryRunTimeoutMinutes 30`.                                                                      |
 | `There were failed tests in the initial test run`        | Unit tests fail under Stryker.                                                          | Fix tests: `bun run test:run` until green.                                                                   |
 | `No changed files under src/`                            | Only tests / `server/` / non-`src` changed, or nothing to diff.                         | Ensure production files under `src/` exist; use `STRYKER_DIFF_BASE` for branch scope.                        |
 | Low `% Mutation score` / many `# no cov` on changed runs | **Expected** for scoped `--mutate`: many mutants are not mapped to a test in this mode. | Use the report to **review survivors**; do not compare the number to full-repo `test:mutation` expectations. |

--- a/.github/workflows/nightly-mutation.yml
+++ b/.github/workflows/nightly-mutation.yml
@@ -1,5 +1,7 @@
-# Nightly full mutation testing (Issue #377 Phase 3).
+# Nightly full mutation testing (Issue #377 Phase 3 / #1050).
 # 全対象で mutation を実行し、スコア推移・レポートを週次確認する用。
+# スコアでは fail させない（stryker.config.nightly.mjs: break 無効）。
+# 失敗時の原因分類は stryker.config.mjs の TSDoc を参照（timeout / score / test error）。
 name: Nightly Mutation
 
 on:
@@ -18,6 +20,8 @@ jobs:
   mutation-full:
     name: Mutation (full)
     runs-on: ubuntu-latest
+    # 完走実績は約 2.5 時間（dry run 約 5 分 + mutation 約 148 分）。余裕を持たせて 5 時間で打ち切る。
+    timeout-minutes: 300
     steps:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
@@ -29,7 +33,7 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
 
       - name: Run mutation tests (full scope)
-        run: bun run test:mutation
+        run: bun run test:mutation -- stryker.config.nightly.mjs
 
       - name: Upload mutation report
         if: always()
@@ -38,3 +42,13 @@ jobs:
           name: mutation-report-nightly
           path: reports/mutation/
           retention-days: 14
+
+      # スコア推移を artifact を開かずに確認できるよう Job Summary に要約を出す（Issue #1050）。
+      - name: Write mutation summary to job summary
+        if: always()
+        run: |
+          if [ -f reports/mutation/mutation.json ]; then
+            STRYKER_SUMMARY_MAX_SURVIVED=30 node scripts/stryker-mutation-report-summarize.mjs --stdout-only >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No \`reports/mutation/mutation.json\` — run failed before reporting (dry-run timeout or test error). See stryker.config.mjs failure triage." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/nightly-mutation.yml
+++ b/.github/workflows/nightly-mutation.yml
@@ -1,13 +1,13 @@
-# Nightly full mutation testing (Issue #377 Phase 3 / #1050).
-# 全対象で mutation を実行し、スコア推移・レポートを週次確認する用。
+# Weekly full mutation testing (Issue #377 Phase 3 / #1050).
+# 全対象で mutation を実行し、スコア推移・レポートを週次確認する用（金曜夜に週 1 回）。
 # スコアでは fail させない（stryker.config.nightly.mjs: break 無効）。
 # 失敗時の原因分類は stryker.config.mjs の TSDoc を参照（timeout / score / test error）。
 name: Nightly Mutation
 
 on:
   schedule:
-    # 毎日 04:00 UTC (JST 13:00)
-    - cron: "0 4 * * *"
+    # 毎週金曜 14:00 UTC (JST 金曜 23:00)。全量実行は約 2.5 時間かかるため週 1 回で運用する。
+    - cron: "0 14 * * 5"
   workflow_dispatch:
 
 permissions:

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -5,6 +5,22 @@
  * - JSON report: `reports/mutation/mutation.json` — input for `mutation:report:summary` (compact Markdown for AI).
  * - HTML report: optional; set `STRYKER_HTML_REPORT=0` to skip (faster, smaller disk; use JSON + Markdown summary for AI).
  * - JSON レポート: `mutation:report:summary` の入力。HTML は `STRYKER_HTML_REPORT=0` で省略可能（AI 向けは要約 MD を利用）。
+ *
+ * ## CI 失敗時の原因分類 / Failure triage (Issue #1050)
+ *
+ * 1. **timeout** — `ERROR DryRunExecutor Initial test run timed out!`、job が数分で終了。
+ *    dry run（全テスト実行）が `dryRunTimeoutMinutes` を超過。テストスイート肥大化が原因なら値を引き上げる。
+ * 2. **score** — `Final mutation score X under breaking threshold Y`、全 mutant 実行後（nightly 全量で 2.5h 程度）に exit 1。
+ *    レポートは生成済み（artifact / Job Summary で確認可）。nightly は `stryker.config.nightly.mjs`（`break: null`）で観測のみ。
+ * 3. **test error** — dry run 中のテスト失敗。mutation 以前の問題なので先に `vitest run` を直す。
+ *
+ * ## Mutate 候補の優先度 / Priority for golden-list expansion (`ci.yml` mutation-light)
+ *
+ * | 優先度 | 基準 | 例 |
+ * |--------|------|----|
+ * | critical | PR golden list 採用済み（スコア 85%+ で安定） | dateUtils, encryption, aiCostUtils, mcpServerImportHelpers, noteViewHelpers, aiChatConversationTitle, onboardingState, useContainerColumns |
+ * | high | 次の追加候補（nightly で 85%+ の lib ユーティリティ） | aiClient, resolveServerModel, noteSharingRisk, mergeAbortSignals, wikiGeneratorUtils, createStorageAdapter |
+ * | medium | テスト強化後に検討（60〜85% の lib / hooks） | contentUtils, tagUtils, markdownToTiptap, wikiLinkUtils, src/hooks/** |
  */
 const htmlReporterDisabled = new Set(["0", "false", "off", "no", "disabled"]);
 const htmlReporterFlag = (process.env.STRYKER_HTML_REPORT ?? "").toLowerCase();
@@ -32,6 +48,8 @@ export default {
   vitest: {
     configFile: "vite.config.ts",
   },
+  // Dry run = 全テスト 1 周。CI ではスイート肥大化により既定の 5 分を超過するため延長（Issue #1050）。
+  dryRunTimeoutMinutes: 20,
   reporters: ["clear-text", "progress", "json", ...(htmlReporterEnabled ? ["html"] : [])],
   jsonReporter: {
     fileName: "reports/mutation/mutation.json",

--- a/stryker.config.nightly.mjs
+++ b/stryker.config.nightly.mjs
@@ -1,0 +1,21 @@
+/**
+ * Stryker config for nightly full mutation runs (`.github/workflows/nightly-mutation.yml`) only.
+ * Same as `stryker.config.mjs` but does not fail the process on global mutation score.
+ *
+ * Nightly はスコア推移の観測・レポート取得が目的（Issue #1050）。現状の全量スコアは
+ * `thresholds.break: 70` を下回るため、break で fail させると完走済みレポートまで
+ * 「失敗」に埋もれてしまう。nightly では `break` を無効化して success で完走させ、
+ * スコアは artifact `mutation-report-nightly` と Job Summary で追跡する。
+ *
+ * PR の `mutation-light`（`ci.yml`）は引き続き `stryker.config.mjs` の `break: 70` を使用。
+ * 全量スコアが安定して 70 を超えたら、本ファイルの `break` を戻すことを検討する（#1050 Phase 4）。
+ */
+import base from "./stryker.config.mjs";
+
+export default {
+  ...base,
+  thresholds: {
+    ...base.thresholds,
+    break: null,
+  },
+};


### PR DESCRIPTION
- stryker.config.mjs: dryRunTimeoutMinutes を 20 に延長
  （CI でテストスイートの dry run が既定 5 分を超過し 'Initial test run
  timed out' で大半の nightly が失敗していた）
- stryker.config.nightly.mjs を新設: thresholds.break を無効化し、
  nightly はスコア観測・レポート取得用として success で完走させる
  （直近完走時のスコア 47.48% は break: 70 未満のため常に failure だった。
  PR の mutation-light は従来どおり break: 70 を維持）
- nightly-mutation.yml: timeout-minutes: 300 を追加、nightly 用 config を
  使用、スコア要約を Job Summary に出力するステップを追加
- stryker.config.mjs TSDoc: 失敗原因の分類（timeout / score / test error）
  と mutate 候補の優先度表（critical / high / medium）を記載
- SKILL.md: dry run 既定値の記載を更新

https://claude.ai/code/session_01KJGBiWnUQEa4UTuL34ubGw