### PR TITLE
fix(ci): gate prod frontend deploy on API git_commit_sha match

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -46,20 +46,40 @@ jobs:
       - migrate
     runs-on: ubuntu-latest
     environment: production
-    if: ${{ vars.API_BASE_URL != '' }}
     steps:
-      # Railway deploys asynchronously after the push event, so retry the
-      # health endpoints to give the platform time to roll out the new image.
-      # Railway は push を受けてから非同期にロールアウトするため、
-      # ヘルスエンドポイントはリトライ付きで検証する。
-      - name: Wait for API /api/health
+      - name: Require API_BASE_URL
+        run: |
+          if [ -z "${{ vars.API_BASE_URL }}" ]; then
+            echo "::error::production environment variable API_BASE_URL is not set"
+            exit 1
+          fi
+      # Railway deploys asynchronously after the push event, so retry until
+      # /api/health reports the pushed commit SHA (not merely HTTP 200).
+      # Railway は push を受けてから非同期にロールアウトするため、200 だけでなく
+      # /api/health の git_commit_sha が github.sha と一致するまでリトライする。
+      - name: Verify API health and deployed commit
         uses: nick-fields/retry@v4
         with:
           max_attempts: 10
-          timeout_minutes: 2
+          timeout_minutes: 5
           retry_wait_seconds: 30
           command: |
-            curl --fail --show-error --silent "${{ vars.API_BASE_URL }}/api/health"
+            BODY=$(curl --fail --show-error --silent "${{ vars.API_BASE_URL }}/api/health")
+            STATUS=$(echo "$BODY" | jq -r '.status')
+            DEPLOYED=$(echo "$BODY" | jq -r '.git_commit_sha // empty')
+            EXPECTED="${{ github.sha }}"
+            if [ "$STATUS" != "ok" ]; then
+              echo "Unexpected health status: $STATUS"
+              exit 1
+            fi
+            if [ -z "$DEPLOYED" ]; then
+              echo "API git_commit_sha missing (stale deploy or rollout in progress)"
+              exit 1
+            fi
+            if [ "$DEPLOYED" != "$EXPECTED" ]; then
+              echo "API git_commit_sha=$DEPLOYED expected=$EXPECTED"
+              exit 1
+            fi
       - name: Wait for MCP /health
         if: ${{ vars.MCP_BASE_URL != '' }}
         uses: nick-fields/retry@v4
@@ -73,25 +93,18 @@ jobs:
   deploy-frontend:
     name: Deploy Frontend
     # `verify-server-health` をフロント公開のゲートにする。バックエンドの
-    # ロールアウトに失敗している状態で新しい UI を本番公開すると、ユーザーが
-    # 直撃する。
+    # ロールアウト（git_commit_sha 一致）に失敗している状態で新しい UI を
+    # 本番公開すると、ユーザーが直撃する。
     #
-    # GitHub Actions は upstream が skipped の場合、downstream を既定で skip
-    # するため、`if: vars.API_BASE_URL != ''` 経由で health チェックが skip
-    # された環境では明示的に `skipped` を success と同等に扱う必要がある
-    # （参照: GitHub Docs "Using jobs in a workflow"）。
-    #
-    # Gate prod frontend rollout on backend health so a failed backend deploy
-    # cannot still publish the new UI. Explicitly allow the `skipped` result
-    # of `verify-server-health` because GitHub Actions skips downstream jobs
-    # by default when an upstream `needs` job is skipped.
+    # Gate prod frontend rollout on backend health + commit SHA match so a
+    # failed or stale backend deploy cannot still publish the new UI.
     needs:
       - migrate
       - verify-server-health
     if: |
       always()
       && needs.migrate.result == 'success'
-      && (needs.verify-server-health.result == 'success' || needs.verify-server-health.result == 'skipped')
+      && needs.verify-server-health.result == 'success'
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -139,17 +152,15 @@ jobs:
 
   deploy-admin:
     name: Deploy Admin
