### PR TITLE
fix(api): implement bindTools on ZediChatModel for Wiki Compose structured output

### DIFF
--- a/server/api/src/__tests__/agents/core/llm/zediChatModel.test.ts
+++ b/server/api/src/__tests__/agents/core/llm/zediChatModel.test.ts
@@ -362,6 +362,10 @@ describe("ZediChatModel.bindTools", () => {
         function: expect.objectContaining({ name: "structure_dialogue" }),
       }),
     ]);
+    expect(spy.calls[0]?.options.toolChoice).toEqual({
+      type: "function",
+      function: { name: "structure_dialogue" },
+    });
     expect(chains.length).toBe(2);
   });
 });

--- a/server/api/src/__tests__/agents/core/llm/zediChatModel.test.ts
+++ b/server/api/src/__tests__/agents/core/llm/zediChatModel.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { HumanMessage, SystemMessage, AIMessage } from "@langchain/core/messages";
+import { z } from "zod";
 import { ZediChatModel } from "../../../../agents/core/llm/zediChatModel.js";
 import { createMockDb } from "../../../createMockDb.js";
 import type {
@@ -290,5 +291,77 @@ describe("ZediChatModel._llmType", () => {
       spy,
     );
     expect(model._llmType()).toBe("zedi-chat");
+  });
+});
+
+describe("ZediChatModel.bindTools", () => {
+  it("passes bound tools to callProvider and supports withStructuredOutput", async () => {
+    const spy = { calls: [] as CallSpy[] };
+    const { db, chains } = asDb([undefined, undefined]);
+    const model = new ZediChatModel({
+      provider: "google",
+      apiKey: "k",
+      apiModelId: "gemini-test",
+      modelRowId: "google:gemini-3.5-flash",
+      inputCostUnits: 1,
+      outputCostUnits: 2,
+      userId: "user-1",
+      tier: "free",
+      db,
+      feature: "wiki_compose:structure",
+      callProvider: async (_provider, _apiKey, _model, _messages, options = {}) => {
+        spy.calls.push({
+          provider: "google",
+          apiKey: "k",
+          model: "gemini-test",
+          messages: _messages,
+          options,
+        });
+        return {
+          content: "",
+          usage: { inputTokens: 12, outputTokens: 34 },
+          finishReason: "STOP",
+          toolCalls: [
+            {
+              id: "call_1",
+              name: "structure_dialogue",
+              args: {
+                sections: [
+                  { heading: "Overview", intent: "Introduce topic", depth: 1 },
+                  { heading: "History", intent: "Timeline", depth: 1 },
+                  { heading: "Legacy", intent: "Impact", depth: 1 },
+                ],
+              },
+            },
+          ],
+        };
+      },
+      streamProvider: async function* () {},
+    });
+
+    const schema = z.object({
+      sections: z.array(
+        z.object({
+          heading: z.string(),
+          intent: z.string(),
+          depth: z.number(),
+        }),
+      ),
+    });
+    const structured = model.withStructuredOutput(schema, { name: "structure_dialogue" });
+    const parsed = await structured.invoke([
+      new SystemMessage("You are an orchestrator."),
+      new HumanMessage("Topic: Surrealism"),
+    ]);
+
+    expect(parsed.sections).toHaveLength(3);
+    expect(spy.calls).toHaveLength(1);
+    expect(spy.calls[0]?.options.tools).toEqual([
+      expect.objectContaining({
+        type: "function",
+        function: expect.objectContaining({ name: "structure_dialogue" }),
+      }),
+    ]);
+    expect(chains.length).toBe(2);
   });
 });

--- a/server/api/src/__tests__/services/aiProviders.test.ts
+++ b/server/api/src/__tests__/services/aiProviders.test.ts
@@ -117,6 +117,52 @@ describe("callOpenAI", () => {
     await expect(callOpenAI("k", "gpt-4o", messages)).rejects.toThrow(/429/);
   });
 
