### PR TITLE
feat(storage): アニメーション PNG (APNG) を WebP 変換対象から除外する

### DIFF
--- a/src/components/editor/TiptapEditor/useImageUploadManagerHelpers.ts
+++ b/src/components/editor/TiptapEditor/useImageUploadManagerHelpers.ts
@@ -1,6 +1,11 @@
 import type { MutableRefObject } from "react";
 import type { Editor } from "@tiptap/core";
-import { getStorageProvider, getSettingsForUpload, convertToWebP } from "@/lib/storage";
+import {
+  getStorageProvider,
+  getSettingsForUpload,
+  convertToWebP,
+  isAnimatedPng,
+} from "@/lib/storage";
 import type { StorageSettings } from "@/types/storage";
 
 export function updateUploadNodeAttributesImpl(
@@ -143,9 +148,10 @@ export async function runSingleUpload(params: RunUploadParams): Promise<void> {
   uploadTimersRef.current.set(uploadId, timerId);
 
   try {
-    // JPEG/PNG のみ WebP に変換（GIF はそのまま。APNG は MIME が image/png のため現状は変換対象）
-    const isStaticImage = file.type === "image/jpeg" || file.type === "image/png";
-    const fileToUpload = isStaticImage ? await convertToWebP(file) : file;
+    // JPEG/PNG のみ WebP に変換（GIF・APNG はアニメーション保持のためそのまま）
+    const shouldConvertToWebP =
+      file.type === "image/jpeg" || (file.type === "image/png" && !(await isAnimatedPng(file)));
+    const fileToUpload = shouldConvertToWebP ? await convertToWebP(file) : file;
     const url = await provider.uploadImage(fileToUpload, {
       onProgress: (progress) => {
         hasRealProgress = true;

--- a/src/components/editor/TiptapEditor/useThumbnailCommit.ts
+++ b/src/components/editor/TiptapEditor/useThumbnailCommit.ts
@@ -3,7 +3,12 @@ import { useNavigate } from "react-router-dom";
 import type { Editor } from "@tiptap/core";
 import { useAuth } from "@/hooks/auth/useAuth";
 import { useToast } from "@zedi/ui";
-import { getStorageProvider, getSettingsForUpload, convertToWebP } from "@/lib/storage";
+import {
+  getStorageProvider,
+  getSettingsForUpload,
+  convertToWebP,
+  isAnimatedPng,
+} from "@/lib/storage";
 import type { StorageSettings } from "@/types/storage";
 import { commitThumbnailFromUrl, AuthRedirectError } from "@/lib/thumbnailCommit";
 import { getThumbnailApiBaseUrl } from "./thumbnailApiHelpers";
@@ -83,9 +88,11 @@ export function useThumbnailCommit({
           providerId = result.provider;
         } else {
           const file = await fetchImageAsFile(imageUrl, previewUrl);
-          // JPEG/PNG のみ WebP に変換（GIF はそのまま。APNG は MIME が image/png のため現状は変換対象）
-          const isStaticImage = file.type === "image/jpeg" || file.type === "image/png";
-          const fileToUpload = isStaticImage ? await convertToWebP(file) : file;
+          // JPEG/PNG のみ WebP に変換（GIF・APNG はアニメーション保持のためそのまま）
+          const shouldConvertToWebP =
+            file.type === "image/jpeg" ||
+            (file.type === "image/png" && !(await isAnimatedPng(file)));
+          const fileToUpload = shouldConvertToWebP ? await convertToWebP(file) : file;
           const provider = getStorageProvider(uploadSettings, {
             getToken: async () => null,
           });

--- a/src/hooks/media/useImageUpload.test.ts
+++ b/src/hooks/media/useImageUpload.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   isStorageConfiguredForUpload: vi.fn(() => true),
   getSettingsForUpload: vi.fn((settings: unknown) => settings),
   convertToWebP: vi.fn(async (file: File) => file),
+  isAnimatedPng: vi.fn(async (_file: File) => false),
   storageSettings: {
     settings: {
       provider: "s3",
@@ -44,6 +45,7 @@ vi.mock("@/lib/storage", () => ({
   getSettingsForUpload: (settings: unknown) => mocks.getSettingsForUpload(settings),
   isStorageConfiguredForUpload: () => mocks.isStorageConfiguredForUpload(),
   convertToWebP: (file: File) => mocks.convertToWebP(file),
+  isAnimatedPng: (file: File) => mocks.isAnimatedPng(file),
 }));
 
 import { useImageUpload } from "@/hooks/media/useImageUpload";
@@ -62,6 +64,7 @@ describe("useImageUpload", () => {
     mocks.providerUploadImage.mockResolvedValue("https://cdn.example.com/image.webp");
     mocks.isStorageConfiguredForUpload.mockReturnValue(true);
     mocks.convertToWebP.mockImplementation(async (file: File) => file);
+    mocks.isAnimatedPng.mockResolvedValue(false);
     mocks.storageSettings = {
       settings: {
         provider: "s3",
@@ -193,6 +196,22 @@ describe("useImageUpload", () => {
         await result.current.uploadImage(original);
       });
 
+      expect(mocks.convertToWebP).not.toHaveBeenCalled();
+      expect(mocks.providerUploadImage).toHaveBeenCalledWith(original, expect.any(Object));
+    });
+
+    it("does NOT convert an APNG (animated image/png) to WebP", async () => {
+      // APNG は MIME が image/png でも acTL を持つためアニメーションを保持してそのまま上げる。
+      // Pin that an animated PNG skips WebP conversion (preserve animation).
+      mocks.isAnimatedPng.mockResolvedValueOnce(true);
+      const original = makeFile("image/png", "anim.png");
+      const { result } = renderHook(() => useImageUpload());
+
+      await act(async () => {
+        await result.current.uploadImage(original);
+      });
+
+      expect(mocks.isAnimatedPng).toHaveBeenCalledWith(original);
       expect(mocks.convertToWebP).not.toHaveBeenCalled();
       expect(mocks.providerUploadImage).toHaveBeenCalledWith(original, expect.any(Object));
     });
@@ -380,9 +399,14 @@ describe("useImageUpload", () => {
     it("returns URLs in input order (Promise.all preserves order)", async () => {
       // 戻り値は入力順を保つ（Promise.all のセマンティクスに依存）。
       // Pin in-order URL return so a `.map` → `.reverse` mutation is caught.
-      mocks.providerUploadImage
-        .mockResolvedValueOnce("https://cdn.example.com/1.webp")
-        .mockResolvedValueOnce("https://cdn.example.com/2.webp");
+      // provider 解決順ではなくファイル名で URL を決め、変換経路の await 深さ差に依存しない。
+      // Map URL by file name (not call order) so the assertion is robust to
+      // differing await depths between the JPEG / PNG conversion paths.
+      mocks.providerUploadImage.mockImplementation(async (file: File) =>
+        file.name === "first.png"
+          ? "https://cdn.example.com/1.webp"
+          : "https://cdn.example.com/2.webp",
+      );
       const { result } = renderHook(() => useImageUpload());
 
       let urls: string[] = [];

--- a/src/hooks/media/useImageUpload.ts
+++ b/src/hooks/media/useImageUpload.ts
@@ -9,6 +9,7 @@ import {
   getSettingsForUpload,
   isStorageConfiguredForUpload,
   convertToWebP,
+  isAnimatedPng,
   UploadProgress,
 } from "@/lib/storage";
 
@@ -89,9 +90,10 @@ export function useImageUpload(): UseImageUploadReturn {
           getToken,
         });
 
-        // JPEG/PNG のみ WebP に変換（GIF はそのまま。APNG は MIME が image/png のため現状は変換対象）
-        const isStaticImage = file.type === "image/jpeg" || file.type === "image/png";
-        const fileToUpload = isStaticImage ? await convertToWebP(file) : file;
+        // JPEG/PNG のみ WebP に変換（GIF・APNG はアニメーション保持のためそのまま）
+        const shouldConvertToWebP =
+          file.type === "image/jpeg" || (file.type === "image/png" && !(await isAnimatedPng(file)));
+        const fileToUpload = shouldConvertToWebP ? await convertToWebP(file) : file;
         throwIfAborted();
 
         const url = await provider.uploadImage(fileToUpload, {

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -125,6 +125,7 @@ export function isStorageConfiguredForUpload(settings: StorageSettings): boolean
 // Re-export types and utilities
 export * from "./types";
 export { convertToWebP } from "./convertToWebP";
+export { isAnimatedPng } from "./isAnimatedPng";
 export { GyazoProvider } from "./providers/GyazoProvider";
 export { GitHubProvider } from "./providers/GitHubProvider";
 export { GoogleDriveProvider } from "./providers/GoogleDriveProvider";

--- a/src/lib/storage/isAnimatedPng.test.ts
+++ b/src/lib/storage/isAnimatedPng.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { isAnimatedPng } from "./isAnimatedPng";
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/** 4 バイトのビッグエンディアン長表現 */
+function uint32be(n: number): number[] {
+  return [(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff];
+}
+
+/** PNG チャンク（length + type + data + CRC プレースホルダ）を組み立てる */
+function chunk(type: string, data: number[] = []): number[] {
+  return [
+    ...uint32be(data.length),
+    ...[...type].map((c) => c.charCodeAt(0)),
+    ...data,
+    0,
+    0,
+    0,
+    0, // CRC（判定では未使用なのでダミー）
+  ];
+}
+
+/** シグネチャ + 任意のチャンク列から PNG ファイルを作る */
+function buildPng(chunks: number[][]): File {
+  const bytes = new Uint8Array([...PNG_SIGNATURE, ...chunks.flat()]);
+  return new File([bytes], "test.png", { type: "image/png" });
+}
+
+describe("isAnimatedPng", () => {
+  it("returns true for APNG (acTL before IDAT)", async () => {
+    const file = buildPng([
+      chunk("IHDR", new Array(13).fill(0)),
+      chunk("acTL", new Array(8).fill(0)),
+      chunk("IDAT", new Array(10).fill(0)),
+      chunk("IEND"),
+    ]);
+    expect(await isAnimatedPng(file)).toBe(true);
+  });
+
+  it("skips chunk data correctly when a large chunk precedes acTL", async () => {
+    const file = buildPng([
+      chunk("IHDR", new Array(13).fill(0)),
+      chunk("iCCP", new Array(256).fill(7)),
+      chunk("acTL", new Array(8).fill(0)),
+      chunk("IDAT", new Array(10).fill(0)),
+    ]);
+    expect(await isAnimatedPng(file)).toBe(true);
+  });
+
+  it("returns false for a static PNG (no acTL)", async () => {
+    const file = buildPng([
+      chunk("IHDR", new Array(13).fill(0)),
+      chunk("IDAT", new Array(10).fill(0)),
+      chunk("IEND"),
+    ]);
+    expect(await isAnimatedPng(file)).toBe(false);
+  });
+
+  it("returns false when acTL appears only after IDAT (not a valid APNG)", async () => {
+    const file = buildPng([
+      chunk("IHDR", new Array(13).fill(0)),
+      chunk("IDAT", new Array(10).fill(0)),
+      chunk("acTL", new Array(8).fill(0)),
+    ]);
+    expect(await isAnimatedPng(file)).toBe(false);
+  });
+
+  it("returns false for a non-PNG file (wrong signature)", async () => {
+    const file = new File([new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 1, 2, 3, 4])], "x.jpg", {
+      type: "image/jpeg",
+    });
+    expect(await isAnimatedPng(file)).toBe(false);
+  });
+
+  it("returns false for truncated / tiny data", async () => {
+    const file = new File([new Uint8Array([0x89, 0x50])], "tiny.png", { type: "image/png" });
+    expect(await isAnimatedPng(file)).toBe(false);
+  });
+
+  it("returns false for an empty file", async () => {
+    const file = new File([new Uint8Array([])], "empty.png", { type: "image/png" });
+    expect(await isAnimatedPng(file)).toBe(false);
+  });
+});

--- a/src/lib/storage/isAnimatedPng.ts
+++ b/src/lib/storage/isAnimatedPng.ts
@@ -25,7 +25,11 @@ const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
  */
 export async function isAnimatedPng(file: File | Blob): Promise<boolean> {
   try {
-    const buffer = await file.arrayBuffer();
+    // acTL は仕様上 IDAT より前（＝ファイル先頭付近）に現れるため、
+    // 巨大な PNG でも先頭の一部だけ読めば判定できる。モバイル等での OOM を避けるため
+    // ファイル全体ではなく先頭 1MB のみをメモリに読み込む。
+    const slice = file.slice(0, 1024 * 1024);
+    const buffer = await slice.arrayBuffer();
     const bytes = new Uint8Array(buffer);
 
     // PNG シグネチャを満たさなければ PNG ではない

--- a/src/lib/storage/isAnimatedPng.ts
+++ b/src/lib/storage/isAnimatedPng.ts
@@ -1,0 +1,69 @@
+/**
+ * APNG（Animated PNG）判定ユーティリティ
+ *
+ * APNG は MIME type が `image/png` のため、静止画 PNG と区別がつかない。
+ * WebP 変換時にアニメーションを失わないよう、acTL（Animation Control）チャンクの
+ * 有無でアニメーション PNG を判定する。
+ *
+ * @see https://github.com/otomatty/zedi/issues/264
+ * @see https://www.w3.org/TR/png/#5ChunkOrdering
+ */
+
+// PNG シグネチャ（先頭 8 バイト）
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/**
+ * PNG ファイルがアニメーション（APNG）かどうかを判定する。
+ *
+ * 仕様上、APNG の acTL チャンクは最初の IDAT チャンクより前に置かれる。
+ * そのため acTL を IDAT より先に見つければ APNG、IDAT を先に見つければ静止画と判定する。
+ *
+ * PNG 以外・破損データ・判定不能な場合は false を返す（変換は通常どおり行われる）。
+ *
+ * @param file 判定対象（image/png を想定）
+ * @returns APNG なら true
+ */
+export async function isAnimatedPng(file: File | Blob): Promise<boolean> {
+  try {
+    const buffer = await file.arrayBuffer();
+    const bytes = new Uint8Array(buffer);
+
+    // PNG シグネチャを満たさなければ PNG ではない
+    if (bytes.length < PNG_SIGNATURE.length) {
+      return false;
+    }
+    for (let i = 0; i < PNG_SIGNATURE.length; i++) {
+      if (bytes[i] !== PNG_SIGNATURE[i]) {
+        return false;
+      }
+    }
+
+    const view = new DataView(buffer);
+    // シグネチャの後ろからチャンク（length: 4B, type: 4B, data, CRC: 4B）を走査する
+    let offset = PNG_SIGNATURE.length;
+    while (offset + 8 <= bytes.length) {
+      const length = view.getUint32(offset);
+      const type = String.fromCharCode(
+        bytes[offset + 4],
+        bytes[offset + 5],
+        bytes[offset + 6],
+        bytes[offset + 7],
+      );
+
+      if (type === "acTL") {
+        return true;
+      }
+      // acTL は IDAT より前に現れる。IDAT に達したら APNG ではない
+      if (type === "IDAT") {
+        return false;
+      }
+
+      // 次のチャンクへ: length(4) + type(4) + data(length) + CRC(4)
+      offset += 12 + length;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
APNG（Animated PNG）は MIME type が image/png のため、JPEG/PNG の WebP 変換で
そのまま変換され、アニメーションが失われていた。

- PNG の acTL（Animation Control）チャンクの有無で APNG を判定する
  isAnimatedPng(file) ヘルパーを追加（acTL が IDAT より前に現れるかで判定）
- 画像アップロードの 3 箇所（useImageUpload / useImageUploadManagerHelpers /
  useThumbnailCommit）で、image/png かつ APNG の場合は convertToWebP を
  スキップしてそのままアップロードするよう変更
- isAnimatedPng のユニットテストと、APNG 変換スキップのフックテストを追加

Closes #264

https://claude.ai/code/session_01NSm9XmkhQPzTGhwKg5w3rN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive support for animated PNG (APNG) uploads. Animated images are now automatically detected and uploaded without conversion to preserve animation quality. Static images (JPEG and non-animated PNG files) continue to be optimized for web performance and faster loading.

* **Tests**
  * Expanded test coverage for image type detection and various upload handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->