### PR TITLE
feat(wikiCompose): 全画面化とモバイルレスポンシブ対応 (#950)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,6 +186,22 @@ const App = () => (
                         </ProtectedRoute>
                       }
                     />
+                    {/* Wiki Compose split-screen UI (issue #950).
+                        Rendered chrome-less (outside `AppShellRoute`) so the
+                        focused authoring view owns the whole viewport — no
+                        global Header or mobile BottomNav — which keeps the
+                        split panes from being clipped on small screens.
+                        Optional `:sessionId` keeps one route element so URL
+                        persistence does not remount and abort the first SSE run.
+
+                        Wiki Compose は集中作業用の全画面ビュー。グローバル
+                        Header / モバイル BottomNav を出さないよう
+                        `AppShellRoute` の外に置き、狭い画面で分割ペインが
+                        見切れないようにする。 */}
+                    <Route
+                      path="/notes/:noteId/:pageId/compose/:sessionId?"
+                      element={<WikiComposePage />}
+                    />
 
                     {/* App shell routes: wrapped with the shared AppLayout
                         so every page gets the common Header + primary nav + user menu + AI dock.
@@ -304,13 +320,6 @@ const App = () => (
                       </Route>
                       <Route path="/notes/:noteId/members" element={<LegacyMembersRedirect />} />
                       <Route path="/notes/:noteId/:pageId" element={<NotePageView />} />
-                      {/* Wiki Compose split-screen UI (issue #950).
-                          Optional `:sessionId` keeps one route element so URL
-                          persistence does not remount and abort the first SSE run. */}
-                      <Route
-                        path="/notes/:noteId/:pageId/compose/:sessionId?"
-                        element={<WikiComposePage />}
-                      />
                       {/* Legacy path — redirect `/notes/:noteId/pages/:pageId` to
                           the shorter `/notes/:noteId/:pageId`.
                           旧パス `/notes/:noteId/pages/:pageId` を短縮形にリダイレクト。 */}

--- a/src/components/wikiCompose/ComposePanel.tsx
+++ b/src/components/wikiCompose/ComposePanel.tsx
@@ -9,7 +9,8 @@
  * actual interaction logic lives in each section component; this is just a
  * layout wrapper.
  */
-import React from "react";
+import React, { useState } from "react";
+import { useVirtualKeyboardOffset } from "@/hooks/useVirtualKeyboardOffset";
 import { PhaseStepper } from "./PhaseStepper";
 import { DialogueSection } from "./DialogueSection";
 import { ResearchSection } from "./ResearchSection";
@@ -84,16 +85,29 @@ export const ComposePanel: React.FC<ComposePanelProps> = (props) => {
     onSubmitConflictAck,
   } = props;
 