-    # 同様に admin の本番公開もバックエンドのヘルスチェック通過後にする。
-    # `deploy-frontend` と同じ理由で skipped を許容する `if` を明示する。
+    # 同様に admin の本番公開もバックエンドのロールアウト検証通過後にする。
     # Gate admin rollout on backend health for the same reason as `deploy-frontend`.
-    # Apply the same explicit `if` to allow the skipped result.
     needs:
       - migrate
       - verify-server-health
     if: |
       always()
       && needs.migrate.result == 'success'
-      && (needs.verify-server-health.result == 'success' || needs.verify-server-health.result == 'skipped')
+      && needs.verify-server-health.result == 'success'
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/server/api/src/__tests__/routes/health.test.ts
+++ b/server/api/src/__tests__/routes/health.test.ts
@@ -1,8 +1,8 @@
 /**
- * /health のテスト。認証不要、レート制限なし、現在時刻を返すだけ。
- * Tests for /health: no auth, no rate limiting, returns current timestamp.
+ * /health のテスト。認証不要、レート制限なし、現在時刻とデプロイ SHA を返す。
+ * Tests for /health: no auth, no rate limiting, returns timestamp and deploy SHA.
  */
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 import { Hono } from "hono";
 import type { AppEnv } from "../../types/index.js";
 import healthRoutes from "../../routes/health.js";
