### PR TITLE
chore(deps): bump actions/checkout from 6.0.2 to 6.0.3

### DIFF
--- a/.github/workflows/analyze-error.yml
+++ b/.github/workflows/analyze-error.yml
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 1
 

--- a/.github/workflows/dependabot-bun-lock.yml
+++ b/.github/workflows/dependabot-bun-lock.yml
@@ -47,7 +47,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           # PR ブランチに直接書き戻すため、head ref をチェックアウトする。
           # Check out the PR head ref so we can push commits back to it.

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@v6.0.3
           attempt_limit: 3
           attempt_delay: 5000
       - uses: ./.github/actions/setup-toolchain
@@ -96,7 +96,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@v6.0.3
           attempt_limit: 3
           attempt_delay: 5000
       - uses: ./.github/actions/setup-toolchain

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@v6.0.3
           attempt_limit: 3
           attempt_delay: 5000
       - uses: ./.github/actions/setup-toolchain
@@ -98,7 +98,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@v6.0.3
           attempt_limit: 3
           attempt_delay: 5000
       - uses: ./.github/actions/setup-toolchain
@@ -156,7 +156,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@v6.0.3
           attempt_limit: 3
           attempt_delay: 5000
       # ルートには wrangler 用の依存が必要なので setup-toolchain の install を

--- a/.github/workflows/nightly-mutation.yml
+++ b/.github/workflows/nightly-mutation.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@v6.0.3
           attempt_limit: 3
           attempt_delay: 5000
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       pr-branch: ${{ steps.rp.outputs.prs_created == 'true' && fromJSON(steps.rp.outputs.pr).headBranchName || '' }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 
@@ -42,7 +42,7 @@ jobs:
     if: needs.release-please.outputs.pr-branch != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           ref: ${{ needs.release-please.outputs.pr-branch }}
 

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -15,7 +15,7 @@ jobs:
     name: Create and auto-merge sync PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       # Pin to commit SHAs (tags are mutable). Tag comments for upgrades.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install system dependencies (Linux)
         if: matrix.platform == 'ubuntu-22.04'

--- a/.github/workflows/terraform-cloudflare-dev.yml
+++ b/.github/workflows/terraform-cloudflare-dev.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: development
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
@@ -56,7 +56,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
       github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false

--- a/.github/workflows/terraform-cloudflare-prod.yml
+++ b/.github/workflows/terraform-cloudflare-prod.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
@@ -56,7 +56,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false

--- a/.github/workflows/terraform-cloudflare-shared.yml
+++ b/.github/workflows/terraform-cloudflare-shared.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
@@ -45,7 +45,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     needs: [plan]
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false


### PR DESCRIPTION
## 概要

GitHub Actions の `actions/checkout` を 6.0.2 から 6.0.3 に更新します。Dependabot PR #1007 の変更内容を develop 最新ベースで再 PR しました。

## 変更点

- `.github/workflows/` 内の `actions/checkout@v6.0.2` を `@v6.0.3` に更新（10 ファイル）

## 変更の種類

- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. CI（Lint / Type Check / Unit Tests 等）が pass すること
2. Terraform Plan が fail する場合は Dependabot PR と同様に secrets 制約の可能性を確認

## チェックリスト

- [ ] テストがすべてパスする
- [ ] Lint エラーがない
- [ ] 必要に応じてドキュメントを更新した（英語正本 + 該当する場合は `.ja.md` ペア）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Supersedes #1007

Made with [Cursor](https://cursor.com)