### PR TITLE
feat(mcp): add Cloudflare Workers entry point and dev deploy workflow

### DIFF
--- a/.github/workflows/deploy-mcp-worker-dev.yml
+++ b/.github/workflows/deploy-mcp-worker-dev.yml
@@ -11,6 +11,13 @@ on:
 permissions:
   contents: read
 
+# デプロイを直列化する。古い push のデプロイが新しい push を追い越さないよう、
+# 実行中ランはキャンセルせず待機させる。
+# Serialize deploys so an older push can't finish after (and clobber) a newer one.
+concurrency:
+  group: deploy-mcp-worker-dev
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -21,9 +28,9 @@ jobs:
     environment: development
     steps:
       - name: Checkout (with retry)
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
         with:
-          action: actions/checkout@v7.0.0
+          action: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           attempt_limit: 3
           attempt_delay: 5000
       - uses: ./.github/actions/setup-toolchain
@@ -53,7 +60,10 @@ jobs:
             --var GIT_COMMIT_SHA:${{ github.sha }}
             --var ENVIRONMENT:development
             ${{ vars.API_BASE_URL != '' && format('--var ZEDI_API_URL:{0}', vars.API_BASE_URL) || '' }}
-      - name: Wait for Worker /health
+      # WORKER_MCP_BASE_URL 未設定時は skip する（deploy-api-worker-dev と同じ
+      # ブートストラップ挙動。URL 確定後に GitHub Environment 変数を設定する）。
+      # Skipped until WORKER_MCP_BASE_URL is configured, mirroring the API workflow.
+      - name: Verify Worker /health (SHA gate)
         if: ${{ vars.WORKER_MCP_BASE_URL != '' }}
         uses: nick-fields/retry@v4
         with:
@@ -61,4 +71,7 @@ jobs:
           timeout_minutes: 3
           retry_wait_seconds: 20
           command: |
-            curl --fail --show-error --silent "${{ vars.WORKER_MCP_BASE_URL }}/health"
+            body="$(curl --fail --show-error --silent "${{ vars.WORKER_MCP_BASE_URL }}/health")"
+            echo "$body"
+            echo "$body" | jq --exit-status --arg sha "${{ github.sha }}" \
+              '.ok == true and .server == "zedi-mcp" and .git_commit_sha == $sha' > /dev/null

--- a/.github/workflows/deploy-mcp-worker-dev.yml
+++ b/.github/workflows/deploy-mcp-worker-dev.yml
@@ -1,0 +1,64 @@
+name: Deploy MCP Worker (dev)
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "server/mcp/**"
+      - ".github/workflows/deploy-mcp-worker-dev.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  deploy-mcp-worker-dev:
+    name: Deploy zedi-mcp-dev Worker
+    runs-on: ubuntu-latest
+    environment: development
+    steps:
+      - name: Checkout (with retry)
+        uses: Wandalen/wretry.action@v3
+        with:
+          action: actions/checkout@v7.0.0
+          attempt_limit: 3
+          attempt_delay: 5000
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          # server/mcp はルート workspace 外のため、ルート install は不要。
+          # server/mcp is outside the root workspace; skip root install.
+          install-deps: "false"
+      - name: Install dependencies
+        working-directory: server/mcp
+        run: bun install --frozen-lockfile
+      - name: Deploy to Cloudflare Workers (dev)
+        uses: nick-fields/retry@v4
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        with:
+          max_attempts: 3
+          timeout_minutes: 10
+          retry_wait_seconds: 60
+          # ZEDI_API_URL は GitHub Environment 変数 API_BASE_URL から注入する。
+          # 未設定時はコードの DEFAULT_API_URL にフォールバックする。
+          # ZEDI_API_URL is injected from the API_BASE_URL environment variable;
+          # the code falls back to DEFAULT_API_URL when it is unset.
+          command: >
+            cd server/mcp &&
+            bunx wrangler deploy --env dev
+            --var GIT_COMMIT_SHA:${{ github.sha }}
+            --var ENVIRONMENT:development
+            ${{ vars.API_BASE_URL != '' && format('--var ZEDI_API_URL:{0}', vars.API_BASE_URL) || '' }}
+      - name: Wait for Worker /health
+        if: ${{ vars.WORKER_MCP_BASE_URL != '' }}
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 10
+          timeout_minutes: 3
+          retry_wait_seconds: 20
+          command: |
+            curl --fail --show-error --silent "${{ vars.WORKER_MCP_BASE_URL }}/health"