+  // While a field inside the panel is focused, reserve space for the on-screen
+  // keyboard so the submit buttons can scroll above it on mobile (issue #927
+  // pattern). On desktop the offset stays 0 and this is a no-op.
+  // パネル内の入力にフォーカスがある間だけ仮想キーボード分の余白を確保し、
+  // モバイルで送信ボタンがキーボードに隠れないようにする（desktop では 0）。
+  const [inputActive, setInputActive] = useState(false);
+  const keyboardOffset = useVirtualKeyboardOffset(inputActive);
+
   return (
     <aside
       data-testid="compose-panel"
-      className="bg-card border-border flex h-full flex-col border-l"
+      className="bg-card border-border flex h-full flex-col md:border-l"
     >
       <header className="border-border border-b px-4 py-3">
         <PhaseStepper phase={phase} />
       </header>
 
-      <div className="flex-1 space-y-4 overflow-auto px-4 py-4">
+      <div
+        className="flex-1 space-y-4 overflow-auto px-4 py-4"
+        onFocus={() => setInputActive(true)}
+        onBlur={() => setInputActive(false)}
+        style={keyboardOffset > 0 ? { paddingBottom: keyboardOffset } : undefined}
+      >
         {/* Phase-specific dialogue: Brief / Structure / Draft. */}
         <DialogueSection
           phase={phase}

--- a/src/components/wikiCompose/EditorPane.tsx
+++ b/src/components/wikiCompose/EditorPane.tsx
@@ -38,7 +38,7 @@ export const EditorPane: React.FC<EditorPaneProps> = ({
   return (
     <div
       data-testid="compose-editor-pane"
-      className="bg-background prose prose-sm dark:prose-invert h-full max-w-none overflow-auto px-6 py-6"
+      className="bg-background prose prose-sm dark:prose-invert h-full max-w-none overflow-auto px-4 py-4 sm:px-6 sm:py-6"
     >
       <h1 className="!mb-2">{title || t("wikiCompose.editor.untitled")}</h1>
 

--- a/src/components/wikiCompose/OutlineEditor.tsx
+++ b/src/components/wikiCompose/OutlineEditor.tsx
@@ -75,10 +75,15 @@ export const OutlineEditor: React.FC<OutlineEditorProps> = ({
         <Card
           key={section.id}
           data-testid={`outline-row-${section.id}`}
-          className={cn("transition-colors", section.depth > 1 && "ml-6")}
+          className={cn("transition-colors", section.depth > 1 && "ml-3 sm:ml-6")}
         >
           <CardContent className="space-y-2 pt-4">
-            <div className="flex items-center gap-2">
+            {/* Heading input on its own row on narrow screens; the control
+                cluster wraps below it so the input never gets crushed. On
+                `sm`+ they share a single row as before.
+                狭幅では見出し入力を 1 行目に、操作ボタン群を下段へ折り返す。
+                sm 以上では従来どおり横並び。 */}
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
               <Input
                 value={section.heading}
                 data-testid={`outline-heading-${section.id}`}
@@ -86,46 +91,48 @@ export const OutlineEditor: React.FC<OutlineEditorProps> = ({
                 placeholder={t("wikiCompose.structure.headingPlaceholder")}
                 disabled={disabled}
               />
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                title={t("wikiCompose.structure.toggleDepth")}
-                onClick={() => update(section.id, { depth: section.depth === 1 ? 2 : 1 })}
-                disabled={disabled}
-              >
-                H{section.depth + 1}
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                title={t("wikiCompose.structure.moveUp")}
-                onClick={() => move(i, -1)}
-                disabled={disabled || i === 0}
-              >
-                <ArrowUp className="h-4 w-4" />
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                title={t("wikiCompose.structure.moveDown")}
-                onClick={() => move(i, +1)}
-                disabled={disabled || i === sections.length - 1}
-              >
-                <ArrowDown className="h-4 w-4" />
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                title={t("wikiCompose.structure.removeSection")}
-                onClick={() => remove(section.id)}
-                disabled={disabled}
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
+              <div className="flex shrink-0 items-center justify-end gap-1">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  title={t("wikiCompose.structure.toggleDepth")}
+                  onClick={() => update(section.id, { depth: section.depth === 1 ? 2 : 1 })}
+                  disabled={disabled}
+                >
+                  H{section.depth + 1}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  title={t("wikiCompose.structure.moveUp")}
+                  onClick={() => move(i, -1)}
+                  disabled={disabled || i === 0}
+                >
+                  <ArrowUp className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  title={t("wikiCompose.structure.moveDown")}
+                  onClick={() => move(i, +1)}
+                  disabled={disabled || i === sections.length - 1}
+                >
+                  <ArrowDown className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  title={t("wikiCompose.structure.removeSection")}
+                  onClick={() => remove(section.id)}
+                  disabled={disabled}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
             </div>
             <Textarea
               value={section.intent}

--- a/src/components/wikiCompose/PhaseStepper.tsx
+++ b/src/components/wikiCompose/PhaseStepper.tsx
@@ -33,7 +33,7 @@ export const PhaseStepper: React.FC<PhaseStepperProps> = ({ phase }) => {
   const currentIndex = Math.max(0, PHASE_ORDER.indexOf(stepPhase));
   return (
     <ol
-      className="flex items-center gap-1 text-xs"
+      className="flex items-center gap-1 overflow-x-auto text-xs"
       aria-label={t("wikiCompose.phase.progressAria")}
     >
       {PHASE_ORDER.map((p, i) => {
@@ -42,7 +42,7 @@ export const PhaseStepper: React.FC<PhaseStepperProps> = ({ phase }) => {
           <React.Fragment key={p}>
             <li
               className={cn(
-                "flex items-center gap-1 rounded-md px-2 py-1",
+                "flex shrink-0 items-center gap-1 rounded-md px-2 py-1 whitespace-nowrap",
                 state === "completed" && "text-emerald-600 dark:text-emerald-400",
                 state === "active" && "text-foreground bg-muted font-medium",
                 state === "upcoming" && "text-muted-foreground",
@@ -59,7 +59,9 @@ export const PhaseStepper: React.FC<PhaseStepperProps> = ({ phase }) => {
               )}
               <span>{t(`wikiCompose.phase.${p}`)}</span>
             </li>
-            {i < PHASE_ORDER.length - 1 ? <li aria-hidden className="bg-border h-px w-3" /> : null}
+            {i < PHASE_ORDER.length - 1 ? (
+              <li aria-hidden className="bg-border h-px w-3 shrink-0" />
+            ) : null}
           </React.Fragment>
         );
       })}

--- a/src/i18n/locales/en/wikiCompose.json
+++ b/src/i18n/locales/en/wikiCompose.json
@@ -6,7 +6,10 @@
     "back": "Back",
     "sessionPrefix": "session:",
     "close": "Close",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "tabPreview": "Preview",
+    "tabCompose": "Compose",
+    "paneSwitchAria": "Switch between preview and compose panes"
   },
   "phase": {
     "brief": "Brief",

--- a/src/i18n/locales/ja/wikiCompose.json
+++ b/src/i18n/locales/ja/wikiCompose.json
@@ -6,7 +6,10 @@
     "back": "戻る",
     "sessionPrefix": "セッション:",
     "close": "閉じる",
-    "cancel": "キャンセル"
+    "cancel": "キャンセル",
+    "tabPreview": "プレビュー",
+    "tabCompose": "作成",
+    "paneSwitchAria": "プレビューと作成パネルを切り替え"
   },
   "phase": {
     "brief": "ブリーフ",

--- a/src/pages/WikiComposePage.test.tsx
+++ b/src/pages/WikiComposePage.test.tsx
@@ -305,7 +305,7 @@ describe("WikiComposePage", () => {
   });
 
   describe("layout direction", () => {
-    it("uses horizontal panel group on desktop", () => {
+    it("uses a horizontal panel group and no mobile tabs on desktop", () => {
       vi.mocked(useIsMobile).mockReturnValue(false);
 
       renderWikiCompose();
@@ -314,17 +314,51 @@ describe("WikiComposePage", () => {
         "data-direction",
         "horizontal",
       );
+      expect(screen.queryByTestId("compose-mobile-tabs")).not.toBeInTheDocument();
     });
 
-    it("uses vertical panel group on mobile", () => {
+    it("shows pane tabs instead of a panel group on mobile", () => {
       vi.mocked(useIsMobile).mockReturnValue(true);
 
       renderWikiCompose();
 
-      expect(screen.getByTestId("resizable-panel-group")).toHaveAttribute(
-        "data-direction",
-        "vertical",
-      );
+      expect(screen.getByTestId("compose-mobile-tabs")).toBeInTheDocument();
+      expect(screen.queryByTestId("resizable-panel-group")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("mobile pane tabs", () => {
+    beforeEach(() => {
+      vi.mocked(useIsMobile).mockReturnValue(true);
+    });
+
+    it("defaults to the compose pane during interrupt phases", () => {
+      vi.mocked(useWikiComposeSession).mockReturnValue(createMockSession({ phase: "brief" }));
+
+      renderWikiCompose();
+
+      expect(screen.getByTestId("compose-tab-compose")).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByTestId("compose-tab-preview")).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("defaults to the preview pane while drafting", () => {
+      vi.mocked(useWikiComposeSession).mockReturnValue(createMockSession({ phase: "draft" }));
+
+      renderWikiCompose();
+
+      expect(screen.getByTestId("compose-tab-preview")).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByTestId("compose-tab-compose")).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("switches the active pane when a tab is clicked", () => {
+      vi.mocked(useWikiComposeSession).mockReturnValue(createMockSession({ phase: "brief" }));
+
+      renderWikiCompose();
+
+      fireEvent.click(screen.getByTestId("compose-tab-preview"));
+
+      expect(screen.getByTestId("compose-tab-preview")).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByTestId("compose-tab-compose")).toHaveAttribute("aria-selected", "false");
     });
   });
 

--- a/src/pages/WikiComposePage.tsx
+++ b/src/pages/WikiComposePage.tsx
@@ -4,18 +4,19 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, X } from "lucide-react";
+import { ArrowLeft, Eye, PencilLine, X } from "lucide-react";
 import {
   Alert,
   AlertDescription,
   AlertTitle,
   Button,
+  cn,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
   useIsMobile,
 } from "@zedi/ui";
-import { useWikiComposeSession } from "@/hooks/wiki/useWikiComposeSession";
+import { useWikiComposeSession, type ComposePhase } from "@/hooks/wiki/useWikiComposeSession";
 import { COMPOSE_SEED_STATE_KEY, type ComposeNavigationSeed } from "@/lib/wikiCompose/navigation";
 import type { ComposeMode, DraftedSection } from "@/lib/wikiCompose/types";
 import { EditorPane } from "@/components/wikiCompose/EditorPane";
@@ -27,6 +28,94 @@ function indexById(items: DraftedSection[]): Record<string, DraftedSection> {
   for (const it of items) out[it.sectionId] = it;
   return out;
 }
+
+/**
+ * Which pane the mobile single-column view shows.
+ * モバイル 1 カラム表示でどちらのペインを出すか。
+ */
+type MobileComposeView = "preview" | "compose";
+
+/**
+ * Pick the most relevant mobile pane for a phase: drafting/completed favour the
+ * live preview (left), while interrupt phases need the compose controls (right).
+ *
+ * フェーズに応じて初期表示ペインを選ぶ。執筆中・完了はプレビュー（左）、入力が
+ * 必要な割込みフェーズは作成パネル（右）を出す。
+ */
+function phaseToMobileView(phase: ComposePhase): MobileComposeView {
+  switch (phase) {
+    case "draft":
+    case "completed":
+      return "preview";
+    case "brief":
+    case "research":
+    case "conflict":
+    case "structure":
+      return "compose";
+    default: {
+      const _exhaustive: never = phase;
+      return _exhaustive;
+    }
+  }
+}
+
+const MOBILE_TAB_BASE =
+  "flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors";
+
+/**
+ * Mobile-only segmented control that toggles between the preview and compose
+ * panes (the desktop shows both side by side via resizable panels).
+ *
+ * モバイル専用のセグメント切替。プレビューと作成パネルを行き来する
+ * （デスクトップはリサイズ可能な分割で両方を同時表示する）。
+ */
+const ComposePaneTabs: React.FC<{
+  view: MobileComposeView;
+  onChange: (view: MobileComposeView) => void;
+}> = ({ view, onChange }) => {
+  const { t } = useTranslation();
+  return (
+    <div
+      data-testid="compose-mobile-tabs"
+      role="tablist"
+      aria-label={t("wikiCompose.page.paneSwitchAria")}
+      className="border-border bg-background/95 flex items-center gap-1 border-b px-2 py-1.5"
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={view === "preview"}
+        data-testid="compose-tab-preview"
+        onClick={() => onChange("preview")}
+        className={cn(
+          MOBILE_TAB_BASE,
+          view === "preview"
+            ? "bg-muted text-foreground"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        <Eye className="h-4 w-4" aria-hidden />
+        {t("wikiCompose.page.tabPreview")}
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={view === "compose"}
+        data-testid="compose-tab-compose"
+        onClick={() => onChange("compose")}
+        className={cn(
+          MOBILE_TAB_BASE,
+          view === "compose"
+            ? "bg-muted text-foreground"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        <PencilLine className="h-4 w-4" aria-hidden />
+        {t("wikiCompose.page.tabCompose")}
+      </button>
+    </div>
+  );
+};
 
 /** Root page for `/notes/:noteId/:pageId/compose[/:sessionId]`. */
 const WikiComposePage: React.FC = () => {
@@ -77,6 +166,23 @@ const WikiComposePage: React.FC = () => {
     initialInput,
     mode,
   });
+
+  // Mobile shows one pane at a time; auto-follow the phase so the user lands on
+  // the pane that matters (controls during interrupts, preview while drafting),
+  // while still allowing manual switching via the tab bar. The phase is adjusted
+  // during render (the "you might not need an effect" pattern) so the switch is
+  // applied without a flash and without calling setState inside an effect.
+  // モバイルは 1 ペイン表示。フェーズに追従して必要なペインへ自動で切り替えつつ、
+  // タブで手動切替もできるようにする。フェーズ変化はレンダー中に反映する
+  // （effect 内 setState を避ける React 推奨パターン）。
+  const [mobileView, setMobileView] = useState<MobileComposeView>(() =>
+    phaseToMobileView(session.phase),
+  );
+  const [trackedPhase, setTrackedPhase] = useState<ComposePhase>(session.phase);
+  if (trackedPhase !== session.phase) {
+    setTrackedPhase(session.phase);
+    setMobileView(phaseToMobileView(session.phase));
+  }
 
   useEffect(() => {
     if (!composeSeed || !location.state) return;
@@ -233,17 +339,35 @@ const WikiComposePage: React.FC = () => {
           ) : null}
         </div>
       ) : null}
-      <div className="min-h-0 flex-1">
-        <ResizablePanelGroup direction={isMobile ? "vertical" : "horizontal"} className="h-full">
-          <ResizablePanel defaultSize={55} minSize={30}>
-            {left}
-          </ResizablePanel>
-          <ResizableHandle withHandle />
-          <ResizablePanel defaultSize={45} minSize={25}>
-            {right}
-          </ResizablePanel>
-        </ResizablePanelGroup>
-      </div>
+      {isMobile ? (
+        <>
+          <ComposePaneTabs view={mobileView} onChange={setMobileView} />
+          <div className="min-h-0 flex-1">
+            {/* Keep both panes mounted (toggle with `hidden`) so in-progress
+                Brief answers and outline edits survive tab switches.
+                両ペインをマウントしたまま `hidden` で切替え、入力途中の
+                Brief 回答やアウトライン編集をタブ切替で失わないようにする。 */}
+            <div className={cn("h-full", mobileView === "preview" ? "block" : "hidden")}>
+              {left}
+            </div>
+            <div className={cn("h-full", mobileView === "compose" ? "block" : "hidden")}>
+              {right}
+            </div>
+          </div>
+        </>
+      ) : (
+        <div className="min-h-0 flex-1">
+          <ResizablePanelGroup direction="horizontal" className="h-full">
+            <ResizablePanel defaultSize={55} minSize={30}>
+              {left}
+            </ResizablePanel>
+            <ResizableHandle withHandle />
+            <ResizablePanel defaultSize={45} minSize={25}>
+              {right}
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Wiki Compose 画面（#950）がモバイルで崩れていた問題を解消する。compose ルートを集中作業用の**全画面（full-bleed）ビュー**にし、モバイルではプレビュー/作成の**タブ切替**に変更、各サブコンポーネントを狭幅で破綻しないように調整した。

[wiki_compose_mobile_responsive_walkthrough.mp4](https://cursor.com/agents/bc-a9b3f4b5-e979-4d5d-be8e-1d0e27b639ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwiki_compose_mobile_responsive_walkthrough.mp4)

390px（iPhone 12 Pro 相当）で全フェーズ（brief / structure / draft / completed）を横溢れ・見切れなく表示。

[structure フェーズ（作成タブ）のアウトライン編集](https://cursor.com/agents/bc-a9b3f4b5-e979-4d5d-be8e-1d0e27b639ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompose_mobile_structure.webp)
[brief フェーズの質問カード・スライダー](https://cursor.com/agents/bc-a9b3f4b5-e979-4d5d-be8e-1d0e27b639ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompose_mobile_brief.webp)

## 変更点

- **全画面化**: compose ルートを `AppShellRoute`（共通 Header + モバイル BottomNav）の外へ移動し、`WikiComposePage` 自身のヘッダーに集約。シェル内 `h-[100dvh]` による高さの二重計上・下端見切れ・BottomNav との重なりを解消（`src/App.tsx`）。
- **モバイルのタブ切替**: `<768px` では縦分割（リサイズ）をやめ、「プレビュー / 作成」セグメント切替で各ペインを全幅・全高表示。フェーズに追従して自動切替（割込み中は作成、執筆中はプレビュー）しつつ手動切替も可能。両ペインは `hidden` で保持し入力途中の状態を失わない（`src/pages/WikiComposePage.tsx`）。デスクトップは従来どおり横分割を維持。
- **狭幅対応**: `PhaseStepper` を横スクロール化、`OutlineEditor` の操作ボタン群を狭幅では 2 段目へ折返し（`sm` 以上は従来の横並び）、`ComposePanel` の左ボーダーを `md:` 限定、`EditorPane` のパディングを縮小（`px-4 sm:px-6`）。
- **仮想キーボード対応**: `ComposePanel` のスクロール領域に `useVirtualKeyboardOffset` を適用し、Brief/Outline 入力時に送信ボタンがキーボードに隠れないようにした。
- i18n（en/ja）にタブ用文言を追加。

## 変更の種類

- [x] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] ✨ 新機能 (New feature)

## テスト方法

1. `bunx vitest run src/pages/WikiComposePage.test.tsx src/components/wikiCompose/PhaseStepper.test.tsx`（24 件パス）
2. 一時ハーネスを実コンポーネントでマウントし、Chrome の iPhone 12 Pro 相当（390×844）で全フェーズ・タブ切替を目視確認（添付の動画・スクショ）。デスクトップ幅では従来の 2 カラム分割を維持することも確認。

## チェックリスト

- [x] テストがすべてパスする
- [x] Lint エラーがない（warning のみ・既存パターンと同様）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

#950


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9b3f4b5-e979-4d5d-be8e-1d0e27b639ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9b3f4b5-e979-4d5d-be8e-1d0e27b639ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