+  it("sends tools and parses tool_calls from the response", async () => {
+    fetchSpy.mockResolvedValue(
+      okJson({
+        choices: [
+          {
+            message: {
+              content: "",
+              tool_calls: [
+                {
+                  id: "call_1",
+                  function: {
+                    name: "brief_dialogue",
+                    arguments: JSON.stringify({ questions: [] }),
+                  },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 7 },
+      }),
+    );
+
+    const result = await callOpenAI("k", "gpt-4o", messages, {
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "brief_dialogue",
+            description: "Ask brief questions",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    });
+
+    const body = JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body)) as {
+      tools?: unknown[];
+    };
+    expect(body.tools).toHaveLength(1);
+    expect(result.toolCalls).toEqual([
+      { id: "call_1", name: "brief_dialogue", args: { questions: [] } },
+    ]);
+  });
+
   it("returns empty content / 0 tokens when fields are missing", async () => {
     fetchSpy.mockResolvedValue(okJson({ choices: [], usage: undefined }));
     const result = await callOpenAI("k", "gpt-4o", messages);
@@ -237,6 +283,53 @@ describe("callGoogle", () => {
       tools?: unknown[];
     };
     expect(body.tools).toEqual([{ googleSearch: {} }]);
+  });
+
+  it("sends functionDeclarations and parses functionCall parts", async () => {
+    fetchSpy.mockResolvedValue(
+      okJson({
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    name: "structure_dialogue",
+                    args: {
+                      sections: [{ heading: "A", intent: "B", depth: 1 }],
+                    },
+                  },
+                },
+              ],
+            },
+            finishReason: "STOP",
+          },
+        ],
+        usageMetadata: { promptTokenCount: 8, candidatesTokenCount: 12 },
+      }),
+    );
+
+    const result = await callGoogle("k", "gemini-2.0", messages, {
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "structure_dialogue",
+            description: "Outline",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    });
+
+    const body = JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body)) as {
+      tools?: Array<{ functionDeclarations?: unknown[] }>;
+    };
+    expect(body.tools?.[0]?.functionDeclarations).toHaveLength(1);
+    expect(result.toolCalls?.[0]?.name).toBe("structure_dialogue");
+    expect(result.toolCalls?.[0]?.args).toEqual({
+      sections: [{ heading: "A", intent: "B", depth: 1 }],
+    });
   });
 
   it("throws on non-200", async () => {

--- a/server/api/src/__tests__/services/providerToolCalling.test.ts
+++ b/server/api/src/__tests__/services/providerToolCalling.test.ts
@@ -3,9 +3,11 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+  buildAnthropicToolRequest,
   buildGoogleToolRequest,
   buildOpenAiToolRequest,
   normalizeFunctionTools,
+  parseAnthropicToolCalls,
   parseGoogleToolCalls,
   parseOpenAiToolCalls,
 } from "../../services/providerToolCalling.js";
@@ -98,5 +100,44 @@ describe("buildGoogleToolRequest", () => {
         allowedFunctionNames: ["structure_dialogue"],
       },
     });
+  });
+
+  it("maps auto and none tool choices explicitly", () => {
+    const normalized = normalizeFunctionTools(sampleTools);
+    expect(buildGoogleToolRequest(normalized, "auto").toolConfig).toEqual({
+      functionCallingConfig: { mode: "AUTO" },
+    });
+    expect(buildGoogleToolRequest(normalized, "none").toolConfig).toEqual({
+      functionCallingConfig: { mode: "NONE" },
+    });
+  });
+});
+
+describe("buildAnthropicToolRequest", () => {
+  it("maps auto and required tool choices separately", () => {
+    const normalized = normalizeFunctionTools(sampleTools);
+    expect(buildAnthropicToolRequest(normalized, "auto").tool_choice).toEqual({ type: "auto" });
+    expect(buildAnthropicToolRequest(normalized, "required").tool_choice).toEqual({ type: "any" });
+  });
+});
+
+describe("parseAnthropicToolCalls", () => {
+  it("maps tool_use blocks and skips null entries", () => {
+    const calls = parseAnthropicToolCalls([
+      null as unknown as { type?: string },
+      {
+        type: "tool_use",
+        id: "toolu_1",
+        name: "structure_dialogue",
+        input: { sections: [{ heading: "Intro" }] },
+      },
+    ]);
+    expect(calls).toEqual([
+      {
+        id: "toolu_1",
+        name: "structure_dialogue",
+        args: { sections: [{ heading: "Intro" }] },
+      },
+    ]);
   });
 });

--- a/server/api/src/__tests__/services/providerToolCalling.test.ts
+++ b/server/api/src/__tests__/services/providerToolCalling.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for provider tool-calling request/response helpers.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildGoogleToolRequest,
+  buildOpenAiToolRequest,
+  normalizeFunctionTools,
+  parseGoogleToolCalls,
+  parseOpenAiToolCalls,
+} from "../../services/providerToolCalling.js";
+import type { ZediChatTool } from "../../types/index.js";
+
+const sampleTools: ZediChatTool[] = [
+  {
+    type: "function",
+    function: {
+      name: "structure_dialogue",
+      description: "Propose an outline",
+      parameters: {
+        type: "object",
+        properties: {
+          sections: { type: "array" },
+        },
+      },
+    },
+  },
+];
+
+describe("normalizeFunctionTools", () => {
+  it("keeps OpenAI-shaped function tools", () => {
+    expect(normalizeFunctionTools(sampleTools)).toEqual([
+      {
+        name: "structure_dialogue",
+        description: "Propose an outline",
+        parameters: sampleTools[0]?.function.parameters,
+      },
+    ]);
+  });
+});
+
+describe("parseOpenAiToolCalls", () => {
+  it("parses JSON string arguments into objects", () => {
+    const calls = parseOpenAiToolCalls({
+      tool_calls: [
+        {
+          id: "call_1",
+          function: {
+            name: "structure_dialogue",
+            arguments: JSON.stringify({ sections: [{ heading: "Intro" }] }),
+          },
+        },
+      ],
+    });
+    expect(calls).toEqual([
+      {
+        id: "call_1",
+        name: "structure_dialogue",
+        args: { sections: [{ heading: "Intro" }] },
+      },
+    ]);
+  });
+});
+
+describe("parseGoogleToolCalls", () => {
+  it("maps Gemini functionCall parts", () => {
+    const calls = parseGoogleToolCalls([
+      {
+        functionCall: {
+          name: "structure_dialogue",
+          args: { sections: [{ heading: "Intro", intent: "x", depth: 1 }] },
+        },
+      },
+    ]);
+    expect(calls[0]?.name).toBe("structure_dialogue");
+    expect(calls[0]?.args).toEqual({
+      sections: [{ heading: "Intro", intent: "x", depth: 1 }],
+    });
+  });
+});
+
+describe("buildOpenAiToolRequest", () => {
+  it("includes tools payload when declarations exist", () => {
+    const payload = buildOpenAiToolRequest(normalizeFunctionTools(sampleTools));
+    expect(payload.tools).toHaveLength(1);
+  });
+});
+
+describe("buildGoogleToolRequest", () => {
+  it("forces a named function when tool choice is set", () => {
+    const payload = buildGoogleToolRequest(normalizeFunctionTools(sampleTools), {
+      type: "function",
+      function: { name: "structure_dialogue" },
+    });
+    expect(payload.toolConfig).toEqual({
+      functionCallingConfig: {
+        mode: "ANY",
+        allowedFunctionNames: ["structure_dialogue"],
+      },
+    });
+  });
+});

