### PR TITLE
chore(api): add Worker secrets bulk-upload for R2 cutover (#1089)

### DIFF
--- a/.agents/skills/cloudflare-zedi/references/secrets-template.md
+++ b/.agents/skills/cloudflare-zedi/references/secrets-template.md
@@ -202,11 +202,14 @@ bunx wrangler secret put BETTER_AUTH_SECRET --env dev
 ## コピー手順（Railway → Worker）/ Copy checklist
 
 1. Railway dashboard → api サービス → Variables をエクスポート（または 1 件ずつ）。
-2. `server/api` で `bunx wrangler secret list --env dev` と突合。
-3. マスター一覧の「必須」をすべて `wrangler secret put`。
-4. `/health` で `runtime: cloudflare-workers` と `git_commit_sha` を確認。
-5. auth / media upload / webhook のスモークテスト。
-6. production は dev 成功後に `--env production` で同手順。
+2. `server/api/.env.worker.dev.example` を `.env.worker.dev` にコピーし値を埋める（gitignored）。
+   production は `.env.worker.production`。
+3. 一括投入: `cd server/api && bun run worker:secrets:put -- --env dev`
+   （確認のみ: `--dry-run`。個別 `wrangler secret put` でも可。）
+4. `bunx wrangler secret list --env dev` とマスター一覧を突合。
+5. `/health` で `runtime: cloudflare-workers` と `git_commit_sha` を確認。
+6. auth / media upload / webhook のスモークテスト。
+7. production は dev 成功後に `.env.worker.production` → `--env production`。
 
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ public/pdfjs/
 .env.production
 .env
 server/.dev.vars
+# Worker secret bulk-upload sources (examples are committed)
+server/api/.env.worker.dev
+server/api/.env.worker.production
+server/mcp/.env.worker.dev
+server/mcp/.env.worker.production
 
 # Server build artifacts
 server/api/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ src-tauri/binaries/claude-sidecar*
 
 # Local-only notes (not tracked). See AGENTS.md.
 /docs/
+/journal/
 
 # AI-DLC — per-user cursors and machine-local runtime (aidlc-workflows v2)
 # Rule: commit shared work (method, state, audit shards, artifacts); ignore cursors/runtime.

--- a/server/api/.env.example
+++ b/server/api/.env.example
@@ -88,3 +88,8 @@ STORAGE_BUCKET_NAME=
 # DATABASE_URL / BETTER_AUTH_* 等も Worker 切替前に設定すること。REDIS_URL は
 # Worker では不要（#1093 で KV_DO Durable Object binding に置換。Railway/Node では引き続き必要）。
 # フェーズ別の登録・削除一覧は secrets-template.md を参照。
+#
+# Bulk upload: copy `.env.worker.dev.example` → `.env.worker.dev` (gitignored), fill values, then
+#   bun run worker:secrets:put -- --env dev
+#   bun run worker:secrets:put -- --env production
+# Dry-run: bun run worker:secrets:put -- --env dev --dry-run

--- a/server/api/.env.worker.dev.example
+++ b/server/api/.env.worker.dev.example
@@ -1,0 +1,16 @@
+# Copy to `.env.worker.dev` (gitignored) and fill values, then:
+#   bun run worker:secrets:put -- --env dev
+#
+# R2 binding (STORAGE_BUCKET) is in wrangler.jsonc — not a secret.
+# These STORAGE_* values are for S3-compatible presigned URLs only (#1089).
+
+STORAGE_ENDPOINT=https://<CLOUDFLARE_ACCOUNT_ID>.r2.cloudflarestorage.com
+STORAGE_ACCESS_KEY=
+STORAGE_SECRET_KEY=
+STORAGE_BUCKET_NAME=zedi-storage-dev
+
+# Add other Worker secrets as needed before cutover (see secrets-template.md):
+# DATABASE_URL=
+# BETTER_AUTH_SECRET=
+# BETTER_AUTH_URL=
+# CORS_ORIGIN=

--- a/server/api/.env.worker.production.example
+++ b/server/api/.env.worker.production.example
@@ -1,0 +1,16 @@
+# Copy to `.env.worker.production` (gitignored) and fill values, then:
+#   bun run worker:secrets:put -- --env production
+#
+# R2 binding (STORAGE_BUCKET) is in wrangler.jsonc — not a secret.
+# These STORAGE_* values are for S3-compatible presigned URLs only (#1089).
+
+STORAGE_ENDPOINT=https://<CLOUDFLARE_ACCOUNT_ID>.r2.cloudflarestorage.com
+STORAGE_ACCESS_KEY=
+STORAGE_SECRET_KEY=
+STORAGE_BUCKET_NAME=zedi-storage-prod
+
+# Add other Worker secrets as needed before cutover (see secrets-template.md):
+# DATABASE_URL=
+# BETTER_AUTH_SECRET=
+# BETTER_AUTH_URL=
+# CORS_ORIGIN=

--- a/server/api/package.json
+++ b/server/api/package.json
@@ -19,7 +19,8 @@
     "worker:dev": "wrangler dev --env dev",
     "worker:deploy:dev": "wrangler deploy --env dev",
     "worker:deploy:production": "wrangler deploy --env production",
-    "worker:types": "wrangler types"
+    "worker:types": "wrangler types",
+    "worker:secrets:put": "tsx scripts/putWorkerSecrets.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1002.0",

--- a/server/api/scripts/parseWorkerEnvFile.test.ts
+++ b/server/api/scripts/parseWorkerEnvFile.test.ts
@@ -1,5 +1,15 @@
+/**
+ * Specification tests for `parseWorkerEnvFile` / `serializeWorkerEnvFile`.
+ *
+ * Accepted syntax: `KEY=VALUE`, optional `export` prefix, `#` comments, blank lines skipped,
+ * empty values skipped, quoted values unwrapped. Invalid lines (no `=`, bad key) throw.
+ *
+ * `parseWorkerEnvFile` / `serializeWorkerEnvFile` の仕様テスト。
+ * 受理: `KEY=VALUE`、`export` 接頭辞、`#` コメント、空行スキップ、空値スキップ、引用符除去。
+ * 拒否: `=` なし行・不正キーは例外。
+ */
 import { describe, expect, it } from "vitest";
-import { parseWorkerEnvFile } from "./parseWorkerEnvFile.js";
+import { parseWorkerEnvFile, serializeWorkerEnvFile } from "./parseWorkerEnvFile.js";
 
 describe("parseWorkerEnvFile", () => {
   it("parses KEY=VALUE pairs and skips comments and blanks", () => {
@@ -22,5 +32,15 @@ EMPTY_SKIP=
 
   it("rejects lines without KEY=VALUE", () => {
     expect(() => parseWorkerEnvFile("NOT_A_PAIR")).toThrow(/invalid/i);
+  });
+});
+
+describe("serializeWorkerEnvFile", () => {
+  it("quotes values with whitespace for wrangler secret bulk", () => {
+    const body = serializeWorkerEnvFile([
+      { name: "STORAGE_ACCESS_KEY", value: "akid" },
+      { name: "STORAGE_SECRET_KEY", value: "secret with spaces" },
+    ]);
+    expect(body).toBe('STORAGE_ACCESS_KEY=akid\nSTORAGE_SECRET_KEY="secret with spaces"');
   });
 });

--- a/server/api/scripts/parseWorkerEnvFile.test.ts
+++ b/server/api/scripts/parseWorkerEnvFile.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { parseWorkerEnvFile } from "./parseWorkerEnvFile.js";
+
+describe("parseWorkerEnvFile", () => {
+  it("parses KEY=VALUE pairs and skips comments and blanks", () => {
+    const text = `
+# comment
+STORAGE_ENDPOINT=https://example.r2.cloudflarestorage.com
+
+STORAGE_BUCKET_NAME=zedi-storage-dev
+export STORAGE_ACCESS_KEY=akid
+STORAGE_SECRET_KEY="secret with spaces"
+EMPTY_SKIP=
+`;
+    expect(parseWorkerEnvFile(text)).toEqual([
+      { name: "STORAGE_ENDPOINT", value: "https://example.r2.cloudflarestorage.com" },
+      { name: "STORAGE_BUCKET_NAME", value: "zedi-storage-dev" },
+      { name: "STORAGE_ACCESS_KEY", value: "akid" },
+      { name: "STORAGE_SECRET_KEY", value: "secret with spaces" },
+    ]);
+  });
+
+  it("rejects lines without KEY=VALUE", () => {
+    expect(() => parseWorkerEnvFile("NOT_A_PAIR")).toThrow(/invalid/i);
+  });
+});

--- a/server/api/scripts/parseWorkerEnvFile.ts
+++ b/server/api/scripts/parseWorkerEnvFile.ts
@@ -1,9 +1,14 @@
+/** One secret name/value pair parsed from a Worker env file. / Worker env ファイルから解析した secret の name/value ペア。 */
 export type WorkerSecretEntry = { name: string; value: string };
 
 /**
  * Parses a dotenv-style Worker secrets file into name/value pairs.
  * Skips blank lines, `#` comments, and empty values. Supports optional `export` prefix
- * and single/double-quoted values.
+ * and single/double-quoted values. Rejects lines without a valid `KEY=VALUE` pair.
+ *
+ * dotenv 形式の Worker secrets ファイルを name/value ペアに解析する。
+ * 空行・`#` コメント・空値はスキップ。`export` 接頭辞と単/二重引用符付き値に対応。
+ * 不正な行（`KEY=VALUE` でない行）は拒否する。
  */
 export function parseWorkerEnvFile(text: string): WorkerSecretEntry[] {
   const entries: WorkerSecretEntry[] = [];
@@ -36,4 +41,23 @@ export function parseWorkerEnvFile(text: string): WorkerSecretEntry[] {
   }
 
   return entries;
+}
+
+/**
+ * Serializes parsed entries to `.env` lines for `wrangler secret bulk`.
+ * Values containing whitespace or `=` are double-quoted.
+ *
+ * 解析済みエントリを `wrangler secret bulk` 向けの `.env` 行に直列化する。
+ * 空白または `=` を含む値は二重引用符で囲む。
+ */
+export function serializeWorkerEnvFile(entries: WorkerSecretEntry[]): string {
+  return entries
+    .map(({ name, value }) => {
+      const needsQuotes = /[\s=#"]/.test(value);
+      const serialized = needsQuotes
+        ? `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+        : value;
+      return `${name}=${serialized}`;
+    })
+    .join("\n");
 }

--- a/server/api/scripts/parseWorkerEnvFile.ts
+++ b/server/api/scripts/parseWorkerEnvFile.ts
@@ -1,0 +1,39 @@
+export type WorkerSecretEntry = { name: string; value: string };
+
+/**
+ * Parses a dotenv-style Worker secrets file into name/value pairs.
+ * Skips blank lines, `#` comments, and empty values. Supports optional `export` prefix
+ * and single/double-quoted values.
+ */
+export function parseWorkerEnvFile(text: string): WorkerSecretEntry[] {
+  const entries: WorkerSecretEntry[] = [];
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const withoutExport = line.startsWith("export ") ? line.slice("export ".length).trim() : line;
+    const eq = withoutExport.indexOf("=");
+    if (eq <= 0) {
+      throw new Error(`Invalid worker env line (expected KEY=VALUE): ${rawLine}`);
+    }
+
+    const name = withoutExport.slice(0, eq).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      throw new Error(`Invalid worker env line (expected KEY=VALUE): ${rawLine}`);
+    }
+
+    let value = withoutExport.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    if (value === "") continue;
+    entries.push({ name, value });
+  }
+
+  return entries;
+}

--- a/server/api/scripts/putWorkerSecrets.ts
+++ b/server/api/scripts/putWorkerSecrets.ts
@@ -1,0 +1,106 @@
+/**
+ * Bulk-upload secrets from `.env.worker.<env>` via `wrangler secret put`.
+ *
+ * Usage:
+ *   bun run worker:secrets:put -- --env dev
+ *   bun run worker:secrets:put -- --env production
+ *   bun run worker:secrets:put -- --env dev --dry-run
+ */
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseWorkerEnvFile } from "./parseWorkerEnvFile.js";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const API_ROOT = resolve(SCRIPT_DIR, "..");
+
+type WranglerEnv = "dev" | "production";
+
+function usage(): never {
+  console.error(
+    "Usage: bun scripts/putWorkerSecrets.ts --env <dev|production> [--file <path>] [--dry-run]",
+  );
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): {
+  env: WranglerEnv;
+  file?: string;
+  dryRun: boolean;
+} {
+  let env: WranglerEnv | undefined;
+  let file: string | undefined;
+  let dryRun = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--env") {
+      const value = argv[++i];
+      if (value !== "dev" && value !== "production") usage();
+      env = value;
+      continue;
+    }
+    if (arg === "--file") {
+      file = argv[++i];
+      if (!file) usage();
+      continue;
+    }
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") usage();
+    usage();
+  }
+
+  if (!env) usage();
+  return { env, file, dryRun };
+}
+
+function putSecret(name: string, value: string, env: WranglerEnv): Promise<void> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn("bunx", ["wrangler", "secret", "put", name, "--env", env], {
+      cwd: API_ROOT,
+      stdio: ["pipe", "inherit", "inherit"],
+      shell: true,
+    });
+    child.stdin.write(value);
+    child.stdin.end();
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolvePromise();
+      else reject(new Error(`wrangler secret put ${name} failed (exit ${code})`));
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const { env, file, dryRun } = parseArgs(process.argv.slice(2));
+  const envPath = resolve(API_ROOT, file ?? `.env.worker.${env}`);
+  const text = readFileSync(envPath, "utf8");
+  const entries = parseWorkerEnvFile(text);
+
+  if (entries.length === 0) {
+    console.error(`No secrets found in ${envPath}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `${dryRun ? "[dry-run] " : ""}Putting ${entries.length} secret(s) from ${envPath} → --env ${env}`,
+  );
+  for (const { name, value } of entries) {
+    if (dryRun) {
+      console.log(`  ${name} (${value.length} chars)`);
+      continue;
+    }
+    console.log(`  ${name}...`);
+    await putSecret(name, value, env);
+  }
+  console.log(dryRun ? "Dry run complete." : "Done.");
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/server/api/scripts/putWorkerSecrets.ts
+++ b/server/api/scripts/putWorkerSecrets.ts
@@ -1,7 +1,8 @@
 /**
- * Bulk-upload secrets from `.env.worker.<env>` via `wrangler secret put`.
+ * Bulk-upload secrets from `.env.worker.<env>` via `wrangler secret bulk` (single deployment).
+ * `.env.worker.<env>` から `wrangler secret bulk` で secrets を一括投入する（1 回のデプロイ）。
  *
- * Usage:
+ * Usage / 使い方:
  *   bun run worker:secrets:put -- --env dev
  *   bun run worker:secrets:put -- --env production
  *   bun run worker:secrets:put -- --env dev --dry-run
@@ -10,7 +11,7 @@ import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseWorkerEnvFile } from "./parseWorkerEnvFile.js";
+import { parseWorkerEnvFile, serializeWorkerEnvFile } from "./parseWorkerEnvFile.js";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const API_ROOT = resolve(SCRIPT_DIR, "..");
@@ -58,19 +59,19 @@ function parseArgs(argv: string[]): {
   return { env, file, dryRun };
 }
 
-function putSecret(name: string, value: string, env: WranglerEnv): Promise<void> {
+/** Upload all secrets in one `wrangler secret bulk` request (single Worker version). */
+function putSecretsBulk(body: string, env: WranglerEnv): Promise<void> {
   return new Promise((resolvePromise, reject) => {
-    const child = spawn("bunx", ["wrangler", "secret", "put", name, "--env", env], {
+    const child = spawn("bunx", ["wrangler", "secret", "bulk", "--env", env], {
       cwd: API_ROOT,
       stdio: ["pipe", "inherit", "inherit"],
-      shell: true,
     });
-    child.stdin.write(value);
+    child.stdin.write(body);
     child.stdin.end();
     child.on("error", reject);
     child.on("close", (code) => {
       if (code === 0) resolvePromise();
-      else reject(new Error(`wrangler secret put ${name} failed (exit ${code})`));
+      else reject(new Error(`wrangler secret bulk failed (exit ${code})`));
     });
   });
 }
@@ -89,15 +90,16 @@ async function main(): Promise<void> {
   console.log(
     `${dryRun ? "[dry-run] " : ""}Putting ${entries.length} secret(s) from ${envPath} → --env ${env}`,
   );
-  for (const { name, value } of entries) {
-    if (dryRun) {
+  if (dryRun) {
+    for (const { name, value } of entries) {
       console.log(`  ${name} (${value.length} chars)`);
-      continue;
     }
-    console.log(`  ${name}...`);
-    await putSecret(name, value, env);
+    console.log("Dry run complete.");
+    return;
   }
-  console.log(dryRun ? "Dry run complete." : "Done.");
+
+  await putSecretsBulk(serializeWorkerEnvFile(entries), env);
+  console.log("Done.");
 }
 
 main().catch((err: unknown) => {


### PR DESCRIPTION
## 概要

Cloudflare ビッグバン移行（#1088）向けに、API Worker の secrets を `.env.worker.<env>` から一括投入できるスクリプトと example を追加します。#1089 では Railway の `STORAGE_*` 切替はスキップし、Worker secrets（presign 用）経路に寄せます。

## 変更点

### `server/api/`
- `.env.worker.dev.example` / `.env.worker.production.example` を追加（実ファイルは gitignore）
- `scripts/putWorkerSecrets.ts` — `wrangler secret put` を一括実行（`--dry-run` 対応）
- `scripts/parseWorkerEnvFile.ts` + テスト
- `bun run worker:secrets:put -- --env <dev|production>`

### ドキュメント / ignore
- `secrets-template.md` のコピー手順を一括投入手順に更新
- `.gitignore` に `.env.worker.*`（実値）を追加
- `.env.example` に使い方を追記

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] 💥 破壊的変更 (Breaking change)
- [x] 📝 ドキュメント (Documentation)
- [ ] 🎨 スタイル/リファクタリング (Style/Refactor)
- [x] 🧪 テスト (Tests)
- [ ] 🔧 ビルド/CI (Build/CI)

## テスト方法

1. `cp server/api/.env.worker.dev.example server/api/.env.worker.dev` し、`STORAGE_*` を埋める
2. `cd server/api && bun run worker:secrets:put -- --env dev --dry-run` でキー一覧を確認
3. `bun run worker:secrets:put -- --env dev` で投入し、`bunx wrangler secret list --env dev` で 4 キーを確認
4. `cd server/api && bunx vitest run scripts/parseWorkerEnvFile.test.ts`

## チェックリスト

- [x] 関連テストがパスする（`parseWorkerEnvFile`）
- [x] Lint / Prettier（pre-commit）エラーがない
- [x] 必要に応じてドキュメントを更新した
- [x] コミットメッセージが Conventional Commits に従っている
- [x] 実 secrets ファイル（`.env.worker.dev` / `.env.worker.production`）はコミットしていない

## 関連 Issue

Related to #1089
Related to #1088


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a template-based workflow for uploading Worker secrets in bulk for development and production.
  * Added a script to upload secrets using a single bulk operation, including a `--dry-run` preview.
* **Documentation**
  * Updated the setup instructions to use environment example files, bulk upload, then verification plus health checks and smoke tests.
  * Added/expanded Worker environment templates for storage and secret configuration.
* **Bug Fixes**
  * Improved parsing/serialization validation, including support for quoted values and correct escaping.
* **Tests**
  * Added automated coverage for parsing and formatting Worker secret entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->