### PR TITLE
fix(api): preserve Google Search grounding when structured-output tools are bound

### DIFF
--- a/server/api/src/__tests__/services/aiProviders.test.ts
+++ b/server/api/src/__tests__/services/aiProviders.test.ts
@@ -332,6 +332,57 @@ describe("callGoogle", () => {
     });
   });
 
+  it("keeps googleSearch when structured-output function tools are also set", async () => {
+    fetchSpy.mockResolvedValue(
+      okJson({
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    name: "web_search_results",
+                    args: {
+                      results: [{ title: "Example", url: "https://example.com" }],
+                    },
+                  },
+                },
+              ],
+            },
+            finishReason: "STOP",
+          },
+        ],
+        usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 6 },
+      }),
+    );
+
+    await callGoogle("k", "gemini-2.0", messages, {
+      useGoogleSearch: true,
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "web_search_results",
+            description: "Web search hits",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    });
+
+    const body = JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body)) as {
+      tools?: unknown[];
+      toolConfig?: { includeServerSideToolInvocations?: boolean };
+    };
+    expect(body.tools).toEqual([
+      {
+        functionDeclarations: [expect.objectContaining({ name: "web_search_results" })],
+      },
+      { googleSearch: {} },
+    ]);
+    expect(body.toolConfig?.includeServerSideToolInvocations).toBe(true);
+  });
+
   it("throws on non-200", async () => {
     fetchSpy.mockResolvedValue(new Response("oops", { status: 503 }));
     await expect(callGoogle("k", "gemini-2.0", messages)).rejects.toThrow(/503/);

--- a/server/api/src/__tests__/services/providerToolCalling.test.ts
+++ b/server/api/src/__tests__/services/providerToolCalling.test.ts
@@ -112,6 +112,16 @@ describe("buildGoogleToolRequest", () => {
     });
   });
 
