### PR TITLE
chore(ci): bump actions/checkout to v7.0.0 across all workflows

### DIFF
--- a/.github/actions/setup-toolchain/README.md
+++ b/.github/actions/setup-toolchain/README.md
@@ -95,7 +95,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.2
+          action: actions/checkout@v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -117,7 +117,7 @@ steps:
   - name: Checkout (with retry)
     uses: Wandalen/wretry.action@v3
     with:
-      action: actions/checkout@v6.0.2
+      action: actions/checkout@v7.0.0
       with: |
         fetch-depth: 0
       attempt_limit: 3
@@ -141,7 +141,7 @@ steps:
   - name: Checkout (with retry)
     uses: Wandalen/wretry.action@v3
     with:
-      action: actions/checkout@v6.0.2
+      action: actions/checkout@v7.0.0
       attempt_limit: 3
       attempt_delay: 5000
 
@@ -163,7 +163,7 @@ steps:
   - name: Checkout (with retry)
     uses: Wandalen/wretry.action@v3
     with:
-      action: actions/checkout@v6.0.2
+      action: actions/checkout@v7.0.0
       attempt_limit: 3
       attempt_delay: 5000
 
@@ -200,7 +200,7 @@ composite action (see samples above).
 
 | ステップ / step                 | リトライ実装 / retry mechanism          | 試行回数 / attempts | 待機 / delay                                |
 | ------------------------------- | --------------------------------------- | ------------------- | ------------------------------------------- |
-| `actions/checkout@v6.0.2`       | caller 側 / `Wandalen/wretry.action@v3` | 3                   | 5000 ms                                     |
+| `actions/checkout@v7.0.0`       | caller 側 / `Wandalen/wretry.action@v3` | 3                   | 5000 ms                                     |
 | `actions/setup-node@v6`         | `Wandalen/wretry.action@v3`             | 3                   | 5000 ms                                     |
 | `oven-sh/setup-bun@v2`          | `Wandalen/wretry.action@v3`             | 3                   | 5000 ms                                     |
 | `bun install --frozen-lockfile` | shell 内ループ / inline shell loop      | 3                   | 5s → 10s（線形バックオフ / linear backoff） |

--- a/.github/workflows/analyze-error.yml
+++ b/.github/workflows/analyze-error.yml
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -65,7 +65,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -104,7 +104,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -135,7 +135,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -198,7 +198,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -270,7 +270,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -294,7 +294,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -342,7 +342,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           with: |
             fetch-depth: 0
           attempt_limit: 3
@@ -379,7 +379,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -403,7 +403,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -445,7 +445,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -487,7 +487,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 
@@ -527,7 +527,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           with: |
             fetch-depth: 0
           attempt_limit: 3

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/dependabot-bun-lock.yml
+++ b/.github/workflows/dependabot-bun-lock.yml
@@ -47,7 +47,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
         with:
           # PR ブランチに直接書き戻すため、head ref をチェックアウトする。
           # Check out the PR head ref so we can push commits back to it.

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.3
+          action: actions/checkout@v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
       - uses: ./.github/actions/setup-toolchain
@@ -96,7 +96,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.3
+          action: actions/checkout@v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
       - uses: ./.github/actions/setup-toolchain
@@ -132,7 +132,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.3
+          action: actions/checkout@v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
       - uses: ./.github/actions/setup-toolchain

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.3
+          action: actions/checkout@v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
       - uses: ./.github/actions/setup-toolchain
@@ -111,7 +111,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.3
+          action: actions/checkout@v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
       - uses: ./.github/actions/setup-toolchain
@@ -167,7 +167,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.3
+          action: actions/checkout@v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
       # ルートには wrangler 用の依存が必要なので setup-toolchain の install を

--- a/.github/workflows/nightly-mutation.yml
+++ b/.github/workflows/nightly-mutation.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout (with retry)
         uses: Wandalen/wretry.action@v3
         with:
-          action: actions/checkout@v6.0.3
+          action: actions/checkout@v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       pr-branch: ${{ steps.rp.outputs.prs_created == 'true' && fromJSON(steps.rp.outputs.pr).headBranchName || '' }}
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
@@ -42,7 +42,7 @@ jobs:
     if: needs.release-please.outputs.pr-branch != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
         with:
           ref: ${{ needs.release-please.outputs.pr-branch }}
 

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -15,7 +15,7 @@ jobs:
     name: Create and auto-merge sync PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       # Pin to commit SHAs (tags are mutable). Tag comments for upgrades.
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install system dependencies (Linux)
         if: matrix.platform == 'ubuntu-22.04'

--- a/.github/workflows/terraform-cloudflare-dev.yml
+++ b/.github/workflows/terraform-cloudflare-dev.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: development
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
@@ -56,7 +56,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
       github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false

--- a/.github/workflows/terraform-cloudflare-prod.yml
+++ b/.github/workflows/terraform-cloudflare-prod.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
@@ -56,7 +56,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false

--- a/.github/workflows/terraform-cloudflare-shared.yml
+++ b/.github/workflows/terraform-cloudflare-shared.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
@@ -45,7 +45,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     needs: [plan]
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Dependabot PR #1096 は workflow の一部のみ `actions/checkout` v7 に更新するため、全参照を一括で v7.0.0 に揃える手動 PR です。

## 変更点

- `.github/workflows/` 内の `actions/checkout` 参照をすべて v7.0.0 に更新
  - `@v6.0.3` / `@v6.0.2` タグ参照
  - `ci.yml` の SHA 固定参照（`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0`）
  - `deploy-*.yml` の `Wandalen/wretry.action` 経由参照
- `.github/actions/setup-toolchain/README.md` のサンプルも v7 に同期

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [ ] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [ ] 🧪 テスト (Tests)
- [x] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. GitHub Actions CI が全ジョブ（Lint / Build / Unit Tests / E2E 等）で成功すること
2. Terraform workflow は develop ブランチ push 時に secrets 付きで Plan が通ること（Dependabot PR では TF token 不足で Plan が落ちる既知挙動）

## チェックリスト

- [ ] CI がすべてパスする
- [x] 全 workflow ファイルで checkout 参照に v6 残存なし

## 関連 Issue

- Supersedes Dependabot #1096
- マージ後、オープン中の Dependabot PR #1096 はクローズしてください
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f0c087f-810e-4324-a2da-ebbe63087b0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f0c087f-810e-4324-a2da-ebbe63087b0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions checkout step to v7.0.0 across all CI/CD workflows and documentation, improving automation reliability and security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->