--- a/server/api/src/agents/core/llm/zediChatModel.ts
+++ b/server/api/src/agents/core/llm/zediChatModel.ts
@@ -36,10 +36,12 @@ import {
   type BaseChatModelCallOptions,
   type BaseChatModelParams,
 } from "@langchain/core/language_models/chat_models";
+import type { BaseLanguageModelInput } from "@langchain/core/language_models/base";
 import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import type { BaseMessage } from "@langchain/core/messages";
-import { AIMessage, AIMessageChunk } from "@langchain/core/messages";
+import { AIMessageChunk } from "@langchain/core/messages";
 import { ChatGenerationChunk, type ChatResult } from "@langchain/core/outputs";
+import type { Runnable } from "@langchain/core/runnables";
 import { callProvider, streamProvider } from "../../../services/aiProviders.js";
 import { calculateCost } from "../../../services/usageService.js";
 import type {
@@ -48,6 +50,8 @@ import type {
   ApiMode,
   Database,
   UserTier,
+  ZediChatTool,
+  ZediToolChoice,
 } from "../../../types/index.js";
 import { recordZediUsage, toZediMessages, type RecordZediUsageResult } from "./usageCallback.js";
 
@@ -134,10 +138,18 @@ export type ExtraProviderOptions = Pick<
 >;
 
 /**
+ * Call options surfaced by {@link ZediChatModel}, including LangChain tool binding.
+ */
+export interface ZediChatModelCallOptions extends BaseChatModelCallOptions {
+  tools?: ZediChatTool[];
+  tool_choice?: ZediToolChoice;
+}
+
+/**
  * Concrete `BaseChatModel` implementation routing through Zedi providers.
  * Zedi の providers 経由で呼び出す `BaseChatModel` 実装。
  */
-export class ZediChatModel extends BaseChatModel<BaseChatModelCallOptions> {
+export class ZediChatModel extends BaseChatModel<ZediChatModelCallOptions, AIMessageChunk> {
   /** LangChain serialization namespace. LangChain シリアライズ識別子。 */
   static lc_name(): string {
     return "ZediChatModel";
@@ -189,26 +201,56 @@ export class ZediChatModel extends BaseChatModel<BaseChatModelCallOptions> {
   }
 
   /**
-   * 非ストリーミング呼び出し。`callProvider` → cost 計算 → `recordUsage`。
+   * Expose LangChain tool-binding kwargs to `_generate`.
+   * `_generate` に LangChain の tool binding 引数を渡す。
+   */
+  get callKeys(): string[] {
+    return [...super.callKeys, "tools", "tool_choice"];
+  }
+
+  /**
+   * Bind OpenAI-shaped function tools for structured output / tool calling.
+   * 構造化出力・tool calling 向けに OpenAI 形式の function tools を束ねる。
+   */
+  bindTools(
+    tools: ZediChatTool[],
+    kwargs?: Partial<ZediChatModelCallOptions>,
+  ): Runnable<BaseLanguageModelInput, AIMessageChunk, ZediChatModelCallOptions> {
+    return this.withConfig({
+      tools,
+      ...kwargs,
+    } as Partial<ZediChatModelCallOptions>);
+  }
+
+  /**
    * Non-streaming generation path.
+   * 非ストリーミング呼び出し。`callProvider` → cost 計算 → `recordUsage`。
    */
   async _generate(
     messages: BaseMessage[],
-    _options: this["ParsedCallOptions"],
+    options: this["ParsedCallOptions"],
     runManager?: CallbackManagerForLLMRun,
   ): Promise<ChatResult> {
     const zediMessages = toZediMessages(messages);
+    const providerOptions: AIChatOptions = {
+      temperature: this.temperature,
+      maxTokens: this.maxTokens,
+      feature: this.feature,
+      ...this.extraProviderOptions,
+    };
+    if (options.tools?.length) {
+      providerOptions.tools = options.tools;
+    }
+    if (options.tool_choice !== undefined) {
+      providerOptions.toolChoice = options.tool_choice;
+    }
+
     const result = await this.callProviderFn(
       this.provider,
       this.apiKey,
       this.apiModelId,
       zediMessages,
-      {
-        temperature: this.temperature,
-        maxTokens: this.maxTokens,
-        feature: this.feature,
-        ...this.extraProviderOptions,
-      },
+      providerOptions,
     );
 
     const usage = await recordZediUsage({
@@ -225,8 +267,16 @@ export class ZediChatModel extends BaseChatModel<BaseChatModelCallOptions> {
     void this.tier;
     void runManager;
 
-    const aiMessage = new AIMessage({
+    const toolCalls = result.toolCalls?.map((call) => ({
+      id: call.id,
+      name: call.name,
+      args: call.args,
+      type: "tool_call" as const,
+    }));
+
+    const aiMessage = new AIMessageChunk({
       content: result.content,
+      tool_calls: toolCalls,
       response_metadata: {
         finishReason: result.finishReason,
         usage: {

--- a/server/api/src/agents/core/llm/zediChatModel.ts
+++ b/server/api/src/agents/core/llm/zediChatModel.ts
@@ -210,14 +210,26 @@ export class ZediChatModel extends BaseChatModel<ZediChatModelCallOptions, AIMes
 
   /**
    * Bind OpenAI-shaped function tools for structured output / tool calling.
+   * When a single tool is bound without tool_choice, force that function so
+   * withStructuredOutput always receives tool_calls from providers.
    * 構造化出力・tool calling 向けに OpenAI 形式の function tools を束ねる。
+   * tool_choice 未指定で 1 件だけ束ねるときは schema function を強制する。
    */
   bindTools(
     tools: ZediChatTool[],
     kwargs?: Partial<ZediChatModelCallOptions>,
   ): Runnable<BaseLanguageModelInput, AIMessageChunk, ZediChatModelCallOptions> {
+    const singleToolName =
+      kwargs?.tool_choice === undefined && tools.length === 1
+        ? tools[0]?.function?.name
+        : undefined;
+    const defaultToolChoice: ZediToolChoice | undefined = singleToolName
+      ? { type: "function", function: { name: singleToolName } }
+      : undefined;
+
     return this.withConfig({
       tools,
+      ...(defaultToolChoice ? { tool_choice: defaultToolChoice } : {}),
       ...kwargs,
     } as Partial<ZediChatModelCallOptions>);
   }

--- a/server/api/src/services/aiProviders.ts
+++ b/server/api/src/services/aiProviders.ts
@@ -178,10 +178,12 @@ export async function callAnthropic(
     usage: { input_tokens: number; output_tokens: number };
   };
 
-  const toolCalls = parseAnthropicToolCalls(data.content);
-  const textContent = data.content
+  const contentBlocks = data.content ?? [];
+  const toolCalls = parseAnthropicToolCalls(contentBlocks);
+  const textContent = contentBlocks
     .filter(
       (block) =>
+        block &&
         block.type !== "tool_use" &&
         typeof block.text === "string" &&
         (block.type === "text" || block.type === undefined),

--- a/server/api/src/services/aiProviders.ts
+++ b/server/api/src/services/aiProviders.ts
@@ -3,7 +3,21 @@
  *
  * 既存 ai-api/lambda/src/services/aiProviders.ts の Drizzle 移植版
  */
-import type { AIMessage, AIProviderType, AIChatOptions, TokenUsage } from "../types/index.js";
+import type {
+  AIMessage,
+  AIChatOptions,
+  AIProviderCallResult,
+  AIProviderType,
+} from "../types/index.js";
+import {
+  buildAnthropicToolRequest,
+  buildGoogleToolRequest,
+  buildOpenAiToolRequest,
+  normalizeFunctionTools,
+  parseAnthropicToolCalls,
+  parseGoogleToolCalls,
+  parseOpenAiToolCalls,
+} from "./providerToolCalling.js";
 
 // ── OpenAI ──────────────────────────────────────────────────────────────────
 
@@ -12,13 +26,14 @@ export async function callOpenAI(
   model: string,
   messages: AIMessage[],
   options: AIChatOptions = {},
-): Promise<{ content: string; usage: TokenUsage; finishReason: string }> {
+): Promise<AIProviderCallResult> {
   const body: Record<string, unknown> = {
     model,
     messages: messages.map((m) => ({ role: m.role, content: m.content })),
     temperature: options.temperature ?? 0.7,
     max_tokens: options.maxTokens ?? 4096,
     stream: false,
+    ...buildOpenAiToolRequest(normalizeFunctionTools(options.tools), options.toolChoice),
   };
 
   if (options.useWebSearch && options.webSearchOptions) {
@@ -40,12 +55,25 @@ export async function callOpenAI(
   }
 
   const data = (await res.json()) as {
-    choices: Array<{ message: { content: string }; finish_reason: string }>;
+    choices: Array<{
+      message: {
+        content?: string | null;
+        tool_calls?: Array<{
+          id?: string;
+          function?: { name?: string; arguments?: string };
+        }>;
+      };
+      finish_reason: string;
+    }>;
     usage: { prompt_tokens: number; completion_tokens: number };
   };
 
+  const message = data.choices[0]?.message;
+  const toolCalls = message ? parseOpenAiToolCalls(message) : [];
+
   return {
-    content: data.choices[0]?.message?.content ?? "",
+    content: message?.content ?? "",
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
     usage: {
       inputTokens: data.usage?.prompt_tokens ?? 0,
       outputTokens: data.usage?.completion_tokens ?? 0,
@@ -107,7 +135,7 @@ export async function callAnthropic(
   model: string,
   messages: AIMessage[],
   options: AIChatOptions = {},
-): Promise<{ content: string; usage: TokenUsage; finishReason: string }> {
+): Promise<AIProviderCallResult> {
   const systemMessages = messages.filter((m) => m.role === "system");
   const nonSystemMessages = messages.filter((m) => m.role !== "system");
 
@@ -116,6 +144,7 @@ export async function callAnthropic(
     messages: nonSystemMessages.map((m) => ({ role: m.role, content: m.content })),
     max_tokens: options.maxTokens ?? 4096,
     temperature: options.temperature ?? 0.7,
+    ...buildAnthropicToolRequest(normalizeFunctionTools(options.tools), options.toolChoice),
   };
 
   if (systemMessages.length > 0) {
@@ -138,13 +167,31 @@ export async function callAnthropic(
   }
 
   const data = (await res.json()) as {
-    content: Array<{ text: string }>;
+    content: Array<{
+      type?: string;
+      text?: string;
+      id?: string;
+      name?: string;
+      input?: Record<string, unknown>;
+    }>;
     stop_reason: string;
     usage: { input_tokens: number; output_tokens: number };
   };
 
+  const toolCalls = parseAnthropicToolCalls(data.content);
+  const textContent = data.content
+    .filter(
+      (block) =>
+        block.type !== "tool_use" &&
+        typeof block.text === "string" &&
+        (block.type === "text" || block.type === undefined),
+    )
+    .map((block) => block.text ?? "")
+    .join("");
+
   return {
-    content: data.content.map((c) => c.text).join(""),
+    content: textContent,
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
     usage: {
       inputTokens: data.usage?.input_tokens ?? 0,
       outputTokens: data.usage?.output_tokens ?? 0,
@@ -213,7 +260,7 @@ export async function callGoogle(
   model: string,
   messages: AIMessage[],
   options: AIChatOptions = {},
-): Promise<{ content: string; usage: TokenUsage; finishReason: string }> {
+): Promise<AIProviderCallResult> {
   const contents = messages
     .filter((m) => m.role !== "system")
     .map((m) => ({
@@ -238,7 +285,10 @@ export async function callGoogle(
     body.systemInstruction = { parts: [{ text: systemInstruction }] };
   }
 
-  if (options.useGoogleSearch) {
+  const functionTools = normalizeFunctionTools(options.tools);
+  if (functionTools.length > 0) {
+    Object.assign(body, buildGoogleToolRequest(functionTools, options.toolChoice));
+  } else if (options.useGoogleSearch) {
     body.tools = [{ googleSearch: {} }];
   }
 
@@ -261,16 +311,24 @@ export async function callGoogle(
 
   const data = (await res.json()) as {
     candidates: Array<{
-      content: { parts: Array<{ text: string }> };
+      content: {
+        parts: Array<{
+          text?: string;
+          functionCall?: { name?: string; args?: Record<string, unknown> };
+        }>;
+      };
       finishReason: string;
     }>;
     usageMetadata?: { promptTokenCount: number; candidatesTokenCount: number };
   };
 
   const candidate = data.candidates?.[0];
+  const parts = candidate?.content?.parts ?? [];
+  const toolCalls = parseGoogleToolCalls(parts);
 
   return {
-    content: candidate?.content?.parts?.map((p) => p.text).join("") ?? "",
+    content: parts.map((p) => p.text ?? "").join(""),
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
     usage: {
       inputTokens: data.usageMetadata?.promptTokenCount ?? 0,
       outputTokens: data.usageMetadata?.candidatesTokenCount ?? 0,
@@ -416,7 +474,7 @@ export async function callProvider(
   model: string,
   messages: AIMessage[],
   options: AIChatOptions = {},
-): Promise<{ content: string; usage: TokenUsage; finishReason: string }> {
+): Promise<AIProviderCallResult> {
   switch (provider) {
     case "openai":
       return callOpenAI(apiKey, model, messages, options);

--- a/server/api/src/services/providerToolCalling.ts
+++ b/server/api/src/services/providerToolCalling.ts
@@ -1,0 +1,208 @@
+/**
+ * Provider tool-calling helpers for `aiProviders` non-streaming paths.
+ *
+ * LangChain passes OpenAI-shaped `{ type: "function", function: ... }` tools via
+ * `ZediChatModel.bindTools`. These helpers normalize that shape into each vendor
+ * API payload and map responses back to {@link ZediToolCall}.
+ */
+import { randomUUID } from "node:crypto";
+import type { ZediChatTool, ZediToolCall, ZediToolChoice } from "../types/index.js";
+
+/** Normalized function declaration shared by request builders. */
+export interface NormalizedFunctionTool {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+/**
+ * Normalize LangChain/OpenAI-style tools into a provider-agnostic list.
+ *
+ * @param tools - Tools from `AIChatOptions.tools`.
+ */
+export function normalizeFunctionTools(
+  tools: ZediChatTool[] | undefined,
+): NormalizedFunctionTool[] {
+  if (!tools?.length) return [];
+  const normalized: NormalizedFunctionTool[] = [];
+  for (const tool of tools) {
+    if (tool.type !== "function" || !tool.function?.name) continue;
+    normalized.push({
+      name: tool.function.name,
+      description: tool.function.description ?? "",
+      parameters: tool.function.parameters ?? { type: "object", properties: {} },
+    });
+  }
+  return normalized;
+}
+
+/**
+ * Build OpenAI Chat Completions `tools` / `tool_choice` fields.
+ *
+ * @param tools - Normalized function tools.
+ * @param toolChoice - Optional tool-choice hint.
+ */
+export function buildOpenAiToolRequest(
+  tools: NormalizedFunctionTool[],
+  toolChoice?: ZediToolChoice,
+): Record<string, unknown> {
+  if (tools.length === 0) return {};
+  const payload: Record<string, unknown> = {
+    tools: tools.map((tool) => ({
+      type: "function",
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      },
+    })),
+  };
+  if (toolChoice !== undefined) {
+    payload.tool_choice = toolChoice;
+  }
+  return payload;
+}
+
+/**
+ * Parse OpenAI Chat Completions tool calls from a response message.
+ *
+ * @param message - `choices[0].message` object from OpenAI.
+ */
+export function parseOpenAiToolCalls(message: {
+  tool_calls?: Array<{
+    id?: string;
+    function?: { name?: string; arguments?: string };
+  }>;
+}): ZediToolCall[] {
+  const calls = message.tool_calls ?? [];
+  const parsed: ZediToolCall[] = [];
+  for (const call of calls) {
+    const name = call.function?.name;
+    if (!name) continue;
+    const rawArgs = call.function?.arguments ?? "{}";
+    let args: Record<string, unknown> = {};
+    try {
+      const value = JSON.parse(rawArgs) as unknown;
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        args = value as Record<string, unknown>;
+      }
+    } catch {
+      args = {};
+    }
+    parsed.push({
+      id: call.id ?? randomUUID(),
+      name,
+      args,
+    });
+  }
+  return parsed;
+}
+
+/**
+ * Build Anthropic Messages API `tools` / `tool_choice` fields.
+ *
+ * @param tools - Normalized function tools.
+ * @param toolChoice - Optional tool-choice hint.
+ */
+export function buildAnthropicToolRequest(
+  tools: NormalizedFunctionTool[],
+  toolChoice?: ZediToolChoice,
+): Record<string, unknown> {
+  if (tools.length === 0) return {};
+  const payload: Record<string, unknown> = {
+    tools: tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      input_schema: tool.parameters,
+    })),
+  };
+  if (toolChoice === "none") {
+    payload.tool_choice = { type: "none" };
+  } else if (toolChoice === "required" || toolChoice === "auto") {
+    payload.tool_choice = { type: "any" };
+  } else if (typeof toolChoice === "object" && toolChoice.type === "function") {
+    payload.tool_choice = { type: "tool", name: toolChoice.function.name };
+  }
+  return payload;
+}
+
+/**
+ * Parse Anthropic tool-use blocks from a Messages API response.
+ *
+ * @param content - `content` array from Anthropic.
+ */
+export function parseAnthropicToolCalls(
+  content: Array<{ type?: string; id?: string; name?: string; input?: Record<string, unknown> }>,
+): ZediToolCall[] {
+  const parsed: ZediToolCall[] = [];
+  for (const block of content) {
+    if (block.type !== "tool_use" || !block.name) continue;
+    parsed.push({
+      id: block.id ?? randomUUID(),
+      name: block.name,
+      args: block.input ?? {},
+    });
+  }
+  return parsed;
+}
+
+/**
+ * Build Gemini `generateContent` tool fields.
+ *
+ * @param tools - Normalized function tools.
+ * @param toolChoice - Optional tool-choice hint.
+ */
+export function buildGoogleToolRequest(
+  tools: NormalizedFunctionTool[],
+  toolChoice?: ZediToolChoice,
+): Record<string, unknown> {
+  if (tools.length === 0) return {};
+  const payload: Record<string, unknown> = {
+    tools: [
+      {
+        functionDeclarations: tools.map((tool) => ({
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.parameters,
+        })),
+      },
+    ],
+  };
+  if (typeof toolChoice === "object" && toolChoice.type === "function") {
+    payload.toolConfig = {
+      functionCallingConfig: {
+        mode: "ANY",
+        allowedFunctionNames: [toolChoice.function.name],
+      },
+    };
+  } else if (toolChoice === "required") {
+    payload.toolConfig = {
+      functionCallingConfig: {
+        mode: "ANY",
+        allowedFunctionNames: tools.map((tool) => tool.name),
+      },
+    };
+  }
+  return payload;
+}
+
+/**
+ * Parse Gemini function-call parts from a candidate content payload.
+ *
+ * @param parts - `candidates[0].content.parts` from Gemini.
+ */
+export function parseGoogleToolCalls(
+  parts: Array<{ text?: string; functionCall?: { name?: string; args?: Record<string, unknown> } }>,
+): ZediToolCall[] {
+  const parsed: ZediToolCall[] = [];
+  for (const part of parts) {
+    const fn = part.functionCall;
+    if (!fn?.name) continue;
+    parsed.push({
+      id: randomUUID(),
+      name: fn.name,
+      args: fn.args ?? {},
+    });
+  }
+  return parsed;
+}

--- a/server/api/src/services/providerToolCalling.ts
+++ b/server/api/src/services/providerToolCalling.ts
@@ -118,8 +118,10 @@ export function buildAnthropicToolRequest(
   };
   if (toolChoice === "none") {
     payload.tool_choice = { type: "none" };
-  } else if (toolChoice === "required" || toolChoice === "auto") {
+  } else if (toolChoice === "required") {
     payload.tool_choice = { type: "any" };
+  } else if (toolChoice === "auto") {
+    payload.tool_choice = { type: "auto" };
   } else if (typeof toolChoice === "object" && toolChoice.type === "function") {
     payload.tool_choice = { type: "tool", name: toolChoice.function.name };
   }
@@ -136,7 +138,7 @@ export function parseAnthropicToolCalls(
 ): ZediToolCall[] {
   const parsed: ZediToolCall[] = [];
   for (const block of content) {
-    if (block.type !== "tool_use" || !block.name) continue;
+    if (!block || block.type !== "tool_use" || !block.name) continue;
     parsed.push({
       id: block.id ?? randomUUID(),
       name: block.name,
@@ -182,6 +184,18 @@ export function buildGoogleToolRequest(
         allowedFunctionNames: tools.map((tool) => tool.name),
       },
     };
+  } else if (toolChoice === "none") {
+    payload.toolConfig = {
+      functionCallingConfig: {
+        mode: "NONE",
+      },
+    };
+  } else if (toolChoice === "auto") {
+    payload.toolConfig = {
+      functionCallingConfig: {
+        mode: "AUTO",
+      },
+    };
   }
   return payload;
 }
@@ -196,7 +210,7 @@ export function parseGoogleToolCalls(
 ): ZediToolCall[] {
   const parsed: ZediToolCall[] = [];
   for (const part of parts) {
-    const fn = part.functionCall;
+    const fn = part?.functionCall;
     if (!fn?.name) continue;
     parsed.push({
       id: randomUUID(),

--- a/server/api/src/types/index.ts
+++ b/server/api/src/types/index.ts
@@ -22,36 +22,36 @@ export interface AIMessage {
   content: string;
 }
 
-/** OpenAI-style function tool definition passed to provider APIs. */
+/** OpenAI-style function tool definition passed to provider APIs. / プロバイダ API に渡す OpenAI 形式の function 定義。 */
 export interface ZediFunctionDefinition {
   name: string;
   description?: string;
   parameters?: Record<string, unknown>;
 }
 
-/** LangChain `bindTools` / OpenAI-compatible tool entry. */
+/** LangChain `bindTools` / OpenAI-compatible tool entry. / LangChain bindTools 向けの OpenAI 互換 tool エントリ。 */
 export interface ZediChatTool {
   type: "function";
   function: ZediFunctionDefinition;
 }
 
-/** Force a specific function tool (OpenAI-compatible shape). */
+/** Force a specific function tool (OpenAI-compatible shape). / 特定 function を強制する OpenAI 互換 tool_choice。 */
 export interface ZediToolChoiceFunction {
   type: "function";
   function: { name: string };
 }
 
-/** Provider tool-choice hint for non-streaming calls. */
+/** Provider tool-choice hint for non-streaming calls. / 非ストリーミング呼び出し向けの tool-choice ヒント。 */
 export type ZediToolChoice = "auto" | "none" | "required" | ZediToolChoiceFunction;
 
-/** Parsed tool call returned by `callProvider` when the model selects a tool. */
+/** Parsed tool call returned by `callProvider` when the model selects a tool. / モデルが tool を選択したとき callProvider が返す解析済み tool call。 */
 export interface ZediToolCall {
   id: string;
   name: string;
   args: Record<string, unknown>;
 }
 
-/** Standard non-streaming provider response from `callOpenAI` / `callAnthropic` / `callGoogle`. */
+/** Standard non-streaming provider response from `callOpenAI` / `callAnthropic` / `callGoogle`. / callOpenAI / callAnthropic / callGoogle の標準非ストリーミング応答。 */
 export interface AIProviderCallResult {
   content: string;
   usage: TokenUsage;
@@ -67,9 +67,9 @@ export interface AIChatOptions {
   webSearchOptions?: { search_context_size: "medium" | "low" | "high" };
   useWebSearch?: boolean;
   useGoogleSearch?: boolean;
-  /** Function tools for structured output / tool calling (non-streaming). */
+  /** Function tools for structured output / tool calling (non-streaming). / 構造化出力・tool calling 用の function tools（非ストリーミング）。 */
   tools?: ZediChatTool[];
-  /** Optional tool-choice hint; defaults to provider-specific auto behaviour. */
+  /** Optional tool-choice hint; defaults to provider-specific auto behaviour. / 任意の tool-choice ヒント。未指定時はプロバイダ既定の auto 挙動。 */
   toolChoice?: ZediToolChoice;
 }
 

--- a/server/api/src/types/index.ts
+++ b/server/api/src/types/index.ts
@@ -22,6 +22,43 @@ export interface AIMessage {
   content: string;
 }
 
+/** OpenAI-style function tool definition passed to provider APIs. */
+export interface ZediFunctionDefinition {
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+}
+
+/** LangChain `bindTools` / OpenAI-compatible tool entry. */
+export interface ZediChatTool {
+  type: "function";
+  function: ZediFunctionDefinition;
+}
+
+/** Force a specific function tool (OpenAI-compatible shape). */
+export interface ZediToolChoiceFunction {
+  type: "function";
+  function: { name: string };
+}
+
+/** Provider tool-choice hint for non-streaming calls. */
+export type ZediToolChoice = "auto" | "none" | "required" | ZediToolChoiceFunction;
+
+/** Parsed tool call returned by `callProvider` when the model selects a tool. */
+export interface ZediToolCall {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+}
+
+/** Standard non-streaming provider response from `callOpenAI` / `callAnthropic` / `callGoogle`. */
+export interface AIProviderCallResult {
+  content: string;
+  usage: TokenUsage;
+  finishReason: string;
+  toolCalls?: ZediToolCall[];
+}
+
 export interface AIChatOptions {
   temperature?: number;
   maxTokens?: number;
@@ -30,6 +67,10 @@ export interface AIChatOptions {
   webSearchOptions?: { search_context_size: "medium" | "low" | "high" };
   useWebSearch?: boolean;
   useGoogleSearch?: boolean;
+  /** Function tools for structured output / tool calling (non-streaming). */
+  tools?: ZediChatTool[];
+  /** Optional tool-choice hint; defaults to provider-specific auto behaviour. */
+  toolChoice?: ZediToolChoice;
 }
 
 export interface AIChatRequest {


### PR DESCRIPTION
## 概要

Wiki Compose の構成フェーズで発生していた `Chat model must implement ".bindTools()" to use withStructuredOutput.` エラーを修正しました。`ZediChatModel` に `bindTools()` を実装し、OpenAI / Anthropic / Google の非ストリーミング API 経路で function tool calling を扱えるようにしました。

## 変更点

### `server/api/`
- **`ZediChatModel`**: `bindTools()`、`callKeys`（`tools` / `tool_choice`）、`AIMessageChunk` + `tool_calls` 返却を追加
- **`aiProviders`**: `callOpenAI` / `callAnthropic` / `callGoogle` に function tools の送受信を追加
- **`providerToolCalling.ts`（新規）**: LangChain/OpenAI 形式の tool 定義を各プロバイダ API 用に変換するヘルパー
- **`types/index.ts`**: `ZediChatTool`、`ZediToolCall`、`AIProviderCallResult` 等の型を追加
- **テスト**: `providerToolCalling.test.ts`（新規）、`zediChatModel.test.ts`、`aiProviders.test.ts` を拡充

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. API サーバーを再起動する
2. Wiki Compose（guided / instant いずれも）を開始し、Brief 完了後に構成フェーズへ進む
3. 以前の `bindTools` エラーが出ず、アウトライン案が生成されることを確認する

```bash
cd server/api && bun run test:run src/__tests__/services/providerToolCalling.test.ts src/__tests__/services/aiProviders.test.ts src/__tests__/agents/core/llm/zediChatModel.test.ts
cd server/api && bun run typecheck
```

## チェックリスト

- [x] テストがすべてパスする（上記 server/api テスト + typecheck）
- [x] Lint エラーがない（`bun run lint` — 既存 warning のみ）
- [ ] 必要に応じてドキュメントを更新した（英語正本 + 該当する場合は `.ja.md` ペア）
- [x] コミットメッセージが Conventional Commits に従っている

## スクリーンショット（UI 変更がある場合）

該当なし（サーバー側のみ）

## 関連 Issue

<!-- 該当 Issue があれば追記 -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tool/function calling across chat requests, including structured tool schemas and `toolChoice` controls.
  * Chat responses can now include parsed `tool_calls` alongside regular message content.
* **Bug Fixes**
  * Improved consistency of tool-call request construction and response parsing across supported AI providers.
  * Enhanced structured-output tool workflow behavior.
* **Tests**
  * Expanded automated coverage for tool request building, provider response parsing, and structured-output flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->