+  it("maps auto to VALIDATED when useGoogleSearch is combined with function tools", () => {
+    const payload = buildGoogleToolRequest(normalizeFunctionTools(sampleTools), "auto", {
+      useGoogleSearch: true,
+    });
+    expect(payload.toolConfig).toEqual({
+      functionCallingConfig: { mode: "VALIDATED" },
+      includeServerSideToolInvocations: true,
+    });
+  });
+
   it("keeps googleSearch when function tools and useGoogleSearch are both set", () => {
     const payload = buildGoogleToolRequest(normalizeFunctionTools(sampleTools), undefined, {
       useGoogleSearch: true,

--- a/server/api/src/__tests__/services/providerToolCalling.test.ts
+++ b/server/api/src/__tests__/services/providerToolCalling.test.ts
@@ -111,6 +111,42 @@ describe("buildGoogleToolRequest", () => {
       functionCallingConfig: { mode: "NONE" },
     });
   });
+
+  it("keeps googleSearch when function tools and useGoogleSearch are both set", () => {
+    const payload = buildGoogleToolRequest(normalizeFunctionTools(sampleTools), undefined, {
+      useGoogleSearch: true,
+    });
+    expect(payload.tools).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "structure_dialogue",
+            description: "Propose an outline",
+            parameters: sampleTools[0]?.function.parameters,
+          },
+        ],
+      },
+      { googleSearch: {} },
+    ]);
+    expect(payload.toolConfig).toEqual({
+      includeServerSideToolInvocations: true,
+    });
+  });
+
+  it("merges functionCallingConfig with includeServerSideToolInvocations", () => {
+    const payload = buildGoogleToolRequest(
+      normalizeFunctionTools(sampleTools),
+      { type: "function", function: { name: "structure_dialogue" } },
+      { useGoogleSearch: true },
+    );
+    expect(payload.toolConfig).toEqual({
+      functionCallingConfig: {
+        mode: "ANY",
+        allowedFunctionNames: ["structure_dialogue"],
+      },
+      includeServerSideToolInvocations: true,
+    });
+  });
 });
 
 describe("buildAnthropicToolRequest", () => {

--- a/server/api/src/services/aiProviders.ts
+++ b/server/api/src/services/aiProviders.ts
@@ -289,7 +289,12 @@ export async function callGoogle(
 
   const functionTools = normalizeFunctionTools(options.tools);
   if (functionTools.length > 0) {
-    Object.assign(body, buildGoogleToolRequest(functionTools, options.toolChoice));
+    Object.assign(
+      body,
+      buildGoogleToolRequest(functionTools, options.toolChoice, {
+        useGoogleSearch: options.useGoogleSearch,
+      }),
+    );
   } else if (options.useGoogleSearch) {
     body.tools = [{ googleSearch: {} }];
   }

--- a/server/api/src/services/providerToolCalling.ts
+++ b/server/api/src/services/providerToolCalling.ts
@@ -204,7 +204,7 @@ export function buildGoogleToolRequest(
     };
   } else if (toolChoice === "auto") {
     toolConfig.functionCallingConfig = {
-      mode: "AUTO",
+      mode: options?.useGoogleSearch ? "VALIDATED" : "AUTO",
     };
   }
   if (options?.useGoogleSearch) {

--- a/server/api/src/services/providerToolCalling.ts
+++ b/server/api/src/services/providerToolCalling.ts
@@ -149,53 +149,69 @@ export function parseAnthropicToolCalls(
 }
 
 /**
+ * Options for {@link buildGoogleToolRequest}.
+ */
+export interface GoogleToolRequestOptions {
+  /** When true, include Gemini built-in `googleSearch` alongside function tools. */
+  useGoogleSearch?: boolean;
+}
+
+/**
  * Build Gemini `generateContent` tool fields.
  *
  * @param tools - Normalized function tools.
  * @param toolChoice - Optional tool-choice hint.
+ * @param options - Optional built-in tool flags (e.g. `useGoogleSearch`).
  */
 export function buildGoogleToolRequest(
   tools: NormalizedFunctionTool[],
   toolChoice?: ZediToolChoice,
+  options?: GoogleToolRequestOptions,
 ): Record<string, unknown> {
   if (tools.length === 0) return {};
+
+  const googleTools: Record<string, unknown>[] = [
+    {
+      functionDeclarations: tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      })),
+    },
+  ];
+  if (options?.useGoogleSearch) {
+    googleTools.push({ googleSearch: {} });
+  }
+
   const payload: Record<string, unknown> = {
-    tools: [
-      {
-        functionDeclarations: tools.map((tool) => ({
-          name: tool.name,
-          description: tool.description,
-          parameters: tool.parameters,
-        })),
-      },
-    ],
+    tools: googleTools,
   };
+
+  const toolConfig: Record<string, unknown> = {};
   if (typeof toolChoice === "object" && toolChoice.type === "function") {
-    payload.toolConfig = {
-      functionCallingConfig: {
-        mode: "ANY",
-        allowedFunctionNames: [toolChoice.function.name],
-      },
+    toolConfig.functionCallingConfig = {
+      mode: "ANY",
+      allowedFunctionNames: [toolChoice.function.name],
     };
   } else if (toolChoice === "required") {
-    payload.toolConfig = {
-      functionCallingConfig: {
-        mode: "ANY",
-        allowedFunctionNames: tools.map((tool) => tool.name),
-      },
+    toolConfig.functionCallingConfig = {
+      mode: "ANY",
+      allowedFunctionNames: tools.map((tool) => tool.name),
     };
   } else if (toolChoice === "none") {
-    payload.toolConfig = {
-      functionCallingConfig: {
-        mode: "NONE",
-      },
+    toolConfig.functionCallingConfig = {
+      mode: "NONE",
     };
   } else if (toolChoice === "auto") {
-    payload.toolConfig = {
-      functionCallingConfig: {
-        mode: "AUTO",
-      },
+    toolConfig.functionCallingConfig = {
+      mode: "AUTO",
     };
+  }
+  if (options?.useGoogleSearch) {
+    toolConfig.includeServerSideToolInvocations = true;
+  }
+  if (Object.keys(toolConfig).length > 0) {
+    payload.toolConfig = toolConfig;
   }
   return payload;
 }


### PR DESCRIPTION
## 概要

#1074 で導入した `bindTools` により、`callGoogle` が function tools ありのとき `useGoogleSearch` を捨てる回帰が発生していた。Wiki Compose の `web_search`（`withStructuredOutput` + `useGoogleSearch: true`）が Gemini 上で幻の URL を `ok: true` で返す問題を修正する。

## 変更点

### `server/api/`
- `buildGoogleToolRequest` に `useGoogleSearch` オプションを追加し、`functionDeclarations` と `googleSearch` を同一リクエストに併記
- `toolConfig.includeServerSideToolInvocations: true` を設定（Gemini API 要件）
- `callGoogle` から `useGoogleSearch` を `buildGoogleToolRequest` に渡す
- 回帰テスト 3 件を追加（単体 + `callGoogle` 統合 + `tool_choice` 併用）

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## テスト方法

1. `cd server/api && bun test src/__tests__/services/aiProviders.test.ts src/__tests__/services/providerToolCalling.test.ts`
2. 新規テスト `keeps googleSearch when structured-output function tools are also set` が pass することを確認
3. （任意）Wiki Compose の research ループで `web_search` を実行し、返却 URL が実在することを確認

## チェックリスト

- [x] テストがすべてパスする（36 pass）
- [x] Lint エラーがない（pre-commit hook 通過）
- [x] コミットメッセージが Conventional Commits に従っている

## 関連 Issue

Related to #1074
Supersedes #1075（最小 diff で再実装）

Made with [Cursor](https://cursor.com)