@@ -14,6 +14,16 @@ function createHealthApp(): Hono<AppEnv> {
 }
 
 describe("GET /health", () => {
+  const originalGitSha = process.env.RAILWAY_GIT_COMMIT_SHA;
+
+  afterEach(() => {
+    if (originalGitSha === undefined) {
+      delete process.env.RAILWAY_GIT_COMMIT_SHA;
+    } else {
+      process.env.RAILWAY_GIT_COMMIT_SHA = originalGitSha;
+    }
+  });
+
   it("returns 200 with status ok and an ISO timestamp", async () => {
     const app = createHealthApp();
 
@@ -41,5 +51,27 @@ describe("GET /health", () => {
     // Confirm 200 is returned even without auth headers.
     const res = await app.request("/health");
     expect(res.status).toBe(200);
+  });
+
+  it("returns git_commit_sha null when RAILWAY_GIT_COMMIT_SHA is unset", async () => {
+    delete process.env.RAILWAY_GIT_COMMIT_SHA;
+    const app = createHealthApp();
+
+    const res = await app.request("/health");
+    const body = (await res.json()) as { git_commit_sha: string | null };
+
+    expect(res.status).toBe(200);
+    expect(body.git_commit_sha).toBeNull();
+  });
+
+  it("returns git_commit_sha from RAILWAY_GIT_COMMIT_SHA when set", async () => {
+    process.env.RAILWAY_GIT_COMMIT_SHA = "abc123def456";
+    const app = createHealthApp();
+
+    const res = await app.request("/health");
+    const body = (await res.json()) as { git_commit_sha: string | null };
+
+    expect(res.status).toBe(200);
+    expect(body.git_commit_sha).toBe("abc123def456");
   });
 });

--- a/server/api/src/__tests__/routes/health.test.ts
+++ b/server/api/src/__tests__/routes/health.test.ts
@@ -2,7 +2,7 @@
  * /health のテスト。認証不要、レート制限なし、現在時刻とデプロイ SHA を返す。
  * Tests for /health: no auth, no rate limiting, returns timestamp and deploy SHA.
  */
-import { afterEach, describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { Hono } from "hono";
 import type { AppEnv } from "../../types/index.js";
 import healthRoutes from "../../routes/health.js";
@@ -14,14 +14,8 @@ function createHealthApp(): Hono<AppEnv> {
 }
 
 describe("GET /health", () => {
-  const originalGitSha = process.env.RAILWAY_GIT_COMMIT_SHA;
-
   afterEach(() => {
-    if (originalGitSha === undefined) {
-      delete process.env.RAILWAY_GIT_COMMIT_SHA;
-    } else {
-      process.env.RAILWAY_GIT_COMMIT_SHA = originalGitSha;
-    }
+    vi.unstubAllEnvs();
   });
 
   it("returns 200 with status ok and an ISO timestamp", async () => {
@@ -54,7 +48,7 @@ describe("GET /health", () => {
   });
 
   it("returns git_commit_sha null when RAILWAY_GIT_COMMIT_SHA is unset", async () => {
-    delete process.env.RAILWAY_GIT_COMMIT_SHA;
+    vi.stubEnv("RAILWAY_GIT_COMMIT_SHA", "");
     const app = createHealthApp();
 
     const res = await app.request("/health");
@@ -65,7 +59,7 @@ describe("GET /health", () => {
   });
 
   it("returns git_commit_sha from RAILWAY_GIT_COMMIT_SHA when set", async () => {
-    process.env.RAILWAY_GIT_COMMIT_SHA = "abc123def456";
+    vi.stubEnv("RAILWAY_GIT_COMMIT_SHA", "abc123def456");
     const app = createHealthApp();
 
     const res = await app.request("/health");

--- a/server/api/src/routes/health.ts
+++ b/server/api/src/routes/health.ts
@@ -3,8 +3,24 @@ import type { AppEnv } from "../types/index.js";
 
 const app = new Hono<AppEnv>();
 
+/**
+ * Railway が GitHub 連携デプロイ時に注入するコミット SHA。ローカルや Railway 外では
+ * 未設定のため null を返す。deploy-prod のロールアウト検証で使う。
+ *
+ * Commit SHA injected by Railway on GitHub-triggered deploys; null locally or
+ * off Railway. Used by deploy-prod rollout verification.
+ */
+function readGitCommitSha(): string | null {
+  const sha = process.env.RAILWAY_GIT_COMMIT_SHA;
+  return typeof sha === "string" && sha.length > 0 ? sha : null;
+}
+
 app.get("/health", (c) => {
-  return c.json({ status: "ok", timestamp: new Date().toISOString() });
+  return c.json({
+    status: "ok",
+    timestamp: new Date().toISOString(),
+    git_commit_sha: readGitCommitSha(),
+  });
 });
 
 export default app;


### PR DESCRIPTION
## 概要

本番フロントだけが先にデプロイされ、Railway API が古いままになる事象（`default_note_id` 欠落による Sync 失敗）の再発を防ぐため、`deploy-prod` のゲートを強化し、API の `/api/health` にデプロイ済みコミット SHA を公開する。

## 変更点

### `.github/workflows/deploy-prod.yml`
- `verify-server-health` を常時実行し、`API_BASE_URL` 未設定時は明示的に fail
- `/api/health` の `git_commit_sha` が `github.sha` と一致するまでリトライ（最大 10 回）
- フロント / admin デプロイ条件から `verify-server-health` の `skipped` 許容を削除（`success` のみ）

### `server/api/src/routes/health.ts`
- レスポンスに `git_commit_sha` を追加（Railway の `RAILWAY_GIT_COMMIT_SHA`、未設定時は `null`）

### `server/api/src/__tests__/routes/health.test.ts`
- `git_commit_sha` の有無に関するテストを追加

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `cd server/api && bun test src/__tests__/routes/health.test.ts` — 4 件 pass
2. マージ後、`main` push 時に `verify-server-health` が `API_BASE_URL/api/health` の `git_commit_sha` を検証することを Deploy Production ワークフローで確認
3. Railway 本番 API が push コミットと一致するまでフロントデプロイがブロックされることを確認

## チェックリスト

- [x] テストがすべてパスする（変更ファイルの health テスト）
- [x] Lint エラーがない（lint-staged / pre-commit 通過）
- [ ] 必要に応じてドキュメントを更新した（英語正本 + 該当する場合は `.ja.md` ペア）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

該当なし

## 関連 Issue

Related to Sync/API `default_note_id` 本番障害調査

## マージ後の運用メモ

- GitHub **production** 環境に `API_BASE_URL=https://api.zedi-note.app` を設定すること（未設定だと `verify-server-health` が fail しフロントはデプロイされない）
- 初回マージ時は Railway 本番 API が新 `/api/health` をデプロイするまで CI が待機する（意図した挙動）

Made with [Cursor](https://cursor.com)