### PR TITLE
feat(wikiCompose): emit [[wiki links]] in drafts and render preview as Markdown

### DIFF
--- a/server/api/src/agents/graphs/wikiCompose/nodes/draftSections.ts
+++ b/server/api/src/agents/graphs/wikiCompose/nodes/draftSections.ts
@@ -30,7 +30,13 @@ const SECTION_SYSTEM_PROMPT =
   "research list. Only cite sources that genuinely support the claim.\n" +
   "4. Aim for ~250–500 words. Use sub-headings only when depth=2 is " +
   "specified for sub-sections within the same draft pass.\n" +
-  "5. Plain Markdown; no HTML, no YAML frontmatter.";
+  "5. When you mention a distinct concept, entity, or term that deserves its " +
+  "own wiki page, wrap its first significant mention in a wiki link using " +
+  "double brackets: `[[Term]]`. Use the natural surface form as the title " +
+  "(e.g. `[[Transformer architecture]]`). Do NOT wiki-link the article's own " +
+  "title, generic words, or the same term more than once per section, and " +
+  "never put a wiki link inside a heading or inside a `[#N]` citation.\n" +
+  "6. Plain Markdown; no HTML, no YAML frontmatter.";
 
 function numberedSourceList(sources: Source[], allowedIds?: string[]): string[] {
   const allow = allowedIds && allowedIds.length > 0 ? new Set(allowedIds) : null;

--- a/src/components/wikiCompose/EditorPane.tsx
+++ b/src/components/wikiCompose/EditorPane.tsx
@@ -30,7 +30,7 @@ import type { DraftedSection, OutlineSection } from "@/lib/wikiCompose/types";
  * draft 本文は Markdown ソースなので、`<pre>` ではなくパースして描画する。
  * `[[Title]]` は wiki link チップとして表示する（プレビューでは遷移しない）。
  */
-const PreviewMarkdown: React.FC<{ source: string }> = ({ source }) => (
+const PreviewMarkdown: React.FC<{ source: string }> = React.memo(({ source }) => (
   <ReactMarkdown
     remarkPlugins={[remarkGfm]}
     components={{
@@ -49,7 +49,8 @@ const PreviewMarkdown: React.FC<{ source: string }> = ({ source }) => (
   >
     {replaceWikiLinksInMarkdown(source)}
   </ReactMarkdown>
-);
+));
+PreviewMarkdown.displayName = "PreviewMarkdown";
 
 export interface EditorPaneProps {
   title: string;

--- a/src/components/wikiCompose/EditorPane.tsx
+++ b/src/components/wikiCompose/EditorPane.tsx
@@ -34,6 +34,10 @@ const PreviewMarkdown: React.FC<{ source: string }> = React.memo(({ source }) =>
   <ReactMarkdown
     remarkPlugins={[remarkGfm]}
     components={{
+      // Drop images so the preview never fires off-site requests (tracking
+      // beacons) for URLs that slipped into the AI-generated body.
+      // 画像はトラッキングビーコン化を防ぐためプレビューでは描画しない。
+      img: () => null,
       a: ({ href, children }) => {
         if (href?.startsWith("wiki:")) {
           return <span className="wiki-link">{children}</span>;

--- a/src/components/wikiCompose/EditorPane.tsx
+++ b/src/components/wikiCompose/EditorPane.tsx
@@ -12,8 +12,44 @@
  */
 import React from "react";
 import { useTranslation } from "react-i18next";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { cn } from "@zedi/ui";
+import { replaceWikiLinksInMarkdown } from "@/components/aiChat/aiChatMarkdownHelpers";
 import type { DraftedSection, OutlineSection } from "@/lib/wikiCompose/types";
+
+/**
+ * Render compose body Markdown to styled HTML.
+ *
+ * The draft body is Markdown source (headings, lists, `[[wiki links]]`, …), so
+ * it must be parsed — not dumped into a `<pre>` — for the surrounding `prose`
+ * styles to apply. `[[Title]]` is normalised to `[Title](wiki:Title)` and shown
+ * as a non-navigating `.wiki-link` chip (the compose preview cannot yet resolve
+ * whether the target page exists).
+ *
+ * draft 本文は Markdown ソースなので、`<pre>` ではなくパースして描画する。
+ * `[[Title]]` は wiki link チップとして表示する（プレビューでは遷移しない）。
+ */
+const PreviewMarkdown: React.FC<{ source: string }> = ({ source }) => (
+  <ReactMarkdown
+    remarkPlugins={[remarkGfm]}
+    components={{
+      a: ({ href, children }) => {
+        if (href?.startsWith("wiki:")) {
+          return <span className="wiki-link">{children}</span>;
+        }
+        const safeHref = href && /^(https?|mailto|tel):/i.test(href) ? href : undefined;
+        return (
+          <a href={safeHref} target="_blank" rel="noopener noreferrer">
+            {children}
+          </a>
+        );
+      },
+    }}
+  >
+    {replaceWikiLinksInMarkdown(source)}
+  </ReactMarkdown>
+);
 
 export interface EditorPaneProps {
   title: string;
@@ -73,13 +109,10 @@ export const EditorPane: React.FC<EditorPaneProps> = ({
                     {isStreaming ? t("wikiCompose.editor.streaming") : section.intent}
                   </p>
                 ) : (
-                  // Plain-text rendering of the running buffer. Once the
-                  // section finalises we still render as <pre> to preserve
-                  // formatting; a future iteration can mount Tiptap here.
-                  // 進行中はバッファをそのまま <pre> で出す（フォーマット保持）。
-                  <pre className="!bg-transparent !p-0 font-sans text-sm leading-relaxed whitespace-pre-wrap">
-                    {body}
-                  </pre>
+                  // Render the running/finalised buffer as Markdown so headings,
+                  // lists and wiki links pick up the surrounding `prose` styles.
+                  // バッファを Markdown として描画し prose スタイルを効かせる。
+                  <PreviewMarkdown source={body} />
                 )}
               </section>
             );
@@ -92,9 +125,7 @@ export const EditorPane: React.FC<EditorPaneProps> = ({
           <h3 className="text-muted-foreground text-xs tracking-wide uppercase">
             {t("wikiCompose.editor.finalMarkdown")}
           </h3>
-          <pre className="!bg-muted/40 rounded-md p-3 font-mono text-xs whitespace-pre-wrap">
-            {completedMarkdown}
-          </pre>
+          <PreviewMarkdown source={completedMarkdown} />
         </section>
       ) : null}
     </div>


### PR DESCRIPTION
Draft sections now instruct the LLM to wrap first significant mentions of
linkable concepts in [[Title]] wiki-link syntax.

EditorPane previously dumped Markdown source into <pre>, so headings, lists
and links showed as raw text and the surrounding `prose` styles never applied.
Render the section/completed buffers through react-markdown (remark-gfm) and
show [[Title]] as styled .wiki-link chips instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced markdown preview rendering in the wiki editor now displays formatted content instead of plain text, improving the editing experience.
  * Improved wiki link handling ensures proper insertion of links while preventing self-linking, repeated links within sections, and links within headings or citations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->