--- a/server/mcp/README.ja.md
+++ b/server/mcp/README.ja.md
@@ -185,6 +185,24 @@ Claude Code の `mcpServers` では、HTTP transport 向け設定を使う。`Au
 
 サーバーはステートレス（リクエストごとに新しい `McpServer` を生成）なので、同じ JWT を複数クライアントから同時に使ってもセッションが競合しない。
 
+### 3c. Cloudflare Workers へのデプロイ（#1092 / Railway から移行中）
+
+Railway の代わりに Cloudflare Workers としてデプロイできる（Issue [#1088](https://github.com/otomatty/zedi/issues/1088) の移行先。Railway は暫定稼働）。エントリポイントは `src/worker.ts`、構成の正本は `wrangler.jsonc`（`env.dev` = `zedi-mcp-dev` / `env.production` = `zedi-mcp`）。
+
+```bash
+cd server/mcp
+bun install
+bun run worker:dev                 # ローカル (wrangler dev --env dev)
+bun run worker:deploy:dev          # dev デプロイ
+bun run worker:deploy:production   # 本番デプロイ
+```
+
+- `ZEDI_API_URL` は `wrangler.jsonc` の `vars`（production）またはデプロイ時の `--var`（dev は CI が GitHub Environment 変数 `API_BASE_URL` から注入）で設定する。
+- CI: `develop` への push（`server/mcp/**` 変更時）で `.github/workflows/deploy-mcp-worker-dev.yml` が `wrangler deploy --env dev` を実行し、`/health` の疎通を確認する。`/health` はデプロイ検証用に `git_commit_sha` を返す。
+- JWT の検証・失効（deny-list）は API 側（`server/api`、#1093 で KV/Durable Objects 化）の責務のため、この Worker に `BETTER_AUTH_SECRET` や Redis/KV は不要。Bearer トークンをそのまま API へ転送する。
+- ステートレスな Streamable HTTP（リクエスト毎に応答を返し、常駐 SSE ストリームを持たない）なので、Workers の実行時間制約と競合しない。API の Workers 本番切替（#1091）後は Service Bindings 化を検討。
+- クライアント設定は 3b と同じ。`url` を Worker のドメイン（`https://zedi-mcp.<account>.workers.dev/mcp` またはカスタムドメイン）に差し替える。
+
 ---
 
 ## 4. 公開されているツール

--- a/server/mcp/README.ja.md
+++ b/server/mcp/README.ja.md
@@ -200,8 +200,8 @@ bun run worker:deploy:production   # 本番デプロイ
 - `ZEDI_API_URL` は `wrangler.jsonc` の `vars`（production）またはデプロイ時の `--var`（dev は CI が GitHub Environment 変数 `API_BASE_URL` から注入）で設定する。
 - CI: `develop` への push（`server/mcp/**` 変更時）で `.github/workflows/deploy-mcp-worker-dev.yml` が `wrangler deploy --env dev` を実行し、`/health` の疎通を確認する。`/health` はデプロイ検証用に `git_commit_sha` を返す。
 - JWT の検証・失効（deny-list）は API 側（`server/api`、#1093 で KV/Durable Objects 化）の責務のため、この Worker に `BETTER_AUTH_SECRET` や Redis/KV は不要。Bearer トークンをそのまま API へ転送する。
-- ステートレスな Streamable HTTP（リクエスト毎に応答を返し、常駐 SSE ストリームを持たない）なので、Workers の実行時間制約と競合しない。API の Workers 本番切替（#1091）後は Service Bindings 化を検討。
-- クライアント設定は 3b と同じ。`url` を Worker のドメイン（`https://zedi-mcp.<account>.workers.dev/mcp` またはカスタムドメイン）に差し替える。
+- ステートレスな Streamable HTTP（リクエスト毎に応答を返し、常駐 SSE ストリームを持たない）なので長時間接続の問題は回避できる。ただしリクエスト単位の Workers 制限（CPU 時間・メモリ・サブリクエスト数）は通常どおり適用される。API の Workers 本番切替（#1091）後は Service Bindings 化を検討。
+- クライアント設定は 3b と同じ。`url` を Worker のドメイン（`https://<worker-name>.<account-subdomain>.workers.dev/mcp`、例: `https://zedi-mcp.<account-subdomain>.workers.dev/mcp`、またはカスタムドメイン）に差し替える。
 
 ---
 

--- a/server/mcp/README.md
+++ b/server/mcp/README.md
@@ -200,8 +200,8 @@ bun run worker:deploy:production   # deploy to production
 - `ZEDI_API_URL` comes from `wrangler.jsonc` `vars` (production) or a deploy-time `--var` (dev CI injects it from the `API_BASE_URL` GitHub Environment variable).
 - CI: pushes to `develop` touching `server/mcp/**` run `.github/workflows/deploy-mcp-worker-dev.yml`, which executes `wrangler deploy --env dev` and probes `/health`. `/health` reports `git_commit_sha` for deploy verification.
 - JWT verification and the revocation deny-list live in the API (`server/api`, moved to KV/Durable Objects in #1093), so this Worker needs no `BETTER_AUTH_SECRET` and no Redis/KV binding — it forwards the bearer token to the API as-is.
-- The transport is stateless Streamable HTTP (each request gets a response; no long-lived SSE stream), so it does not conflict with Workers execution-time limits. Once the API cuts over to Workers (#1091), consider Service Bindings for the internal hop.
-- Client configuration is the same as 3b — point `url` at the Worker domain (`https://zedi-mcp.<account>.workers.dev/mcp` or a custom domain).
+- The transport is stateless Streamable HTTP (each request gets a response; no long-lived SSE stream), so it avoids long-lived-connection issues — though each request still runs under the usual per-request Worker limits (CPU time, memory, subrequests). Once the API cuts over to Workers (#1091), consider Service Bindings for the internal hop.
+- Client configuration is the same as 3b — point `url` at the Worker domain (`https://<worker-name>.<account-subdomain>.workers.dev/mcp`, e.g. `https://zedi-mcp.<account-subdomain>.workers.dev/mcp`, or a custom domain).
 
 ---
 

--- a/server/mcp/README.md
+++ b/server/mcp/README.md
@@ -185,6 +185,24 @@ Use HTTP transport settings in Claude Code `mcpServers`. Set `Authorization` hea
 
 The server is stateless (new `McpServer` per request), so the same JWT can be used from multiple clients without session conflicts.
 
+### 3c. Deploy on Cloudflare Workers (#1092 / migrating from Railway)
+
+The HTTP transport can also be deployed as a Cloudflare Worker (the migration target per issue [#1088](https://github.com/otomatty/zedi/issues/1088); Railway remains transitional). Entry point is `src/worker.ts`; the source of truth for configuration is `wrangler.jsonc` (`env.dev` = `zedi-mcp-dev` / `env.production` = `zedi-mcp`).
+
+```bash
+cd server/mcp
+bun install
+bun run worker:dev                 # local (wrangler dev --env dev)
+bun run worker:deploy:dev          # deploy to dev
+bun run worker:deploy:production   # deploy to production
+```
+
+- `ZEDI_API_URL` comes from `wrangler.jsonc` `vars` (production) or a deploy-time `--var` (dev CI injects it from the `API_BASE_URL` GitHub Environment variable).
+- CI: pushes to `develop` touching `server/mcp/**` run `.github/workflows/deploy-mcp-worker-dev.yml`, which executes `wrangler deploy --env dev` and probes `/health`. `/health` reports `git_commit_sha` for deploy verification.
+- JWT verification and the revocation deny-list live in the API (`server/api`, moved to KV/Durable Objects in #1093), so this Worker needs no `BETTER_AUTH_SECRET` and no Redis/KV binding — it forwards the bearer token to the API as-is.
+- The transport is stateless Streamable HTTP (each request gets a response; no long-lived SSE stream), so it does not conflict with Workers execution-time limits. Once the API cuts over to Workers (#1091), consider Service Bindings for the internal hop.
+- Client configuration is the same as 3b — point `url` at the Worker domain (`https://zedi-mcp.<account>.workers.dev/mcp` or a custom domain).
+
 ---
 
 ## 4. Available tools

--- a/server/mcp/bun.lock
+++ b/server/mcp/bun.lock
@@ -17,6 +17,7 @@
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
         "vitest": "4.1.4",
+        "wrangler": "^4.71.0",
       },
     },
   },
@@ -30,6 +31,22 @@
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260710.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-OqJl2eWF5+y9jarMm3YqqCTUe7Hd4ihogX5jyRU8iaAgOVyDr/Bk6aXpPCVUi1/MHzO93a18R/TmSTtzmB0sQw=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260710.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MYBqWgUblO+VlGvO73zYsH3hB9tdRj+yLyt5IHDFWryipb2l1efmNiWtAOkIhSRfypqLYGFrfpaDm2Hg00XVKw=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260710.1", "", { "os": "linux", "cpu": "x64" }, "sha512-lVWUgqI8qrkqvaCBGElu1kdaUFdAvaS2RD8K4qkCFP9hI3f5TCXumEs5qWSeZkvKum0+X/uJZ5hBFWsYI5SmoQ=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260710.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-kDwDPItBjAI4JL0df9Fma2N+Qggbm77IB/DnroAkEGQ79fpR80sYMyuB/ZQKyjEk9f48Ocq7HCCLq59qVSyNqA=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260710.1", "", { "os": "win32", "cpu": "x64" }, "sha512-GcLHy1oN1dfK6g1Z7UDV9f5xMGyTfPwcjWQ0sfWKH31IsoEVCRapnj3IC0PoIrDbnoo6irGPP0CwVs3WzdTajw=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
@@ -91,6 +108,56 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
 
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
     "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
@@ -102,6 +169,12 @@
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
 
@@ -134,6 +207,10 @@
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -172,6 +249,8 @@
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.4", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA=="],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
@@ -216,6 +295,8 @@
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -311,6 +392,8 @@
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
@@ -351,6 +434,8 @@
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
+    "miniflare": ["miniflare@4.20260710.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260710.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-x1LLRkU6o1p7hiKrB0TRnL0MJn6xFOT+/vrlEQINz5cRDKLP8ru4hBqWTIvXAetzr1acKAnmAaG84pQ4W/K14g=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -373,7 +458,7 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
-    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -412,6 +497,8 @@
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -455,7 +542,11 @@
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
@@ -469,12 +560,84 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
+    "workerd": ["workerd@1.20260710.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260710.1", "@cloudflare/workerd-darwin-arm64": "1.20260710.1", "@cloudflare/workerd-linux-64": "1.20260710.1", "@cloudflare/workerd-linux-arm64": "1.20260710.1", "@cloudflare/workerd-windows-64": "1.20260710.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-U2sBPPrb9U97sBKnnMN6Kv8p65903P35nwMkPE9vSH/bRuRqkZ3a1EjUw3jV28RhiyXpkLF77Evzw8XimFxyTw=="],
+
+    "wrangler": ["wrangler@4.111.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260710.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260710.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260710.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-bffpI9EyrnpKkF/1S+RaIv8oRD93GtbsA7TlfWwOsGJGB7VO3jVbdGzpC9TU7Bqom3z7jUxcte4Z9MPhaQ4HoQ=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "wrangler/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "wrangler/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "wrangler/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "wrangler/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
   }
 }

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -16,6 +16,9 @@
     "start:stdio": "node dist/stdio.js",
     "start:http": "node dist/http.js",
     "typecheck": "tsc --noEmit",
+    "worker:dev": "wrangler dev --env dev",
+    "worker:deploy:dev": "wrangler deploy --env dev",
+    "worker:deploy:production": "wrangler deploy --env production",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest"
@@ -32,6 +35,7 @@
     "@vitest/coverage-v8": "4.1.4",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
-    "vitest": "4.1.4"
+    "vitest": "4.1.4",
+    "wrangler": "^4.71.0"
   }
 }

--- a/server/mcp/src/__tests__/http.test.ts
+++ b/server/mcp/src/__tests__/http.test.ts
@@ -76,6 +76,35 @@ describe("createHttpApp", () => {
     expect(body.apiUrl).toBe(API_URL);
   });
 
+  it("GET /health returns git_commit_sha null when no commit env is set", async () => {
+    vi.stubEnv("GIT_COMMIT_SHA", "");
+    vi.stubEnv("RAILWAY_GIT_COMMIT_SHA", "");
+    const app = createHttpApp(API_URL);
+    const res = await app.request("/health");
+    const body = (await res.json()) as { git_commit_sha: string | null };
+    expect(body.git_commit_sha).toBeNull();
+    vi.unstubAllEnvs();
+  });
+
+  it("GET /health returns git_commit_sha from GIT_COMMIT_SHA (Workers CI var)", async () => {
+    vi.stubEnv("GIT_COMMIT_SHA", "abc123def456");
+    const app = createHttpApp(API_URL);
+    const res = await app.request("/health");
+    const body = (await res.json()) as { git_commit_sha: string | null };
+    expect(body.git_commit_sha).toBe("abc123def456");
+    vi.unstubAllEnvs();
+  });
+
+  it("GET /health falls back to RAILWAY_GIT_COMMIT_SHA", async () => {
+    vi.stubEnv("GIT_COMMIT_SHA", "");
+    vi.stubEnv("RAILWAY_GIT_COMMIT_SHA", "railway-sha-789");
+    const app = createHttpApp(API_URL);
+    const res = await app.request("/health");
+    const body = (await res.json()) as { git_commit_sha: string | null };
+    expect(body.git_commit_sha).toBe("railway-sha-789");
+    vi.unstubAllEnvs();
+  });
+
   it("POST /mcp without Authorization returns 401", async () => {
     const res = await mcpPost();
     expect(res.status).toBe(401);

--- a/server/mcp/src/__tests__/http.test.ts
+++ b/server/mcp/src/__tests__/http.test.ts
@@ -6,7 +6,7 @@
  *
  * Tests for the HTTP transport entry point — health, auth, and per-request MCP wiring.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockConnect = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockClose = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
@@ -66,6 +66,12 @@ describe("createHttpApp", () => {
     });
   });
 
+  afterEach(() => {
+    // stubEnv した環境変数がテスト失敗時にも他のテストへ漏れないようにする。
+    // Ensure stubbed env vars never leak into later tests, even on failure.
+    vi.unstubAllEnvs();
+  });
+
   it("GET /health returns ok", async () => {
     const app = createHttpApp(API_URL);
     const res = await app.request("/health");
@@ -83,7 +89,6 @@ describe("createHttpApp", () => {
     const res = await app.request("/health");
     const body = (await res.json()) as { git_commit_sha: string | null };
     expect(body.git_commit_sha).toBeNull();
-    vi.unstubAllEnvs();
   });
 
   it("GET /health returns git_commit_sha from GIT_COMMIT_SHA (Workers CI var)", async () => {
@@ -92,7 +97,6 @@ describe("createHttpApp", () => {
     const res = await app.request("/health");
     const body = (await res.json()) as { git_commit_sha: string | null };
     expect(body.git_commit_sha).toBe("abc123def456");
-    vi.unstubAllEnvs();
   });
 
   it("GET /health falls back to RAILWAY_GIT_COMMIT_SHA", async () => {
@@ -102,7 +106,6 @@ describe("createHttpApp", () => {
     const res = await app.request("/health");
     const body = (await res.json()) as { git_commit_sha: string | null };
     expect(body.git_commit_sha).toBe("railway-sha-789");
-    vi.unstubAllEnvs();
   });
 
   it("POST /mcp without Authorization returns 401", async () => {

--- a/server/mcp/src/__tests__/worker.test.ts
+++ b/server/mcp/src/__tests__/worker.test.ts
@@ -1,0 +1,135 @@
+/**
+ * worker.ts のテスト — Cloudflare Workers エントリポイント (#1092)
+ *
+ * - Workers の env バインディング (`ZEDI_API_URL`) からバックエンド API URL を解決する
+ * - 未設定時は `DEFAULT_API_URL` にフォールバックする
+ * - `/health` は `GIT_COMMIT_SHA` var をデプロイ検証用に公開する
+ * - `/mcp` は Node エントリと同じ Bearer 認証配線を共有する
+ *
+ * Tests for the Cloudflare Workers entry point: env-based API URL resolution,
+ * health metadata for deploy verification, and shared /mcp auth wiring.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockConnect = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockClose = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockHandleRequest = vi.hoisted(() => vi.fn());
+const mockCreateMcpServer = vi.hoisted(() => vi.fn());
+const mockHttpZediClient = vi.hoisted(() => vi.fn());
+
+vi.mock("../server.js", () => ({
+  createMcpServer: mockCreateMcpServer,
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js", () => ({
+  WebStandardStreamableHTTPServerTransport: vi.fn(
+    function MockWebStandardStreamableHTTPServerTransport() {
+      return { handleRequest: mockHandleRequest };
+    },
+  ),
+}));
+
+vi.mock("../client/httpClient.js", () => ({
+  HttpZediClient: mockHttpZediClient,
+}));
+
+import worker from "../worker.js";
+import { DEFAULT_API_URL } from "../app.js";
+
+const ENV = { ZEDI_API_URL: "https://api.dev.example.com", GIT_COMMIT_SHA: "abc123def456" };
+const MCP_BODY = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+
+interface HealthBody {
+  ok: boolean;
+  server: string;
+  apiUrl: string;
+  git_commit_sha: string | null;
+}
+
+describe("worker (Cloudflare Workers entry)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateMcpServer.mockReturnValue({
+      connect: mockConnect,
+      close: mockClose,
+    });
+    mockHandleRequest.mockResolvedValue(
+      new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    mockHttpZediClient.mockImplementation(function MockHttpZediClient(opts: {
+      baseUrl: string;
+      token: string;
+    }) {
+      return { baseUrl: opts.baseUrl, token: opts.token };
+    });
+  });
+
+  it("GET /health resolves apiUrl from env binding ZEDI_API_URL", async () => {
+    const res = await worker.request("/health", {}, ENV);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as HealthBody;
+    expect(body.ok).toBe(true);
+    expect(body.server).toBe("zedi-mcp");
+    expect(body.apiUrl).toBe("https://api.dev.example.com");
+  });
+
+  it("GET /health falls back to DEFAULT_API_URL when ZEDI_API_URL is unset", async () => {
+    const res = await worker.request("/health", {}, {});
+    const body = (await res.json()) as HealthBody;
+    expect(body.apiUrl).toBe(DEFAULT_API_URL);
+  });
+
+  it("GET /health treats empty ZEDI_API_URL as unset", async () => {
+    const res = await worker.request("/health", {}, { ZEDI_API_URL: "" });
+    const body = (await res.json()) as HealthBody;
+    expect(body.apiUrl).toBe(DEFAULT_API_URL);
+  });
+
+  it("GET /health exposes git_commit_sha from env binding", async () => {
+    const res = await worker.request("/health", {}, ENV);
+    const body = (await res.json()) as HealthBody;
+    expect(body.git_commit_sha).toBe("abc123def456");
+  });
+
+  it("GET /health returns git_commit_sha null when GIT_COMMIT_SHA is unset", async () => {
+    const res = await worker.request("/health", {}, { ZEDI_API_URL: "https://x.example.com" });
+    const body = (await res.json()) as HealthBody;
+    expect(body.git_commit_sha).toBeNull();
+  });
+
+  it("POST /mcp without Authorization returns 401", async () => {
+    const res = await worker.request(
+      "/mcp",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: MCP_BODY,
+      },
+      ENV,
+    );
+    expect(res.status).toBe(401);
+    expect(mockCreateMcpServer).not.toHaveBeenCalled();
+  });
+
+  it("POST /mcp with Bearer token builds client against env apiUrl", async () => {
+    const res = await worker.request(
+      "/mcp",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer valid-token" },
+        body: MCP_BODY,
+      },
+      ENV,
+    );
+    expect(res.status).toBe(200);
+    expect(mockHttpZediClient).toHaveBeenCalledWith({
+      baseUrl: "https://api.dev.example.com",
+      token: "valid-token",
+    });
+    expect(mockConnect).toHaveBeenCalledOnce();
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+});

--- a/server/mcp/src/app.ts
+++ b/server/mcp/src/app.ts
@@ -1,0 +1,133 @@
+/**
+ * Zedi MCP — トランスポート中立の Hono アプリ構築 (#1092)
+ *
+ * Node (`http.ts`) と Cloudflare Workers (`worker.ts`) の両エントリポイントから
+ * 共有される。Node 専用 API (`@hono/node-server` 等) を import しないこと —
+ * Workers バンドルに含まれるため、Web 標準 API のみで書く。
+ *
+ * リクエストはセッションごとに以下の流れで処理する:
+ *   1. クライアントが `Authorization: Bearer <MCP JWT>` ヘッダ付きでアクセス
+ *   2. ヘッダから JWT を取り出し、新しい `HttpZediClient` を生成
+ *   3. リクエストごとに新しい `McpServer` を建て、トランスポートを通して応答する
+ *      (ステートレスモード — sessionIdGenerator: undefined)
+ *
+ * JWT の検証・失効 (deny-list) はバックエンド API (`server/api`) 側の責務。
+ * この層は Bearer トークンをそのまま API へ転送するだけで秘密鍵を持たない。
+ *
+ * Transport-neutral Hono app factory shared by the Node entry (`http.ts`) and
+ * the Cloudflare Workers entry (`worker.ts`). Keep this module free of
+ * Node-only imports — it is bundled into the Worker. JWT verification and the
+ * revocation deny-list live in `server/api`; this layer only forwards the
+ * bearer token.
+ */
+import { Hono } from "hono";
+import type { Context, Env } from "hono";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { createMcpServer } from "./server.js";
+import { HttpZediClient } from "./client/httpClient.js";
+
+/** バックエンド API のデフォルト URL / Default backend API base URL. */
+export const DEFAULT_API_URL = "https://api.zedi.app";
+
+/** Workers の env バインディング / Worker env bindings (wrangler.jsonc `vars`). */
+export interface McpWorkerEnv {
+  /** バックエンド REST API の URL / Backend REST API base URL. */
+  ZEDI_API_URL?: string;
+  /** デプロイ検証用のコミット SHA (CI が `--var` で注入) / Commit SHA injected by CI. */
+  GIT_COMMIT_SHA?: string;
+  /** development / production */
+  ENVIRONMENT?: string;
+}
+
+/** `/health` が公開するリクエスト毎のメタ情報 / Per-request metadata surfaced by `/health`. */
+interface RequestContextInfo {
+  apiUrl: string;
+  gitCommitSha: string | null;
+}
+
+function extractBearer(authHeader: string | undefined): string | null {
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  const token = authHeader.slice(7).trim();
+  return token || null;
+}
+
+/** 空文字は未設定として扱う / Treat empty strings as unset. */
+function normalize(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+/**
+ * リクエストごとに `HttpZediClient` と `McpServer` を生成し、トランスポートで応答する。
+ * Per-request handler: builds an isolated MCP server bound to the caller's bearer token.
+ */
+async function handleMcpRequest(rawRequest: Request, apiUrl: string): Promise<Response> {
+  const token = extractBearer(rawRequest.headers.get("Authorization") ?? undefined);
+  if (!token) {
+    return new Response(
+      JSON.stringify({ error: "unauthorized", message: "Bearer token required" }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const client = new HttpZediClient({ baseUrl: apiUrl, token });
+  const server = createMcpServer(client);
+  // Stateless mode: each HTTP exchange creates its own ephemeral session.
+  // セッションは持たず、リクエストごとに新規生成する。
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
+  await server.connect(transport);
+
+  try {
+    return await transport.handleRequest(rawRequest);
+  } finally {
+    // Best-effort cleanup; the per-request server isn't reused.
+    // 使い捨てサーバーは後始末のみする。
+    await server.close().catch(() => {});
+  }
+}
+
+/**
+ * `/health` と `/mcp` を持つ Hono アプリを構築する。API URL / コミット SHA の
+ * 解決方法だけがエントリポイント間で異なるため、resolver として注入する。
+ * Builds the Hono app; entry points differ only in how they resolve the API
+ * URL and commit SHA, injected here as a resolver.
+ */
+function buildApp<E extends Env>(resolve: (c: Context<E>) => RequestContextInfo): Hono<E> {
+  const app = new Hono<E>();
+
+  app.get("/health", (c) => {
+    const { apiUrl, gitCommitSha } = resolve(c);
+    return c.json({ ok: true, server: "zedi-mcp", apiUrl, git_commit_sha: gitCommitSha });
+  });
+
+  app.all("/mcp", async (c) => handleMcpRequest(c.req.raw, resolve(c).apiUrl));
+
+  return app;
+}
+
+/**
+ * Node エントリ用アプリ。API URL は起動時に固定し、コミット SHA は
+ * `GIT_COMMIT_SHA` (CI) → `RAILWAY_GIT_COMMIT_SHA` (Railway) の順で解決する。
+ * App for the Node entry: fixed API URL, commit SHA from process.env.
+ */
+export function createHttpApp(apiUrl: string): Hono {
+  return buildApp(() => ({
+    apiUrl,
+    gitCommitSha:
+      normalize(process.env.GIT_COMMIT_SHA) ?? normalize(process.env.RAILWAY_GIT_COMMIT_SHA),
+  }));
+}
+
+/**
+ * Cloudflare Workers エントリ用アプリ。API URL / コミット SHA を env バインディング
+ * (`wrangler.jsonc` の `vars` / デプロイ時 `--var`) からリクエスト毎に解決する。
+ * App for the Workers entry: resolves API URL / commit SHA from env bindings.
+ */
+export function createWorkerApp(): Hono<{ Bindings: McpWorkerEnv }> {
+  return buildApp<{ Bindings: McpWorkerEnv }>((c) => ({
+    apiUrl: normalize(c.env?.ZEDI_API_URL) ?? DEFAULT_API_URL,
+    gitCommitSha: normalize(c.env?.GIT_COMMIT_SHA),
+  }));
+}

--- a/server/mcp/src/app.ts
+++ b/server/mcp/src/app.ts
@@ -35,7 +35,7 @@ export interface McpWorkerEnv {
   ZEDI_API_URL?: string;
   /** デプロイ検証用のコミット SHA (CI が `--var` で注入) / Commit SHA injected by CI. */
   GIT_COMMIT_SHA?: string;
-  /** development / production */
+  /** 実行環境の識別子 (development / production) / Runtime environment identifier. */
   ENVIRONMENT?: string;
 }
 

--- a/server/mcp/src/app.ts
+++ b/server/mcp/src/app.ts
@@ -45,6 +45,10 @@ interface RequestContextInfo {
   gitCommitSha: string | null;
 }
 
+/**
+ * `Authorization` ヘッダから Bearer トークンを取り出す。形式不正・空は null。
+ * Extracts the bearer token from an Authorization header; null when malformed or empty.
+ */
 function extractBearer(authHeader: string | undefined): string | null {
   if (!authHeader?.startsWith("Bearer ")) return null;
   const token = authHeader.slice(7).trim();

--- a/server/mcp/src/http.ts
+++ b/server/mcp/src/http.ts
@@ -1,82 +1,26 @@
 #!/usr/bin/env node
 /**
- * Zedi MCP — HTTP / Streamable HTTP エントリーポイント
+ * Zedi MCP — HTTP / Streamable HTTP エントリーポイント (Node)
  *
  * Hono + `WebStandardStreamableHTTPServerTransport` を使い、外部 Claude Code クライアントから
- * リモート接続を受け付ける。Railway などの単独サービスとしてデプロイする想定。
+ * リモート接続を受け付ける。Railway などの単独 Node サービスとしてデプロイする想定。
+ * アプリ本体 (ルーティング / Bearer 認証 / MCP 配線) は `app.ts` に切り出しており、
+ * Cloudflare Workers エントリ (`worker.ts`) と共有する (#1092)。
  *
  * 環境変数:
  *   ZEDI_API_URL    バックエンド REST API の URL (例: http://api.railway.internal:3000)
  *   PORT            待ち受けポート (default: 3100)
  *   MCP_HOST        待ち受けホスト (default: 0.0.0.0)
  *
- * リクエストはセッションごとに以下の流れで処理する:
- *   1. クライアントが `Authorization: Bearer <MCP JWT>` ヘッダ付きでアクセス
- *   2. ヘッダから JWT を取り出し、新しい `HttpZediClient` を生成
- *   3. リクエストごとに新しい `McpServer` を建て、トランスポートを通して応答する
- *      (ステートレスモード — sessionIdGenerator: undefined)
- *
- * HTTP entry point for the Zedi MCP server using Streamable HTTP transport.
- * Each request gets its own per-token client + server instance (stateless).
+ * Node HTTP entry point for the Zedi MCP server. The Hono app itself lives in
+ * `app.ts`, shared with the Cloudflare Workers entry (`worker.ts`).
  */
 import { serve } from "@hono/node-server";
-import { Hono } from "hono";
-import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import { createMcpServer } from "./server.js";
-import { HttpZediClient } from "./client/httpClient.js";
+import { createHttpApp, DEFAULT_API_URL } from "./app.js";
 
-const DEFAULT_API_URL = "https://api.zedi.app";
-
-function extractBearer(authHeader: string | undefined): string | null {
-  if (!authHeader?.startsWith("Bearer ")) return null;
-  const token = authHeader.slice(7).trim();
-  return token || null;
-}
-
-/**
- * リクエストごとに `HttpZediClient` と `McpServer` を生成し、トランスポートで応答する。
- * Per-request handler: builds an isolated MCP server bound to the caller's bearer token.
- */
-async function handleMcpRequest(rawRequest: Request, apiUrl: string): Promise<Response> {
-  const token = extractBearer(rawRequest.headers.get("Authorization") ?? undefined);
-  if (!token) {
-    return new Response(
-      JSON.stringify({ error: "unauthorized", message: "Bearer token required" }),
-      { status: 401, headers: { "Content-Type": "application/json" } },
-    );
-  }
-
-  const client = new HttpZediClient({ baseUrl: apiUrl, token });
-  const server = createMcpServer(client);
-  // Stateless mode: each HTTP exchange creates its own ephemeral session.
-  // セッションは持たず、リクエストごとに新規生成する。
-  const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: undefined,
-  });
-  await server.connect(transport);
-
-  try {
-    return await transport.handleRequest(rawRequest);
-  } finally {
-    // Best-effort cleanup; the per-request server isn't reused.
-    // 使い捨てサーバーは後始末のみする。
-    await server.close().catch(() => {});
-  }
-}
-
-/**
- * Hono アプリを生成する。テストから呼べるよう関数として export する。
- * Builds the Hono app; exported for testing.
- */
-export function createHttpApp(apiUrl: string): Hono {
-  const app = new Hono();
-
-  app.get("/health", (c) => c.json({ ok: true, server: "zedi-mcp", apiUrl }));
-
-  app.all("/mcp", async (c) => handleMcpRequest(c.req.raw, apiUrl));
-
-  return app;
-}
+// 後方互換のため再エクスポートする (既存テスト / 利用側は `http.js` から import している)。
+// Re-exported for backward compatibility with existing imports.
+export { createHttpApp } from "./app.js";
 
 async function main() {
   const apiUrl = process.env.ZEDI_API_URL ?? DEFAULT_API_URL;

--- a/server/mcp/src/worker.ts
+++ b/server/mcp/src/worker.ts
@@ -1,0 +1,14 @@
+/**
+ * Cloudflare Workers entry for the Zedi MCP server (#1092 / Phase 2).
+ * Hono default export — same pattern as `server/api/src/worker.ts`.
+ *
+ * `ZEDI_API_URL` / `GIT_COMMIT_SHA` は `wrangler.jsonc` の `vars` またはデプロイ時の
+ * `--var` で注入され、リクエスト毎に env バインディングから解決される。
+ *
+ * Zedi MCP サーバーの Cloudflare Workers エントリポイント。
+ */
+import { createWorkerApp } from "./app.js";
+
+const app = createWorkerApp();
+
+export default app;

--- a/server/mcp/wrangler.jsonc
+++ b/server/mcp/wrangler.jsonc
@@ -1,0 +1,30 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "zedi-mcp",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-06-25",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": {
+    "enabled": true,
+  },
+  // ZEDI_API_URL: バックエンド REST API の URL。dev はデプロイ CI が GitHub
+  // Environment 変数 (API_BASE_URL) から `--var` で注入する。未指定時はコードの
+  // DEFAULT_API_URL にフォールバックする。JWT 検証・deny-list は API 側 (#1093)。
+  // ZEDI_API_URL: backend REST API base URL. The dev deploy workflow injects it
+  // via `--var` from the GitHub Environment; production pins the custom domain.
+  "env": {
+    "dev": {
+      "name": "zedi-mcp-dev",
+      "vars": {
+        "ENVIRONMENT": "development",
+      },
+    },
+    "production": {
+      "name": "zedi-mcp",
+      "vars": {
+        "ENVIRONMENT": "production",
+        "ZEDI_API_URL": "https://api.zedi-note.app",
+      },
+    },
+  },
+}


### PR DESCRIPTION
Phase 2 of the Railway → Cloudflare migration (#1088) for server/mcp
(#1092), mirroring the API Worker skeleton (Phase 2a):

- Extract the transport-neutral Hono app (routing / bearer auth / MCP
  wiring) from src/http.ts into src/app.ts, free of Node-only imports
- Add src/worker.ts (Hono default export) resolving ZEDI_API_URL /
  GIT_COMMIT_SHA from Worker env bindings per request
- Add wrangler.jsonc (zedi-mcp-dev / zedi-mcp, nodejs_compat,
  observability) and worker:* scripts + wrangler devDependency
- Expose git_commit_sha in /health for deploy verification, reading
  GIT_COMMIT_SHA (Workers CI) then RAILWAY_GIT_COMMIT_SHA (Railway)
- Add deploy-mcp-worker-dev.yml: develop push → wrangler deploy
  --env dev with ZEDI_API_URL injected from the API_BASE_URL GitHub
  Environment variable, then /health gate
- Document Workers deployment in README.md / README.ja.md

JWT verification and the token deny-list stay in server/api (#1093),
so the Worker carries no secrets. The transport is stateless Streamable
HTTP (no long-lived SSE stream), compatible with Workers time limits.
Railway deployment remains available in parallel until cutover.

Closes #1092

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0165wQZWpA75jPZoLbUKEZ3o

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Cloudflare Workers entrypoint for the MCP HTTP transport, including `/health` (effective API URL + `git_commit_sha`) and bearer-token–protected `/mcp` with stateless request handling.
  - Introduced Wrangler-based dev/production commands for running and deploying the Worker.

- **Documentation**
  - Updated English and Japanese guides with Cloudflare Workers migration steps, configuration, and `/health` verification.

- **Tests**
  - Expanded test coverage for `/health` commit SHA resolution/fallback and Worker request/auth behavior.
  - Improved test isolation to avoid environment stub leakage.

- **Chores**
  - Added a CI workflow to deploy the Worker to the development environment with health probing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->