### PR TITLE
feat(infra): Cloudflare 移行 Phase 0–2a（skill / R2 / Worker 骨格 / secrets チェックリスト）(#1088)

### DIFF
--- a/.agents/skills/cloudflare-zedi/SKILL.md
+++ b/.agents/skills/cloudflare-zedi/SKILL.md
@@ -71,6 +71,15 @@ Fetch live docs via the `cloudflare-docs` MCP rather than trusting baked-in know
 [references/migration-plan.md](references/migration-plan.md) に従う。1 フェーズ = 1 PR を基本とし、
 各 PR で「実装 → MCP で状態確認 → health/SHA 検証」のループを回す。
 
+## Secrets / Bindings ライフサイクル
+
+フェーズごとに **何を登録・更新・削除してよいか** のチェックリストは
+[references/secrets-template.md](references/secrets-template.md) を正とする。
+Worker 切替 PR を出す前に、Railway Variables と `wrangler secret list` を突合すること。
+
+_Secrets lifecycle per phase: [secrets-template.md](references/secrets-template.md).
+Reconcile Railway vars with `wrangler secret list` before each cutover PR._
+
 ## やってはいけないこと / Guardrails
 
 - **Terraform に新規リソースを足さない。** 移行対象（Workers/R2/D1/KV/DO）はすべて

--- a/.agents/skills/cloudflare-zedi/SKILL.md
+++ b/.agents/skills/cloudflare-zedi/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: cloudflare-zedi
+description: >
+  Zedi 固有の Cloudflare 作業ガイド。Railway → Cloudflare 移行（Issue #1088）で
+  Terraform を全廃し、Wrangler（wrangler.jsonc）と Cloudflare MCP を正本にする際の
+  使い分け・命名・トークンスコープ・フェーズ計画をまとめる。
+  Use when working on Cloudflare for Zedi: migrating server/api, server/mcp,
+  server/hocuspocus, Postgres/Redis/S3 to Workers/D1/KV/R2/Durable Objects,
+  moving frontend/admin from Pages to Workers Static Assets, removing Terraform,
+  or reconfiguring CI/CD. Triggers: "Cloudflare 移行", "Workers 化", "R2",
+  "D1", "Durable Objects", "Terraform 廃止", "wrangler", "#1088"〜"#1095".
+---
+
+# Cloudflare for Zedi (Railway → Cloudflare 移行)
+
+Zedi の Cloudflare 作業に着手する前に、**汎用 Cloudflare/Wrangler スキルではなく本スキルで
+Zedi 固有の前提**を確認する。汎用知識は古い可能性があるため、数値・API・設定は必ず
+`cloudflare-docs` MCP または公式ドキュメントで最新を取得する（retrieval over pre-training）。
+
+_Before any Cloudflare work in Zedi, load this skill for project-specific facts.
+Fetch live docs via the `cloudflare-docs` MCP rather than trusting baked-in knowledge._
+
+## 方針（決定済み） / Decisions
+
+- **Terraform は全廃する。** 構成の正本はリポジトリ内の `wrangler.jsonc`。DNS とドメインは
+  Worker の `routes` の `custom_domain: true` に内包し、Terraform Cloud のステート管理をやめる。
+  _Terraform is being removed. Source of truth = in-repo `wrangler.jsonc`._
+- **フロント/admin は Pages を廃止し Workers Static Assets へ移す。** これにより Terraform が
+  管理していた Pages プロジェクトと Pages 用 DNS の対象自体が消える。
+  _Frontend/admin migrate from Pages to Workers Static Assets; Pages projects retired._
+- **CI/CD はハイブリッド。** 品質ゲート（lint / vitest / typecheck / migration check）は
+  GitHub Actions に残し、デプロイは `wrangler deploy`。PR プレビューは `wrangler versions upload`。
+  _Hybrid CI/CD: GitHub Actions for gates, `wrangler deploy` for rollout, `versions upload` for PR previews._
+- データ移行は **ビッグバン・カットオーバー**（Issue #1088 / #1090 の方針。デュアルライトしない）。
+  _Big-bang cutover, no dual-write window._
+
+## アクセス手段の使い分け / Which tool for what
+
+| やりたいこと                           | 使うもの                                                                                                                |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| R2 / D1 / KV / Worker の一覧・状態確認 | Cloudflare MCP `cloudflare-bindings`（`r2_buckets_list`, `d1_databases_list`, `kv_namespaces_list`, `workers_list` 等） |
+| D1 への SQL 実行・確認                 | MCP `d1_database_query`                                                                                                 |
+| Worker のログ・メトリクス              | MCP `cloudflare-observability`（`query_worker_observability`）/ `wrangler tail`                                         |
+| Workers Builds の状態・ログ            | MCP `cloudflare-builds`                                                                                                 |
+| Cloudflare ドキュメント確認            | MCP `cloudflare-docs` の `search_cloudflare_documentation`                                                              |
+| Pages→Workers 移行手順                 | MCP `migrate_pages_to_workers_guide`（移行前に必ず読む）                                                                |
+| ローカル dev / deploy / secret 設定    | `bunx wrangler`（汎用 `wrangler` スキル参照）                                                                           |
+
+**重要 / Important:** MCP ツールは呼ぶ前に必ず
+`mcps/<server>/tools/<tool>.json` のスキーマを読む。
+
+## 認証 / Auth (一度だけ / one-time)
+
+1. **Cloudflare MCP**: Cursor のプラグインで Cloudflare に OAuth ログイン。疎通確認は
+   「Workers 一覧を取得」→ `workers_list` が返ること。
+2. **ローカル Wrangler**: `bunx wrangler whoami`。未ログインなら `wrangler login`、
+   または移行用トークンを env に設定（`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`）。
+   必要スコープは [references/token-scopes.md](references/token-scopes.md)。
+3. 既存 GitHub Secrets `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` は **同一アカウント・
+   同一ゾーン**。Pages deploy と（廃止予定の）Terraform CI が現在使用中。
+
+## Zedi のリソース対応 / Resource map
+
+現状の Railway サービスと Cloudflare 移行先・サブ Issue の対応は
+[references/resource-map.md](references/resource-map.md) を正とする。
+ドメイン・プロジェクト名・環境名の固定値は [references/naming.md](references/naming.md)。
+
+## 移行フェーズ / Migration phases
+
+フェーズ順・各フェーズの検証基準・削除対象は
+[references/migration-plan.md](references/migration-plan.md) に従う。1 フェーズ = 1 PR を基本とし、
+各 PR で「実装 → MCP で状態確認 → health/SHA 検証」のループを回す。
+
+## やってはいけないこと / Guardrails
+
+- **Terraform に新規リソースを足さない。** 移行対象（Workers/R2/D1/KV/DO）はすべて
+  `wrangler.jsonc` で管理する。Terraform は Phase 5 でまとめて削除するまで「凍結」。
+  _Do not add new resources to Terraform; it is frozen until removal in Phase 5._
+- **DNS を Terraform と Wrangler で二重管理しない。** カットオーバー時は Worker の
+  `custom_domain` 側へ寄せ、旧 Terraform レコードは同一 PR で除去（または Phase 5 で一括）。
+- **Secrets をリポジトリに置かない。** Worker の秘密値は `wrangler secret put`。
+  `.env.example` には鍵名とコメントのみ。
+- スキーマ変更時は Zedi の DB ルール（[AGENTS.md](../../../AGENTS.md) §DB スキーマ変更）に従う。
+  Postgres → D1 移行（#1090）では `drizzle-migration-check` ガードも D1 用に更新する。

--- a/.agents/skills/cloudflare-zedi/references/migration-plan.md
+++ b/.agents/skills/cloudflare-zedi/references/migration-plan.md
@@ -13,8 +13,16 @@
 
 ## Phase 1: #1089 R2 (低リスク)
 
-- api 用 `wrangler.jsonc` に R2 binding を追加、`server/api` の S3 クライアントを R2 へ切替。
-- **検証**: MCP `r2_bucket_create` → `r2_buckets_list`、アップロード/取得の E2E。
+**方針**: R2 は S3 互換 API を持つため、Railway 上の現 API（`@aws-sdk/client-s3`）はコード変更
+なしで R2 に向けられる。Worker の R2 バインディングは API の Workers 化（Phase 2 / #1091）まで
+導入しない。Phase 1 は「S3 互換エンドポイント＋ env 切替」に限定する。
+
+- バケット作成: `zedi-storage-dev` / `zedi-storage-prod`（作成済み。MCP `r2_bucket_create`）。
+- R2 API トークン発行（ダッシュボード R2 → Manage R2 API Tokens。MCP では不可）。
+- `STORAGE_ENDPOINT` / `STORAGE_ACCESS_KEY` / `STORAGE_SECRET_KEY` / `STORAGE_BUCKET_NAME` を
+  Railway（dev/prod）に設定。`.env.example` に書式を記載済み。
+- 既存オブジェクトの R2 への移送（必要なら `rclone` 等。ビッグバン前提なら新規のみでも可）。
+- **検証**: MCP `r2_buckets_list`、dev で `/api/media` アップロード→取得→削除の E2E。
 
 ## Phase 2: server を Workers 化 (中リスク)
 

--- a/.agents/skills/cloudflare-zedi/references/migration-plan.md
+++ b/.agents/skills/cloudflare-zedi/references/migration-plan.md
@@ -1,0 +1,87 @@
+# 移行フェーズ計画 / Migration phases
+
+1 フェーズ = 1 PR を基本。各 PR で「実装 → MCP で状態確認 → health/SHA 検証」を回す。
+出典: [Issue #1088](https://github.com/otomatty/zedi/issues/1088) のロードマップ。
+
+## Phase 0: 基盤整備 / Foundation (コード影響ほぼ無し)
+
+1. 本スキル（`.agents/skills/cloudflare-zedi/`）整備 → `bun run setup:agent-mirrors`。
+2. 移行専用 API トークン作成（[token-scopes.md](token-scopes.md)）。
+3. `wrangler whoami` と Cloudflare MCP の疎通確認。
+
+- **検証**: MCP `workers_list` / `r2_buckets_list` が応答する。
+
+## Phase 1: #1089 R2 (低リスク)
+
+- api 用 `wrangler.jsonc` に R2 binding を追加、`server/api` の S3 クライアントを R2 へ切替。
+- **検証**: MCP `r2_bucket_create` → `r2_buckets_list`、アップロード/取得の E2E。
+
+## Phase 2: server を Workers 化 (中リスク)
+
+- #1091 api（Hono は Workers 互換、`nodejs_compat`）/ #1092 mcp / #1093 Redis→KV。
+- 各 `wrangler.jsonc` に `env.dev` / `env.production`、Secrets は `wrangler secret put`。
+- **検証**: `wrangler dev` ローカル → dev デプロイ → `/health` の `git_commit_sha` 一致。
+
+## Phase 3: フロント/admin を Pages→Workers Static Assets (Terraform 廃止の本丸)
+
+- 移行前に MCP `migrate_pages_to_workers_guide` を必ず読む。
+- web/admin に `assets.directory` を持つ Worker 設定を追加、`routes` で `custom_domain: true`。
+- dev で先行カットオーバー → prod。
+- **検証**: dev ドメインが Worker 経由で配信され、DNS が自動生成されていること。
+
+## Phase 4: #1090 D1+DO / #1094 Hocuspocus / #1095 LangGraph (高リスク・一体設計)
+
+- ビッグバン・カットオーバー（デュアルライトしない）。
+- Drizzle を SQLite 方言へ、DO で realtime、Workflows/Queues で LangGraph。
+- `drizzle-migration-check` ガードを D1 用に更新。
+- **検証**: MCP `d1_database_query`、DO 動作、observability でエラー率。
+
+## Phase 5: Terraform / Railway 完全撤去 / Teardown
+
+- `terraform/cloudflare/**` 削除、`terraform-cloudflare-{shared,dev,prod}.yml` 3 本削除。
+- Terraform Cloud ワークスペース（shared/dev/prod）削除、`TF_API_TOKEN` Secret 整理。
+- Railway サービス停止（api / hocuspocus / mcp）、Postgres / Redis 廃止。
+- `README` / `AGENTS.md` のデプロイ章を Workers ベースへ改訂。
+- **検証**: `main` push で Terraform 不在のまま全デプロイ完走。
+
+## CI/CD（ハイブリッド）/ CI/CD design
+
+現状維持: PR ゲート（`ci.yml`: lint / format / vitest / typecheck / `drizzle-migration-check`）、
+`develop`→dev / `main`→prod 自動、prod の health + commit SHA 一致ゲート。
+
+現状超え:
+
+| 強化                            | 手段                                                             |
+| ------------------------------- | ---------------------------------------------------------------- |
+| PR プレビュー環境               | `wrangler versions upload` → preview URL を PR にコメント        |
+| 段階デプロイ / 即時ロールバック | `wrangler versions deploy`（gradual %）/ `wrangler rollback`     |
+| DB migration の D1 化           | `wrangler d1 migrations apply`（`drizzle-kit migrate` から置換） |
+| デプロイ後の自動検証            | `cloudflare-observability` MCP / `wrangler tail` でエラー率確認  |
+
+ワークフロー構成（案）:
+
+- `ci.yml`: PR 品質ゲート（＋ `wrangler types` 検証を追加）
+- `preview.yml`: PR で各 Worker を `versions upload`、preview URL を貼る
+- `deploy-dev.yml`: `develop` push → `wrangler deploy --env dev` ＋ D1 dev migrate
+- `deploy-prod.yml`: `main` push → D1 prod migrate → `wrangler deploy --env production` → health/SHA ゲート → 必要なら gradual rollout
+- **削除**: `terraform-cloudflare-{shared,dev,prod}.yml`
+
+## 削除されるもの / To be removed
+
+```
+terraform/cloudflare/**                          (全 25 ファイル)
+.github/workflows/terraform-cloudflare-dev.yml
+.github/workflows/terraform-cloudflare-prod.yml
+.github/workflows/terraform-cloudflare-shared.yml
+Terraform Cloud: cloudflare-shared / -dev / -prod ワークスペース
+GitHub Secrets: TF_API_TOKEN
+Railway: api / hocuspocus / mcp サービス、Postgres / Redis
+```
+
+## リスクと対策 / Risks
+
+| リスク                           | 対策                                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------------ |
+| DNS カットオーバーのダウンタイム | dev 先行検証。低 TTL で切替、Worker 稼働確認後に旧 Railway CNAME 撤去                |
+| Terraform 削除でドメイン設定喪失 | 削除は Phase 5（全 Worker 稼働後）。先に DNS を Wrangler 管理へ移してから state 破棄 |
+| Pages→Workers の挙動差           | docs の compatibility matrix を確認。`_headers` / `_redirects` 差分を移行時に検証    |

--- a/.agents/skills/cloudflare-zedi/references/migration-plan.md
+++ b/.agents/skills/cloudflare-zedi/references/migration-plan.md
@@ -24,10 +24,22 @@
 - 既存オブジェクトの R2 への移送（必要なら `rclone` 等。ビッグバン前提なら新規のみでも可）。
 - **検証**: MCP `r2_buckets_list`、dev で `/api/media` アップロード→取得→削除の E2E。
 
-## Phase 2: server を Workers 化 (中リスク)
+## Phase 2: server を Workers 化 (中リスク) — Phase 2a 実装済み
+
+**Phase 2a（完了）**: API Worker 骨格 + R2 binding + storage 抽象化 + dev deploy CI。
+
+- `server/api/wrangler.jsonc`（`env.dev` / `env.production`、R2 `STORAGE_BUCKET` binding）
+- `server/api/src/worker.ts` — Hono `export default app`（Workers エントリ）
+- `server/api/src/lib/storage/` — `StorageClient` 抽象（R2 binding + S3 互換 presign）
+- `storageMiddleware` — リクエストごとに `c.set("storage", ...)`
+- `deploy-api-worker-dev.yml` — `develop` push で `wrangler deploy --env dev`
+- Railway `index.ts` は維持（並行稼働）。本番 DNS 切替は Phase 2b 以降。
+
+**Phase 2b（未着手）**: #1091 全 API の Workers 本番切替、#1092 mcp、#1093 Redis→KV。
 
 - #1091 api（Hono は Workers 互換、`nodejs_compat`）/ #1092 mcp / #1093 Redis→KV。
-- 各 `wrangler.jsonc` に `env.dev` / `env.production`、Secrets は `wrangler secret put`。
+- Worker secrets（`DATABASE_URL`, `REDIS_URL`, `BETTER_AUTH_*`, `STORAGE_*` for presign）を
+  `wrangler secret put --env dev` で設定してから health/E2E 検証。
 - **検証**: `wrangler dev` ローカル → dev デプロイ → `/health` の `git_commit_sha` 一致。
 
 ## Phase 3: フロント/admin を Pages→Workers Static Assets (Terraform 廃止の本丸)

--- a/.agents/skills/cloudflare-zedi/references/naming.md
+++ b/.agents/skills/cloudflare-zedi/references/naming.md
@@ -1,0 +1,50 @@
+# 命名・ドメイン固定値 / Naming & domains
+
+移行前（Terraform 管理）の固定値と、移行後（Wrangler 管理）の方針。
+出典: `terraform/cloudflare/{shared,dev,prod}/`（Phase 5 で削除予定）。
+
+## ゾーン / Zone
+
+- DNS ゾーン: `zedi-note.app`（単一アカウント・単一ゾーン。dev/prod 同一トークンで可）
+
+## ドメイン対応 / Domains
+
+| 用途     | prod                     | dev                       |
+| -------- | ------------------------ | ------------------------- |
+| フロント | `zedi-note.app` (apex)   | `dev.zedi-note.app`       |
+| 管理画面 | `admin.zedi-note.app`    | `admin-dev.zedi-note.app` |
+| API      | `api.zedi-note.app`      | （dev 設定に従う）        |
+| Realtime | `realtime.zedi-note.app` | （dev 設定に従う）        |
+
+> 移行前は `api` / `realtime` は Railway への CNAME（proxied）。Workers 化後は各 Worker の
+> `routes` に `{ pattern: "api.zedi-note.app", custom_domain: true }` を設定し、DNS を
+> Cloudflare に自動生成させる。旧 Railway CNAME と検証 TXT はカットオーバー後に撤去。
+
+## プロジェクト/Worker 名 / Project & Worker names
+
+移行前 Pages プロジェクト名（参考。Workers 化で置換）:
+
+| 環境 | フロント   | 管理画面         |
+| ---- | ---------- | ---------------- |
+| prod | `zedi`     | `zedi-admin`     |
+| dev  | `zedi-dev` | `zedi-admin-dev` |
+
+移行後 Worker 名（提案。`wrangler.jsonc` の `name` + `env`）:
+
+| サービス      | 提案 Worker 名  | 環境分離                     |
+| ------------- | --------------- | ---------------------------- |
+| フロント      | `zedi-web`      | `env.dev` / `env.production` |
+| 管理画面      | `zedi-admin`    | `env.dev` / `env.production` |
+| API           | `zedi-api`      | `env.dev` / `env.production` |
+| MCP           | `zedi-mcp`      | `env.dev` / `env.production` |
+| Realtime (DO) | `zedi-realtime` | `env.dev` / `env.production` |
+
+> Worker 名は Cloudflare の名前制約（長さ等）に従う。環境は単一 Worker を `env.*` で分けるか、
+> 名前サフィックス（`-dev`）で分けるかを Phase 2 着手時に確定する。
+
+## 環境変数の対応 / Env vars
+
+GitHub Environments（development / production）の既存 `vars` / `secrets`:
+
+- `vars`: `API_BASE_URL`, `REALTIME_URL`, `MAIN_APP_URL`, `MCP_BASE_URL`, `POLAR_MONTHLY_ID`, `POLAR_YEARLY_ID`
+- `secrets`: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `DATABASE_URL`（D1 移行で不要化予定）, `TF_API_TOKEN`（Terraform 廃止で削除）

--- a/.agents/skills/cloudflare-zedi/references/naming.md
+++ b/.agents/skills/cloudflare-zedi/references/naming.md
@@ -42,6 +42,20 @@
 > Worker 名は Cloudflare の名前制約（長さ等）に従う。環境は単一 Worker を `env.*` で分けるか、
 > 名前サフィックス（`-dev`）で分けるかを Phase 2 着手時に確定する。
 
+## R2 バケット / R2 buckets (#1089)
+
+メディア / サムネイル / PDF ハイライトを単一バケットに格納する（現状の `STORAGE_BUCKET_NAME`
+1 個構成を踏襲）。環境ごとに 1 バケット。
+
+| 環境 | バケット名          | 状態                       |
+| ---- | ------------------- | -------------------------- |
+| dev  | `zedi-storage-dev`  | 作成済み (APAC / Standard) |
+| prod | `zedi-storage-prod` | 作成済み (APAC / Standard) |
+
+- S3 互換エンドポイント: `https://<CLOUDFLARE_ACCOUNT_ID>.r2.cloudflarestorage.com`
+- R2 API トークン（Access Key ID / Secret）はダッシュボード R2 → Manage R2 API Tokens で発行
+  （MCP では発行不可）。`STORAGE_*` env に設定する。
+
 ## 環境変数の対応 / Env vars
 
 GitHub Environments（development / production）の既存 `vars` / `secrets`:

--- a/.agents/skills/cloudflare-zedi/references/resource-map.md
+++ b/.agents/skills/cloudflare-zedi/references/resource-map.md
@@ -1,0 +1,30 @@
+# リソース対応表 / Resource map (Issue #1088)
+
+現状の Railway 等のサービスと Cloudflare 移行先・サブ Issue・確認用 MCP の対応。
+出典: [Issue #1088](https://github.com/otomatty/zedi/issues/1088)。
+
+| #   | 現状                          | 役割                              | 移行先 (Cloudflare)                                                | サブ Issue | 確認に使う MCP                            |
+| --- | ----------------------------- | --------------------------------- | ------------------------------------------------------------------ | ---------- | ----------------------------------------- |
+| 1   | フロント `zedi`               | React/Vite SPA                    | **Workers Static Assets**（旧 Pages）                              | #1088 本体 | `workers_list`                            |
+| 2   | 管理画面 `zedi-admin`         | React/Vite SPA                    | **Workers Static Assets**（旧 Pages）                              | #1088 本体 | `workers_list`                            |
+| 3   | S3 互換ストレージ             | メディア・サムネ・PDF ハイライト  | **R2**                                                             | #1089      | `r2_buckets_list` / `r2_bucket_create`    |
+| 4   | Railway PostgreSQL            | 主 DB (Drizzle)                   | **D1（コントロールプレーン）＋ ノート単位 DO ＋ ユーザーシャード** | #1090      | `d1_databases_list` / `d1_database_query` |
+| 5   | `server/api` (Hono)           | 認証・REST・AI チャット           | **Workers**                                                        | #1091      | `workers_list` / `workers_get_worker`     |
+| 6   | `server/mcp` (Hono + MCP SDK) | 外部 MCP クライアント連携         | **Workers**                                                        | #1092      | `workers_list`                            |
+| 7   | Railway Redis                 | レート制限・deny-list・キャッシュ | **KV / Durable Objects**                                           | #1093      | `kv_namespaces_list`                      |
+| 8   | `server/hocuspocus` (WS/Yjs)  | リアルタイム共同編集 (CRDT)       | **Durable Objects**                                                | #1094      | `observability` / `wrangler tail`         |
+| 9   | LangGraph (server/api 内蔵)   | Wiki Compose / Research Loop      | **Workflows / Queues**                                             | #1095      | `cloudflare-docs`                         |
+
+## 横断的な確認事項 / Cross-cutting
+
+- Workers の `nodejs_compat` で `@aws-sdk/client-s3` / `ioredis` の動作確認（`pg` は Postgres 廃止で不要化）。
+- Drizzle を SQLite 方言へ移植（`text[]` / `jsonb` / `gen_random_uuid()` / ILIKE→FTS5 の書き換え。詳細は #1090）。
+- Better Auth（`BETTER_AUTH_SECRET` 共有）を D1 アダプタ＋KV セッションキャッシュで動かす。
+- Secrets を Railway → Cloudflare へ（`wrangler secret put`）。
+- CORS / `TRUST_PROXY` の見直し。
+- コスト試算（Workers / DO / D1 / R2 / KV）。
+
+## #1090 / #1094 / #1095 は一体設計 / Designed together
+
+ノート単位 Durable Object は #1094 のリアルタイム層と同一オブジェクトに統合し、
+ユーザーシャードの LangGraph チェックポイントは #1095 に依存する。Phase 4 でまとめて実施。

--- a/.agents/skills/cloudflare-zedi/references/secrets-template.md
+++ b/.agents/skills/cloudflare-zedi/references/secrets-template.md
@@ -1,0 +1,227 @@
+# Secrets / Bindings 一覧テンプレート / Secrets lifecycle template
+
+移行フェーズ（[migration-plan.md](migration-plan.md)）ごとに **何を登録・削除してよいか** を追跡するための
+チェックリスト。正本は `.env.example` と実装の `getEnv` / `process.env` 参照。
+Worker への秘密値は **リポジトリに置かず** `wrangler secret put` で設定する。
+
+_Secrets lifecycle checklist per migration phase. Source of truth = `.env.example` + code.
+Never commit secret values; use `wrangler secret put` for Workers._
+
+## 記号 / Legend
+
+| 記号        | 意味                                                                                    |
+| ----------- | --------------------------------------------------------------------------------------- |
+| **Secret**  | `wrangler secret put` / Railway Variables / GitHub Encrypted Secret                     |
+| **Binding** | `wrangler.jsonc` の `r2_buckets` / `kv_namespaces` / `d1_databases` / `durable_objects` |
+| **Var**     | `wrangler.jsonc` の `vars`（平文可。CI が注入する `GIT_COMMIT_SHA` 等）                 |
+| **—**       | 当フェーズでは触らない（前フェーズの設定を維持）                                        |
+
+## 配置先の早見表 / Where secrets live
+
+| 配置先                                                             | 用途                                      | 例                                               |
+| ------------------------------------------------------------------ | ----------------------------------------- | ------------------------------------------------ |
+| **Railway** (api / mcp / hocuspocus)                               | 現行本番・dev ランタイム                  | `DATABASE_URL`, `STORAGE_*`                      |
+| **Worker secrets** (`wrangler secret put --env <dev\|production>`) | Cloudflare 上の API / MCP Worker          | Railway と同値をコピー（Phase 2b 以降）          |
+| **GitHub Actions Secrets**                                         | CI デプロイ・Terraform（廃止予定）        | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`  |
+| **R2 API Token** (Cloudflare Dashboard)                            | S3 互換 presign / Railway S3 クライアント | `STORAGE_ACCESS_KEY` / `STORAGE_SECRET_KEY` の元 |
+
+---
+
+## マスター一覧（API Worker）/ Master inventory — `server/api`
+
+### Bindings（`wrangler.jsonc`、秘密値ではない）
+
+| Binding 名       | リソース                                    | Phase 導入 |
+| ---------------- | ------------------------------------------- | ---------- |
+| `STORAGE_BUCKET` | R2 `zedi-storage-dev` / `zedi-storage-prod` | 2a ✅      |
+| `KV`（仮名）     | Redis 代替 KV namespace                     | 2b (#1093) |
+| `DB`（仮名）     | D1 database                                 | 4 (#1090)  |
+| DO bindings      | Hocuspocus / realtime                       | 4 (#1094)  |
+
+### Vars（平文、`wrangler.jsonc` の `vars`）
+
+| 名前             | 用途                                              | Phase |
+| ---------------- | ------------------------------------------------- | ----- |
+| `ENVIRONMENT`    | `development` / `production`                      | 2a ✅ |
+| `GIT_COMMIT_SHA` | `/health` ロールアウト検証（CI が deploy 時注入） | 2b    |
+
+### Secrets — 必須（Worker 本番切替前）
+
+| 名前                                        | 用途                              | Railway → Worker                                |
+| ------------------------------------------- | --------------------------------- | ----------------------------------------------- |
+| `DATABASE_URL`                              | Postgres（Phase 4 まで）          | 同値コピー → Phase 4 で **削除**                |
+| `BETTER_AUTH_SECRET`                        | セッション・署名                  | 同値（**必ず同一** — Hocuspocus / MCP と共有）  |
+| `BETTER_AUTH_URL`                           | OAuth コールバック base           | Worker URL に更新（DNS 切替 PR で）             |
+| `CORS_ORIGIN`                               | CSRF / trusted origins            | フロント URL（Phase 3 後に Workers ドメインへ） |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth                      | 同値                                            |
+| `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | GitHub OAuth                      | 同値                                            |
+| `STORAGE_ENDPOINT`                          | R2 S3 互換 endpoint（presign 用） | 同値                                            |
+| `STORAGE_ACCESS_KEY` / `STORAGE_SECRET_KEY` | R2 API token（presign 用）        | 同値（binding とは別 — presign に必要）         |
+| `STORAGE_BUCKET_NAME`                       | バケット名                        | `zedi-storage-dev` / `zedi-storage-prod`        |
+| `MCP_REDIRECT_URI_ALLOW`                    | MCP OAuth redirect 許可リスト     | 同値（未設定時 MCP は拒否）                     |
+
+### Secrets — 機能別（未設定なら該当機能のみ無効）
+
+| 名前                                                                      | 用途                                | 備考                                              |
+| ------------------------------------------------------------------------- | ----------------------------------- | ------------------------------------------------- |
+| `REDIS_URL`                                                               | レート制限・キャッシュ等            | Phase 2b まで Worker にも必要。**2b KV 後に削除** |
+| `POLAR_ACCESS_TOKEN`                                                      | 課金 API                            |                                                   |
+| `POLAR_WEBHOOK_SECRET`                                                    | Polar webhook 署名                  |                                                   |
+| `POLAR_PRO_MONTHLY_PRODUCT_ID` / `POLAR_PRO_YEARLY_PRODUCT_ID`            | プラン ID                           | Var 化可（秘密ではない）                          |
+| `RESEND_API_KEY` / `RESEND_FROM_EMAIL`                                    | メール送信                          | 未設定時 no-op                                    |
+| `SENTRY_DSN_API`                                                          | Sentry 送信                         |                                                   |
+| `SENTRY_WEBHOOK_SECRET`                                                   | Sentry webhook 署名                 |                                                   |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`                                    | システム LLM（BYOK 以外）           |                                                   |
+| `OPENROUTER_API_KEY`                                                      | AI モデル料金 sync                  | 未設定時デフォルト cost                           |
+| `USER_AI_CREDENTIALS_ENCRYPTION_KEY`                                      | BYOK 暗号化                         | 32 bytes base64/hex                               |
+| `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY` / `GITHUB_APP_INSTALLATION_ID` | Sentry→GitHub dispatch              |                                                   |
+| `GITHUB_DISPATCH_REPOSITORY`                                              | dispatch 先 `owner/repo`            | 未設定時 dispatch スキップ                        |
+| `MONITORING_NOTIFY_EMAIL` / `ADMIN_BASE_URL`                              | エラー通知メール                    |                                                   |
+| `GOOGLE_CUSTOM_SEARCH_API_KEY` / `GOOGLE_CUSTOM_SEARCH_ENGINE_ID`         | サムネ画像検索                      |                                                   |
+| `YOUTUBE_DATA_API_KEY`                                                    | クリップ / ext                      |                                                   |
+| `SYNC_AI_MODELS_SECRET`                                                   | admin モデル sync                   |                                                   |
+| `HOCUSPOCUS_INTERNAL_URL`                                                 | Y.js 無効化通知                     | Phase 4 まで Railway internal URL                 |
+| `TRUST_PROXY`                                                             | `true` when behind CF/Railway proxy | Worker では通常 `true`                            |
+| `EXTENSION_ORIGIN`                                                        | ブラウザ拡張 origin                 | 本番のみ                                          |
+
+### Railway のみ（Worker では不要）
+
+| 名前                     | 用途             | 削除タイミング                     |
+| ------------------------ | ---------------- | ---------------------------------- |
+| `PORT`                   | 待ち受けポート   | Phase 5 Railway 撤去               |
+| `RAILWAY_GIT_COMMIT_SHA` | Railway 注入 SHA | Phase 5                            |
+| `NODE_ENV`               | Node ランタイム  | Worker は `ENVIRONMENT` var を使用 |
+
+---
+
+## MCP Worker（`server/mcp`）/ Phase 2b (#1092)
+
+| 名前                 | 種別         | 備考                                                                                                |
+| -------------------- | ------------ | --------------------------------------------------------------------------------------------------- |
+| `ZEDI_API_URL`       | Secret / Var | Worker 化後は **内部 URL**（例: `https://zedi-api-dev.<account>.workers.dev` または custom domain） |
+| `BETTER_AUTH_SECRET` | Secret       | API と **同一値**                                                                                   |
+| `PORT` / `MCP_HOST`  | —            | Workers では不要                                                                                    |
+
+---
+
+## GitHub Actions Secrets
+
+| 名前                    | Phase | 操作                                                        |
+| ----------------------- | ----- | ----------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`  | 0〜   | **維持** — `wrangler deploy` / Pages deploy（Phase 3 まで） |
+| `CLOUDFLARE_ACCOUNT_ID` | 0〜   | **維持**                                                    |
+| `TF_API_TOKEN`          | 0〜4  | Phase 5 で **削除**（Terraform CI 廃止後）                  |
+
+---
+
+## フェーズ別 Δ / Per-phase register & remove
+
+### Phase 0 — 基盤
+
+| 操作     | 対象                                                                                      |
+| -------- | ----------------------------------------------------------------------------------------- |
+| **登録** | 移行用 Cloudflare API トークン（ローカル `CLOUDFLARE_API_TOKEN` または `wrangler login`） |
+| **登録** | GitHub `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` が同一アカウントであることを確認  |
+| **削除** | なし                                                                                      |
+
+### Phase 1 — #1089 R2（Railway のみ）
+
+| 操作                         | 対象                                                                                      |
+| ---------------------------- | ----------------------------------------------------------------------------------------- |
+| **登録（Railway dev/prod）** | `STORAGE_ENDPOINT`, `STORAGE_ACCESS_KEY`, `STORAGE_SECRET_KEY`, `STORAGE_BUCKET_NAME`     |
+| **登録（Dashboard）**        | R2 バケット `zedi-storage-dev` / `zedi-storage-prod`、R2 API Token                        |
+| **削除**                     | 旧 S3 互換ストレージの env（Railway から `STORAGE_*` を旧値から差し替え。キー自体は残す） |
+| **Worker**                   | 触らない（Phase 2a まで Worker 未デプロイ or secrets 未設定でよい）                       |
+
+### Phase 2a — #1091 Worker 骨格（実装済み）
+
+| 操作                       | 対象                                                           |
+| -------------------------- | -------------------------------------------------------------- |
+| **登録（wrangler.jsonc）** | R2 binding `STORAGE_BUCKET` ✅                                 |
+| **登録（GitHub Actions）** | `deploy-api-worker-dev.yml` が `CLOUDFLARE_*` を使用           |
+| **登録（Worker secrets）** | **任意（dev E2E 前に必須）**: 上記マスター「必須」+ 利用機能分 |
+| **削除**                   | なし（Railway は並行稼働）                                     |
+
+```bash
+# dev Worker secrets 設定例（server/api で実行）
+cd server/api
+bunx wrangler secret put DATABASE_URL --env dev
+bunx wrangler secret put BETTER_AUTH_SECRET --env dev
+# ... マスター一覧を参照
+```
+
+### Phase 2b — #1091 本番切替 + #1092 MCP + #1093 KV
+
+| 操作                                        | 対象                                                                    |
+| ------------------------------------------- | ----------------------------------------------------------------------- |
+| **登録（wrangler.jsonc）**                  | KV namespace binding（#1093）                                           |
+| **登録（Worker secrets dev + production）** | マスター「必須」+ Redis 利用機能があれば `REDIS_URL`（KV 移行完了まで） |
+| **登録（vars / CI）**                       | `GIT_COMMIT_SHA` を deploy workflow で注入                              |
+| **更新**                                    | `BETTER_AUTH_URL` → Worker custom domain（`api.zedi-note.app` 等）      |
+| **更新**                                    | OAuth プロバイダの redirect URI を Worker URL に追加                    |
+| **更新**                                    | Polar / Sentry webhook URL を Worker URL に                             |
+| **登録（MCP Worker）**                      | `ZEDI_API_URL`, `BETTER_AUTH_SECRET`                                    |
+| **削除（Worker secrets）**                  | `REDIS_URL` — KV binding + コード切替完了後                             |
+| **削除（Railway）**                         | **まだしない** — DNS 切替・検証後 Phase 5                               |
+
+### Phase 3 — フロント/admin Static Assets
+
+| 操作                           | 対象                                                                            |
+| ------------------------------ | ------------------------------------------------------------------------------- |
+| **登録（GitHub Secrets）**     | 追加不要（既存 `CLOUDFLARE_*` で `wrangler deploy`）                            |
+| **更新（API Worker secrets）** | `CORS_ORIGIN` — 新 Workers Static Assets の origin                              |
+| **更新（OAuth）**              | Google/GitHub redirect に新フロント URL                                         |
+| **削除（GitHub / Terraform）** | まだ Terraform Pages 関連は Phase 5 まで維持可                                  |
+| **削除（Cloudflare Pages）**   | dev/prod カットオーバー検証後、Pages プロジェクト停止（Phase 5 と同 PR でも可） |
+
+### Phase 4 — #1090 D1 + #1094 Hocuspocus + #1095 LangGraph
+
+| 操作                           | 対象                                                          |
+| ------------------------------ | ------------------------------------------------------------- |
+| **登録（wrangler.jsonc）**     | D1 binding、DO bindings、Queues / Workflows 設定              |
+| **登録（D1）**                 | 移行後 DB — `DATABASE_URL` の代わりに D1 binding              |
+| **登録（Worker secrets）**     | D1 移行に必要な新 secrets（Workflows API 等、実装 PR で追記） |
+| **削除（Worker secrets）**     | `DATABASE_URL` — D1 カットオーバー後                          |
+| **削除（Worker secrets）**     | `HOCUSPOCUS_INTERNAL_URL` — DO 化後                           |
+| **削除（Railway hocuspocus）** | Phase 5 まで猶予可                                            |
+
+### Phase 5 — Terraform / Railway 完全撤去
+
+| 操作                               | 対象                                                                 |
+| ---------------------------------- | -------------------------------------------------------------------- |
+| **削除（GitHub Secrets）**         | `TF_API_TOKEN`                                                       |
+| **削除（GitHub Workflows）**       | `terraform-cloudflare-{shared,dev,prod}.yml`                         |
+| **削除（Railway 全サービス env）** | api / mcp / hocuspocus の Variables 一式                             |
+| **削除（Railway リソース）**       | Postgres、Redis、各サービス                                          |
+| **削除（Terraform Cloud）**        | shared / dev / prod ワークスペース                                   |
+| **削除（Dashboard）**              | 未使用 R2 API Token（presign 仍用なら **残す**）                     |
+| **維持**                           | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, Worker secrets 一式 |
+
+---
+
+## コピー手順（Railway → Worker）/ Copy checklist
+
+1. Railway dashboard → api サービス → Variables をエクスポート（または 1 件ずつ）。
+2. `server/api` で `bunx wrangler secret list --env dev` と突合。
+3. マスター一覧の「必須」をすべて `wrangler secret put`。
+4. `/health` で `runtime: cloudflare-workers` と `git_commit_sha` を確認。
+5. auth / media upload / webhook のスモークテスト。
+6. production は dev 成功後に `--env production` で同手順。
+
+---
+
+## やってはいけないこと / Guardrails
+
+- **異なる `BETTER_AUTH_SECRET` を API / MCP / Hocuspocus / Worker に置かない。**
+- **`STORAGE_*` secrets を binding 導入後も削除しない** — presigned PUT に S3 API 資格情報が必要（Phase 2a 時点）。
+- **Terraform / Railway の secrets を Phase 5 前に一括削除しない** — ロールバック不能。
+- **GitHub Issue / PR に秘密値を貼らない** — 名前とフェーズのみ。
+
+---
+
+## 関連 / Related
+
+- [migration-plan.md](migration-plan.md) — フェーズ定義
+- [token-scopes.md](token-scopes.md) — API トークンスコープ
+- `server/api/.env.example` — 鍵名とコメント
+- Epic [#1088](https://github.com/otomatty/zedi/issues/1088)

--- a/.agents/skills/cloudflare-zedi/references/token-scopes.md
+++ b/.agents/skills/cloudflare-zedi/references/token-scopes.md
@@ -1,0 +1,27 @@
+# API トークンスコープ / API token scopes
+
+移行作業で必要な Cloudflare API トークン権限。**移行専用トークンを 1 つ作成**し、
+ローカル env と（必要なら）GitHub Environment secret に設定する。本番 Terraform 用トークンとは
+分離する（Terraform は Phase 5 で廃止）。
+
+_Create one dedicated migration token; keep it separate from the existing Terraform token._
+
+## 必要権限 / Required permissions
+
+| スコープ                            | レベル                 | 用途                                | 必要フェーズ    |
+| ----------------------------------- | ---------------------- | ----------------------------------- | --------------- |
+| Workers Scripts (Edit)              | Account                | Worker の deploy / versions         | Phase 2〜       |
+| Workers R2 Storage (Edit)           | Account                | R2 バケット作成・操作               | Phase 1 (#1089) |
+| Workers KV Storage (Edit)           | Account                | KV namespace 作成・操作             | Phase 2 (#1093) |
+| D1 (Edit)                           | Account                | D1 作成・マイグレーション・クエリ   | Phase 4 (#1090) |
+| Workers Tail / Observability (Read) | Account                | ログ・メトリクス確認                | デバッグ全般    |
+| Cloudflare Pages (Edit)             | Account                | 既存 Pages deploy（移行完了まで）   | Phase 3 まで    |
+| DNS (Edit)                          | Zone (`zedi-note.app`) | `custom_domain` による DNS 自動作成 | Phase 2〜3      |
+| Workers Routes (Edit)               | Zone (`zedi-note.app`) | カスタムドメインのルート設定        | Phase 2〜3      |
+
+## 注意 / Notes
+
+- トークンは最小権限から始め、フェーズ進行に合わせて拡張する。
+- ローカルでは `.env.local`（gitignore）に置く。リポジトリにはコミットしない。
+- `wrangler whoami` で有効性とアカウント ID を確認できる。
+- 既存 `TF_API_TOKEN`（Terraform Cloud 用）は Phase 5 で GitHub Secrets から削除する。

--- a/.agents/skills/hono/SKILL.md
+++ b/.agents/skills/hono/SKILL.md
@@ -1,0 +1,579 @@
+---
+name: hono
+description: Use when building Hono web applications or when the user asks about Hono APIs, routing, middleware, JSX, validation, testing, or streaming. TRIGGER when code imports from 'hono' or 'hono/*', or user mentions Hono. Use `npx hono request` to test endpoints.
+---
+
+# Hono Skill
+
+Build Hono web applications. This skill provides inline API knowledge for AI. Use `npx hono request` to test endpoints. If the `hono-docs` MCP server is configured, prefer its tools for the latest documentation over the inline reference.
+
+## Hono CLI Usage
+
+### Request Testing
+
+Test endpoints without starting an HTTP server. Uses `app.request()` internally.
+
+```bash
+# GET request
+npx hono request [file] -P /path
+
+# POST request with JSON body
+npx hono request [file] -X POST -P /api/users -d '{"name": "test"}'
+```
+
+**Note:** Do not pass credentials directly in CLI arguments. Use environment variables for sensitive values. `hono request` does not support Cloudflare Workers bindings (KV, D1, R2, etc.). When bindings are required, use `workers-fetch` instead:
+
+```bash
+npx workers-fetch /path
+npx workers-fetch -X POST -H "Content-Type:application/json" -d '{"name":"test"}' /api/users
+```
+
+---
+
+## Hono API Reference
+
+### App Constructor
+
+```ts
+import { Hono } from "hono";
+
+const app = new Hono();
+
+// With TypeScript generics
+type Env = {
+  Bindings: { DATABASE: D1Database; KV: KVNamespace };
+  Variables: { user: User };
+};
+const app = new Hono<Env>();
+```
+
+### Routing Methods
+
+```ts
+app.get("/path", handler);
+app.post("/path", handler);
+app.put("/path", handler);
+app.delete("/path", handler);
+app.patch("/path", handler);
+app.options("/path", handler);
+app.all("/path", handler); // all HTTP methods
+app.on("PURGE", "/path", handler); // custom method
+app.on(["PUT", "DELETE"], "/path", handler); // multiple methods
+```
+
+### Routing Patterns
+
+```ts
+// Path parameters
+app.get("/user/:name", (c) => {
+  const name = c.req.param("name");
+  return c.json({ name });
+});
+
+// Multiple params
+app.get("/posts/:id/comments/:commentId", (c) => {
+  const { id, commentId } = c.req.param();
+});
+
+// Optional parameters
+app.get("/api/animal/:type?", (c) => c.text("Animal!"));
+
+// Wildcards
+app.get("/wild/*/card", (c) => c.text("Wildcard"));
+
+// Regexp constraints
+app.get("/post/:date{[0-9]+}/:title{[a-z]+}", (c) => {
+  const { date, title } = c.req.param();
+});
+
+// Chained routes
+app
+  .get("/endpoint", (c) => c.text("GET"))
+  .post((c) => c.text("POST"))
+  .delete((c) => c.text("DELETE"));
+```
+
+### Route Grouping
+
+```ts
+// Using route()
+const api = new Hono();
+api.get("/users", (c) => c.json([]));
+
+const app = new Hono();
+app.route("/api", api); // mounts at /api/users
+
+// Using basePath()
+const app = new Hono().basePath("/api");
+app.get("/users", (c) => c.json([])); // GET /api/users
+```
+
+### Error Handling
+
+```ts
+app.notFound((c) => c.json({ message: "Not Found" }, 404));
+
+app.onError((err, c) => {
+  console.error(err);
+  return c.json({ message: "Internal Server Error" }, 500);
+});
+```
+
+---
+
+## Context (c)
+
+### Response Methods
+
+```ts
+c.text("Hello"); // text/plain
+c.json({ message: "Hello" }); // application/json
+c.html("<h1>Hello</h1>"); // text/html
+c.redirect("/new-path"); // 302 redirect
+c.redirect("/new-path", 301); // 301 redirect
+c.body("raw body", 200, headers); // raw response
+c.notFound(); // 404 response
+```
+
+### Headers & Status
+
+```ts
+c.status(201);
+c.header("X-Custom", "value");
+c.header("Cache-Control", "no-store");
+```
+
+### Variables (request-scoped data)
+
+```ts
+// In middleware
+c.set("user", { id: 1, name: "Alice" });
+
+// In handler
+const user = c.get("user");
+// or
+const user = c.var.user;
+```
+
+### Environment (Cloudflare Workers)
+
+```ts
+const value = await c.env.KV.get("key");
+const db = c.env.DATABASE;
+c.executionCtx.waitUntil(promise);
+```
+
+### Renderer
+
+```ts
+app.use(async (c, next) => {
+  c.setRenderer((content) =>
+    c.html(
+      <html><body>{content}</body></html>
+    )
+  )
+  await next()
+})
+
+app.get('/', (c) => c.render(<h1>Hello</h1>))
+```
+
+---
+
+## HonoRequest (c.req)
+
+```ts
+c.req.param("id"); // path parameter
+c.req.param(); // all path params as object
+c.req.query("page"); // query string parameter
+c.req.query(); // all query params as object
+c.req.queries("tags"); // multiple values: ?tags=A&tags=B → ['A', 'B']
+c.req.header("Authorization"); // request header
+c.req.header(); // all headers (keys are lowercase)
+
+// Body parsing
+await c.req.json(); // parse JSON body
+await c.req.text(); // parse text body
+await c.req.formData(); // parse as FormData
+await c.req.parseBody(); // parse multipart/form-data or urlencoded
+await c.req.arrayBuffer(); // parse as ArrayBuffer
+await c.req.blob(); // parse as Blob
+
+// Validated data (used with validator middleware)
+c.req.valid("json");
+c.req.valid("query");
+c.req.valid("form");
+c.req.valid("param");
+
+// Properties
+c.req.url; // full URL string
+c.req.path; // pathname
+c.req.method; // HTTP method
+c.req.raw; // underlying Request object
+```
+
+---
+
+## Middleware
+
+### Using Built-in Middleware
+
+```ts
+import { cors } from "hono/cors";
+import { logger } from "hono/logger";
+import { basicAuth } from "hono/basic-auth";
+import { prettyJSON } from "hono/pretty-json";
+import { secureHeaders } from "hono/secure-headers";
+import { etag } from "hono/etag";
+import { compress } from "hono/compress";
+import { poweredBy } from "hono/powered-by";
+import { timing } from "hono/timing";
+import { cache } from "hono/cache";
+import { bearerAuth } from "hono/bearer-auth";
+import { jwt } from "hono/jwt";
+import { csrf } from "hono/csrf";
+import { ipRestriction } from "hono/ip-restriction";
+import { bodyLimit } from "hono/body-limit";
+import { requestId } from "hono/request-id";
+import { methodOverride } from "hono/method-override";
+import { trailingSlash, trimTrailingSlash } from "hono/trailing-slash";
+
+// Registration
+app.use(logger()); // all routes
+app.use("/api/*", cors()); // specific path
+app.post("/api/*", basicAuth({ username: "admin", password: "secret" }));
+```
+
+### Custom Middleware
+
+```ts
+// Inline
+app.use(async (c, next) => {
+  const start = Date.now();
+  await next();
+  const elapsed = Date.now() - start;
+  c.res.headers.set("X-Response-Time", `${elapsed}ms`);
+});
+
+// Reusable with createMiddleware
+import { createMiddleware } from "hono/factory";
+
+const auth = createMiddleware(async (c, next) => {
+  const token = c.req.header("Authorization");
+  if (!token) return c.json({ error: "Unauthorized" }, 401);
+  await next();
+});
+
+app.use("/api/*", auth);
+```
+
+### Middleware Execution Order
+
+Middleware executes in registration order. `await next()` calls the next middleware/handler, and code after `next()` runs on the way back:
+
+```
+Request → mw1 before → mw2 before → handler → mw2 after → mw1 after → Response
+```
+
+```ts
+app.use(async (c, next) => {
+  // before handler
+  await next();
+  // after handler
+});
+```
+
+---
+
+## Validation
+
+Validation targets: `json`, `form`, `query`, `header`, `param`, `cookie`.
+
+### Zod Validator
+
+```ts
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+
+const schema = z.object({
+  title: z.string().min(1),
+  body: z.string(),
+});
+
+app.post("/posts", zValidator("json", schema), (c) => {
+  const data = c.req.valid("json"); // fully typed
+  return c.json(data, 201);
+});
+```
+
+### Valibot / Standard Schema Validator
+
+```ts
+import { sValidator } from "@hono/standard-validator";
+import * as v from "valibot";
+
+const schema = v.object({ name: v.string(), age: v.number() });
+
+app.post("/users", sValidator("json", schema), (c) => {
+  const data = c.req.valid("json");
+  return c.json(data, 201);
+});
+```
+
+---
+
+## JSX
+
+### Setup
+
+In `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx"
+  }
+}
+```
+
+Or use pragma: `/** @jsxImportSource hono/jsx */`
+
+**Important:** Files using JSX must have a `.tsx` extension. Rename `.ts` to `.tsx` or the compiler will fail.
+
+### Components
+
+```tsx
+import type { PropsWithChildren } from "hono/jsx";
+
+const Layout = (props: PropsWithChildren) => (
+  <html>
+    <head>
+      <title>My App</title>
+    </head>
+    <body>{props.children}</body>
+  </html>
+);
+
+const UserCard = ({ name }: { name: string }) => (
+  <div class="card">
+    <h2>{name}</h2>
+  </div>
+);
+
+app.get("/", (c) => {
+  return c.html(
+    <Layout>
+      <UserCard name="Alice" />
+    </Layout>,
+  );
+});
+```
+
+### jsxRenderer Middleware
+
+Use `jsxRenderer` middleware for layouts. See `npx hono docs /docs/middleware/builtin/jsx-renderer` for details.
+
+### Async Components
+
+```tsx
+const UserList = async () => {
+  const users = await fetchUsers();
+  return (
+    <ul>
+      {users.map((u) => (
+        <li>{u.name}</li>
+      ))}
+    </ul>
+  );
+};
+```
+
+### Fragments
+
+```tsx
+const Items = () => (
+  <>
+    <li>Item 1</li>
+    <li>Item 2</li>
+  </>
+);
+```
+
+---
+
+## Streaming
+
+```ts
+import { stream, streamText, streamSSE } from "hono/streaming";
+
+// Basic stream
+app.get("/stream", (c) => {
+  return stream(c, async (stream) => {
+    stream.onAbort(() => console.log("Aborted"));
+    await stream.write(new Uint8Array([0x48, 0x65]));
+    await stream.pipe(readableStream);
+  });
+});
+
+// Text stream
+app.get("/stream-text", (c) => {
+  return streamText(c, async (stream) => {
+    await stream.writeln("Hello");
+    await stream.sleep(1000);
+    await stream.write("World");
+  });
+});
+
+// Server-Sent Events
+app.get("/sse", (c) => {
+  return streamSSE(c, async (stream) => {
+    let id = 0;
+    while (true) {
+      await stream.writeSSE({
+        data: JSON.stringify({ time: new Date().toISOString() }),
+        event: "time-update",
+        id: String(id++),
+      });
+      await stream.sleep(1000);
+    }
+  });
+});
+```
+
+---
+
+## Testing with app.request()
+
+Test endpoints without starting an HTTP server:
+
+```ts
+// GET
+const res = await app.request("/posts");
+expect(res.status).toBe(200);
+expect(await res.json()).toEqual({ posts: [] });
+
+// POST with JSON
+const res = await app.request("/posts", {
+  method: "POST",
+  body: JSON.stringify({ title: "Hello" }),
+  headers: { "Content-Type": "application/json" },
+});
+
+// POST with FormData
+const formData = new FormData();
+formData.append("name", "Alice");
+const res = await app.request("/users", { method: "POST", body: formData });
+
+// With mock env (Cloudflare Workers bindings)
+const res = await app.request("/api/data", {}, { KV: mockKV, DATABASE: mockDB });
+
+// Using Request object
+const req = new Request("http://localhost/api", { method: "DELETE" });
+const res = await app.request(req);
+```
+
+---
+
+## Hono Client (RPC)
+
+Type-safe API client using shared types between server and client.
+
+**IMPORTANT: Routes MUST be chained for type inference to work. Without chaining, the client cannot infer route types.**
+
+```ts
+// Server: routes MUST be chained to preserve types
+const route = app
+  .post("/posts", zValidator("json", schema), (c) => {
+    return c.json({ ok: true }, 201);
+  })
+  .get("/posts", (c) => {
+    return c.json({ posts: [] });
+  });
+export type AppType = typeof route;
+
+// Client: use hc() with the exported type
+import { hc } from "hono/client";
+import type { AppType } from "./server";
+
+const client = hc<AppType>("http://localhost:8787/");
+const res = await client.posts.$post({ json: { title: "Hello" } });
+const data = await res.json(); // fully typed
+```
+
+Type utilities:
+
+```ts
+import type { InferRequestType, InferResponseType } from "hono/client";
+
+type ReqType = InferRequestType<typeof client.posts.$post>;
+type ResType = InferResponseType<typeof client.posts.$post, 200>;
+```
+
+---
+
+## Helpers
+
+Helpers are utility functions imported from `hono/<helper-name>`:
+
+```ts
+import { getConnInfo } from "hono/conninfo";
+import { getCookie, setCookie, deleteCookie } from "hono/cookie";
+import { css, Style } from "hono/css";
+import { createFactory } from "hono/factory";
+import { html, raw } from "hono/html";
+import { stream, streamText, streamSSE } from "hono/streaming";
+import { testClient } from "hono/testing";
+import { upgradeWebSocket } from "hono/cloudflare-workers"; // or other adapter
+```
+
+Available helpers: Accepts, Adapter, ConnInfo, Cookie, css, Dev, Factory, html, JWT, Proxy, Route, SSG, Streaming, Testing, WebSocket.
+
+For details, use `npx hono docs /docs/helpers/<helper-name>`.
+
+### Factory
+
+Use `createFactory` to define `Env` once and share it across app, middleware, and handlers:
+
+```ts
+import { createFactory } from "hono/factory";
+
+const factory = createFactory<Env>();
+
+// Create app (Env type is inherited)
+const app = factory.createApp();
+
+// Create middleware (Env type is inherited, no need to pass generics)
+const mw = factory.createMiddleware(async (c, next) => {
+  await next();
+});
+
+// Create handlers separately (preserves type inference)
+const handlers = factory.createHandlers(logger(), (c) => c.json({ message: "Hello" }));
+app.get("/api", ...handlers);
+```
+
+---
+
+## Best Practices
+
+- Write handlers inline in route definitions for proper type inference of path params.
+- Use `app.route()` to organize large apps by feature, not Rails-style controllers.
+- Use `createFactory()` to share Env type across app, middleware, and handlers.
+- Use `c.set()`/`c.get()` to pass data between middleware and handlers.
+- Chain validators for multiple request parts (param + query + json).
+- Export app type for RPC: `export type AppType = typeof routes`
+- Use `app.request()` for testing — no server startup needed.
+
+## Adapters
+
+Hono runs on multiple runtimes. The default export works for Cloudflare Workers, Deno, and Bun. For Node.js, use the Node adapter:
+
+```ts
+// Cloudflare Workers / Deno / Bun
+export default app;
+
+// Node.js
+import { serve } from "@hono/node-server";
+serve(app);
+```

--- a/.github/workflows/deploy-api-worker-dev.yml
+++ b/.github/workflows/deploy-api-worker-dev.yml
@@ -26,6 +26,11 @@ jobs:
           action: actions/checkout@v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          # server/api はルート workspace 外のため、ルート install は不要。
+          # server/api is outside the root workspace; skip root install.
+          install-deps: "false"
       - name: Install dependencies
         working-directory: server/api
         run: bun install --frozen-lockfile

--- a/.github/workflows/deploy-api-worker-dev.yml
+++ b/.github/workflows/deploy-api-worker-dev.yml
@@ -1,0 +1,54 @@
+name: Deploy API Worker (dev)
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "server/api/**"
+      - ".github/workflows/deploy-api-worker-dev.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  deploy-api-worker-dev:
+    name: Deploy zedi-api-dev Worker
+    runs-on: ubuntu-latest
+    environment: development
+    steps:
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
+        with:
+          action: actions/checkout@v7.0.0
+          attempt_limit: 3
+          attempt_delay: 5000
+      - name: Install dependencies
+        working-directory: server/api
+        run: bun install --frozen-lockfile
+      - name: Deploy to Cloudflare Workers (dev)
+        uses: nick-fields/retry@v4
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        with:
+          max_attempts: 3
+          timeout_minutes: 10
+          retry_wait_seconds: 60
+          command: >
+            cd server/api &&
+            bunx wrangler deploy --env dev
+            --var GIT_COMMIT_SHA:${{ github.sha }}
+            --var ENVIRONMENT:development
+      - name: Wait for Worker /api/health
+        if: ${{ vars.WORKER_API_BASE_URL != '' }}
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 10
+          timeout_minutes: 3
+          retry_wait_seconds: 20
+          command: |
+            curl --fail --show-error --silent "${{ vars.WORKER_API_BASE_URL }}/api/health"

--- a/server/api/.env.example
+++ b/server/api/.env.example
@@ -78,8 +78,10 @@ STORAGE_BUCKET_NAME=
 # Cloudflare Workers (#1091 Phase 2a): set via `wrangler secret put` (not in wrangler.jsonc).
 # Required for presigned upload URLs when using the R2 binding (S3 API credentials).
 # Also set DATABASE_URL, REDIS_URL, BETTER_AUTH_SECRET, BETTER_AUTH_URL, and other
-# server secrets on the Worker before dev/prod cutover. See `.agents/skills/cloudflare-zedi/`.
+# server secrets on the Worker before dev/prod cutover. See
+# `.agents/skills/cloudflare-zedi/references/secrets-template.md`.
 #
 # Workers (#1091 Phase 2a): `wrangler secret put <NAME> --env dev` で設定する。
 # R2 binding 利用時の presigned URL 用に STORAGE_* も Worker secrets へ。
 # DATABASE_URL / REDIS_URL / BETTER_AUTH_* 等も Worker 切替前に設定すること。
+# フェーズ別の登録・削除一覧は secrets-template.md を参照。

--- a/server/api/.env.example
+++ b/server/api/.env.example
@@ -74,3 +74,12 @@ STORAGE_ENDPOINT=
 STORAGE_ACCESS_KEY=
 STORAGE_SECRET_KEY=
 STORAGE_BUCKET_NAME=
+
+# Cloudflare Workers (#1091 Phase 2a): set via `wrangler secret put` (not in wrangler.jsonc).
+# Required for presigned upload URLs when using the R2 binding (S3 API credentials).
+# Also set DATABASE_URL, REDIS_URL, BETTER_AUTH_SECRET, BETTER_AUTH_URL, and other
+# server secrets on the Worker before dev/prod cutover. See `.agents/skills/cloudflare-zedi/`.
+#
+# Workers (#1091 Phase 2a): `wrangler secret put <NAME> --env dev` で設定する。
+# R2 binding 利用時の presigned URL 用に STORAGE_* も Worker secrets へ。
+# DATABASE_URL / REDIS_URL / BETTER_AUTH_* 等も Worker 切替前に設定すること。

--- a/server/api/.env.example
+++ b/server/api/.env.example
@@ -51,3 +51,26 @@ MONITORING_NOTIFY_EMAIL=
 # 32 raw bytes as Base64 or 64-char hex. Never commit the real value.
 # Wiki Compose BYOK 用。`user_ai_credentials` の at-rest 暗号化鍵（32 バイト）。
 USER_AI_CREDENTIALS_ENCRYPTION_KEY=
+
+# Object storage (media / thumbnails / PDF highlights). S3-compatible client
+# (`@aws-sdk/client-s3`) used by media.ts, thumbnail/serve.ts, commitService.ts,
+# thumbnailGcService.ts. All four share `region: "auto"` + `forcePathStyle: true`.
+#
+# Cloudflare R2 migration (#1089): R2 exposes an S3-compatible API, so these same
+# four vars point at R2 with no code change. Create the bucket (done: zedi-storage-dev
+# / zedi-storage-prod) and an R2 API token (dashboard → R2 → Manage R2 API Tokens),
+# then set the values below. The Worker R2 binding is introduced later when the API
+# moves to Workers (#1091, Phase 2); on Railway we use the S3 endpoint.
+#
+# オブジェクトストレージ（メディア / サムネイル / PDF ハイライト）。S3 互換クライアント。
+# Cloudflare R2 移行 (#1089): R2 は S3 互換 API を持つため、コード変更なしで下記 4 変数を
+# R2 に向けるだけで切替できる。バケット（作成済み: zedi-storage-dev / zedi-storage-prod）と
+# R2 API トークン（ダッシュボード → R2 → Manage R2 API Tokens）を用意して値を設定する。
+# Worker の R2 バインディングは API の Workers 化 (#1091, Phase 2) で導入する。
+#
+# - R2 endpoint: https://<CLOUDFLARE_ACCOUNT_ID>.r2.cloudflarestorage.com
+# - Bucket: zedi-storage-dev (development) / zedi-storage-prod (production)
+STORAGE_ENDPOINT=
+STORAGE_ACCESS_KEY=
+STORAGE_SECRET_KEY=
+STORAGE_BUCKET_NAME=

--- a/server/api/bun.lock
+++ b/server/api/bun.lock
@@ -42,6 +42,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250625.0",
         "@types/jsdom": "^28.0.0",
         "@types/node": "^26.0.1",
         "@types/pg": "^8.18.0",
@@ -53,6 +54,7 @@
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
         "vitest": "4.1.9",
+        "wrangler": "^4.71.0",
       },
     },
   },
@@ -189,6 +191,24 @@
 
     "@chevrotain/utils": ["@chevrotain/utils@10.5.0", "", {}, "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ=="],
 
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260625.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-naCfBv0WnnTQIQPTniqMoUlklOIFjrAcSn1X+IAOhY8aFLF/xGYtFjs1eEE8sFib3ZuChGGpU23FFORVczqr0A=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260625.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jmH6zjp6Wrux46+qtFwDwrj+vd7s5bdwEqeGvdnwE0a4IEeAhKs0L42HQOyID+g5lkrHq9m55+AbhtmRAm63Pw=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260625.1", "", { "os": "linux", "cpu": "x64" }, "sha512-MiQkpA/dX8d83Zp64pzHUKfd6ca4cvwxnNobSP6CnXvfESvnNI9pfa+nfwnParla36sPmnYntNkjR7NjRuDeKQ=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260625.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-LxxW7Qv60Xvv37+w6gUSDpYZziyqMy+cZWd9IvSA5ehVgKAxmzEaYPMiSZlxk32nbIWL9u/tfjXYCOKJ4Lo+XQ=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260625.1", "", { "os": "win32", "cpu": "x64" }, "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260629.1", "", {}, "sha512-5vq2ErIFVRSQ8Dcw5YOeEoBdZBudqBjHFKTWD3SBGiJR5hD1+/86aRUV/DTpEK9sXXCGOTGgpWBGlPSlW7djVg=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 
     "@csstools/css-calc": ["@csstools/css-calc@3.1.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ=="],
@@ -208,6 +228,8 @@
     "@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.0.20", "", { "peerDependencies": { "@electric-sql/pglite": "0.3.15" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg=="],
 
     "@electric-sql/pglite-tools": ["@electric-sql/pglite-tools@0.2.20", "", { "peerDependencies": { "@electric-sql/pglite": "0.3.15" } }, "sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
@@ -272,6 +294,56 @@
     "@google/generative-ai": ["@google/generative-ai@0.24.1", "", {}, "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q=="],
 
     "@hono/node-server": ["@hono/node-server@2.0.0", "", { "peerDependencies": { "hono": "^4" } }, "sha512-n3GfHwwCvHCkGmOwKfxUPOlbfzuO64Sbc5XC4NGPIXxkuOnJrdgExdRKmHfF924r914WRJPT397GdqLvdYTeyQ=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
 
@@ -366,6 +438,12 @@
     "@opentelemetry/sql-common": ["@opentelemetry/sql-common@0.41.2", "", { "dependencies": { "@opentelemetry/core": "^2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0" } }, "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ=="],
 
     "@polar-sh/sdk": ["@polar-sh/sdk@0.48.0", "", { "dependencies": { "standardwebhooks": "^1.0.0", "zod": "^3.25.65 || ^4.0.0" } }, "sha512-2NOr+VBh/wfHMpeWySjHJ5TKHF5SIfktrIabR3y7QNnYn7ew3BlYIgiklV+dYTngS8zLIIxc41KrfylUf38c4g=="],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
     "@prisma/client": ["@prisma/client@7.4.2", "", { "dependencies": { "@prisma/client-runtime-utils": "7.4.2" }, "peerDependencies": { "prisma": "*", "typescript": ">=5.4.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-ts2mu+cQHriAhSxngO3StcYubBGTWDtu/4juZhXCUKOwgh26l+s4KD3vT2kMUzFyrYnll9u/3qWrtzRv9CGWzA=="],
 
@@ -495,6 +573,8 @@
 
     "@sentry/opentelemetry": ["@sentry/opentelemetry@10.51.0", "", { "dependencies": { "@sentry/core": "10.51.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-Qc7AlCE4uhB+SvHLqah4RgR1WdY7wmmr/hx9g/prDP9R1ocshmUEMrZK9qjuwaklW7/fmkFCXI8ETxo5L1bHIA=="],
 
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
     "@smithy/abort-controller": ["@smithy/abort-controller@4.2.11", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ=="],
 
     "@smithy/chunked-blob-reader": ["@smithy/chunked-blob-reader@5.2.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-y5d4xRiD6TzeP5BWlb+Ig/VFqF+t9oANNhGeMqyzU7obw7FYgTgVi50i5JqBTeKp+TABeDIeeXFZdz65RipNtA=="],
@@ -596,6 +676,8 @@
     "@smithy/util-waiter": ["@smithy/util-waiter@4.2.10", "", { "dependencies": { "@smithy/abort-controller": "^4.2.10", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-4eTWph/Lkg1wZEDAyObwme0kmhEb7J/JjibY2znJdrYRgKbKqB7YoEhhJVJ4R1g/SYih4zuwX7LpJaM8RsnTVg=="],
 
     "@smithy/uuid": ["@smithy/uuid@1.1.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
@@ -741,6 +823,8 @@
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
@@ -769,6 +853,8 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -795,6 +881,8 @@
 
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
@@ -816,6 +904,8 @@
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
@@ -913,6 +1003,8 @@
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
     "kysely": ["kysely@0.28.11", "", {}, "sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg=="],
 
     "langsmith": ["langsmith@0.7.2", "", { "dependencies": { "p-queue": "6.6.2" }, "peerDependencies": { "@opentelemetry/api": "*", "@opentelemetry/exporter-trace-otlp-proto": "*", "@opentelemetry/sdk-trace-base": "*", "openai": "*", "ws": ">=7" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/exporter-trace-otlp-proto", "@opentelemetry/sdk-trace-base", "openai", "ws"] }, "sha512-3dZUwQDJluxi2ih5eIygFODtlrQKrs3Tua0Ck3l+DAUkSGFkB1Dc0JPqkGbqiVSN+TQDElnkev/ydAOAz6jndA=="],
@@ -957,6 +1049,8 @@
 
     "meriyah": ["meriyah@6.1.4", "", {}, "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ=="],
 
+    "miniflare": ["miniflare@4.20260625.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260625.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-3kKXwRUObJsnBYPBgR0NiNZYKF/yv8GFyha1cx2EeAEraxNODgRVcyeRo+F1ok1tg5Mg7iUpOWSkknQTHuFhwA=="],
+
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
@@ -998,6 +1092,8 @@
     "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -1137,6 +1233,8 @@
 
     "set-cookie-parser": ["set-cookie-parser@3.0.1", "", {}, "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q=="],
 
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
@@ -1203,6 +1301,8 @@
 
     "undici-types": ["undici-types@7.24.3", "", {}, "sha512-frL/LoWYV3AWaHtW+Oa3oNLX1k6fVDBd/4gspN4nkRwzO9tRj/R1HzDQpyXnt0H/5DKHbFpdn2BktNQl1tbFYA=="],
 
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
     "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
@@ -1225,6 +1325,10 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
+    "workerd": ["workerd@1.20260625.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260625.1", "@cloudflare/workerd-darwin-arm64": "1.20260625.1", "@cloudflare/workerd-linux-64": "1.20260625.1", "@cloudflare/workerd-linux-arm64": "1.20260625.1", "@cloudflare/workerd-windows-64": "1.20260625.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-GApQvFX52SDM6L4u0+RRnUDB1wJOnEwoXjinkmOPtIyofWBxrlZckdegJSYc1leg++lLZ3+DQ4zMVmBqYVtzfA=="],
+
+    "wrangler": ["wrangler@4.105.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260625.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260625.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260625.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g=="],
+
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
@@ -1236,6 +1340,10 @@
     "y-protocols": ["y-protocols@1.0.7", "", { "dependencies": { "lib0": "^0.2.85" }, "peerDependencies": { "yjs": "^13.0.0" } }, "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw=="],
 
     "yjs": ["yjs@13.6.30", "", { "dependencies": { "lib0": "^0.2.99" } }, "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ=="],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
     "youtubei.js": ["youtubei.js@17.0.1", "", { "dependencies": { "@bufbuild/protobuf": "^2.0.0", "meriyah": "^6.1.4" } }, "sha512-1lO4b8UqMDzE0oh2qEGzbBOd4UYRdxn/4PdpRM7BGTHxM6ddsEsKZTu90jp8V9FHVgC2h1UirQyqoqLiKwl+Zg=="],
 
@@ -1315,6 +1423,8 @@
 
     "@better-auth/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@fastify/otel/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.212.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.212.0", "import-in-the-middle": "^2.0.6", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg=="],
@@ -1328,6 +1438,8 @@
     "@opentelemetry/instrumentation-http/@opentelemetry/core": ["@opentelemetry/core@2.6.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g=="],
 
     "@opentelemetry/instrumentation-pg/@types/pg": ["@types/pg@8.15.6", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ=="],
+
+    "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "@prisma/dev/@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
@@ -1447,6 +1559,10 @@
 
     "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "miniflare/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "miniflare/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "nypm/citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
 
     "pg/pg-protocol": ["pg-protocol@1.13.0", "", {}, "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="],
@@ -1456,6 +1572,8 @@
     "tsx/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "vite/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "wrangler/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
@@ -1678,6 +1796,58 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
+    "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "wrangler/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "wrangler/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "wrangler/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 

--- a/server/api/package.json
+++ b/server/api/package.json
@@ -15,7 +15,11 @@
     "inspect:ai-models-cost": "tsx scripts/inspect-ai-models-cost.ts",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "worker:dev": "wrangler dev --env dev",
+    "worker:deploy:dev": "wrangler deploy --env dev",
+    "worker:deploy:production": "wrangler deploy --env production",
+    "worker:types": "wrangler types"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1002.0",
@@ -55,6 +59,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250625.0",
     "@types/jsdom": "^28.0.0",
     "@types/node": "^26.0.1",
     "@types/pg": "^8.18.0",
@@ -65,6 +70,7 @@
     "drizzle-kit": "^0.31.10",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
-    "vitest": "4.1.9"
+    "vitest": "4.1.9",
+    "wrangler": "^4.71.0"
   }
 }

--- a/server/api/src/__tests__/lib/storage/parseHttpRangeToR2Range.test.ts
+++ b/server/api/src/__tests__/lib/storage/parseHttpRangeToR2Range.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { parseHttpRangeToR2Range } from "../../../lib/storage/r2StorageClient.js";
+
+describe("parseHttpRangeToR2Range", () => {
+  it("parses bytes=start-end into offset and length", () => {
+    expect(parseHttpRangeToR2Range("bytes=0-499")).toEqual({ offset: 0, length: 500 });
+    expect(parseHttpRangeToR2Range("bytes=500-999")).toEqual({ offset: 500, length: 500 });
+  });
+
+  it("parses bytes=start- into open-ended offset", () => {
+    expect(parseHttpRangeToR2Range("bytes=500-")).toEqual({ offset: 500 });
+  });
+
+  it("parses bytes=-suffix into suffix length", () => {
+    expect(parseHttpRangeToR2Range("bytes=-500")).toEqual({ suffix: 500 });
+  });
+
+  it("returns undefined for unsupported or invalid range headers", () => {
+    expect(parseHttpRangeToR2Range("bytes=0-499,500-999")).toBeUndefined();
+    expect(parseHttpRangeToR2Range("items=0-1")).toBeUndefined();
+    expect(parseHttpRangeToR2Range("bytes=10-5")).toBeUndefined();
+    expect(parseHttpRangeToR2Range("bytes=-0")).toBeUndefined();
+  });
+});

--- a/server/api/src/__tests__/routes/media.test.ts
+++ b/server/api/src/__tests__/routes/media.test.ts
@@ -65,6 +65,7 @@ vi.mock("@aws-sdk/s3-request-presigner", () => ({
 import { Hono } from "hono";
 import mediaRoutes from "../../routes/media.js";
 import { createMockDb } from "../createMockDb.js";
+import { createStorageClient } from "../../lib/storage/createStorageClient.js";
 
 const TEST_USER_ID = "user-test-123";
 const ATTACKER_ID = "attacker-456";
@@ -77,13 +78,18 @@ function authHeaders(userId = TEST_USER_ID) {
   };
 }
 
+function attachTestContext(app: Hono<AppEnv>, db: AppEnv["Variables"]["db"]): void {
+  app.use("*", async (c, next) => {
+    c.set("db", db);
+    c.set("storage", createStorageClient());
+    await next();
+  });
+}
+
 function createMediaApp(dbResults: unknown[]) {
   const { db } = createMockDb(dbResults);
   const app = new Hono<AppEnv>();
-  app.use("*", async (c, next) => {
-    c.set("db", db as unknown as AppEnv["Variables"]["db"]);
-    await next();
-  });
+  attachTestContext(app, db as unknown as AppEnv["Variables"]["db"]);
   app.route("/api/media", mediaRoutes);
   return app;
 }
@@ -416,10 +422,7 @@ describe("DELETE /api/media/:id — DB-first deletion order", () => {
     mockS3Send.mockResolvedValueOnce({});
     const { db, chains } = createMockDb([[mediaRow], [{ s3Key }]]);
     const app = new Hono<AppEnv>();
-    app.use("*", async (c, next) => {
-      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
-      await next();
-    });
+    attachTestContext(app, db as unknown as AppEnv["Variables"]["db"]);
     app.route("/api/media", mediaRoutes);
 
     const res = await app.request(`/api/media/${MEDIA_ID}`, {
@@ -440,10 +443,7 @@ describe("DELETE /api/media/:id — DB-first deletion order", () => {
     // Ownership changed between SELECT and DELETE; S3 must not be touched.
     const { db, chains } = createMockDb([[mediaRow], []]);
     const app = new Hono<AppEnv>();
-    app.use("*", async (c, next) => {
-      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
-      await next();
-    });
+    attachTestContext(app, db as unknown as AppEnv["Variables"]["db"]);
     app.route("/api/media", mediaRoutes);
 
     const res = await app.request(`/api/media/${MEDIA_ID}`, {
@@ -466,10 +466,7 @@ describe("DELETE /api/media/:id — DB-first deletion order", () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { db } = createMockDb([[mediaRow], [{ s3Key }]]);
     const app = new Hono<AppEnv>();
-    app.use("*", async (c, next) => {
-      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
-      await next();
-    });
+    attachTestContext(app, db as unknown as AppEnv["Variables"]["db"]);
     app.route("/api/media", mediaRoutes);
 
     const res = await app.request(`/api/media/${MEDIA_ID}`, {
@@ -489,10 +486,7 @@ describe("DELETE /api/media/:id — DB-first deletion order", () => {
     });
     const { db } = createMockDb([[mediaRow], [{ s3Key }]]);
     const app = new Hono<AppEnv>();
-    app.use("*", async (c, next) => {
-      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
-      await next();
-    });
+    attachTestContext(app, db as unknown as AppEnv["Variables"]["db"]);
     app.route("/api/media", mediaRoutes);
 
     const res = await app.request(`/api/media/${MEDIA_ID}`, {
@@ -507,10 +501,7 @@ describe("DELETE /api/media/:id — DB-first deletion order", () => {
   it("returns 403 when media belongs to another user (no storage call, no DB delete)", async () => {
     const { chains, db } = createMockDb([[{ ...mediaRow, ownerId: ATTACKER_ID }]]);
     const app = new Hono<AppEnv>();
-    app.use("*", async (c, next) => {
-      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
-      await next();
-    });
+    attachTestContext(app, db as unknown as AppEnv["Variables"]["db"]);
     app.route("/api/media", mediaRoutes);
 
     const res = await app.request(`/api/media/${MEDIA_ID}`, {
@@ -527,10 +518,7 @@ describe("DELETE /api/media/:id — DB-first deletion order", () => {
   it("returns 404 when media row is missing (no storage call, no DB delete)", async () => {
     const { chains, db } = createMockDb([[]]);
     const app = new Hono<AppEnv>();
-    app.use("*", async (c, next) => {
-      c.set("db", db as unknown as AppEnv["Variables"]["db"]);
-      await next();
-    });
+    attachTestContext(app, db as unknown as AppEnv["Variables"]["db"]);
     app.route("/api/media", mediaRoutes);
 
     const res = await app.request(`/api/media/${MEDIA_ID}`, {

--- a/server/api/src/__tests__/routes/thumbnail/commit.test.ts
+++ b/server/api/src/__tests__/routes/thumbnail/commit.test.ts
@@ -33,15 +33,31 @@ import { Hono } from "hono";
 import commitRoutes from "../../../routes/thumbnail/commit.js";
 import { errorHandler } from "../../../middleware/errorHandler.js";
 import { createMockDb } from "../../createMockDb.js";
+import { createStorageClient } from "../../../lib/storage/createStorageClient.js";
 
 const TEST_USER_ID = "user-thumb-1";
 const ORIGINAL_ENV = { ...process.env };
+
+function setStorageEnv(): void {
+  process.env.STORAGE_BUCKET_NAME = "test-bucket";
+  process.env.STORAGE_ENDPOINT = "http://localhost:9000";
+  process.env.STORAGE_ACCESS_KEY = "test-key";
+  process.env.STORAGE_SECRET_KEY = "test-secret";
+}
+
+function clearStorageEnv(): void {
+  delete process.env.STORAGE_BUCKET_NAME;
+  delete process.env.STORAGE_ENDPOINT;
+  delete process.env.STORAGE_ACCESS_KEY;
+  delete process.env.STORAGE_SECRET_KEY;
+}
 
 function createTestApp() {
   const { db } = createMockDb([]);
   const app = new Hono<AppEnv>();
   app.use("*", async (c, next) => {
     c.set("db", db as unknown as AppEnv["Variables"]["db"]);
+    c.set("storage", createStorageClient());
     await next();
   });
   app.onError(errorHandler);
@@ -59,7 +75,7 @@ function authHeaders(): Record<string, string> {
 beforeEach(() => {
   mockCommitImage.mockReset();
   process.env = { ...ORIGINAL_ENV };
-  process.env.STORAGE_BUCKET_NAME = "test-bucket";
+  setStorageEnv();
 });
 
 // process.env と vi.spyOn(...) を必ずクリーンアップする。
@@ -97,8 +113,8 @@ describe("POST /api/thumbnail/commit", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns 503 when STORAGE_BUCKET_NAME is not configured", async () => {
-    delete process.env.STORAGE_BUCKET_NAME;
+  it("returns 503 when storage is not configured", async () => {
+    clearStorageEnv();
     const app = createTestApp();
 
     const res = await app.request("/api/thumbnail/commit", {
@@ -140,6 +156,7 @@ describe("POST /api/thumbnail/commit", () => {
       TEST_USER_ID,
       "https://example.com/img.png",
       "https://example.com/fallback.png",
+      expect.anything(),
       expect.anything(),
     );
   });

--- a/server/api/src/__tests__/routes/thumbnail/serve.test.ts
+++ b/server/api/src/__tests__/routes/thumbnail/serve.test.ts
@@ -65,6 +65,7 @@ vi.mock("../../../services/thumbnailGcService.js", () => ({
 import { Hono } from "hono";
 import serveRoutes from "../../../routes/thumbnail/serve.js";
 import { createMockDb } from "../../createMockDb.js";
+import { createStorageClient } from "../../../lib/storage/createStorageClient.js";
 
 const TEST_USER_ID = "user-test-123";
 const ATTACKER_ID = "attacker-456";
@@ -75,6 +76,7 @@ function createServeApp(dbResults: unknown[] = []) {
   const app = new Hono<AppEnv>();
   app.use("*", async (c, next) => {
     c.set("db", mockDb.db as unknown as AppEnv["Variables"]["db"]);
+    c.set("storage", createStorageClient());
     await next();
   });
   app.route("/api/thumbnail/serve", serveRoutes);

--- a/server/api/src/__tests__/services/commitService.test.ts
+++ b/server/api/src/__tests__/services/commitService.test.ts
@@ -7,9 +7,10 @@
  * generation when the env is configured.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { StorageClient } from "../../lib/storage/types.js";
 
-const { mockS3Send, envMap } = vi.hoisted(() => ({
-  mockS3Send: vi.fn(),
+const { mockPutObject, envMap } = vi.hoisted(() => ({
+  mockPutObject: vi.fn(),
   envMap: {} as Record<string, string | undefined>,
 }));
 
@@ -21,19 +22,6 @@ vi.mock("../../lib/env.js", () => ({
   },
 }));
 
-vi.mock("@aws-sdk/client-s3", () => {
-  class MockS3Client {
-    send = (...args: unknown[]) => mockS3Send(...args);
-  }
-  function MockPutObjectCommand() {
-    /* stub */
-  }
-  return {
-    S3Client: MockS3Client,
-    PutObjectCommand: MockPutObjectCommand,
-  };
-});
-
 vi.mock("../../services/subscriptionService.js", () => ({
   getUserTier: vi.fn().mockResolvedValue("free"),
 }));
@@ -44,34 +32,32 @@ const TINY_PNG_BASE64 =
 const TEST_USER_ID = "user-test-123";
 const DATA_URI = `data:image/png;base64,${TINY_PNG_BASE64}`;
 
+function makeMockStorage(): StorageClient {
+  return {
+    putObject: mockPutObject,
+    getObject: vi.fn(),
+    headObject: vi.fn(),
+    deleteObject: vi.fn(),
+    getSignedPutUrl: vi.fn(),
+  };
+}
+
 function setBaseEnv() {
-  envMap.STORAGE_ENDPOINT = "http://localhost:9000";
-  envMap.STORAGE_ACCESS_KEY = "test-key";
-  envMap.STORAGE_SECRET_KEY = "test-secret";
-  envMap.STORAGE_BUCKET_NAME = "test-bucket";
   envMap.BETTER_AUTH_URL = "https://zedi.example.com";
-  process.env.STORAGE_BUCKET_NAME = "test-bucket";
 }
 
 function clearEnv() {
   for (const key of Object.keys(envMap)) {
     envMap[key] = undefined;
   }
-  process.env.STORAGE_BUCKET_NAME = undefined;
 }
 
 async function importCommitService() {
-  // 動的 import にして、モック適用後の最新モジュールを取得する。
-  // Use dynamic import so the module picks up our mocks.
   return await import("../../services/commitService.js");
 }
 
-function makeDbMock(tier: string, quotaBytes: number, usedBytes: number) {
-  // commitService は次の順番で DB を呼び出す:
-  // 1) getUserTier (モック済み、DB は使わない)
-  // 2) getStorageQuotaBytes: select().from().where().limit()
-  // 3) getStorageUsedBytes: select().from().where()
-  // 4) insert().values()
+function makeDbMock(_tier: string, quotaBytes: number, usedBytes: number) {
+  let selectCount = 0;
   const chain = (final: unknown) =>
     new Proxy(
       {},
@@ -84,21 +70,21 @@ function makeDbMock(tier: string, quotaBytes: number, usedBytes: number) {
         },
       },
     );
-
-  let call = 0;
   const db = new Proxy(
     {},
     {
       get(_, prop: string) {
-        return () => {
-          if (prop === "select") {
-            call++;
-            if (call === 1) return chain([{ storageLimitBytes: quotaBytes }]);
-            if (call === 2) return chain([{ sum: String(usedBytes) }]);
-          }
-          if (prop === "insert") return chain([]);
-          return chain([]);
-        };
+        if (prop === "select") {
+          return () => {
+            selectCount += 1;
+            if (selectCount === 1) {
+              return chain([{ storageLimitBytes: quotaBytes }]);
+            }
+            return chain([{ sum: String(usedBytes) }]);
+          };
+        }
+        if (prop === "insert") return () => chain([]);
+        return () => chain([]);
       },
     },
   );
@@ -108,8 +94,8 @@ function makeDbMock(tier: string, quotaBytes: number, usedBytes: number) {
 describe("commitImage — BETTER_AUTH_URL handling", () => {
   beforeEach(() => {
     clearEnv();
-    mockS3Send.mockReset();
-    mockS3Send.mockResolvedValue({});
+    mockPutObject.mockReset();
+    mockPutObject.mockResolvedValue(undefined);
     vi.resetModules();
   });
 
@@ -119,26 +105,26 @@ describe("commitImage — BETTER_AUTH_URL handling", () => {
 
     const { commitImage } = await importCommitService();
     const db = makeDbMock("free", 10 * 1024 * 1024, 0) as never;
+    const storage = makeMockStorage();
 
-    await expect(commitImage(TEST_USER_ID, DATA_URI, undefined, db)).rejects.toThrow(
+    await expect(commitImage(TEST_USER_ID, DATA_URI, undefined, db, storage)).rejects.toThrow(
       /Missing required env var: BETTER_AUTH_URL/,
     );
   });
 
-  it("BETTER_AUTH_URL 未設定時は S3 アップロード前に throw する / rejects before any S3 PUT when BETTER_AUTH_URL is unset", async () => {
+  it("BETTER_AUTH_URL 未設定時は storage 書き込み前に throw する / rejects before any storage PUT when BETTER_AUTH_URL is unset", async () => {
     setBaseEnv();
     envMap.BETTER_AUTH_URL = undefined;
 
     const { commitImage } = await importCommitService();
     const db = makeDbMock("free", 10 * 1024 * 1024, 0) as never;
+    const storage = makeMockStorage();
 
-    await expect(commitImage(TEST_USER_ID, DATA_URI, undefined, db)).rejects.toThrow(
+    await expect(commitImage(TEST_USER_ID, DATA_URI, undefined, db, storage)).rejects.toThrow(
       /Missing required env var: BETTER_AUTH_URL/,
     );
 
-    // オーファンオブジェクトを生まないために、S3 への PUT が一切発生していないこと。
-    // Verify we never hit S3 — otherwise a missing env leaves orphan objects.
-    expect(mockS3Send).not.toHaveBeenCalled();
+    expect(mockPutObject).not.toHaveBeenCalled();
   });
 
   it("BETTER_AUTH_URL が設定されていれば絶対 URL を返す / returns an absolute URL when BETTER_AUTH_URL is set", async () => {
@@ -146,8 +132,9 @@ describe("commitImage — BETTER_AUTH_URL handling", () => {
 
     const { commitImage } = await importCommitService();
     const db = makeDbMock("free", 10 * 1024 * 1024, 0) as never;
+    const storage = makeMockStorage();
 
-    const { imageUrl } = await commitImage(TEST_USER_ID, DATA_URI, undefined, db);
+    const { imageUrl } = await commitImage(TEST_USER_ID, DATA_URI, undefined, db, storage);
 
     expect(imageUrl).toMatch(/^https:\/\/zedi\.example\.com\/api\/thumbnail\/serve\/[0-9a-f-]+$/);
   });
@@ -158,8 +145,9 @@ describe("commitImage — BETTER_AUTH_URL handling", () => {
 
     const { commitImage } = await importCommitService();
     const db = makeDbMock("free", 10 * 1024 * 1024, 0) as never;
+    const storage = makeMockStorage();
 
-    const { imageUrl } = await commitImage(TEST_USER_ID, DATA_URI, undefined, db);
+    const { imageUrl } = await commitImage(TEST_USER_ID, DATA_URI, undefined, db, storage);
 
     expect(imageUrl.startsWith("https://zedi.example.com/api/thumbnail/serve/")).toBe(true);
     expect(imageUrl.startsWith("https://zedi.example.com//")).toBe(false);
@@ -170,8 +158,15 @@ describe("commitImage — BETTER_AUTH_URL handling", () => {
 
     const { commitImage } = await importCommitService();
     const db = makeDbMock("free", 10 * 1024 * 1024, 0) as never;
+    const storage = makeMockStorage();
 
-    const { imageUrl, objectId } = await commitImage(TEST_USER_ID, DATA_URI, undefined, db);
+    const { imageUrl, objectId } = await commitImage(
+      TEST_USER_ID,
+      DATA_URI,
+      undefined,
+      db,
+      storage,
+    );
 
     expect(objectId).toMatch(/^[0-9a-f-]+$/);
     expect(imageUrl.endsWith(`/api/thumbnail/serve/${objectId}`)).toBe(true);
@@ -181,8 +176,6 @@ describe("commitImage — BETTER_AUTH_URL handling", () => {
     setBaseEnv();
 
     const { commitImage } = await importCommitService();
-    // クォータ行が無い（rows[] = []）状態を再現する。
-    // Simulate the unseeded `thumbnail_tier_quotas` table.
     const db = new Proxy(
       {},
       {
@@ -208,8 +201,11 @@ describe("commitImage — BETTER_AUTH_URL handling", () => {
         },
       },
     ) as never;
+    const storage = makeMockStorage();
 
-    await expect(commitImage(TEST_USER_ID, DATA_URI, undefined, db)).resolves.toMatchObject({
+    await expect(
+      commitImage(TEST_USER_ID, DATA_URI, undefined, db, storage),
+    ).resolves.toMatchObject({
       objectId: expect.stringMatching(/^[0-9a-f-]+$/),
     });
   });

--- a/server/api/src/__tests__/services/thumbnailGcService.test.ts
+++ b/server/api/src/__tests__/services/thumbnailGcService.test.ts
@@ -1,47 +1,32 @@
 /**
  * `thumbnailGcService.deleteThumbnailObject` の振る舞いを検証する。
  * 所有者一致時に限り、ライブページの参照ガードを通過した場合だけ
- * DB → S3 の順で削除し、参照中なら `referenced` を返して削除を拒否、
+ * DB → storage の順で削除し、参照中なら `referenced` を返して削除を拒否、
  * 行が無ければ `not_found` を返すことを確認する。
  *
  * Tests for `thumbnailGcService.deleteThumbnailObject`: deletes the DB row
- * and S3 object only when (a) the owner predicate matches and (b) no
+ * and storage object only when (a) the owner predicate matches and (b) no
  * non-deleted `pages` row still references the thumbnail. Returns
  * `not_found` for missing/foreign rows, `referenced` when a live page row
- * still points at the object (issue #820), and swallows S3 failures so
+ * still points at the object (issue #820), and swallows storage failures so
  * callers can treat GC as best-effort.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createMockDb } from "../createMockDb.js";
+import type { StorageClient } from "../../lib/storage/types.js";
 
-const { mockS3Send, envMap } = vi.hoisted(() => ({
-  mockS3Send: vi.fn(),
-  envMap: {} as Record<string, string | undefined>,
+const { mockDeleteObject } = vi.hoisted(() => ({
+  mockDeleteObject: vi.fn(),
 }));
 
-vi.mock("../../lib/env.js", () => ({
-  getEnv: (key: string) => {
-    const value = envMap[key];
-    if (!value) throw new Error(`Missing required env var: ${key}`);
-    return value;
-  },
-}));
-
-vi.mock("@aws-sdk/client-s3", () => {
-  class MockS3Client {
-    send = (...args: unknown[]) => mockS3Send(...args);
-  }
-  function MockDeleteObjectCommand(input: unknown) {
-    return input;
-  }
-  return { S3Client: MockS3Client, DeleteObjectCommand: MockDeleteObjectCommand };
-});
-
-function setBaseEnv() {
-  envMap.STORAGE_ENDPOINT = "http://localhost:9000";
-  envMap.STORAGE_ACCESS_KEY = "test-key";
-  envMap.STORAGE_SECRET_KEY = "test-secret";
-  envMap.STORAGE_BUCKET_NAME = "test-bucket";
+function makeMockStorage(): StorageClient {
+  return {
+    putObject: vi.fn(),
+    getObject: vi.fn(),
+    headObject: vi.fn(),
+    deleteObject: mockDeleteObject,
+    getSignedPutUrl: vi.fn(),
+  };
 }
 
 async function importGcService() {
@@ -50,112 +35,105 @@ async function importGcService() {
 
 describe("deleteThumbnailObject", () => {
   beforeEach(() => {
-    setBaseEnv();
-    mockS3Send.mockReset();
-    mockS3Send.mockResolvedValue({});
+    mockDeleteObject.mockReset();
+    mockDeleteObject.mockResolvedValue(undefined);
     vi.resetModules();
   });
 
-  // 各テスト後に console spy を確実に元に戻す。これを忘れると前のテストで貼った
-  // `console.error` spy が次のテストの呼び出し履歴に紛れ込み、誤検知する。
-  // Restore console spies between tests; otherwise a spy from one case leaks
-  // its call history into the next one and produces false negatives.
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("削除成功時は 'deleted' を返し S3 も削除する / returns 'deleted' and removes S3 object", async () => {
+  it("削除成功時は 'deleted' を返し storage も削除する / returns 'deleted' and removes storage object", async () => {
     const { deleteThumbnailObject } = await importGcService();
-    // [ownership SELECT] [referrer SELECT — empty] [DELETE returning]
+    const storage = makeMockStorage();
     const { db } = createMockDb([
       [{ id: "obj-1" }],
       [],
       [{ s3Key: "users/u1/thumbnails/abc.png" }],
     ]);
 
-    await expect(deleteThumbnailObject("obj-1", "u1", db as never)).resolves.toBe("deleted");
-    expect(mockS3Send).toHaveBeenCalledTimes(1);
+    await expect(deleteThumbnailObject("obj-1", "u1", db as never, storage)).resolves.toBe(
+      "deleted",
+    );
+    expect(mockDeleteObject).toHaveBeenCalledTimes(1);
   });
 
-  it("所有者不一致なら 'not_found' を返し参照チェックも S3 も呼ばない / returns 'not_found' on ownership mismatch", async () => {
+  it("所有者不一致なら 'not_found' を返し参照チェックも storage も呼ばない / returns 'not_found' on ownership mismatch", async () => {
     const { deleteThumbnailObject } = await importGcService();
+    const storage = makeMockStorage();
     const { db, chains } = createMockDb([[]]);
 
-    await expect(deleteThumbnailObject("obj-foreign", "u1", db as never)).resolves.toBe(
+    await expect(deleteThumbnailObject("obj-foreign", "u1", db as never, storage)).resolves.toBe(
       "not_found",
     );
-    expect(mockS3Send).not.toHaveBeenCalled();
-    // ownership SELECT のみで終わる。参照チェックや DELETE は実行しない。
-    // We stop after the ownership SELECT — no reference check or DELETE issued.
+    expect(mockDeleteObject).not.toHaveBeenCalled();
     expect(chains.filter((c) => c.startMethod === "delete")).toHaveLength(0);
   });
 
   it("生きているページが参照していれば 'referenced' を返し DELETE を発行しない / refuses delete when a live page references the thumbnail", async () => {
     const { deleteThumbnailObject } = await importGcService();
-    // [ownership SELECT — found] [referrer SELECT — one live page]
+    const storage = makeMockStorage();
     const { db, chains } = createMockDb([[{ id: "obj-2" }], [{ id: "page-live-1" }]]);
 
-    await expect(deleteThumbnailObject("obj-2", "u1", db as never)).resolves.toBe("referenced");
-    expect(mockS3Send).not.toHaveBeenCalled();
+    await expect(deleteThumbnailObject("obj-2", "u1", db as never, storage)).resolves.toBe(
+      "referenced",
+    );
+    expect(mockDeleteObject).not.toHaveBeenCalled();
     expect(chains.filter((c) => c.startMethod === "delete")).toHaveLength(0);
   });
 
   it("他ユーザーのページが参照していてもブロックしない / foreign-owner referrer does not block deletion", async () => {
-    // 第三者が `POST /api/pages` 経由で他人の `thumbnail_object_id` を指す
-    // ダミーページを作成しても、参照ガードは所有者一致行のみを見るので
-    // 被害者の DELETE は成功する。owner predicate が WHERE から外れている
-    // と、攻撃者がガードを永久に発火させて被害者の容量枠を消費し続ける
-    // DoS が成立してしまう（PR #839 のレビュー指摘）。
-    //
-    // A third party who plants a page that references another user's
-    // thumbnail (POST /api/pages currently doesn't validate thumbnail
-    // ownership) must not be able to lock the victim's GC. The guard
-    // scopes its referrer SELECT to `pages.owner_id = userId`, so the
-    // referrer SELECT here returns empty for the victim and the DELETE
-    // proceeds. Without the owner predicate this would degenerate into a
-    // permanent quota-burning DoS.
     const { deleteThumbnailObject } = await importGcService();
-    // [ownership SELECT — found] [referrer SELECT — empty (owner-scoped)] [DELETE returning]
+    const storage = makeMockStorage();
     const { db } = createMockDb([
       [{ id: "obj-foreign-ref" }],
       [],
       [{ s3Key: "users/u1/thumbnails/z.png" }],
     ]);
 
-    await expect(deleteThumbnailObject("obj-foreign-ref", "u1", db as never)).resolves.toBe(
-      "deleted",
-    );
-    expect(mockS3Send).toHaveBeenCalledTimes(1);
+    await expect(
+      deleteThumbnailObject("obj-foreign-ref", "u1", db as never, storage),
+    ).resolves.toBe("deleted");
+    expect(mockDeleteObject).toHaveBeenCalledTimes(1);
   });
 
-  it("DELETE が 0 行返したら 'not_found' に縮退して S3 を呼ばない / DELETE returning 0 rows collapses to 'not_found'", async () => {
+  it("DELETE が 0 行返したら 'not_found' に縮退して storage を呼ばない / DELETE returning 0 rows collapses to 'not_found'", async () => {
     const { deleteThumbnailObject } = await importGcService();
-    // [ownership SELECT — found] [referrer SELECT — empty] [DELETE — 0 rows]
+    const storage = makeMockStorage();
     const { db } = createMockDb([[{ id: "obj-3" }], [], []]);
 
-    await expect(deleteThumbnailObject("obj-3", "u1", db as never)).resolves.toBe("not_found");
-    expect(mockS3Send).not.toHaveBeenCalled();
+    await expect(deleteThumbnailObject("obj-3", "u1", db as never, storage)).resolves.toBe(
+      "not_found",
+    );
+    expect(mockDeleteObject).not.toHaveBeenCalled();
   });
 
-  it("S3 削除失敗は飲み込んで throw しない / swallows S3 errors (best-effort GC)", async () => {
+  it("storage 削除失敗は飲み込んで throw しない / swallows storage errors (best-effort GC)", async () => {
     const { deleteThumbnailObject } = await importGcService();
+    const storage = makeMockStorage();
     const { db } = createMockDb([[{ id: "obj-4" }], [], [{ s3Key: "users/u1/thumbnails/x.png" }]]);
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const s3Err = Object.assign(new Error("network"), { name: "TimeoutError" });
-    mockS3Send.mockRejectedValueOnce(s3Err);
+    const storageErr = Object.assign(new Error("network"), { name: "TimeoutError" });
+    mockDeleteObject.mockRejectedValueOnce(storageErr);
 
-    await expect(deleteThumbnailObject("obj-4", "u1", db as never)).resolves.toBe("deleted");
+    await expect(deleteThumbnailObject("obj-4", "u1", db as never, storage)).resolves.toBe(
+      "deleted",
+    );
     expect(errorSpy).toHaveBeenCalled();
   });
 
   it("NoSuchKey は冪等としてログ抑制 / NoSuchKey is treated as idempotent (no log)", async () => {
     const { deleteThumbnailObject } = await importGcService();
+    const storage = makeMockStorage();
     const { db } = createMockDb([[{ id: "obj-5" }], [], [{ s3Key: "users/u1/thumbnails/y.png" }]]);
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const noSuchKey = Object.assign(new Error("missing"), { name: "NoSuchKey" });
-    mockS3Send.mockRejectedValueOnce(noSuchKey);
+    mockDeleteObject.mockRejectedValueOnce(noSuchKey);
 
-    await expect(deleteThumbnailObject("obj-5", "u1", db as never)).resolves.toBe("deleted");
+    await expect(deleteThumbnailObject("obj-5", "u1", db as never, storage)).resolves.toBe(
+      "deleted",
+    );
     expect(errorSpy).not.toHaveBeenCalled();
   });
 });

--- a/server/api/src/app.ts
+++ b/server/api/src/app.ts
@@ -5,6 +5,7 @@ import { errorHandler } from "./middleware/errorHandler.js";
 import { csrfOriginCheck } from "./middleware/csrfOrigin.js";
 import { dbMiddleware } from "./middleware/db.js";
 import { redisMiddleware } from "./middleware/redis.js";
+import { storageMiddleware } from "./middleware/storage.js";
 import { auth } from "./auth.js";
 import type { AppEnv } from "./types/index.js";
 
@@ -92,6 +93,7 @@ export function createApp(): Hono<AppEnv> {
   app.use("*", csrfOriginCheck);
   app.use("*", dbMiddleware);
   app.use("*", redisMiddleware);
+  app.use("*", storageMiddleware);
   app.onError(errorHandler);
 
   // Better Auth の magicLink プラグインは `POST /api/auth/sign-in/magic-link` を

--- a/server/api/src/lib/storage/createStorageClient.ts
+++ b/server/api/src/lib/storage/createStorageClient.ts
@@ -1,0 +1,29 @@
+import type { CloudflareBindings } from "../../types/cloudflare.js";
+import { createR2StorageClient } from "./r2StorageClient.js";
+import { S3StorageClient } from "./s3StorageClient.js";
+import type { StorageClient } from "./types.js";
+
+/**
+ * Whether object storage is configured for the current runtime.
+ * 現在のランタイムでオブジェクトストレージが設定済みか。
+ */
+export function isStorageConfigured(bindings?: Partial<CloudflareBindings>): boolean {
+  if (bindings?.STORAGE_BUCKET) return true;
+  return Boolean(
+    process.env.STORAGE_BUCKET_NAME &&
+    process.env.STORAGE_ENDPOINT &&
+    process.env.STORAGE_ACCESS_KEY &&
+    process.env.STORAGE_SECRET_KEY,
+  );
+}
+
+/**
+ * Creates a storage client: R2 binding on Workers when available, else S3-compatible env.
+ * ストレージクライアントを生成（Workers では R2 binding、それ以外は S3 互換 env）。
+ */
+export function createStorageClient(bindings?: Partial<CloudflareBindings>): StorageClient {
+  if (bindings?.STORAGE_BUCKET) {
+    return createR2StorageClient(bindings.STORAGE_BUCKET);
+  }
+  return new S3StorageClient();
+}

--- a/server/api/src/lib/storage/index.ts
+++ b/server/api/src/lib/storage/index.ts
@@ -1,0 +1,4 @@
+export type { StorageClient, StorageGetObjectResult, StorageHeadObjectResult } from "./types.js";
+export { createStorageClient, isStorageConfigured } from "./createStorageClient.js";
+export { S3StorageClient, getS3Client, resetS3ClientCacheForTests } from "./s3StorageClient.js";
+export { R2StorageClient, createR2StorageClient } from "./r2StorageClient.js";

--- a/server/api/src/lib/storage/r2StorageClient.ts
+++ b/server/api/src/lib/storage/r2StorageClient.ts
@@ -2,6 +2,39 @@ import type { StorageClient, StorageGetObjectResult, StorageHeadObjectResult } f
 import { S3StorageClient } from "./s3StorageClient.js";
 
 /**
+ * Parses an HTTP `Range: bytes=...` header into Cloudflare R2's `R2Range` shape.
+ * HTTP Range ヘッダを R2 の `R2Range` に変換する。
+ */
+export function parseHttpRangeToR2Range(rangeHeader: string): R2Range | undefined {
+  const trimmed = rangeHeader.trim();
+  const match = /^bytes=(\d*)-(\d*)$/i.exec(trimmed);
+  if (!match) return undefined;
+
+  const [, startStr, endStr] = match;
+
+  if (startStr === "" && endStr !== "") {
+    const suffix = Number(endStr);
+    if (!Number.isFinite(suffix) || suffix <= 0) return undefined;
+    return { suffix };
+  }
+
+  if (startStr !== "") {
+    const offset = Number(startStr);
+    if (!Number.isFinite(offset) || offset < 0) return undefined;
+
+    if (endStr === "") {
+      return { offset };
+    }
+
+    const end = Number(endStr);
+    if (!Number.isFinite(end) || end < offset) return undefined;
+    return { offset, length: end - offset + 1 };
+  }
+
+  return undefined;
+}
+
+/**
  * R2 binding adapter: server-side ops use the binding; presigned URLs use the S3 API.
  * R2 バインディングアダプタ: サーバ側操作は binding、presigned URL は S3 API。
  */
@@ -22,8 +55,12 @@ export class R2StorageClient implements StorageClient {
   }
 
   async getObject(params: { key: string; range?: string }): Promise<StorageGetObjectResult> {
+    const r2Range = params.range ? parseHttpRangeToR2Range(params.range) : undefined;
+    if (params.range && !r2Range) {
+      throw Object.assign(new Error("Invalid range"), { name: "InvalidRange" });
+    }
     const object = await this.bucket.get(params.key, {
-      ...(params.range ? { range: params.range } : {}),
+      ...(r2Range ? { range: r2Range } : {}),
     });
     if (!object) {
       throw Object.assign(new Error("Object not found"), { name: "NoSuchKey" });

--- a/server/api/src/lib/storage/r2StorageClient.ts
+++ b/server/api/src/lib/storage/r2StorageClient.ts
@@ -1,0 +1,75 @@
+import type { StorageClient, StorageGetObjectResult, StorageHeadObjectResult } from "./types.js";
+import { S3StorageClient } from "./s3StorageClient.js";
+
+/**
+ * R2 binding adapter: server-side ops use the binding; presigned URLs use the S3 API.
+ * R2 バインディングアダプタ: サーバ側操作は binding、presigned URL は S3 API。
+ */
+export class R2StorageClient implements StorageClient {
+  constructor(
+    private readonly bucket: R2Bucket,
+    private readonly presignClient: StorageClient,
+  ) {}
+
+  async putObject(params: {
+    key: string;
+    body: Uint8Array | Buffer;
+    contentType?: string;
+  }): Promise<void> {
+    await this.bucket.put(params.key, params.body, {
+      httpMetadata: params.contentType ? { contentType: params.contentType } : undefined,
+    });
+  }
+
+  async getObject(params: { key: string; range?: string }): Promise<StorageGetObjectResult> {
+    const object = await this.bucket.get(params.key, {
+      ...(params.range ? { range: params.range } : {}),
+    });
+    if (!object) {
+      throw Object.assign(new Error("Object not found"), { name: "NoSuchKey" });
+    }
+    const body = object.body;
+    if (!body) {
+      throw new Error("Object not found");
+    }
+    let contentRange: string | undefined;
+    const range = object.range;
+    if (range && "offset" in range && range.offset !== undefined && range.length !== undefined) {
+      contentRange = `bytes ${range.offset}-${range.offset + range.length - 1}/${object.size}`;
+    }
+    return {
+      body,
+      contentType: object.httpMetadata?.contentType,
+      contentLength: object.size,
+      contentRange,
+    };
+  }
+
+  async headObject(params: { key: string }): Promise<StorageHeadObjectResult> {
+    const head = await this.bucket.head(params.key);
+    if (!head) {
+      throw Object.assign(new Error("Object not found"), { name: "NotFound" });
+    }
+    return {
+      contentLength: head.size,
+      contentType: head.httpMetadata?.contentType,
+    };
+  }
+
+  async deleteObject(params: { key: string }): Promise<void> {
+    await this.bucket.delete(params.key);
+  }
+
+  async getSignedPutUrl(params: {
+    key: string;
+    contentType: string;
+    expiresInSeconds: number;
+  }): Promise<string> {
+    return this.presignClient.getSignedPutUrl(params);
+  }
+}
+
+/** Creates an R2 binding client with S3 presign fallback. / R2 binding + S3 presign フォールバック。 */
+export function createR2StorageClient(bucket: R2Bucket): StorageClient {
+  return new R2StorageClient(bucket, new S3StorageClient());
+}

--- a/server/api/src/lib/storage/s3StorageClient.ts
+++ b/server/api/src/lib/storage/s3StorageClient.ts
@@ -1,0 +1,114 @@
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+  HeadObjectCommand,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { getEnv } from "../env.js";
+import type { StorageClient, StorageGetObjectResult, StorageHeadObjectResult } from "./types.js";
+
+let _client: S3Client | null = null;
+let _bucketName: string | null = null;
+
+/**
+ * Returns a lazily initialized S3-compatible client from `STORAGE_*` env vars.
+ * `STORAGE_*` 環境変数から S3 互換クライアントを遅延初期化して返す。
+ */
+export function getS3Client(): S3Client {
+  if (!_client) {
+    _client = new S3Client({
+      endpoint: getEnv("STORAGE_ENDPOINT"),
+      region: "auto",
+      credentials: {
+        accessKeyId: getEnv("STORAGE_ACCESS_KEY"),
+        secretAccessKey: getEnv("STORAGE_SECRET_KEY"),
+      },
+      forcePathStyle: true,
+    });
+  }
+  return _client;
+}
+
+/** Resets cached client (tests only). / キャッシュクライアントをリセット（テスト用）。 */
+export function resetS3ClientCacheForTests(): void {
+  _client = null;
+  _bucketName = null;
+}
+
+function getBucketName(): string {
+  if (!_bucketName) _bucketName = getEnv("STORAGE_BUCKET_NAME");
+  return _bucketName;
+}
+
+/**
+ * S3-compatible storage client (MinIO / Wasabi / Cloudflare R2 S3 API).
+ * S3 互換ストレージクライアント。
+ */
+export class S3StorageClient implements StorageClient {
+  async putObject(params: {
+    key: string;
+    body: Uint8Array | Buffer;
+    contentType?: string;
+  }): Promise<void> {
+    await getS3Client().send(
+      new PutObjectCommand({
+        Bucket: getBucketName(),
+        Key: params.key,
+        Body: params.body,
+        ContentType: params.contentType,
+      }),
+    );
+  }
+
+  async getObject(params: { key: string; range?: string }): Promise<StorageGetObjectResult> {
+    const response = await getS3Client().send(
+      new GetObjectCommand({
+        Bucket: getBucketName(),
+        Key: params.key,
+        ...(params.range ? { Range: params.range } : {}),
+      }),
+    );
+    const body = response.Body;
+    if (!body) {
+      throw new Error("Object not found");
+    }
+    return {
+      body: body as NodeJS.ReadableStream,
+      contentType: response.ContentType,
+      contentLength: response.ContentLength,
+      contentRange: response.ContentRange,
+    };
+  }
+
+  async headObject(params: { key: string }): Promise<StorageHeadObjectResult> {
+    const head = await getS3Client().send(
+      new HeadObjectCommand({ Bucket: getBucketName(), Key: params.key }),
+    );
+    return {
+      contentLength: head.ContentLength,
+      contentType: head.ContentType,
+    };
+  }
+
+  async deleteObject(params: { key: string }): Promise<void> {
+    await getS3Client().send(new DeleteObjectCommand({ Bucket: getBucketName(), Key: params.key }));
+  }
+
+  async getSignedPutUrl(params: {
+    key: string;
+    contentType: string;
+    expiresInSeconds: number;
+  }): Promise<string> {
+    return getSignedUrl(
+      getS3Client(),
+      new PutObjectCommand({
+        Bucket: getBucketName(),
+        Key: params.key,
+        ContentType: params.contentType,
+      }),
+      { expiresIn: params.expiresInSeconds },
+    );
+  }
+}

--- a/server/api/src/lib/storage/types.ts
+++ b/server/api/src/lib/storage/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Object storage abstraction for S3-compatible backends and Cloudflare R2 bindings.
+ * オブジェクトストレージ抽象（S3 互換 API / R2 バインディング）。
+ */
+
+/** Result of a storage GET (full or ranged). / GET（全体または Range）の結果。 */
+export interface StorageGetObjectResult {
+  body: ReadableStream | NodeJS.ReadableStream;
+  contentType?: string;
+  contentLength?: number;
+  contentRange?: string;
+}
+
+/** Result of HEAD. / HEAD の結果。 */
+export interface StorageHeadObjectResult {
+  contentLength?: number;
+  contentType?: string;
+}
+
+/**
+ * Storage operations used by media, thumbnails, and commit flows.
+ * メディア・サムネ・commit フローで使うストレージ操作。
+ */
+export interface StorageClient {
+  /** Upload an object. / オブジェクトをアップロード。 */
+  putObject(params: {
+    key: string;
+    body: Uint8Array | Buffer;
+    contentType?: string;
+  }): Promise<void>;
+
+  /** Download an object (optional HTTP Range). / オブジェクト取得（Range 任意）。 */
+  getObject(params: { key: string; range?: string }): Promise<StorageGetObjectResult>;
+
+  /** Metadata without body. / ボディなしのメタデータ取得。 */
+  headObject(params: { key: string }): Promise<StorageHeadObjectResult>;
+
+  /** Delete an object. / オブジェクト削除。 */
+  deleteObject(params: { key: string }): Promise<void>;
+
+  /** Presigned PUT URL for direct client upload. / クライアント直接アップロード用 presigned PUT URL。 */
+  getSignedPutUrl(params: {
+    key: string;
+    contentType: string;
+    expiresInSeconds: number;
+  }): Promise<string>;
+}

--- a/server/api/src/middleware/storage.ts
+++ b/server/api/src/middleware/storage.ts
@@ -1,0 +1,12 @@
+import { createMiddleware } from "hono/factory";
+import { createStorageClient } from "../lib/storage/index.js";
+import type { AppEnv } from "../types/index.js";
+
+/**
+ * Injects a {@link StorageClient} per request (R2 binding on Workers, S3 env on Node).
+ * リクエストごとに {@link StorageClient} を注入（Workers は R2 binding、Node は S3 env）。
+ */
+export const storageMiddleware = createMiddleware<AppEnv>(async (c, next) => {
+  c.set("storage", createStorageClient(c.env));
+  await next();
+});

--- a/server/api/src/routes/health.ts
+++ b/server/api/src/routes/health.ts
@@ -1,25 +1,38 @@
 import { Hono } from "hono";
 import type { AppEnv } from "../types/index.js";
+import type { CloudflareBindings } from "../types/cloudflare.js";
 
 const app = new Hono<AppEnv>();
 
 /**
- * Railway が GitHub 連携デプロイ時に注入するコミット SHA。ローカルや Railway 外では
- * 未設定のため null を返す。deploy-prod のロールアウト検証で使う。
+ * Deployment commit SHA for rollout verification (deploy-prod / deploy-dev).
+ * Railway injects `RAILWAY_GIT_COMMIT_SHA`; Workers CI sets `GIT_COMMIT_SHA` via wrangler vars.
  *
- * Commit SHA injected by Railway on GitHub-triggered deploys; null locally or
- * off Railway. Used by deploy-prod rollout verification.
+ * デプロイコミット SHA（ロールアウト検証用）。
+ * Railway は `RAILWAY_GIT_COMMIT_SHA`、Workers CI は wrangler vars の `GIT_COMMIT_SHA`。
  */
 function readGitCommitSha(): string | null {
-  const sha = process.env.RAILWAY_GIT_COMMIT_SHA;
-  return typeof sha === "string" && sha.length > 0 ? sha : null;
+  const candidates = [process.env.GIT_COMMIT_SHA, process.env.RAILWAY_GIT_COMMIT_SHA];
+  for (const sha of candidates) {
+    if (typeof sha === "string" && sha.length > 0) return sha;
+  }
+  return null;
+}
+
+/** Detect Workers runtime from R2 binding presence. / R2 binding の有無で Workers を判定。 */
+function readRuntime(
+  bindings: Partial<CloudflareBindings> | undefined,
+): "cloudflare-workers" | "node" {
+  return bindings?.STORAGE_BUCKET ? "cloudflare-workers" : "node";
 }
 
 app.get("/health", (c) => {
+  const bindings = c.env as Partial<CloudflareBindings> | undefined;
   return c.json({
     status: "ok",
     timestamp: new Date().toISOString(),
     git_commit_sha: readGitCommitSha(),
+    runtime: readRuntime(bindings),
   });
 });
 

--- a/server/api/src/routes/media.ts
+++ b/server/api/src/routes/media.ts
@@ -2,30 +2,11 @@ import { Readable } from "node:stream";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { eq, and } from "drizzle-orm";
-import {
-  S3Client,
-  PutObjectCommand,
-  GetObjectCommand,
-  DeleteObjectCommand,
-  HeadObjectCommand,
-} from "@aws-sdk/client-s3";
-import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { media } from "../schema/index.js";
 import { authRequired } from "../middleware/auth.js";
-import { getEnv } from "../lib/env.js";
 import type { AppEnv } from "../types/index.js";
 
-const s3 = new S3Client({
-  endpoint: getEnv("STORAGE_ENDPOINT"),
-  region: "auto",
-  credentials: {
-    accessKeyId: getEnv("STORAGE_ACCESS_KEY"),
-    secretAccessKey: getEnv("STORAGE_SECRET_KEY"),
-  },
-  forcePathStyle: true,
-});
-
-const BUCKET = getEnv("STORAGE_BUCKET_NAME");
+const BUCKET_UPLOAD_EXPIRY_SECONDS = 900;
 
 /**
  * api オリジンでバイトを返すため、ユーザー提供の Content-Type をそのまま使わない。
@@ -108,6 +89,7 @@ const app = new Hono<AppEnv>();
 
 app.post("/upload", authRequired, async (c) => {
   const userId = c.get("userId");
+  const storage = c.get("storage");
 
   const body = await c.req.json<{
     file_name: string;
@@ -132,15 +114,11 @@ app.post("/upload", authRequired, async (c) => {
   const mediaId = crypto.randomUUID();
   const s3Key = `users/${userId}/media/${mediaId}/${body.file_name}`;
 
-  const presignedUrl = await getSignedUrl(
-    s3,
-    new PutObjectCommand({
-      Bucket: BUCKET,
-      Key: s3Key,
-      ContentType: body.content_type,
-    }),
-    { expiresIn: 900 },
-  );
+  const presignedUrl = await storage.getSignedPutUrl({
+    key: s3Key,
+    contentType: body.content_type,
+    expiresInSeconds: BUCKET_UPLOAD_EXPIRY_SECONDS,
+  });
 
   return c.json({ upload_url: presignedUrl, media_id: mediaId, s3_key: s3Key });
 });
@@ -148,6 +126,7 @@ app.post("/upload", authRequired, async (c) => {
 app.post("/confirm", authRequired, async (c) => {
   const userId = c.get("userId");
   const db = c.get("db");
+  const storage = c.get("storage");
 
   const body = await c.req.json<{
     media_id: string;
@@ -190,10 +169,10 @@ app.post("/confirm", authRequired, async (c) => {
   // about `file_size` cannot leave >50MB blobs attached to their account.
   let verifiedSize: number | null = null;
   try {
-    const head = await s3.send(new HeadObjectCommand({ Bucket: BUCKET, Key: body.s3_key }));
-    const length = typeof head.ContentLength === "number" ? head.ContentLength : null;
+    const head = await storage.headObject({ key: body.s3_key });
+    const length = typeof head.contentLength === "number" ? head.contentLength : null;
     if (length !== null && length > MAX_UPLOAD_SIZE_BYTES) {
-      await s3.send(new DeleteObjectCommand({ Bucket: BUCKET, Key: body.s3_key })).catch((err) => {
+      await storage.deleteObject({ key: body.s3_key }).catch((err) => {
         console.warn("[media] failed to delete oversized upload", {
           s3Key: body.s3_key,
           err,
@@ -245,6 +224,7 @@ app.get("/:id", authRequired, async (c) => {
   const mediaId = c.req.param("id");
   const userId = c.get("userId");
   const db = c.get("db");
+  const storage = c.get("storage");
 
   const result = await db.select().from(media).where(eq(media.id, mediaId)).limit(1);
 
@@ -267,13 +247,10 @@ app.get("/:id", authRequired, async (c) => {
 
   let response;
   try {
-    response = await s3.send(
-      new GetObjectCommand({
-        Bucket: BUCKET,
-        Key: row.s3Key,
-        ...(rangeHeader ? { Range: rangeHeader } : {}),
-      }),
-    );
+    response = await storage.getObject({
+      key: row.s3Key,
+      ...(rangeHeader ? { range: rangeHeader } : {}),
+    });
   } catch (err) {
     const meta = (err as { name?: string; $metadata?: { httpStatusCode?: number } } | undefined)
       ?.$metadata;
@@ -285,16 +262,16 @@ app.get("/:id", authRequired, async (c) => {
     if (name === "InvalidRange" || code === 416) {
       return c.json({ error: "Requested range not satisfiable" }, 416);
     }
-    console.error("[media] S3 GetObject failed:", err);
+    console.error("[media] storage GetObject failed:", err);
     return c.json({ error: "Failed to retrieve object" }, 502);
   }
 
-  const body = response.Body;
+  const body = response.body;
   if (!body) return c.json({ error: "Object not found" }, 404);
 
   const { contentType, contentDisposition } = resolveProxyContentHeaders(
     row.contentType,
-    response.ContentType,
+    response.contentType,
     row.fileName,
   );
 
@@ -314,17 +291,17 @@ app.get("/:id", authRequired, async (c) => {
   if (contentDisposition) {
     headers["Content-Disposition"] = contentDisposition;
   }
-  const len = response.ContentLength;
+  const len = response.contentLength;
   if (typeof len === "number" && len >= 0) {
     headers["Content-Length"] = String(len);
   }
-  if (response.ContentRange) {
-    headers["Content-Range"] = response.ContentRange;
+  if (response.contentRange) {
+    headers["Content-Range"] = response.contentRange;
   }
 
   // S3 が部分応答を返した場合は 206 でそのまま返す。
   // Relay S3's partial-content responses as HTTP 206.
-  const status = response.ContentRange ? 206 : 200;
+  const status = response.contentRange ? 206 : 200;
 
   return new Response(webStream as BodyInit, {
     status,
@@ -336,6 +313,7 @@ app.delete("/:id", authRequired, async (c) => {
   const mediaId = c.req.param("id");
   const userId = c.get("userId");
   const db = c.get("db");
+  const storage = c.get("storage");
 
   const result = await db.select().from(media).where(eq(media.id, mediaId)).limit(1);
 
@@ -371,12 +349,7 @@ app.delete("/:id", authRequired, async (c) => {
   }
 
   try {
-    await s3.send(
-      new DeleteObjectCommand({
-        Bucket: BUCKET,
-        Key: deletedRow.s3Key,
-      }),
-    );
+    await storage.deleteObject({ key: deletedRow.s3Key });
   } catch (err) {
     // DB 行は既に削除済み。NoSuchKey は冪等として無視し、それ以外の失敗は
     // 孤立オブジェクトとして警告だけ残す（DB と storage の再同期は別経路に任せる）。
@@ -385,7 +358,7 @@ app.delete("/:id", authRequired, async (c) => {
     // so ops can sweep the orphaned S3 object — do NOT resurrect the DB row.
     const s3Err = err as { name?: string } | null;
     if (s3Err?.name !== "NoSuchKey") {
-      console.error("[media] S3 DeleteObject failed after DB delete (orphaned object):", {
+      console.error("[media] storage DeleteObject failed after DB delete (orphaned object):", {
         mediaId,
         s3Key: deletedRow.s3Key,
         err,

--- a/server/api/src/routes/pages.ts
+++ b/server/api/src/routes/pages.ts
@@ -476,7 +476,7 @@ app.delete("/:id", authRequired, async (c) => {
   // soft-delete from the user's perspective. `deleteThumbnailObject` already
   // logs S3 failures so a sweeper can reclaim orphans.
   if (target?.thumbnailObjectId && target.ownerId) {
-    await deleteThumbnailObject(target.thumbnailObjectId, target.ownerId, db);
+    await deleteThumbnailObject(target.thumbnailObjectId, target.ownerId, db, c.get("storage"));
   }
 
   return c.json({ id: pageId, deleted: true });

--- a/server/api/src/routes/thumbnail/commit.ts
+++ b/server/api/src/routes/thumbnail/commit.ts
@@ -3,6 +3,7 @@ import { HTTPException } from "hono/http-exception";
 import { authRequired } from "../../middleware/auth.js";
 import { rateLimit } from "../../middleware/rateLimit.js";
 import { commitImage } from "../../services/commitService.js";
+import { isStorageConfigured } from "../../lib/storage/index.js";
 import type { AppEnv } from "../../types/index.js";
 
 const app = new Hono<AppEnv>();
@@ -21,7 +22,7 @@ app.post("/", authRequired, rateLimit(), async (c) => {
     throw new HTTPException(400, { message: "sourceUrl is required" });
   }
 
-  if (!process.env.STORAGE_BUCKET_NAME) {
+  if (!isStorageConfigured(c.env)) {
     throw new HTTPException(503, { message: "サムネイルの保存先が設定されていません" });
   }
 
@@ -31,6 +32,7 @@ app.post("/", authRequired, rateLimit(), async (c) => {
       body.sourceUrl.trim(),
       body.fallbackUrl?.trim(),
       db,
+      c.get("storage"),
     );
     return c.json({ imageUrl, objectId, provider: "s3" as const });
   } catch (err) {

--- a/server/api/src/routes/thumbnail/serve.ts
+++ b/server/api/src/routes/thumbnail/serve.ts
@@ -1,24 +1,10 @@
 import { Readable } from "node:stream";
 import { Hono } from "hono";
 import { eq, and } from "drizzle-orm";
-import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import { authRequired } from "../../middleware/auth.js";
 import { thumbnailObjects } from "../../schema/index.js";
-import { getEnv } from "../../lib/env.js";
 import { deleteThumbnailObject } from "../../services/thumbnailGcService.js";
 import type { AppEnv } from "../../types/index.js";
-
-const s3 = new S3Client({
-  endpoint: getEnv("STORAGE_ENDPOINT"),
-  region: "auto",
-  credentials: {
-    accessKeyId: getEnv("STORAGE_ACCESS_KEY"),
-    secretAccessKey: getEnv("STORAGE_SECRET_KEY"),
-  },
-  forcePathStyle: true,
-});
-
-const BUCKET = getEnv("STORAGE_BUCKET_NAME");
 
 /** SVG は XSS リスクがあるためサムネイル配信では許可しない */
 const MIME_TYPES: Record<string, string> = {
@@ -40,6 +26,7 @@ app.get("/:id", authRequired, async (c) => {
   const objectId = c.req.param("id");
   const userId = c.get("userId");
   const db = c.get("db");
+  const storage = c.get("storage");
 
   const rows = await db
     .select()
@@ -57,7 +44,7 @@ app.get("/:id", authRequired, async (c) => {
 
   let response;
   try {
-    response = await s3.send(new GetObjectCommand({ Bucket: BUCKET, Key: row.s3Key }));
+    response = await storage.getObject({ key: row.s3Key });
   } catch (err) {
     const meta = (err as { name?: string; $metadata?: { httpStatusCode?: number } } | undefined)
       ?.$metadata;
@@ -66,11 +53,11 @@ app.get("/:id", authRequired, async (c) => {
     if (name === "NoSuchKey" || code === 404) {
       return c.json({ error: "Object not found" }, 404);
     }
-    console.error("[thumbnail/serve] S3 GetObject failed:", err);
+    console.error("[thumbnail/serve] storage GetObject failed:", err);
     return c.json({ error: "Failed to retrieve object" }, 502);
   }
 
-  const body = response.Body;
+  const body = response.body;
   if (!body) return c.json({ error: "Object not found" }, 404);
 
   const webStream = body instanceof Readable ? Readable.toWeb(body) : (body as ReadableStream);
@@ -88,6 +75,7 @@ app.delete("/:id", authRequired, async (c) => {
   const objectId = c.req.param("id");
   const userId = c.get("userId");
   const db = c.get("db");
+  const storage = c.get("storage");
 
   // 共通 GC サービスに委譲する。サービスは所有者チェック → ライブ参照ガード →
   // DB 削除 → S3 削除を一貫した順序で実行する（issue #820）。
@@ -96,7 +84,7 @@ app.delete("/:id", authRequired, async (c) => {
   // live-reference guard, DB delete, and S3 delete (issue #820). The
   // ownership check is performed first so unauthorized callers always see
   // 404 — never 409 — and cannot probe other users' thumbnail state.
-  const outcome = await deleteThumbnailObject(objectId, userId, db);
+  const outcome = await deleteThumbnailObject(objectId, userId, db, storage);
 
   if (outcome === "not_found") {
     return c.json({ error: "Not found" }, 404);

--- a/server/api/src/services/commitService.ts
+++ b/server/api/src/services/commitService.ts
@@ -1,19 +1,9 @@
-import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { eq, sql } from "drizzle-orm";
 import { thumbnailObjects, thumbnailTierQuotas } from "../schema/index.js";
 import { getUserTier } from "./subscriptionService.js";
 import { getEnv } from "../lib/env.js";
+import type { StorageClient } from "../lib/storage/index.js";
 import type { Database } from "../types/index.js";
-
-const s3 = new S3Client({
-  endpoint: getEnv("STORAGE_ENDPOINT"),
-  region: "auto",
-  credentials: {
-    accessKeyId: getEnv("STORAGE_ACCESS_KEY"),
-    secretAccessKey: getEnv("STORAGE_SECRET_KEY"),
-  },
-  forcePathStyle: true,
-});
 
 // `thumbnail_tier_quotas` がシードされていない環境でフォールバック上限が小さすぎると
 // 数件クリップしただけで 413 を踏む。drizzle/0020_seed_thumbnail_tier_quotas.sql の
@@ -105,6 +95,7 @@ export async function commitImage(
   sourceUrl: string,
   fallbackUrl: string | undefined,
   db: Database,
+  storage: StorageClient,
 ): Promise<{ imageUrl: string; objectId: string }> {
   // BETTER_AUTH_URL は必須。S3 アップロードや DB 挿入より前に検証して fail-fast する。
   // Validate BETTER_AUTH_URL before any side effects so a missing env var cannot
@@ -142,16 +133,12 @@ export async function commitImage(
 
   const objectId = crypto.randomUUID();
   const s3Key = `users/${userId}/thumbnails/${objectId}.${ext}`;
-  const bucketName = process.env.STORAGE_BUCKET_NAME;
 
-  await s3.send(
-    new PutObjectCommand({
-      Bucket: bucketName,
-      Key: s3Key,
-      Body: buffer,
-      ContentType: mimeType,
-    }),
-  );
+  await storage.putObject({
+    key: s3Key,
+    body: buffer,
+    contentType: mimeType,
+  });
 
   await db.insert(thumbnailObjects).values({
     id: objectId,

--- a/server/api/src/services/thumbnailGcService.ts
+++ b/server/api/src/services/thumbnailGcService.ts
@@ -30,46 +30,10 @@
  * delete fires after a successful page commit, the server preserves the
  * thumbnail.
  */
-import { S3Client, DeleteObjectCommand } from "@aws-sdk/client-s3";
 import { and, eq } from "drizzle-orm";
 import { pages, thumbnailObjects } from "../schema/index.js";
-import { getEnv } from "../lib/env.js";
+import type { StorageClient } from "../lib/storage/index.js";
 import type { Database } from "../types/index.js";
-
-// S3 クライアントとバケット名は遅延初期化する。`serve.ts` と違い、このサービス
-// は `pages.ts` から import される。`pages.ts` のテスト（routes/pages.test.ts）
-// などで STORAGE_* を未設定のまま実行されるケースがあり、モジュール直下で
-// `getEnv` を呼ぶと無関係なテストまで道連れに落ちてしまう。最初の GC 呼び出し
-// 時にだけ必須環境変数を要求し、テスト環境では env を仕込まずに pages の他
-// ロジックを検証できるようにする。
-//
-// Lazy-init the S3 client and bucket name. Unlike `serve.ts`, this module is
-// imported by `pages.ts`, which has tests that don't set STORAGE_* (the pages
-// route doesn't need storage for most cases). Calling `getEnv` at module
-// top-level would crash those unrelated tests on import; deferring the lookup
-// keeps the dependency local to actual GC calls.
-let s3: S3Client | undefined;
-let bucket: string | undefined;
-
-function getS3(): S3Client {
-  if (!s3) {
-    s3 = new S3Client({
-      endpoint: getEnv("STORAGE_ENDPOINT"),
-      region: "auto",
-      credentials: {
-        accessKeyId: getEnv("STORAGE_ACCESS_KEY"),
-        secretAccessKey: getEnv("STORAGE_SECRET_KEY"),
-      },
-      forcePathStyle: true,
-    });
-  }
-  return s3;
-}
-
-function getBucket(): string {
-  if (!bucket) bucket = getEnv("STORAGE_BUCKET_NAME");
-  return bucket;
-}
 
 /**
  * `deleteThumbnailObject` の結果種別。
@@ -145,6 +109,7 @@ export async function deleteThumbnailObject(
   objectId: string,
   userId: string,
   db: Database,
+  storage: StorageClient,
 ): Promise<DeleteThumbnailOutcome> {
   const txResult = await db.transaction(async (tx) => {
     // 1. 所有者チェック。所有者でない / 存在しない場合は `not_found` を返し、
@@ -217,7 +182,7 @@ export async function deleteThumbnailObject(
   // S3 deletion runs outside the transaction so external IO doesn't pin the
   // DB connection.
   try {
-    await getS3().send(new DeleteObjectCommand({ Bucket: getBucket(), Key: txResult.s3Key }));
+    await storage.deleteObject({ key: txResult.s3Key });
   } catch (err) {
     const s3Err = err as { name?: string } | null;
     if (s3Err?.name !== "NoSuchKey") {

--- a/server/api/src/types/cloudflare.ts
+++ b/server/api/src/types/cloudflare.ts
@@ -1,0 +1,10 @@
+/**
+ * Cloudflare Workers bindings for the Zedi API Worker (#1091 / Phase 2a).
+ * Generated types are merged via `worker-configuration.d.ts` (`wrangler types`).
+ *
+ * Zedi API Worker 用の Cloudflare バインディング型。
+ */
+export interface CloudflareBindings {
+  /** R2 bucket for media / thumbnails / PDF highlights (#1089). */
+  STORAGE_BUCKET: R2Bucket;
+}

--- a/server/api/src/types/index.ts
+++ b/server/api/src/types/index.ts
@@ -1,12 +1,16 @@
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import type * as schema from "../schema/index.js";
+import type { CloudflareBindings } from "./cloudflare.js";
+import type { StorageClient } from "../lib/storage/index.js";
 
 export type AppEnv = {
+  Bindings: Partial<CloudflareBindings>;
   Variables: {
     userId: string;
     userEmail?: string;
     db: Database;
     redis: import("ioredis").Redis;
+    storage: StorageClient;
   };
 };
 

--- a/server/api/src/worker.ts
+++ b/server/api/src/worker.ts
@@ -1,0 +1,11 @@
+/**
+ * Cloudflare Workers entry for the Zedi API (#1091 / Phase 2a).
+ * Hono default export — see Hono skill "Adapters".
+ *
+ * Zedi API の Cloudflare Workers エントリポイント。
+ */
+import { createApp } from "./app.js";
+
+const app = createApp();
+
+export default app;

--- a/server/api/tsconfig.json
+++ b/server/api/tsconfig.json
@@ -16,8 +16,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "noUncheckedIndexedAccess": true,
-    "types": ["node", "bun-types"]
+    "types": ["node", "bun-types", "@cloudflare/workers-types"]
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "worker-configuration.d.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/server/api/worker-configuration.d.ts
+++ b/server/api/worker-configuration.d.ts
@@ -1,0 +1,21 @@
+/* eslint-disable */
+// Generated / maintained for Wrangler. Run `bun run worker:types` to refresh from wrangler.jsonc.
+/// <reference types="@cloudflare/workers-types" />
+
+declare namespace Cloudflare {
+  interface Env {
+    ENVIRONMENT?: string;
+    GIT_COMMIT_SHA?: string;
+    STORAGE_BUCKET: R2Bucket;
+    DATABASE_URL: string;
+    REDIS_URL?: string;
+    BETTER_AUTH_SECRET: string;
+    BETTER_AUTH_URL: string;
+    STORAGE_ENDPOINT: string;
+    STORAGE_ACCESS_KEY: string;
+    STORAGE_SECRET_KEY: string;
+    STORAGE_BUCKET_NAME: string;
+  }
+}
+
+interface Env extends Cloudflare.Env {}

--- a/server/api/wrangler.jsonc
+++ b/server/api/wrangler.jsonc
@@ -1,0 +1,42 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "zedi-api",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-06-25",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": {
+    "enabled": true,
+  },
+  "r2_buckets": [
+    {
+      "binding": "STORAGE_BUCKET",
+      "bucket_name": "zedi-storage-prod",
+    },
+  ],
+  "env": {
+    "dev": {
+      "name": "zedi-api-dev",
+      "r2_buckets": [
+        {
+          "binding": "STORAGE_BUCKET",
+          "bucket_name": "zedi-storage-dev",
+        },
+      ],
+      "vars": {
+        "ENVIRONMENT": "development",
+      },
+    },
+    "production": {
+      "name": "zedi-api",
+      "r2_buckets": [
+        {
+          "binding": "STORAGE_BUCKET",
+          "bucket_name": "zedi-storage-prod",
+        },
+      ],
+      "vars": {
+        "ENVIRONMENT": "production",
+      },
+    },
+  },
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "hono": {
+      "source": "yusukebe/hono-skill",
+      "sourceType": "github",
+      "skillPath": "skills/hono/SKILL.md",
+      "computedHash": "24bad73932f309cec73a5a9171b838f59050990a634d8590c2d2c204507e64f9"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Railway → Cloudflare 移行（Epic #1088）の Phase 0〜2a と、フェーズ別 secrets ライフサイクルのチェックリストをまとめた PR。Terraform は凍結したまま `wrangler.jsonc` を正本にし、API を Workers + R2 binding で動かせる骨格を導入する。Railway は並行稼働を維持し、本番 DNS 切替は Phase 2b 以降。

## 含まれる変更

### Phase 0 — 基盤 (#1088)
- `.agents/skills/cloudflare-zedi/`（SKILL + references: resource-map / naming / token-scopes / migration-plan）

### Phase 1 — R2 (#1089)
- R2 バケット `zedi-storage-dev` / `zedi-storage-prod`（S3 互換）
- `server/api/.env.example` に `STORAGE_*` の書式を追記

### Phase 2a — API Worker 骨格 (#1091)
- `server/api/src/worker.ts`（Hono `export default app`）, `wrangler.jsonc`（`env.dev` / `env.production` + R2 `STORAGE_BUCKET` binding, `nodejs_compat`）
- `server/api/src/lib/storage/`（`StorageClient` 抽象: R2 binding + S3 互換 presign）, `storageMiddleware`
- `/health` に `runtime` / `git_commit_sha` を追加
- `.github/workflows/deploy-api-worker-dev.yml`（`develop` push → `wrangler deploy --env dev`）

### Secrets チェックリスト (#1105)
- `references/secrets-template.md` — Phase 0〜5 ごとの **登録 / 更新 / 削除** 一覧
- `SKILL.md` / `.env.example` からリンク

## 設計メモ

- **Storage**: Workers ではサーバ側操作に R2 binding、presigned PUT URL は引き続き S3 API（`STORAGE_*` secrets）を使う。
- **Railway**: `server/api/src/index.ts`（`@hono/node-server`）は維持。本番 `api.zedi-note.app` は Phase 2b まで Railway。
- **Terraform**: 凍結。Phase 5 で一括撤去。

## Test plan

- [x] `bun run test:run`（1644 tests pass、Phase 2a 時点）
- [x] Prettier / pre-commit hook 通過
- [ ] dev Worker secrets 設定後に `/health` で `runtime: cloudflare-workers` と `git_commit_sha` 一致を確認（マージ後の運用作業）
- [ ] dev で `/api/media` アップロード→取得→削除の E2E（R2 binding 経由）

## 関連

- Epic #1088 / #1089 / #1091 / #1105

Made with [Cursor](https://cursor.com)