### PR TITLE
Add SSRF protection to thumbnail image fetching with redirect validation

### DIFF
--- a/server/api/src/__tests__/routes/thumbnail/commit.test.ts
+++ b/server/api/src/__tests__/routes/thumbnail/commit.test.ts
@@ -195,6 +195,23 @@ describe("POST /api/thumbnail/commit", () => {
     expect(res.status).toBe(502);
   });
 
+  it("returns 400 when commitService throws ClipFetchBlockedError", async () => {
+    const { ClipFetchBlockedError, DISALLOWED_CLIP_URL_MESSAGE } =
+      await import("../../../lib/clipServerFetch.js");
+    mockCommitImage.mockRejectedValue(new ClipFetchBlockedError(DISALLOWED_CLIP_URL_MESSAGE));
+    const app = createTestApp();
+
+    const res = await app.request("/api/thumbnail/commit", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ sourceUrl: "https://example.com/img.png" }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe(DISALLOWED_CLIP_URL_MESSAGE);
+  });
+
   it("returns 401 without auth", async () => {
     const app = createTestApp();
 

--- a/server/api/src/__tests__/services/commitService.test.ts
+++ b/server/api/src/__tests__/services/commitService.test.ts
@@ -172,6 +172,27 @@ describe("commitImage — BETTER_AUTH_URL handling", () => {
     expect(imageUrl.endsWith(`/api/thumbnail/serve/${objectId}`)).toBe(true);
   });
 
+  it.each([
+    "http://127.0.0.1/image.png",
+    "http://localhost/image.png",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://10.0.0.5/image.png",
+  ])(
+    "SSRF ポリシーで内部/プライベート URL の取得を拒否する / rejects fetching internal/private URLs (%s)",
+    async (sourceUrl) => {
+      setBaseEnv();
+
+      const { commitImage } = await importCommitService();
+      const db = makeDbMock("free", 10 * 1024 * 1024, 0) as never;
+      const storage = makeMockStorage();
+
+      await expect(commitImage(TEST_USER_ID, sourceUrl, undefined, db, storage)).rejects.toThrow(
+        /URL not allowed/,
+      );
+      expect(mockPutObject).not.toHaveBeenCalled();
+    },
+  );
+
   it("クォータ未シードでも 100MB のフォールバックでアップロードできる / accepts upload using 100MB fallback when quota table is unseeded", async () => {
     setBaseEnv();
 

--- a/server/api/src/__tests__/services/commitService.test.ts
+++ b/server/api/src/__tests__/services/commitService.test.ts
@@ -6,12 +6,17 @@
  * Verifies fail-fast behavior when BETTER_AUTH_URL is unset, and imageUrl
  * generation when the env is configured.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { lookup } from "node:dns/promises";
 import type { StorageClient } from "../../lib/storage/types.js";
 
 const { mockPutObject, envMap } = vi.hoisted(() => ({
   mockPutObject: vi.fn(),
   envMap: {} as Record<string, string | undefined>,
+}));
+
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn(),
 }));
 
 vi.mock("../../lib/env.js", () => ({
@@ -25,6 +30,8 @@ vi.mock("../../lib/env.js", () => ({
 vi.mock("../../services/subscriptionService.js", () => ({
   getUserTier: vi.fn().mockResolvedValue("free"),
 }));
+
+const originalFetch = globalThis.fetch;
 
 const TINY_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII=";
@@ -96,7 +103,15 @@ describe("commitImage — BETTER_AUTH_URL handling", () => {
     clearEnv();
     mockPutObject.mockReset();
     mockPutObject.mockResolvedValue(undefined);
+    vi.mocked(lookup).mockReset();
+    vi.mocked(lookup).mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+    ] as unknown as Awaited<ReturnType<typeof lookup>>);
     vi.resetModules();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   it("BETTER_AUTH_URL 未設定時は fail-fast で throw する / throws when BETTER_AUTH_URL is unset", async () => {
@@ -192,6 +207,29 @@ describe("commitImage — BETTER_AUTH_URL handling", () => {
       expect(mockPutObject).not.toHaveBeenCalled();
     },
   );
+
+  it("公開 URL からのプライベート宛リダイレクトを拒否する / rejects redirect from public URL to a private address", async () => {
+    setBaseEnv();
+
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { Location: "http://127.0.0.1/secret.png" },
+      }),
+    );
+
+    const { commitImage } = await importCommitService();
+    const db = makeDbMock("free", 10 * 1024 * 1024, 0) as never;
+    const storage = makeMockStorage();
+
+    await expect(
+      commitImage(TEST_USER_ID, "https://example.com/image.png", undefined, db, storage),
+    ).rejects.toThrow(/URL not allowed/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mockPutObject).not.toHaveBeenCalled();
+  });
 
   it("クォータ未シードでも 100MB のフォールバックでアップロードできる / accepts upload using 100MB fallback when quota table is unseeded", async () => {
     setBaseEnv();

--- a/server/api/src/routes/composeSessions.ts
+++ b/server/api/src/routes/composeSessions.ts
@@ -408,7 +408,9 @@ app.post("/:pageId/compose-sessions/:id/run", authRequired, rateLimit(), async (
         finalStatus = "failed";
         lastError = lastError ?? "Client disconnected";
       }
-      void persistSession();
+      void persistSession().catch((err) => {
+        console.error(`[composeSessions] persistSession failed on abort for session=${id}:`, err);
+      });
     });
 
     // `DATABASE_URL` が設定された本番経路では `PostgresSaver` を取得して

--- a/server/api/src/routes/thumbnail/commit.ts
+++ b/server/api/src/routes/thumbnail/commit.ts
@@ -3,6 +3,7 @@ import { HTTPException } from "hono/http-exception";
 import { authRequired } from "../../middleware/auth.js";
 import { rateLimit } from "../../middleware/rateLimit.js";
 import { commitImage } from "../../services/commitService.js";
+import { ClipFetchBlockedError } from "../../lib/clipServerFetch.js";
 import { isStorageConfigured } from "../../lib/storage/index.js";
 import type { AppEnv } from "../../types/index.js";
 
@@ -36,6 +37,9 @@ app.post("/", authRequired, rateLimit(), async (c) => {
     );
     return c.json({ imageUrl, objectId, provider: "s3" as const });
   } catch (err) {
+    if (err instanceof ClipFetchBlockedError) {
+      throw new HTTPException(400, { message: err.message });
+    }
     if (err instanceof Error && err.message === "STORAGE_QUOTA_EXCEEDED") {
       // クライアントは `code` を見てアップグレード誘導 UI を出す。
       // The client looks at `code` to surface the upgrade-plan prompt.

--- a/server/api/src/services/commitService.ts
+++ b/server/api/src/services/commitService.ts
@@ -69,6 +69,9 @@ async function fetchImageAsBuffer(
     const isRedirect =
       response.type === "opaqueredirect" || [301, 302, 303, 307, 308].includes(response.status);
     if (isRedirect) {
+      // リダイレクト応答の本文は読まないので接続を解放する。
+      // Cancel unused redirect bodies so connections are released promptly.
+      await response.body?.cancel();
       const location = response.headers.get("Location");
       if (!location || hop === MAX_REDIRECTS) {
         throw new ClipFetchBlockedError("Redirect chain not allowed");

--- a/server/api/src/services/commitService.ts
+++ b/server/api/src/services/commitService.ts
@@ -2,8 +2,11 @@ import { eq, sql } from "drizzle-orm";
 import { thumbnailObjects, thumbnailTierQuotas } from "../schema/index.js";
 import { getUserTier } from "./subscriptionService.js";
 import { getEnv } from "../lib/env.js";
+import { assertClipFetchUrlAllowed, ClipFetchBlockedError } from "../lib/clipServerFetch.js";
 import type { StorageClient } from "../lib/storage/index.js";
 import type { Database } from "../types/index.js";
+
+const MAX_REDIRECTS = 5;
 
 // `thumbnail_tier_quotas` がシードされていない環境でフォールバック上限が小さすぎると
 // 数件クリップしただけで 413 を踏む。drizzle/0020_seed_thumbnail_tier_quotas.sql の
@@ -45,12 +48,43 @@ async function fetchImageAsBuffer(
     return { buffer, mimeType, ext };
   }
 
-  const response = await fetch(sourceUrl, {
-    headers: {
-      "User-Agent": "zedi-thumbnail-api/1.0 (https://zedi.app)",
-      Accept: "image/*,*/*;q=0.8",
-    },
-  });
+  // SSRF 対策: 初回 URL と各リダイレクト先を DNS 解決込みで検証する
+  // (clip-fetch と同じポリシー)。redirect: "manual" で自動追従させない。
+  // SSRF protection: validate the initial URL and every redirect hop with DNS
+  // resolution (same policy as clip-fetch); manual redirects prevent
+  // unvalidated auto-follow to internal hosts.
+  await assertClipFetchUrlAllowed(sourceUrl);
+
+  let response!: Response;
+  let currentUrl = sourceUrl;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    response = await fetch(currentUrl, {
+      headers: {
+        "User-Agent": "zedi-thumbnail-api/1.0 (https://zedi.app)",
+        Accept: "image/*,*/*;q=0.8",
+      },
+      redirect: "manual",
+    });
+    const isRedirect =
+      response.type === "opaqueredirect" || [301, 302, 303, 307, 308].includes(response.status);
+    if (isRedirect) {
+      const location = response.headers.get("Location");
+      if (!location || hop === MAX_REDIRECTS) {
+        throw new ClipFetchBlockedError("Redirect chain not allowed");
+      }
+      let nextUrl: string;
+      try {
+        nextUrl = new URL(location, currentUrl).href;
+      } catch {
+        throw new ClipFetchBlockedError("Invalid redirect Location");
+      }
+      await assertClipFetchUrlAllowed(nextUrl);
+      currentUrl = nextUrl;
+      continue;
+    }
+    break;
+  }
 
   if (!response.ok) {
     throw new Error(`Image fetch failed: ${response.status}`);


### PR DESCRIPTION
## 概要

Thumbnail API の画像取得機能に SSRF（Server-Side Request Forgery）対策を追加しました。初期 URL とリダイレクト先の URL を DNS 解決を含めて検証し、内部/プライベートアドレスへのアクセスを防ぎます。

## 変更点

- **commitService.ts**: 
  - `assertClipFetchUrlAllowed` を使用した SSRF 検証を追加
  - `redirect: "manual"` で自動リダイレクト追従を無効化
  - リダイレクトチェーン（最大 5 ホップ）を手動で処理し、各ホップで URL 検証を実施
  - `ClipFetchBlockedError` をスロー

- **commitService.test.ts**:
  - SSRF ポリシーで内部/プライベート URL（127.0.0.1、localhost、169.254.169.254、10.0.0.5）の取得を拒否することを検証するテストを追加

- **commit.ts**:
  - `ClipFetchBlockedError` をキャッチして HTTP 400 で返すエラーハンドリングを追加

- **composeSessions.ts**:
  - `persistSession()` の未処理エラーをログ出力（エラーハンドリング改善）

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)

## テスト方法

1. 既存テストスイートが全てパスすることを確認
2. 新規テストケース（SSRF ポリシー検証）が追加され、内部アドレスへのアクセスが拒否されることを確認
3. 正常な外部 URL からの画像取得は引き続き動作することを確認

## チェックリスト

- [x] テストがすべてパスする（新規テストケース追加済み）
- [x] Lint エラーがない
- [x] コミットメッセージが Conventional Commits に従っている

## 関連情報

- clip-fetch と同じ SSRF ポリシーを適用
- リダイレクト検証により、攻撃者が初期 URL を許可リストに通してもリダイレクト先で内部ホストへのアクセスを防止

https://claude.ai/code/session_01EikV65FYf13Axyn8P4HoHe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened protection against unsafe image URLs (including private/local and cloud metadata addresses).
  * Validates every redirect hop, blocking redirect chains that attempt to reach disallowed destinations.
* **Bug Fixes**
  * Thumbnail commit requests blocked by URL safety now return an HTTP 400 with a clear error message.
  * Session persistence on aborted/early termination now includes error handling and logging.
* **Tests**
  * Added coverage for disallowed URL and redirect-blocking behavior, plus the thumbnail endpoint’s 400 response for blocked fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->